### PR TITLE
Routing and navigation

### DIFF
--- a/.github/workflows/gating.yml
+++ b/.github/workflows/gating.yml
@@ -4,7 +4,7 @@ name: Gating tests
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [main, devel]
 
 jobs:
   audit-and-build:

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@patternfly/react-core": "^4.198.19",
         "@patternfly/react-table": "^4.93.1",
         "react": "^17.0.2",
-        "react-dom": "^17.0.2"
+        "react-dom": "^17.0.2",
+        "react-router-dom": "^6.3.0"
       },
       "devDependencies": {
         "@babel/core": "^7.18.9",
@@ -1750,7 +1751,6 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
       "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -5897,6 +5897,14 @@
         "he": "bin/he"
       }
     },
+    "node_modules/history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
     "node_modules/hpack.js": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
@@ -8306,6 +8314,30 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "node_modules/react-router": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "dependencies": {
+        "history": "^5.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
+      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+      "dependencies": {
+        "history": "^5.2.0",
+        "react-router": "6.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -8404,8 +8436,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "dev": true
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.0",
@@ -11518,7 +11549,6 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
       "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -14727,6 +14757,14 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "requires": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
     "hpack.js": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
@@ -16478,6 +16516,23 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "react-router": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "requires": {
+        "history": "^5.2.0"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
+      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+      "requires": {
+        "history": "^5.2.0",
+        "react-router": "6.3.0"
+      }
+    },
     "readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -16554,8 +16609,7 @@
     "regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "dev": true
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "regenerator-transform": {
       "version": "0.15.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "@patternfly/react-core": "^4.198.19",
     "@patternfly/react-table": "^4.93.1",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "react-router-dom": "^6.3.0"
   },
   "scripts": {
     "build": "webpack build --mode production --progress",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -5,18 +5,52 @@ import "@patternfly/react-core/dist/styles/base.css";
 import { AppLayout } from "./AppLayout";
 // Navigation
 import { AppRoutes } from "./navigation/AppRoutes";
-import { Navigate, Route, Routes } from "react-router-dom";
-// Pages
-import ActiveUsers from "./pages/ActiveUsers/ActiveUsers";
-import ActiveUsersTabs from "./pages/ActiveUsers/ActiveUsersTabs";
-import StageUsers from "./pages/StageUsers/StageUsers";
-import PreservedUsers from "./pages/PreservedUsers/PreservedUsers";
+
+// Context
+export const Context = React.createContext<{
+  groupActive: string;
+  setGroupActive: React.Dispatch<any>;
+  browserTitle: string;
+  setBrowserTitle: React.Dispatch<any>;
+  superGroupActive: string;
+  setSuperGroupActive: React.Dispatch<any>;
+}>({
+  groupActive: "active-users",
+  setGroupActive: () => null,
+  browserTitle: "Active users title",
+  setBrowserTitle: () => null,
+  superGroupActive: "users",
+  setSuperGroupActive: () => null,
+});
 
 const App: React.FunctionComponent = () => {
+  // - Initial active group
+  const [groupActive, setGroupActive] = React.useState("active-users");
+  // - Initial title
+  const [browserTitle, setBrowserTitle] = React.useState("Active users title");
+  // - Initial active super group
+  const [superGroupActive, setSuperGroupActive] = React.useState("users");
+
+  // Update the 'browserTitle' on document.title when this changes
+  React.useEffect(() => {
+    document.title = browserTitle;
+  }, [browserTitle]);
+
   return (
-    <AppLayout>
-      <AppRoutes />
-    </AppLayout>
+    <Context.Provider
+      value={{
+        groupActive,
+        setGroupActive,
+        browserTitle,
+        setBrowserTitle,
+        superGroupActive,
+        setSuperGroupActive,
+      }}
+    >
+      <AppLayout>
+        <AppRoutes />
+      </AppLayout>
+    </Context.Provider>
   );
 };
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,8 +1,23 @@
 import React from "react";
 
 import "@patternfly/react-core/dist/styles/base.css";
+// Layouts
 import { AppLayout } from "./AppLayout";
+// Navigation
+import { AppRoutes } from "./navigation/AppRoutes";
+import { Navigate, Route, Routes } from "react-router-dom";
+// Pages
+import ActiveUsers from "./pages/ActiveUsers/ActiveUsers";
+import ActiveUsersTabs from "./pages/ActiveUsers/ActiveUsersTabs";
+import StageUsers from "./pages/StageUsers/StageUsers";
+import PreservedUsers from "./pages/PreservedUsers/PreservedUsers";
 
-const App: React.FunctionComponent = () => <AppLayout>Hello world</AppLayout>;
+const App: React.FunctionComponent = () => {
+  return (
+    <AppLayout>
+      <AppRoutes />
+    </AppLayout>
+  );
+};
 
 export default App;

--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -14,6 +14,8 @@ import {
 } from "@patternfly/react-core";
 import React from "react";
 import BarsIcon from "@patternfly/react-icons/dist/esm/icons/bars-icon";
+// Navigation
+import Navigation from "./navigation/Nav";
 
 const AppLayout = ({ children }: { children: React.ReactNode }) => {
   const headerToolbar = (
@@ -44,7 +46,7 @@ const AppLayout = ({ children }: { children: React.ReactNode }) => {
     </Masthead>
   );
 
-  const Sidebar = <PageSidebar nav="Navigation" />;
+  const Sidebar = <PageSidebar nav={<Navigation />} />;
 
   const pageId = "primary-app-container";
 

--- a/src/app/navigation/AppRoutes.tsx
+++ b/src/app/navigation/AppRoutes.tsx
@@ -1,20 +1,22 @@
 import * as React from "react";
+// React router dom
 import { Navigate, Route, Routes } from "react-router-dom";
 import NotFound from "./NotFound";
-// import { useDocumentTitle } from "./utils/useDocumentTitle";
 
 // PAGE COMPONENTS
 import ActiveUsers from "app/pages/ActiveUsers/ActiveUsers";
 import ActiveUsersTabs from "app/pages/ActiveUsers/ActiveUsersTabs";
 import StageUsers from "app/pages/StageUsers/StageUsers";
+import StageUsersTabs from "app/pages/StageUsers/StageUsersTabs";
 import PreservedUsers from "app/pages/PreservedUsers/PreservedUsers";
-// import ActiveUsersSettings from "./pages/ActiveUsersSettings";
-// import ActiveUsersIsMemberOf from "./pages/ActiveUsersIsMemberOf";
-// import ActiveUsersIsMemberOfAdd from "./pages/ActiveUsersIsMemberOfAdd";
+import UserGroups from "app/pages/UserGroups/UserGroups";
+import HostGroups from "app/pages/HostGroups/HostGroups";
+import Netgroups from "app/pages/Netgroups/Netgroups";
+
 // Navigation
 import { URL_PREFIX } from "./NavRoutes";
 
-// Renders routes
+// Renders routes (React)
 export const AppRoutes = (): React.ReactElement => (
   <Routes>
     <Route path={URL_PREFIX}>
@@ -24,9 +26,64 @@ export const AppRoutes = (): React.ReactElement => (
       </Route>
       <Route path="stage-users">
         <Route path="" element={<StageUsers />} />
+        <Route path="settings" element={<StageUsersTabs />} />
       </Route>
       <Route path="preserved-users">
         <Route path="" element={<PreservedUsers />} />
+      </Route>
+      <Route path="hosts">
+        <Route path="" />
+      </Route>
+      <Route path="services">
+        <Route path="" />
+      </Route>
+      <Route path="user-groups">
+        <Route path="" element={<UserGroups />} />
+      </Route>
+      <Route path="host-groups">
+        <Route path="" element={<HostGroups />} />
+      </Route>
+      <Route path="netgroups">
+        <Route path="" element={<Netgroups />} />
+      </Route>
+      <Route path="id-views">
+        <Route path="" />
+      </Route>
+      <Route path="user-group-rules">
+        <Route path="" />
+      </Route>
+      <Route path="host-group-rules">
+        <Route path="" />
+      </Route>
+      <Route path="hbac-rules">
+        <Route path="" />
+      </Route>
+      <Route path="hbac-services">
+        <Route path="" />
+      </Route>
+      <Route path="hbac-service-groups">
+        <Route path="" />
+      </Route>
+      <Route path="hbac-test">
+        <Route path="" />
+      </Route>
+      <Route path="sudo-rules">
+        <Route path="" />
+      </Route>
+      <Route path="sudo-commands">
+        <Route path="" />
+      </Route>
+      <Route path="sudo-command-group">
+        <Route path="" />
+      </Route>
+      <Route path="selinux-user-maps">
+        <Route path="" />
+      </Route>
+      <Route path="password-policies">
+        <Route path="" />
+      </Route>
+      <Route path="kerberos-ticket-policy">
+        <Route path="" />
       </Route>
     </Route>
     <Route

--- a/src/app/navigation/AppRoutes.tsx
+++ b/src/app/navigation/AppRoutes.tsx
@@ -1,0 +1,38 @@
+import * as React from "react";
+import { Navigate, Route, Routes } from "react-router-dom";
+import NotFound from "./NotFound";
+// import { useDocumentTitle } from "./utils/useDocumentTitle";
+
+// PAGE COMPONENTS
+import ActiveUsers from "app/pages/ActiveUsers/ActiveUsers";
+import ActiveUsersTabs from "app/pages/ActiveUsers/ActiveUsersTabs";
+import StageUsers from "app/pages/StageUsers/StageUsers";
+import PreservedUsers from "app/pages/PreservedUsers/PreservedUsers";
+// import ActiveUsersSettings from "./pages/ActiveUsersSettings";
+// import ActiveUsersIsMemberOf from "./pages/ActiveUsersIsMemberOf";
+// import ActiveUsersIsMemberOfAdd from "./pages/ActiveUsersIsMemberOfAdd";
+// Navigation
+import { URL_PREFIX } from "./NavRoutes";
+
+// Renders routes
+export const AppRoutes = (): React.ReactElement => (
+  <Routes>
+    <Route path={URL_PREFIX}>
+      <Route path="active-users">
+        <Route path="" element={<ActiveUsers />} />
+        <Route path="settings" element={<ActiveUsersTabs />} />
+      </Route>
+      <Route path="stage-users">
+        <Route path="" element={<StageUsers />} />
+      </Route>
+      <Route path="preserved-users">
+        <Route path="" element={<PreservedUsers />} />
+      </Route>
+    </Route>
+    <Route
+      path=""
+      element={<Navigate to={URL_PREFIX + "/active-users"} replace />}
+    />
+    <Route path="*" element={<NotFound />} />
+  </Routes>
+);

--- a/src/app/navigation/Nav.tsx
+++ b/src/app/navigation/Nav.tsx
@@ -1,0 +1,54 @@
+import { Nav, NavExpandable, NavItem, NavList } from "@patternfly/react-core";
+import React, { useState } from "react";
+import {
+  NavLink,
+  useInRouterContext,
+  useLocation,
+  useMatch,
+  useResolvedPath,
+} from "react-router-dom";
+// Navigation (PatternFly)
+import { navigationRoutes } from "./NavRoutes";
+
+const renderNavItem = (item: { label: string; url: string }, id: number) => {
+  const location = useLocation();
+  console.log(useMatch(item.url));
+
+  return (
+    <NavItem key={id} isActive={!!useMatch(item.url)}>
+      <NavLink to={item.url}>{item.label}</NavLink>
+    </NavItem>
+  );
+};
+
+const Navigation = () => {
+  return (
+    <Nav>
+      <NavList>
+        {navigationRoutes.map((section, id) => {
+          return (
+            <NavExpandable key={id} title={section.label} isActive isExpanded>
+              {section.items.map((subsection, sid) => {
+                return (
+                  <NavExpandable
+                    key={sid}
+                    title={subsection.label}
+                    isActive
+                    isExpanded
+                  >
+                    {subsection.items.map(
+                      (linkItem, lid) =>
+                        linkItem.url && renderNavItem(linkItem, lid)
+                    )}
+                  </NavExpandable>
+                );
+              })}
+            </NavExpandable>
+          );
+        })}
+      </NavList>
+    </Nav>
+  );
+};
+
+export default Navigation;

--- a/src/app/navigation/Nav.tsx
+++ b/src/app/navigation/Nav.tsx
@@ -1,47 +1,71 @@
 import { Nav, NavExpandable, NavItem, NavList } from "@patternfly/react-core";
-import React, { useState } from "react";
-import {
-  NavLink,
-  useInRouterContext,
-  useLocation,
-  useMatch,
-  useResolvedPath,
-} from "react-router-dom";
+import React from "react";
+import { NavLink } from "react-router-dom";
 // Navigation (PatternFly)
 import { navigationRoutes } from "./NavRoutes";
+// Context
+import { Context } from "app/App";
 
-const renderNavItem = (item: { label: string; url: string }, id: number) => {
-  const location = useLocation();
-  console.log(useMatch(item.url));
-
+// Renders NavItem
+const renderNavItem = (
+  item: { label: string; group: string; path: string; title: string },
+  id: number,
+  superGroup: string
+) => {
+  const { groupActive, setGroupActive, setBrowserTitle, setSuperGroupActive } =
+    React.useContext(Context);
   return (
-    <NavItem key={id} isActive={!!useMatch(item.url)}>
-      <NavLink to={item.url}>{item.label}</NavLink>
+    <NavItem
+      key={id}
+      isActive={groupActive === item.group}
+      onClick={() => {
+        setGroupActive(item.group);
+        setBrowserTitle(item.title);
+        setSuperGroupActive(superGroup);
+      }}
+    >
+      <NavLink to={item.path}>{item.label}</NavLink>
     </NavItem>
   );
 };
 
+// Renders 'Navigation'
 const Navigation = () => {
+  const { superGroupActive } = React.useContext(Context);
   return (
     <Nav>
       <NavList>
         {navigationRoutes.map((section, id) => {
           return (
-            <NavExpandable key={id} title={section.label} isActive isExpanded>
+            <NavExpandable
+              key={id}
+              title={section.label}
+              isActive={section.items.some(
+                (route) => route.group === superGroupActive
+              )}
+              isExpanded={section.items.some(
+                (route) => route.group === superGroupActive
+              )}
+            >
               {section.items.map((subsection, sid) => {
-                return (
-                  <NavExpandable
-                    key={sid}
-                    title={subsection.label}
-                    isActive
-                    isExpanded
-                  >
-                    {subsection.items.map(
-                      (linkItem, lid) =>
-                        linkItem.url && renderNavItem(linkItem, lid)
-                    )}
-                  </NavExpandable>
-                );
+                if (subsection.items.length > 0) {
+                  return (
+                    <NavExpandable
+                      key={sid}
+                      title={subsection.label}
+                      isActive={superGroupActive === subsection.group}
+                      isExpanded={superGroupActive === subsection.group}
+                    >
+                      {subsection.items.map(
+                        (linkItem, lid) =>
+                          linkItem.path &&
+                          renderNavItem(linkItem, lid, subsection.group)
+                      )}
+                    </NavExpandable>
+                  );
+                } else {
+                  return renderNavItem(subsection, sid, subsection.group);
+                }
               })}
             </NavExpandable>
           );

--- a/src/app/navigation/NavRoutes.ts
+++ b/src/app/navigation/NavRoutes.ts
@@ -1,64 +1,251 @@
+// Navigation
 export const URL_PREFIX = "/ipa/modern_ui";
 
+// Group reference variables (group names)
+// IDENTITY
+// - Users
+const usersGroupRef = "users";
+const ActiveUsersGroupRef = "active-users";
+const StageUsersGroupRef = "stage-users";
+const PreservedUsersGroupRef = "preserved-users";
+// - Hosts
+const HostsGroupRef = "hosts";
+// - Services
+const ServicesGroupRef = "services";
+// - Groups
+const GroupsGroupRef = "groups";
+const UserGroupsGroupRef = "user-groups";
+const HostGroupsGroupRef = "host-groups";
+const NetgroupsGroupRef = "netgroups";
+// - Views
+const IdViewsGroupRef = "id-views";
+// - Automember
+const AutomemberGroupRef = "automember";
+const UserGroupRulesGroupRef = "user-group-rules";
+const HostGroupRulesGroupRef = "host-group-rules";
+// POLICY
+// - Host-based access control
+const HostBasedAccessControlGroupRef = "host-based-access-control";
+const HbacRulesGroupRef = "hbac-rules";
+const HbacServicesGroupRef = "hbac-services";
+const HbacServiceGroupsGroupRef = "hbac-service-groups";
+const HbacTestGroupRef = "hbac-test";
+// - Sudo
+const SudoGroupRef = "sudo";
+const SudoRulesGroupRef = "sudo-rules";
+const SudoCommandsGroupRef = "sudo-commands";
+const SudoCommandGroupsGroupRef = "sudo-command-groups";
+// - SELinux user maps
+const SelinuxUserMapsGroupRef = "selinux-user-maps";
+// - Password policies
+const PasswordPoliciesGroupRef = "password-policies";
+// - Kerberos ticket policy
+const KerberosTicketPolicyGroupRef = "kerberos-ticket-policy";
+
+// List of navigation routes (UI)
 export const navigationRoutes = [
   {
     label: "Identity",
+    group: "",
+    title: "Identity title",
+    path: "",
     items: [
       {
         label: "Users",
+        group: usersGroupRef,
+        title: "Users title",
+        path: "",
         items: [
           {
             label: "Active users",
-            url: `${URL_PREFIX}/active-users`,
+            group: ActiveUsersGroupRef,
+            title: "Active users title",
+            path: `${URL_PREFIX}/active-users`,
             items: [
               {
                 label: "Active users Settings",
-                url: `${URL_PREFIX}/active-users/settings`,
+                group: ActiveUsersGroupRef,
+                title: "Active users Settings title",
+                path: `${URL_PREFIX}/active-users/settings`,
               },
             ],
           },
           {
             label: "Stage users",
-            url: `${URL_PREFIX}/stage-users`,
+            group: StageUsersGroupRef,
+            title: "Stage users title",
+            path: `${URL_PREFIX}/stage-users`,
+            items: [
+              {
+                label: "Stage users Settings",
+                group: StageUsersGroupRef,
+                title: "Stage users Settings title",
+                path: `${URL_PREFIX}/stage-users/settings`,
+              },
+            ],
           },
           {
             label: "Preserved users",
-            url: `${URL_PREFIX}/preserved-users`,
+            group: PreservedUsersGroupRef,
+            title: "Preserved users title",
+            path: `${URL_PREFIX}/preserved-users`,
           },
         ],
       },
-      // {
-      //   label: "Hosts",
-      //   items: [],
-      //   url: `${URL_PREFIX}/active-users`,
-      // },
-      // {
-      //   label: "Services",
-      //   items: [],
-      //   url: `${URL_PREFIX}/active-users`,
-      // },
-      // {
-      //   label: "Groups",
-      //   items: [],
-      // },
-      // {
-      //   label: "ID views",
-      //   items: [],
-      //   url: `${URL_PREFIX}/active-users`,
-      // },
-      // {
-      //   label: "Automember",
-      //   items: [
-      //     {
-      //       label: "User Group Rules",
-      //       url: `${URL_PREFIX}/active-users`,
-      //     },
-      //     {
-      //       label: "Host Group Rules",
-      //       url: `${URL_PREFIX}/stage-users`,
-      //     },
-      //   ],
-      // },
+      {
+        label: "Hosts",
+        group: HostsGroupRef,
+        title: "Hosts title",
+        items: [],
+        path: `${URL_PREFIX}/hosts`,
+      },
+      {
+        label: "Services",
+        group: ServicesGroupRef,
+        title: "Services title",
+        items: [],
+        path: `${URL_PREFIX}/services`,
+      },
+      {
+        label: "Groups",
+        group: GroupsGroupRef,
+        title: "Groups title",
+        path: "",
+        items: [
+          {
+            label: "User groups",
+            group: UserGroupsGroupRef,
+            title: "User groups title",
+            path: `${URL_PREFIX}/user-groups`,
+          },
+          {
+            label: "Host groups",
+            group: HostGroupsGroupRef,
+            title: "Host groups title",
+            path: `${URL_PREFIX}/host-groups`,
+          },
+          {
+            label: "Netgroups",
+            group: NetgroupsGroupRef,
+            title: "Netgroups title",
+            path: `${URL_PREFIX}/netgroups`,
+          },
+        ],
+      },
+      {
+        label: "ID views",
+        group: IdViewsGroupRef,
+        title: "ID views title",
+        items: [],
+        path: `${URL_PREFIX}/id-views`,
+      },
+      {
+        label: "Automember",
+        group: AutomemberGroupRef,
+        title: "Automamber title",
+        path: "",
+        items: [
+          {
+            label: "User Group Rules",
+            group: UserGroupRulesGroupRef,
+            title: "User Group Rules title",
+            path: `${URL_PREFIX}/user-group-rules`,
+          },
+          {
+            label: "Host Group Rules",
+            group: HostGroupRulesGroupRef,
+            title: "Host Group Rules title",
+            path: `${URL_PREFIX}/host-group-rules`,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    label: "Policy",
+    group: "",
+    title: "Policy title",
+    path: "",
+    items: [
+      {
+        label: "Host-based access control",
+        group: HostBasedAccessControlGroupRef,
+        title: "Host-based access control title",
+        path: "",
+        items: [
+          {
+            label: "HBAC rules",
+            group: HbacRulesGroupRef,
+            title: "HBAC rules title",
+            path: `${URL_PREFIX}/hbac-rules`,
+          },
+          {
+            label: "HBAC services",
+            group: HbacServicesGroupRef,
+            title: "HBAC services title",
+            path: `${URL_PREFIX}/hbac-services`,
+          },
+          {
+            label: "HBAC service groups",
+            group: HbacServiceGroupsGroupRef,
+            title: "HBAC service groups title",
+            path: `${URL_PREFIX}/hbac-service-groups`,
+          },
+          {
+            label: "HBAC test",
+            group: HbacTestGroupRef,
+            title: "HBAC test title",
+            path: `${URL_PREFIX}/hbac-test`,
+          },
+        ],
+      },
+      {
+        label: "Sudo",
+        group: SudoGroupRef,
+        title: "Sudo title",
+        path: "",
+        items: [
+          {
+            label: "Sudo rules",
+            group: SudoRulesGroupRef,
+            title: "Sudo rules title",
+            path: `${URL_PREFIX}/sudo-rules`,
+          },
+          {
+            label: "Sudo commands",
+            group: SudoCommandsGroupRef,
+            title: "Sudo commands title",
+            path: `${URL_PREFIX}/sudo-commands`,
+          },
+          {
+            label: "Sudo command groups",
+            group: SudoCommandGroupsGroupRef,
+            title: "Sudo command groups title",
+            path: `${URL_PREFIX}/sudo-command-groups`,
+          },
+        ],
+      },
+      {
+        label: "SELinux user maps",
+        group: SelinuxUserMapsGroupRef,
+        title: "SELinux user maps title",
+        path: "",
+        items: [],
+      },
+      {
+        label: "Password policies",
+        group: PasswordPoliciesGroupRef,
+        title: "Password policies title",
+        path: "",
+        items: [],
+      },
+      {
+        label: "Kerberos ticket policy",
+        group: KerberosTicketPolicyGroupRef,
+        title: "Kerberos ticket policy title",
+        path: "",
+        items: [],
+      },
     ],
   },
 ];

--- a/src/app/navigation/NavRoutes.ts
+++ b/src/app/navigation/NavRoutes.ts
@@ -1,0 +1,64 @@
+export const URL_PREFIX = "/ipa/modern_ui";
+
+export const navigationRoutes = [
+  {
+    label: "Identity",
+    items: [
+      {
+        label: "Users",
+        items: [
+          {
+            label: "Active users",
+            url: `${URL_PREFIX}/active-users`,
+            items: [
+              {
+                label: "Active users Settings",
+                url: `${URL_PREFIX}/active-users/settings`,
+              },
+            ],
+          },
+          {
+            label: "Stage users",
+            url: `${URL_PREFIX}/stage-users`,
+          },
+          {
+            label: "Preserved users",
+            url: `${URL_PREFIX}/preserved-users`,
+          },
+        ],
+      },
+      // {
+      //   label: "Hosts",
+      //   items: [],
+      //   url: `${URL_PREFIX}/active-users`,
+      // },
+      // {
+      //   label: "Services",
+      //   items: [],
+      //   url: `${URL_PREFIX}/active-users`,
+      // },
+      // {
+      //   label: "Groups",
+      //   items: [],
+      // },
+      // {
+      //   label: "ID views",
+      //   items: [],
+      //   url: `${URL_PREFIX}/active-users`,
+      // },
+      // {
+      //   label: "Automember",
+      //   items: [
+      //     {
+      //       label: "User Group Rules",
+      //       url: `${URL_PREFIX}/active-users`,
+      //     },
+      //     {
+      //       label: "Host Group Rules",
+      //       url: `${URL_PREFIX}/stage-users`,
+      //     },
+      //   ],
+      // },
+    ],
+  },
+];

--- a/src/app/navigation/NotFound.tsx
+++ b/src/app/navigation/NotFound.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const NotFound = () => {
+  return <p>404: Page not found!</p>;
+};
+
+export default NotFound;

--- a/src/app/pages/ActiveUsers/ActiveUsers.tsx
+++ b/src/app/pages/ActiveUsers/ActiveUsers.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+// React router dom
+import { NavLink } from "react-router-dom";
+
+const ActiveUsers = () => {
+  // return <Link to="settings">Active Users Page</Link>;
+  return <NavLink to="settings">Active Users Page</NavLink>;
+};
+
+export default ActiveUsers;

--- a/src/app/pages/ActiveUsers/ActiveUsers.tsx
+++ b/src/app/pages/ActiveUsers/ActiveUsers.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import { NavLink } from "react-router-dom";
 
 const ActiveUsers = () => {
-  // return <Link to="settings">Active Users Page</Link>;
   return <NavLink to="settings">Active Users Page</NavLink>;
 };
 

--- a/src/app/pages/ActiveUsers/ActiveUsersTabs.tsx
+++ b/src/app/pages/ActiveUsers/ActiveUsersTabs.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+// React router dom
+import { Link } from "react-router-dom";
+
+const ActiveUsersTabs = () => {
+  return <Link to="third-level-page">This is Active users tabs!</Link>;
+};
+
+export default ActiveUsersTabs;

--- a/src/app/pages/HostGroups/HostGroups.tsx
+++ b/src/app/pages/HostGroups/HostGroups.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const HostGroups = () => {
+  return <p>Host groups Page</p>;
+};
+
+export default HostGroups;

--- a/src/app/pages/Netgroups/Netgroups.tsx
+++ b/src/app/pages/Netgroups/Netgroups.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Netgroups = () => {
+  return <p>Netgroups Page</p>;
+};
+
+export default Netgroups;

--- a/src/app/pages/PreservedUsers/PreservedUsers.tsx
+++ b/src/app/pages/PreservedUsers/PreservedUsers.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const PreservedUsers = () => {
+  return <p>Preserved Users Page</p>;
+};
+
+export default PreservedUsers;

--- a/src/app/pages/StageUsers/StageUsers.tsx
+++ b/src/app/pages/StageUsers/StageUsers.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const StageUsers = () => {
+  return <p>Stage Users Page</p>;
+};
+
+export default StageUsers;

--- a/src/app/pages/StageUsers/StageUsers.tsx
+++ b/src/app/pages/StageUsers/StageUsers.tsx
@@ -1,7 +1,9 @@
 import React from "react";
+// React router dom
+import { NavLink } from "react-router-dom";
 
 const StageUsers = () => {
-  return <p>Stage Users Page</p>;
+  return <NavLink to="settings">Stage Users Page</NavLink>;
 };
 
 export default StageUsers;

--- a/src/app/pages/StageUsers/StageUsersTabs.tsx
+++ b/src/app/pages/StageUsers/StageUsersTabs.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+// React router dom
+import { Link } from "react-router-dom";
+
+const StageUsersTabs = () => {
+  return <Link to="third-level-page-stage">This is Stage users tabs!</Link>;
+};
+
+export default StageUsersTabs;

--- a/src/app/pages/UserGroups/UserGroups.tsx
+++ b/src/app/pages/UserGroups/UserGroups.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const UserGroups = () => {
+  return <p>User groups Page</p>;
+};
+
+export default UserGroups;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,17 @@
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
+    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+code {
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
+    monospace;
+}
+
+#root {
+  height: 100%;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,10 +2,14 @@ import React from "react";
 import ReactDOM from "react-dom";
 import App from "app/App";
 import "./index.css";
+// react router dom
+import { BrowserRouter } from "react-router-dom";
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>,
   document.getElementById("root")
 );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import App from "app/App";
+import "./index.css";
 
 ReactDOM.render(
   <React.StrictMode>


### PR DESCRIPTION
_(From commit message:)_ This adds a way to tell what navigation elements (in terms of Patternfly components) are active and manage some data related to this fact is needed.

In order to do so, some global variables (and its setter functions) have been defined:
* `groupActive` will tell the current active group. That means that this value will change every time a new navigation element is clicked. Its setter function is `setGroupActive`.
* `superGroupActive` is similar to the `groupActive` one, but it takes into account the upper-level component that is active. This is useful to highlight the parent section when the navigation menu is collapsed. Eg: In `Identity` > `Users` > `Active users`, if we decide not to set the `superGroupActive` variable, `Active users` will be highlighted but its parent (`Users`) won't. Its setter function is `setSuperGroupActive`.
* `browserTitle` refers to the title shown in the browser tab. Its setter function is `setBrowserTitle`.

The aforementioned variables are taking the values defined in the `NavRoutes.ts` structure file.

![Screenshot from 2022-10-21 17-54-55](https://user-images.githubusercontent.com/217367/197287536-1d620aab-0462-4689-9252-c8a7c799b916.png)
