### PR TITLE
Fix comments on 'store.ts'

### DIFF
--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,21 +1,11 @@
 import { configureStore } from "@reduxjs/toolkit";
 import usersReducer from "./Identity/users-slice";
 import sharedReducer from "./shared/shared-slice";
-// import userGroupsReducer from "./Identity/userGroups-slice";
-// import netgroupsReducer from "./Identity/netgroups-slice";
-// import rolesReducer from "./IPA server/roles-slice";
-// import hbacRulesReducer from "./Policy/hbacRules-slice";
-// import sudoRulesReducer from "./Policy/sudoRules-slice";
 
 const store = configureStore({
   reducer: {
     users: usersReducer,
     shared: sharedReducer,
-    // usergroups: userGroupsReducer,
-    // netgroups: netgroupsReducer,
-    // roles: rolesReducer,
-    // hbacrules: hbacRulesReducer,
-    // sudorules: sudoRulesReducer,
   },
 });
 


### PR DESCRIPTION
The commented leftover text on `store.ts` needs to be removed as part of the fix.

Fixes: 1ba0ad0c2634e72cbb3c5c464767146f1a2dda7f
Signed-off-by: Carla Martinez <carlmart@redhat.com>