### PR TITLE
Active users member of

### DIFF
--- a/src/components/BulkSelectorPrep.tsx
+++ b/src/components/BulkSelectorPrep.tsx
@@ -22,7 +22,7 @@ import {
   setIsDisableEnableOp,
   setSelectedUserIds,
   setSelectedPerPage,
-} from "src/store/shared/shared-slice";
+} from "src/store/shared/activeUsersShared-slice";
 // Utils
 import { checkEqualStatus } from "src/utils/utils";
 
@@ -40,9 +40,11 @@ const BulkSelectorPrep = (props: PropsToBulkSelectorPrep) => {
   const dispatch = useAppDispatch();
 
   // Retrieve shared variables (Redux)
-  const selectedUsers = useAppSelector((state) => state.shared.selectedUsers);
+  const selectedUsers = useAppSelector(
+    (state) => state.activeUsersShared.selectedUsers
+  );
   const selectedPerPage = useAppSelector(
-    (state) => state.shared.selectedPerPage
+    (state) => state.activeUsersShared.selectedPerPage
   );
 
   // Table functionality (from parent component) to manage the bulk selector functionality

--- a/src/components/MemberOf/MemberOfAddModal.tsx
+++ b/src/components/MemberOf/MemberOfAddModal.tsx
@@ -1,0 +1,228 @@
+import React, { ReactNode, useEffect, useState } from "react";
+// PatternFly
+import { Button, DualListSelector } from "@patternfly/react-core";
+// Modals
+import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
+// Data types
+import {
+  UserGroup,
+  Netgroup,
+  Roles,
+  HBACRules,
+  SudoRules,
+} from "src/utils/datatypes/globalDataTypes";
+// Redux
+import { useAppSelector, useAppDispatch } from "src/store/hooks";
+import { setShowAddModal } from "src/store/shared/activeUsersMemberOf-slice";
+
+export interface PropsToAdd {
+  show: boolean;
+  availableData: UserGroup[] | Netgroup[] | Roles[] | HBACRules[] | SudoRules[];
+  userGroupData: unknown[];
+  updateGroupRepository: (
+    args: UserGroup[] | Netgroup[] | Roles[] | HBACRules[] | SudoRules[]
+  ) => void;
+  updateAvOptionsList: (args: unknown[]) => void;
+  userName: string;
+}
+
+// Although tabs data types habe been already defined, it is not possible to access to all
+//  its variables. Just the mandatory ones ('name' and 'description') are accessible at this point.
+// To display all the possible data types for all the tabs (and not only the mandatory ones)
+//   an extra interface 'MemberOfElement' will be defined. This will be called when assigning
+//   a new group instead of refering to each type (UserGroup | Netgroup | Roles | HBACRules |
+//   SudoRules).
+interface MemberOfElement {
+  name: string;
+  gid?: string;
+  status?: string;
+  description: string;
+}
+
+const MemberOfAddModal = (props: PropsToAdd) => {
+  // Set dispatch (Redux)
+  const dispatch = useAppDispatch();
+
+  // Retrieve shared data (Redux)
+  const showAddModal = useAppSelector(
+    (state) => state.activeUsersMemberOfShared.showAddModal
+  );
+  const tabName = useAppSelector(
+    (state) => state.activeUsersMemberOfShared.tabName
+  );
+  const userGroupsRepository = useAppSelector(
+    (state) => state.activeUsersMemberOfShared.userGroupsRepository
+  );
+  const netgroupsRepository = useAppSelector(
+    (state) => state.activeUsersMemberOfShared.netgroupsRepository
+  );
+  const rolesRepository = useAppSelector(
+    (state) => state.activeUsersMemberOfShared.rolesRepository
+  );
+  const hbacRulesRepository = useAppSelector(
+    (state) => state.activeUsersMemberOfShared.hbacRulesRepository
+  );
+  const sudoRulesRepository = useAppSelector(
+    (state) => state.activeUsersMemberOfShared.sudoRulesRepository
+  );
+
+  // Set Modal toggle
+  const onModalToggle = () => {
+    dispatch(setShowAddModal(!showAddModal));
+  };
+
+  // Dual list data
+  const data = props.availableData.map((d) => d.name);
+
+  // Dual list selector
+  const [availableOptions, setAvailableOptions] = useState<ReactNode[]>(data);
+  const [chosenOptions, setChosenOptions] = useState<ReactNode[]>([]);
+
+  const listChange = (
+    newAvailableOptions: ReactNode[],
+    newChosenOptions: ReactNode[]
+  ) => {
+    setAvailableOptions(newAvailableOptions.sort());
+    setChosenOptions(newChosenOptions.sort());
+    props.updateAvOptionsList(newAvailableOptions.sort());
+  };
+
+  const fields = [
+    {
+      id: "dual-list-selector",
+      pfComponent: (
+        <DualListSelector
+          isSearchable
+          availableOptions={availableOptions}
+          chosenOptions={chosenOptions}
+          onListChange={listChange}
+          id="basicSelectorWithSearch"
+        />
+      ),
+    },
+  ];
+
+  // When clean data, set to original values
+  const cleanData = () => {
+    setAvailableOptions(data);
+    setChosenOptions([]);
+  };
+
+  // Clean fields and close modal (To prevent data persistence when reopen modal)
+  const cleanAndCloseModal = () => {
+    cleanData();
+    onModalToggle();
+  };
+
+  // Buttons are disabled until the user fills the required fields
+  const [buttonDisabled, setButtonDisabled] = useState(true);
+  useEffect(() => {
+    if (chosenOptions.length > 0) {
+      setButtonDisabled(false);
+    } else {
+      setButtonDisabled(true);
+    }
+  }, [chosenOptions]);
+
+  // Get all info from a chosen option
+  const getInfoFromGroupData = (option: unknown) => {
+    return props.availableData.find((d) => option === d.name);
+  };
+
+  // Add group option
+  const onClickAddGroupHandler = () => {
+    // Copy of the repository to add new data
+    let repositoryCopy: unknown[] = [];
+    // Define a general 'groupRepository' variable to assign the
+    //  right repository depending on the 'tabName'.
+    let groupRepository: unknown[] = [];
+    switch (tabName) {
+      case "User groups":
+        groupRepository = [...userGroupsRepository] as UserGroup[];
+        break;
+      case "Netgroups":
+        groupRepository = [...netgroupsRepository] as Netgroup[];
+        break;
+      case "Roles":
+        groupRepository = [...rolesRepository] as Roles[];
+        break;
+      case "HBAC rules":
+        groupRepository = [...hbacRulesRepository] as HBACRules[];
+        break;
+      case "Sudo rules":
+        groupRepository = [...sudoRulesRepository] as SudoRules[];
+        break;
+    }
+    // Add the chosed options to the repository list
+    chosenOptions.map((opt) => {
+      const optionData: MemberOfElement | undefined = getInfoFromGroupData(opt);
+      if (optionData !== undefined) {
+        repositoryCopy =
+          repositoryCopy.length === 0
+            ? [...groupRepository]
+            : [...repositoryCopy];
+        repositoryCopy.push({
+          name: optionData.name !== undefined && optionData.name,
+          description:
+            optionData.description !== undefined && optionData.description,
+          gid: optionData.gid !== undefined && optionData.gid,
+          status: optionData.status !== undefined && optionData.status,
+        });
+        // Send updated data to table (specifying the group data type)
+        switch (tabName) {
+          case "User groups":
+            props.updateGroupRepository(repositoryCopy as UserGroup[]);
+            break;
+          case "Netgroups":
+            props.updateGroupRepository(repositoryCopy as Netgroup[]);
+            break;
+          case "Roles":
+            props.updateGroupRepository(repositoryCopy as Roles[]);
+            break;
+          case "HBAC rules":
+            props.updateGroupRepository(repositoryCopy as HBACRules[]);
+            break;
+          case "Sudo rules":
+            props.updateGroupRepository(repositoryCopy as SudoRules[]);
+            break;
+        }
+      }
+    });
+    // Clean chosen options and close modal
+    setChosenOptions([]);
+    onModalToggle();
+  };
+
+  // Buttons that will be shown at the end of the form
+  const modalActions = [
+    <Button
+      key="add-new-user"
+      variant="secondary"
+      isDisabled={buttonDisabled}
+      form="modal-form"
+      onClick={onClickAddGroupHandler}
+    >
+      Add
+    </Button>,
+    <Button key="cancel-new-user" variant="link" onClick={cleanAndCloseModal}>
+      Cancel
+    </Button>,
+  ];
+
+  // Render 'MemberOfaddModal'
+  return (
+    <ModalWithFormLayout
+      variantType="medium"
+      modalPosition="top"
+      offPosition="76px"
+      title={"Add user '" + props.userName + "' into " + tabName}
+      formId="is-member-of-add-modal"
+      fields={fields}
+      show={props.show}
+      onClose={cleanAndCloseModal}
+      actions={modalActions}
+    />
+  );
+};
+
+export default MemberOfAddModal;

--- a/src/components/MemberOf/MemberOfDeleteModal.tsx
+++ b/src/components/MemberOf/MemberOfDeleteModal.tsx
@@ -1,0 +1,156 @@
+import React, { useState } from "react";
+// PatternFly
+import {
+  TextContent,
+  Text,
+  TextVariants,
+  Button,
+} from "@patternfly/react-core";
+// Modals
+import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
+// Tables
+import MemberOfDeletedGroupsTable from "src/components/MemberOf/MemberOfDeletedGroupsTable";
+// Redux
+import { useAppDispatch, useAppSelector } from "src/store/hooks";
+import {
+  setIsDeleteButtonDisabled,
+  setIsDeletion,
+  setShowDeleteModal,
+} from "src/store/shared/activeUsersMemberOf-slice";
+
+// Although tabs data types habe been already defined, it is not possible to access to all
+//  its variables. Just the mandatory ones ('name' and 'description') are accessible at this point.
+// To display all the possible data types for all the tabs (and not only the mandatory ones)
+//   an extra interface 'MemberOfElement' will be defined. This will be called in the 'PropsToTable'
+//   interface instead of each type (UserGroup | Netgroup | Roles | HBACRules | SudoRules).
+interface MemberOfElement {
+  name: string;
+  gid?: string;
+  status?: string;
+  description: string;
+}
+
+interface PropsToDelete {
+  activeTabKey: number;
+  groupRepository: MemberOfElement[];
+  updateGroupRepository: (args: MemberOfElement[]) => void;
+}
+
+const MemberOfDeleteModal = (props: PropsToDelete) => {
+  // Set dispatch (Redux)
+  const dispatch = useAppDispatch();
+
+  // Retrieve shared data (Redux)
+  const groupsNamesSelected = useAppSelector(
+    (state) => state.activeUsersMemberOfShared.groupsNamesSelected
+  );
+  const tabName = useAppSelector(
+    (state) => state.activeUsersMemberOfShared.tabName
+  );
+  const showDeleteModal = useAppSelector(
+    (state) => state.activeUsersMemberOfShared.showDeleteModal
+  );
+
+  // On modal toggle
+  const onModalDeleteToggle = () => {
+    dispatch(setShowDeleteModal(!showDeleteModal));
+  };
+
+  // Given a single group name, obtain full info to be sent and shown on the deletion table
+  const getGroupInfoByName = (groupName: string) => {
+    const res = props.groupRepository.filter(
+      (group) => group.name === groupName
+    );
+    return res[0];
+  };
+
+  const getListOfGroupsToDelete = () => {
+    const groupsToDelete: MemberOfElement[] = [];
+    groupsNamesSelected.map((groupName) =>
+      groupsToDelete.push(getGroupInfoByName(groupName))
+    );
+    return groupsToDelete;
+  };
+
+  // Groups to delete list
+  const [groupsToDelete] = useState<MemberOfElement[]>(getListOfGroupsToDelete);
+
+  // List of fields
+  const fields = [
+    {
+      id: "question-text",
+      pfComponent: (
+        <TextContent>
+          <Text component={TextVariants.p}>
+            Are you sure you want to remove the selected entries from the list?
+          </Text>
+        </TextContent>
+      ),
+    },
+    {
+      id: "deleted-users-table",
+      pfComponent: (
+        <MemberOfDeletedGroupsTable
+          groupsToDelete={groupsToDelete}
+          tabName={tabName}
+        />
+      ),
+    },
+  ];
+
+  // Close modal
+  const closeModal = () => {
+    onModalDeleteToggle();
+  };
+
+  // Delete groups
+  const deleteGroups = () => {
+    // Define function that will be reused to delete the selected entries
+    let generalUpdatedGroupList = props.groupRepository;
+    groupsNamesSelected.map((groupName) => {
+      const updatedGroupList = generalUpdatedGroupList.filter(
+        (grp) => grp.name !== groupName
+      );
+      // If not empty, replace groupList by new array
+      if (updatedGroupList) {
+        generalUpdatedGroupList = updatedGroupList;
+      }
+    });
+    props.updateGroupRepository(generalUpdatedGroupList);
+    dispatch(setIsDeleteButtonDisabled(true));
+    dispatch(setIsDeletion(true));
+    closeModal();
+  };
+
+  // Set the Modal and Action buttons for 'Delete' option
+  const modalActionsDelete: JSX.Element[] = [
+    <Button
+      key="delete-groups"
+      variant="danger"
+      onClick={deleteGroups}
+      form="active-users-remove-groups-modal"
+    >
+      Delete
+    </Button>,
+    <Button key="cancel-remove-group" variant="link" onClick={closeModal}>
+      Cancel
+    </Button>,
+  ];
+
+  // Render 'MemberOfDeleteModal'
+  return (
+    <ModalWithFormLayout
+      variantType="medium"
+      modalPosition="top"
+      offPosition="76px"
+      title={"Remove " + tabName}
+      formId="active-users-remove-groups-modal"
+      fields={fields}
+      show={showDeleteModal}
+      onClose={closeModal}
+      actions={modalActionsDelete}
+    />
+  );
+};
+
+export default MemberOfDeleteModal;

--- a/src/components/MemberOf/MemberOfDeletedGroupsTable.tsx
+++ b/src/components/MemberOf/MemberOfDeletedGroupsTable.tsx
@@ -1,0 +1,113 @@
+import React, { useState } from "react";
+// PatternFly
+import { Td, Th, Tr } from "@patternfly/react-table";
+// Layout
+import TableLayout from "src/components/layouts/TableLayout";
+
+// Although tabs data types habe been already defined, it is not possible to access to all
+//  its variables. Just the mandatory ones ('name' and 'description') are accessible at this point.
+// To display all the possible data types for all the tabs (and not only the mandatory ones)
+//   an extra interface 'MemberOfElement' will be defined. This will be assigned in the
+//   'PropsToDeleteOnTable' interface instead of each type (UserGroup | Netgroup | Roles
+//   | HBACRules | SudoRules).
+interface MemberOfElement {
+  name: string;
+  gid?: string;
+  status?: string;
+  description: string;
+}
+
+// Interface for Column names
+// All variables are defined as optional as it won't need to be explicitely defined when
+//   generating the column names (on 'generateColumnNames()')
+interface ColumnNames {
+  name?: string;
+  gid?: string;
+  status?: string;
+  description?: string;
+}
+
+interface PropsToDeleteOnTable {
+  groupsToDelete: MemberOfElement[];
+  tabName: string;
+}
+
+const MemberOfDeletedGroupsTable = (props: PropsToDeleteOnTable) => {
+  // Function to generate the column names
+  const generateColumnNames = () => {
+    switch (props.tabName) {
+      case "User groups":
+        return {
+          name: "Role name",
+          gid: "GID",
+          description: "Description",
+        } as ColumnNames;
+      case "Netgroups":
+        return {
+          name: "Netgroup name",
+          description: "Description",
+        } as ColumnNames;
+      case "Roles":
+        return {
+          name: "Role name",
+          description: "Description",
+        } as ColumnNames;
+      case "HBAC rules":
+        return {
+          name: "Rule name",
+          status: "Status",
+          description: "Description",
+        } as ColumnNames;
+      case "Sudo rules":
+        return {
+          name: "Rule name",
+          status: "Status",
+          description: "Description",
+        } as ColumnNames;
+      default:
+        return {};
+    }
+  };
+
+  // Column names state
+  const [columnNames] = useState<ColumnNames>(generateColumnNames());
+
+  // Define table header and body
+  const header = (
+    <Tr>
+      {columnNames.name && <Th modifier="wrap">{columnNames.name}</Th>}
+      {columnNames.gid && <Th modifier="wrap">{columnNames.gid}</Th>}
+      {columnNames.status && <Th modifier="wrap">{columnNames.status}</Th>}
+      {columnNames.description && (
+        <Th modifier="wrap">{columnNames.description}</Th>
+      )}
+    </Tr>
+  );
+
+  const body = props.groupsToDelete.map((group) => (
+    <Tr key={group.name} id={group.name}>
+      {group.name && <Td dataLabel={group.name}>{group.name}</Td>}
+      {group.gid && <Td dataLabel={group.gid}>{group.gid}</Td>}
+      {group.status && <Td dataLabel={group.status}>{group.status}</Td>}
+      {group.description && (
+        <Td dataLabel={group.description}>{group.description}</Td>
+      )}
+    </Tr>
+  ));
+
+  // Render 'MemberOfDeletedGroupsTable'
+  return (
+    <TableLayout
+      ariaLabel={"Remove groups table"}
+      name="cn"
+      variant={"compact"}
+      hasBorders={true}
+      tableId={"remove-groups-table"}
+      isStickyHeader={true}
+      tableHeader={header}
+      tableBody={body}
+    />
+  );
+};
+
+export default MemberOfDeletedGroupsTable;

--- a/src/components/MemberOf/MemberOfTable.tsx
+++ b/src/components/MemberOf/MemberOfTable.tsx
@@ -1,0 +1,304 @@
+import React, { useEffect, useState } from "react";
+import {
+  Title,
+  Bullseye,
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  EmptyStateBody,
+  Button,
+} from "@patternfly/react-core";
+import { Td, Th, Tr } from "@patternfly/react-table";
+// Icons
+import SearchIcon from "@patternfly/react-icons/dist/esm/icons/search-icon";
+// Layouts
+import TableLayout from "../layouts/TableLayout";
+import SkeletonOnTableLayout from "../layouts/Skeleton/SkeletonOnTableLayout";
+// Redux
+import { useAppDispatch, useAppSelector } from "src/store/hooks";
+import {
+  setIsDeleteButtonDisabled,
+  setGroupsNamesSelected,
+  setIsDeletion,
+} from "src/store/shared/activeUsersMemberOf-slice";
+
+interface ColumnNames {
+  name: string;
+  gid?: string;
+  status?: string;
+  description: string;
+}
+
+// Although tabs data types habe been already defined, it is not possible to access to all
+//  its variables. Just the mandatory ones ('name' and 'description') are accessible at this point.
+// To display all the possible data types for all the tabs (and not only the mandatory ones)
+//   an extra interface 'MemberOfElement' will be defined. This will be called in the 'PropsToTable'
+//   interface instead of each type (UserGroup | Netgroup | Roles | HBACRules | SudoRules).
+interface MemberOfElement {
+  name: string;
+  gid?: string;
+  status?: string;
+  description: string;
+}
+
+export interface PropsToTable {
+  group: MemberOfElement[];
+  columnNames: ColumnNames;
+  tableName: string;
+  activeTabKey: number;
+  showTableRows: boolean;
+}
+
+const MemberOfTable = (props: PropsToTable) => {
+  // Set dispatch (Redux)
+  const dispatch = useAppDispatch();
+
+  // retrieved shared data (Redux)
+  const isDeletion = useAppSelector(
+    (state) => state.activeUsersMemberOfShared.isDeletion
+  );
+
+  // selected user ids state
+  const [selectedGroupNameIds, setSelectedGroupNameIds] = useState<string[]>(
+    []
+  );
+
+  // Selectable checkboxes on table
+  const isGroupSelectable = (group: MemberOfElement) => group.name !== "";
+  const selectableGroups = props.group.filter(isGroupSelectable);
+
+  // Selected rows are tracked. Primary key: userLogin
+  const [selectedGroupNames, setSelectedGroupNames] = useState<string[]>([]);
+
+  const setGroupSelected = (group: MemberOfElement, isSelecting = true) =>
+    setSelectedGroupNames((prevSelected) => {
+      const otherSelectedGroupNames = prevSelected.filter(
+        (r) => r !== group.name
+      );
+      return isSelecting && isGroupSelectable(group)
+        ? [...otherSelectedGroupNames, group.name]
+        : otherSelectedGroupNames;
+    });
+
+  const areAllGroupsSelected =
+    selectedGroupNames.length === selectableGroups.length;
+
+  const isGroupSelected = (group: MemberOfElement) =>
+    selectedGroupNames.includes(group.name);
+
+  // Multiple selection
+  const selectAllGroups = (isSelecting = true) => {
+    setSelectedGroupNames(
+      isSelecting ? selectableGroups.map((g) => g.name) : []
+    );
+
+    // Enable/disable 'Delete' button
+    if (isSelecting) {
+      const groupsNameArray: string[] = [];
+      selectableGroups.map((group) => groupsNameArray.push(group.name));
+      setSelectedGroupNameIds(groupsNameArray);
+      dispatch(setGroupsNamesSelected(groupsNameArray));
+      dispatch(setIsDeleteButtonDisabled(false));
+    } else {
+      dispatch(setGroupsNamesSelected([]));
+      dispatch(setIsDeleteButtonDisabled(true));
+    }
+  };
+
+  // To allow shift+click to select/deselect multiple rows
+  const [recentSelectedRowIndex, setRecentSelectedRowIndex] = useState<
+    number | null
+  >(null);
+  const [shifting, setShifting] = useState(false);
+
+  // On selecting one single row
+  const onSelectGroup = (
+    group: MemberOfElement,
+    rowIndex: number,
+    isSelecting: boolean
+  ) => {
+    // If the group is shift + selecting the checkboxes, then all intermediate checkboxes should be selected
+    if (shifting && recentSelectedRowIndex !== null) {
+      const numberSelected = rowIndex - recentSelectedRowIndex;
+      const intermediateIndexes =
+        numberSelected > 0
+          ? Array.from(
+              new Array(numberSelected + 1),
+              (_x, i) => i + recentSelectedRowIndex
+            )
+          : Array.from(
+              new Array(Math.abs(numberSelected) + 1),
+              (_x, i) => i + rowIndex
+            );
+      intermediateIndexes.forEach((index) =>
+        setGroupSelected(props.group[index], isSelecting)
+      );
+    } else {
+      setGroupSelected(group, isSelecting);
+    }
+    setRecentSelectedRowIndex(rowIndex);
+
+    // Update selectedGroups array
+    let selectedGroupsArray = selectedGroupNames;
+    if (isSelecting) {
+      selectedGroupsArray.push(group.name);
+      setSelectedGroupNameIds(selectedGroupsArray);
+      dispatch(setGroupsNamesSelected(selectedGroupsArray));
+    } else {
+      selectedGroupsArray = selectedGroupsArray.filter(
+        (groupName) => groupName !== group.name
+      );
+      setSelectedGroupNameIds(selectedGroupsArray);
+      dispatch(setGroupsNamesSelected(selectedGroupsArray));
+    }
+  };
+
+  // Reset 'updateIsDeletion' when a delete operation has been done
+  useEffect(() => {
+    if (isDeletion) {
+      setSelectedGroupNameIds([]);
+      setSelectedGroupNames([]);
+      dispatch(setIsDeletion(false));
+    }
+  }, [isDeletion]);
+
+  // Enable 'Delete' button if any group on the table is selected
+  useEffect(() => {
+    if (selectedGroupNameIds.length > 0) {
+      dispatch(setIsDeleteButtonDisabled(false));
+    }
+    if (selectedGroupNameIds.length === 0) {
+      dispatch(setIsDeleteButtonDisabled(true));
+    }
+  }, [selectedGroupNameIds]);
+
+  // When the tableName changes, the selected checkboxes are reset
+  useEffect(() => {
+    setSelectedGroupNameIds([]);
+    setSelectedGroupNames([]);
+  }, [props.activeTabKey]);
+
+  // Keyboard event
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Shift") {
+        setShifting(true);
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === "Shift") {
+        setShifting(false);
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("keyup", onKeyUp);
+
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("keyup", onKeyUp);
+    };
+  }, []);
+
+  // Define body for empty tables
+  const emptyBody = (
+    <Tr>
+      <Td colSpan={8}>
+        <Bullseye>
+          <EmptyState variant={EmptyStateVariant.small}>
+            <EmptyStateIcon icon={SearchIcon} />
+            <Title headingLevel="h2" size="lg">
+              No results found
+            </Title>
+            <EmptyStateBody>Clear all filters and try again.</EmptyStateBody>
+            <Button variant="link">Clear all filters</Button>
+          </EmptyState>
+        </Bullseye>
+      </Td>
+    </Tr>
+  );
+
+  // Define table header
+  const header = (
+    <Tr>
+      <Th
+        select={{
+          onSelect: (_event, isSelecting) => selectAllGroups(isSelecting),
+          isSelected: areAllGroupsSelected,
+        }}
+      />
+      <Th key={props.columnNames.name} modifier="wrap">
+        {props.columnNames.name}
+      </Th>
+      {props.columnNames.gid && (
+        <Th key={props.columnNames.gid} modifier="wrap">
+          {props.columnNames.gid}
+        </Th>
+      )}
+      {props.columnNames.status && (
+        <Th key={props.columnNames.status} modifier="wrap">
+          {props.columnNames.status}
+        </Th>
+      )}
+      {props.columnNames.description && (
+        <Th key={props.columnNames.description} modifier="wrap">
+          {props.columnNames.description}
+        </Th>
+      )}
+    </Tr>
+  );
+
+  // Define table body
+  const body = props.group.map((group, rowIndex) => (
+    <Tr key={group.name} id={group.name}>
+      <Td
+        dataLabel="checkbox"
+        select={{
+          rowIndex,
+          onSelect: (_event, isSelecting) =>
+            onSelectGroup(group, rowIndex, isSelecting),
+          isSelected: isGroupSelected(group),
+          disable: !isGroupSelectable(group),
+        }}
+      />
+      <Td dataLabel={group.name}>{group.name}</Td>
+      {group.gid && <Td dataLabel={group.gid}>{group.gid}</Td>}
+      {group.status && <Td dataLabel={group.status}>{group.status}</Td>}
+      {group.description && (
+        <Td dataLabel={group.description}>{group.description}</Td>
+      )}
+    </Tr>
+  ));
+
+  // Define skeleton
+  const skeleton = (
+    <SkeletonOnTableLayout
+      rows={4}
+      colSpan={9}
+      screenreaderText={"Loading table rows"}
+    />
+  );
+
+  // Render 'MemberOfTable'
+  return (
+    <TableLayout
+      ariaLabel={props.tableName + " table"}
+      name="cn"
+      variant={"compact"}
+      hasBorders={true}
+      classes={"pf-u-mt-md"}
+      tableId={props.tableName.replace(" ", "-").toLowerCase() + "-table"}
+      isStickyHeader={true}
+      tableHeader={props.group.length === 0 ? undefined : header}
+      tableBody={
+        !props.showTableRows
+          ? skeleton
+          : props.group.length === 0
+          ? emptyBody
+          : body
+      }
+    />
+  );
+};
+
+export default MemberOfTable;

--- a/src/components/MemberOf/MemberOfToolbar.tsx
+++ b/src/components/MemberOf/MemberOfToolbar.tsx
@@ -1,0 +1,529 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React, { useState } from "react";
+import {
+  ToggleGroup,
+  Button,
+  Form,
+  FormGroup,
+  SearchInput,
+  ToggleGroupItem,
+  Text,
+  ToolbarItemVariant,
+  TextContent,
+  TextVariants,
+  Pagination,
+} from "@patternfly/react-core";
+// Icons
+import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
+// Toolbar layout
+import ToolbarLayout, {
+  ToolbarItemAlignment,
+  ToolbarItemSpacer,
+} from "src/components/layouts/ToolbarLayout";
+// Data types
+import {
+  UserGroup,
+  Netgroup,
+  Roles,
+  HBACRules,
+  SudoRules,
+} from "src/utils/datatypes/globalDataTypes";
+// Redux
+import { useAppDispatch, useAppSelector } from "src/store/hooks";
+import {
+  onClickAddHandler,
+  onClickDeleteHandler,
+  setTabName,
+  setPage,
+  setPerPage,
+} from "src/store/shared/activeUsersMemberOf-slice";
+
+export interface PropsToToolbar {
+  pageRepo: UserGroup[] | Netgroup[] | Roles[] | HBACRules[] | SudoRules[];
+  shownItems: UserGroup[] | Netgroup[] | Roles[] | HBACRules[] | SudoRules[];
+  toolbar: "user groups" | "netgroups" | "roles" | "HBAC rules" | "sudo rules";
+  changeMemberGroupsList: (
+    arg: UserGroup[] | Netgroup[] | Roles[] | HBACRules[] | SudoRules[]
+  ) => void;
+  changeSetPage: (
+    newPage: number,
+    perPage: number | undefined,
+    startIdx: number | undefined,
+    endIdx: number | undefined
+  ) => void;
+  changePerPageSelect: (
+    newPerPage: number,
+    newPage: number,
+    startIdx: number | undefined,
+    endIdx: number | undefined
+  ) => void;
+}
+
+const MemberOfToolbar = (props: PropsToToolbar) => {
+  // Set dispatch (Redux)
+  const dispatch = useAppDispatch();
+
+  // Retrieve shared data (Redux)
+  const isDeleteButtonDisabled = useAppSelector(
+    (state) => state.activeUsersMemberOfShared.isDeleteButtonDisabled
+  );
+  const page = useAppSelector((state) => state.activeUsersMemberOfShared.page);
+  const perPage = useAppSelector(
+    (state) => state.activeUsersMemberOfShared.perPage
+  );
+
+  // - Page setters
+  const onSetPage = (
+    _event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
+    newPage: number,
+    perPage: number | undefined,
+    startIdx: number | undefined,
+    endIdx: number | undefined
+  ) => {
+    dispatch(setPage(newPage));
+    props.changeMemberGroupsList(props.pageRepo.slice(startIdx, endIdx));
+    props.changeSetPage(newPage, perPage, startIdx, endIdx);
+  };
+
+  const onPerPageSelect = (
+    _event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
+    newPerPage: number,
+    newPage: number,
+    startIdx: number | undefined,
+    endIdx: number | undefined
+  ) => {
+    dispatch(setPerPage(newPerPage));
+    props.changeMemberGroupsList(props.pageRepo.slice(startIdx, endIdx));
+    props.changePerPageSelect(newPerPage, newPage, startIdx, endIdx);
+  };
+
+  // Toggle group
+  // - User groups
+  const [isTGUserGroupsSelected, setIsTGUserGroupsSelected] =
+    useState("direct");
+
+  const TGUserGroupsHandler = (
+    isSelected: boolean,
+    event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent
+  ) => {
+    const id = event.currentTarget.id;
+    setIsTGUserGroupsSelected(id);
+  };
+
+  const userGroupsOnClickAddHandler = () => {
+    dispatch(setTabName("User groups"));
+    dispatch(onClickAddHandler());
+  };
+
+  const userGroupsOnDeleteClickHandler = () => {
+    dispatch(setTabName("User groups"));
+    dispatch(onClickDeleteHandler());
+  };
+
+  // - Netgroups
+  const [isTGNetgroupsSelected, setIsTGNetgroupsSelected] = useState("direct");
+
+  const TGNetgroupsHandler = (
+    isSelected: boolean,
+    event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent
+  ) => {
+    const id = event.currentTarget.id;
+    setIsTGNetgroupsSelected(id);
+  };
+
+  const netgroupsOnClickAddHandler = () => {
+    dispatch(setTabName("Netgroups"));
+    dispatch(onClickAddHandler());
+  };
+
+  const netgroupsOnDeleteClickHandler = () => {
+    dispatch(setTabName("Netgroups"));
+    dispatch(onClickDeleteHandler());
+  };
+
+  // - Roles
+  const [isTGRolesSelected, setIsTGRolesSelected] = useState("direct");
+
+  const TGRolesHandler = (
+    isSelected: boolean,
+    event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent
+  ) => {
+    const id = event.currentTarget.id;
+    setIsTGRolesSelected(id);
+  };
+
+  const rolesOnClickAddHandler = () => {
+    dispatch(setTabName("Roles"));
+    dispatch(onClickAddHandler());
+  };
+
+  const rolesOnDeleteClickHandler = () => {
+    dispatch(setTabName("Roles"));
+    dispatch(onClickDeleteHandler());
+  };
+
+  // - HBAC rules
+  const [isTGHbacRulesSelected, setIsTGHbacRulesSelected] = useState("direct");
+
+  const TGHbacRulesHandler = (
+    isSelected: boolean,
+    event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent
+  ) => {
+    const id = event.currentTarget.id;
+    setIsTGHbacRulesSelected(id);
+  };
+
+  const hbacRulesOnClickAddHandler = () => {
+    dispatch(setTabName("HBAC rules"));
+    dispatch(onClickAddHandler());
+  };
+
+  const hbacRulesOnDeleteClickHandler = () => {
+    dispatch(setTabName("HBAC rules"));
+    dispatch(onClickDeleteHandler());
+  };
+
+  // - Sudo rules
+  const [isTGSudoRulesSelected, setIsTGSudoRulesSelected] = useState("direct");
+
+  const TGSudoRulesHandler = (
+    isSelected: boolean,
+    event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent
+  ) => {
+    const id = event.currentTarget.id;
+    setIsTGSudoRulesSelected(id);
+  };
+
+  const sudoRulesOnClickAddHandler = () => {
+    dispatch(setTabName("Sudo rules"));
+    dispatch(onClickAddHandler());
+  };
+
+  const sudoRulesOnDeleteClickHandler = () => {
+    dispatch(setTabName("Sudo rules"));
+    dispatch(onClickDeleteHandler());
+  };
+
+  // 'User groups' toolbar elements data
+  const userGroupsToolbarData = {
+    searchId: "userGroups-search",
+    separator1Id: "userGroups-separator-1",
+    refreshButton: {
+      id: "userGroups-button-refresh",
+    },
+    deleteButton: {
+      id: "userGroups-button-delete",
+      isDisabledHandler: isDeleteButtonDisabled,
+      onClickHandler: userGroupsOnDeleteClickHandler,
+    },
+    addButton: {
+      id: "userGroups-button-add",
+      onClickHandler: userGroupsOnClickAddHandler,
+    },
+    separator2Id: "userGroups-separator-2",
+    membership: {
+      formId: "userGroups-form",
+      toggleGroupId: "userGroups-toggle-group",
+      isDirectSelected: isTGUserGroupsSelected === "direct",
+      onDirectChange: TGUserGroupsHandler,
+      isIndirectSelected: isTGUserGroupsSelected === "indirect",
+      onIndirectChange: TGUserGroupsHandler,
+    },
+    separator3Id: "userGroups-separator-3",
+    helpIcon: {
+      id: "userGroups-help-icon",
+      // href: TDB
+    },
+    paginationId: "userGroups-pagination",
+  };
+
+  // 'Netgroups' toolbar elements data
+  const netgroupsToolbarData = {
+    searchId: "netgroups-search",
+    separator1Id: "netgroups-separator-1",
+    refreshButton: {
+      id: "netgroups-button-refresh",
+    },
+    deleteButton: {
+      id: "netgroups-button-delete",
+      isDisabledHandler: isDeleteButtonDisabled,
+      onClickHandler: netgroupsOnDeleteClickHandler,
+    },
+    addButton: {
+      id: "netgroups-button-add",
+      onClickHandler: netgroupsOnClickAddHandler,
+    },
+    separator2Id: "netgroups-separator-2",
+    membership: {
+      formId: "netgroups-form",
+      toggleGroupId: "netgroups-toggle-group",
+      isDirectSelected: isTGNetgroupsSelected === "direct",
+      onDirectChange: TGNetgroupsHandler,
+      isIndirectSelected: isTGNetgroupsSelected === "indirect",
+      onIndirectChange: TGNetgroupsHandler,
+    },
+    separator3Id: "netgroups-separator-3",
+    helpIcon: {
+      id: "netgroups-help-icon",
+      // href: TDB
+    },
+    paginationId: "netgroups-pagination",
+  };
+
+  // 'Roles' toolbar elements data
+  const rolesToolbarData = {
+    searchId: "roles-search",
+    separator1Id: "roles-separator-1",
+    refreshButton: {
+      id: "roles-button-refresh",
+    },
+    deleteButton: {
+      id: "roles-button-delete",
+      isDisabledHandler: isDeleteButtonDisabled,
+      onClickHandler: rolesOnDeleteClickHandler,
+    },
+    addButton: {
+      id: "roles-button-add",
+      onClickHandler: rolesOnClickAddHandler,
+    },
+    separator2Id: "roles-separator-2",
+    membership: {
+      formId: "roles-form",
+      toggleGroupId: "roles-toggle-group",
+      isDirectSelected: isTGRolesSelected === "direct",
+      onDirectChange: TGRolesHandler,
+      isIndirectSelected: isTGRolesSelected === "indirect",
+      onIndirectChange: TGRolesHandler,
+    },
+    separator3Id: "roles-separator-3",
+    helpIcon: {
+      id: "roles-help-icon",
+      // href: TDB
+    },
+    paginationId: "roles-pagination",
+  };
+
+  // 'HBAC rules' toolbar elements data
+  const hbacRulesToolbarData = {
+    searchId: "hbacRules-search",
+    separator1Id: "hbacRules-separator-1",
+    refreshButton: {
+      id: "hbacRules-button-refresh",
+    },
+    deleteButton: {
+      id: "hbacRules-button-delete",
+      isDisabledHandler: isDeleteButtonDisabled,
+      onClickHandler: hbacRulesOnDeleteClickHandler,
+    },
+    addButton: {
+      id: "hbacRules-button-add",
+      onClickHandler: hbacRulesOnClickAddHandler,
+    },
+    separator2Id: "hbacRules-separator-2",
+    membership: {
+      formId: "hbacRules-form",
+      toggleGroupId: "hbacRules-toggle-group",
+      isDirectSelected: isTGHbacRulesSelected === "direct",
+      onDirectChange: TGHbacRulesHandler,
+      isIndirectSelected: isTGHbacRulesSelected === "indirect",
+      onIndirectChange: TGHbacRulesHandler,
+    },
+    separator3Id: "hbacRules-separator-3",
+    helpIcon: {
+      id: "hbacRules-help-icon",
+      // href: TDB
+    },
+    paginationId: "hbacRules-pagination",
+  };
+
+  // 'Sudo rules' toolbar elements data
+  const sudoRulesToolbarData = {
+    searchId: "sudoRules-search",
+    separator1Id: "sudoRules-separator-1",
+    refreshButton: {
+      id: "sudoRules-button-refresh",
+    },
+    deleteButton: {
+      id: "sudoRules-button-delete",
+      isDisabledHandler: isDeleteButtonDisabled,
+      onClickHandler: sudoRulesOnDeleteClickHandler,
+    },
+    addButton: {
+      id: "sudoRules-button-add",
+      onClickHandler: sudoRulesOnClickAddHandler,
+    },
+    separator2Id: "sudoRules-separator-2",
+    membership: {
+      formId: "sudoRules-form",
+      toggleGroupId: "sudoRules-toggle-group",
+      isDirectSelected: isTGSudoRulesSelected === "direct",
+      onDirectChange: TGSudoRulesHandler,
+      isIndirectSelected: isTGSudoRulesSelected === "indirect",
+      onIndirectChange: TGSudoRulesHandler,
+    },
+    separator3Id: "sudoRules-separator-3",
+    helpIcon: {
+      id: "sudoRules-help-icon",
+      // href: TDB
+    },
+    paginationId: "sudoRules-pagination",
+  };
+
+  // Specify which toolbar to show
+  const toolbarData = () => {
+    switch (props.toolbar) {
+      case "user groups":
+        return userGroupsToolbarData;
+      case "netgroups":
+        return netgroupsToolbarData;
+      case "roles":
+        return rolesToolbarData;
+      case "HBAC rules":
+        return hbacRulesToolbarData;
+      case "sudo rules":
+        return sudoRulesToolbarData;
+    }
+  };
+
+  // Toolbar fields data structure
+  // - Depending on the 'toolbarData' response, a
+  //   specific set of data will be shown.
+  const toolbarFields = [
+    {
+      id: toolbarData().searchId,
+      key: 0,
+      element: (
+        <SearchInput
+          name="search"
+          aria-label="Search user"
+          placeholder="Search"
+        />
+      ),
+      toolbarItemVariant: ToolbarItemVariant["search-filter"],
+      toolbarItemSpacer: {
+        default: "spacerMd",
+      } as ToolbarItemSpacer,
+    },
+    {
+      id: toolbarData().separator1Id,
+      key: 1,
+      toolbarItemVariant: ToolbarItemVariant.separator,
+    },
+    {
+      id: toolbarData().refreshButton.id,
+      key: 2,
+      element: (
+        <Button variant="secondary" name="refresh">
+          Refresh
+        </Button>
+      ),
+    },
+    {
+      id: toolbarData().deleteButton.id,
+      key: 3,
+      element: (
+        <Button
+          variant="secondary"
+          name="remove"
+          isDisabled={toolbarData().deleteButton.isDisabledHandler}
+          onClick={toolbarData().deleteButton.onClickHandler}
+        >
+          Delete
+        </Button>
+      ),
+    },
+    {
+      id: toolbarData().addButton.id,
+      key: 4,
+      element: (
+        <Button
+          variant="secondary"
+          name="add"
+          onClick={toolbarData().addButton.onClickHandler}
+        >
+          Add
+        </Button>
+      ),
+    },
+    {
+      id: toolbarData().separator2Id,
+      key: 5,
+      toolbarItemVariant: ToolbarItemVariant.separator,
+    },
+    {
+      id: "membership-form",
+      key: 6,
+      element: (
+        <Form isHorizontal maxWidth="93px" className="pf-u-pb-xs">
+          <FormGroup
+            fieldId="membership"
+            label="Membership"
+            className="pf-u-pt-0"
+          ></FormGroup>
+        </Form>
+      ),
+    },
+    {
+      id: toolbarData().membership.formId,
+      key: 7,
+      element: (
+        <ToggleGroup isCompact aria-label="Toggle group with single selectable">
+          <ToggleGroupItem
+            text="Direct"
+            name="user-memberof-group-type-radio-direct"
+            buttonId="direct"
+            isSelected={toolbarData().membership.isDirectSelected}
+            onChange={toolbarData().membership.onDirectChange}
+          />
+          <ToggleGroupItem
+            text="Indirect"
+            name="user-memberof-group-type-radio-indirect"
+            buttonId="indirect"
+            isSelected={toolbarData().membership.isIndirectSelected}
+            onChange={toolbarData().membership.onIndirectChange}
+          />
+        </ToggleGroup>
+      ),
+    },
+    {
+      id: toolbarData().separator3Id,
+      key: 8,
+      toolbarItemVariant: ToolbarItemVariant.separator,
+    },
+    {
+      id: toolbarData().helpIcon.id,
+      key: 9,
+      element: (
+        <TextContent>
+          <Text component={TextVariants.p}>
+            <OutlinedQuestionCircleIcon className="pf-u-primary-color-100 pf-u-mr-sm" />
+            <Text component={TextVariants.a} isVisitedLink>
+              Help
+            </Text>
+          </Text>
+        </TextContent>
+      ),
+    },
+    {
+      id: toolbarData().paginationId,
+      key: 10,
+      element: (
+        <Pagination
+          itemCount={props.pageRepo.length}
+          perPage={perPage}
+          page={page}
+          onSetPage={onSetPage}
+          widgetId="pagination-options-menu-top"
+          onPerPageSelect={onPerPageSelect}
+          isCompact
+        />
+      ),
+      toolbarItemAlignment: { default: "alignRight" } as ToolbarItemAlignment,
+    },
+  ];
+
+  // Render toolbar content
+  return <ToolbarLayout isSticky={false} toolbarItems={toolbarFields} />;
+};
+
+export default MemberOfToolbar;

--- a/src/components/PaginationPrep.tsx
+++ b/src/components/PaginationPrep.tsx
@@ -8,7 +8,7 @@ import { useAppDispatch, useAppSelector } from "src/store/hooks";
 import {
   setSelectedPerPage,
   setShowTableRows,
-} from "src/store/shared/shared-slice";
+} from "src/store/shared/activeUsersShared-slice";
 
 interface PropsToPaginationPrep {
   list: User[]; // TODO: Multi-type
@@ -29,7 +29,9 @@ const PaginationPrep = (props: PropsToPaginationPrep) => {
   const dispatch = useAppDispatch();
 
   // Get shared props
-  const showTableRows = useAppSelector((state) => state.shared.showTableRows);
+  const showTableRows = useAppSelector(
+    (state) => state.activeUsersShared.showTableRows
+  );
 
   // Refresh displayed users every time users list changes (from Redux or somewhere else)
   React.useEffect(() => {

--- a/src/components/layouts/TableLayout.tsx
+++ b/src/components/layouts/TableLayout.tsx
@@ -8,6 +8,7 @@ import React from "react";
 
 export interface PropsToTable {
   ariaLabel: string;
+  name?: string;
   variant: TableVariant | "compact";
   hasBorders: boolean;
   classes?: string;
@@ -21,6 +22,7 @@ const TableLayout = (props: PropsToTable) => {
   return (
     <TableComposable
       aria-label={props.ariaLabel}
+      name={props.name}
       variant={props.variant}
       borders={props.hasBorders}
       className={props.classes}

--- a/src/components/layouts/ToolbarLayout.tsx
+++ b/src/components/layouts/ToolbarLayout.tsx
@@ -2,7 +2,7 @@ import React from "react";
 // PatternFly
 import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core";
 
-interface ToolbarItemSpacer {
+export interface ToolbarItemSpacer {
   default?: "spacerNone" | "spacerSm" | "spacerMd" | "spacerLg";
   md?: "spacerNone" | "spacerSm" | "spacerMd" | "spacerLg";
   lg?: "spacerNone" | "spacerSm" | "spacerMd" | "spacerLg";
@@ -10,7 +10,7 @@ interface ToolbarItemSpacer {
   "2xl"?: "spacerNone" | "spacerSm" | "spacerMd" | "spacerLg";
 }
 
-interface ToolbarItemAlignment {
+export interface ToolbarItemAlignment {
   default?: "alignRight" | "alignLeft";
   md?: "alignRight" | "alignLeft";
   lg?: "alignRight" | "alignLeft";
@@ -20,7 +20,7 @@ interface ToolbarItemAlignment {
 
 export interface ToolbarItem {
   key: number;
-  // element: JSX.Element | undefined;
+  id?: string;
   element?: JSX.Element;
   toolbarItemVariant?:
     | "bulk-select"

--- a/src/components/modals/DeleteUsers.tsx
+++ b/src/components/modals/DeleteUsers.tsx
@@ -17,7 +17,7 @@ import {
   setIsDeleteButtonDisabled,
   setSelectedUsers,
   setIsDeletion,
-} from "src/store/shared/shared-slice";
+} from "src/store/shared/activeUsersShared-slice";
 import { removeUser } from "src/store/Identity/users-slice";
 
 export interface PropsToDeleteUsers {
@@ -30,7 +30,9 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
   const dispatch = useAppDispatch();
 
   // Get shared props (Redux)
-  const selectedUsers = useAppSelector((state) => state.shared.selectedUsers);
+  const selectedUsers = useAppSelector(
+    (state) => state.activeUsersShared.selectedUsers
+  );
 
   // Radio buttons states
   const [isDeleteChecked, setIsDeleteChecked] = useState(true);

--- a/src/components/modals/DisableEnableUsers.tsx
+++ b/src/components/modals/DisableEnableUsers.tsx
@@ -13,7 +13,7 @@ import {
   setIsEnableButtonDisabled,
   setIsDisableButtonDisabled,
   setIsDisableEnableOp,
-} from "src/store/shared/shared-slice";
+} from "src/store/shared/activeUsersShared-slice";
 import { changeStatus } from "src/store/Identity/users-slice";
 
 export interface PropsToDisableEnableUsers {
@@ -27,7 +27,9 @@ const DisableEnableUsers = (props: PropsToDisableEnableUsers) => {
   const dispatch = useAppDispatch();
 
   // Get shared props (Redux)
-  const selectedUsers = useAppSelector((state) => state.shared.selectedUsers);
+  const selectedUsers = useAppSelector(
+    (state) => state.activeUsersShared.selectedUsers
+  );
 
   // List of fields
   const fields = [

--- a/src/pages/ActiveUsers/ActiveUsers.tsx
+++ b/src/pages/ActiveUsers/ActiveUsers.tsx
@@ -25,7 +25,7 @@ import {
   setIsDeleteButtonDisabled,
   setIsEnableButtonDisabled,
   setIsDisableButtonDisabled,
-} from "src/store/shared/shared-slice";
+} from "src/store/shared/activeUsersShared-slice";
 // Layouts
 import TitleLayout from "src/components/layouts/TitleLayout";
 import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
@@ -50,13 +50,13 @@ const ActiveUsers = () => {
 
   // Get shared variables (Redux)
   const isDeleteButtonDisabled = useAppSelector(
-    (state) => state.shared.isDeleteButtonDisabled
+    (state) => state.activeUsersShared.isDeleteButtonDisabled
   );
   const isEnableButtonDisabled = useAppSelector(
-    (state) => state.shared.isEnableButtonDisabled
+    (state) => state.activeUsersShared.isEnableButtonDisabled
   );
   const isDisableButtonDisabled = useAppSelector(
-    (state) => state.shared.isDisableButtonDisabled
+    (state) => state.activeUsersShared.isDisableButtonDisabled
   );
 
   // Initialize active users list (Redux)

--- a/src/pages/ActiveUsers/ActiveUsersTabs.tsx
+++ b/src/pages/ActiveUsers/ActiveUsersTabs.tsx
@@ -19,6 +19,7 @@ import { URL_PREFIX } from "src/navigation/NavRoutes";
 import { User } from "src/utils/datatypes/globalDataTypes";
 // Other
 import UserSettings from "./UserSettings";
+import UserMemberOf from "./UserMemberOf";
 // Layouts
 import BreadcrumbLayout from "src/components/layouts/BreadcrumbLayout";
 
@@ -38,7 +39,7 @@ const ActiveUsersTabs = () => {
   };
 
   // 'pagesVisited' array will contain the visited pages.
-  // Those will be passed to the BreadcrumbLayout component.
+  // - Those will be passed to the BreadcrumbLayout component.
   const pagesVisited = [
     {
       name: "Active users",
@@ -68,9 +69,20 @@ const ActiveUsersTabs = () => {
           isBox
           className="pf-u-ml-lg"
         >
-          <Tab eventKey={0} title={<TabTitleText>Settings</TabTitleText>}>
+          <Tab
+            eventKey={0}
+            name="details"
+            title={<TabTitleText>Settings</TabTitleText>}
+          >
             <PageSection className="pf-u-pb-0"></PageSection>
             <UserSettings user={userData} />
+          </Tab>
+          <Tab
+            eventKey={1}
+            name="memberof-details"
+            title={<TabTitleText>Is a member of</TabTitleText>}
+          >
+            <UserMemberOf user={userData} />
           </Tab>
         </Tabs>
       </PageSection>

--- a/src/pages/ActiveUsers/UserMemberOf.tsx
+++ b/src/pages/ActiveUsers/UserMemberOf.tsx
@@ -1,0 +1,736 @@
+import React, { useEffect, useState } from "react";
+import {
+  TabTitleText,
+  Page,
+  PageSection,
+  PageSectionVariants,
+  Tab,
+  Tabs,
+  Badge,
+  Pagination,
+  PaginationVariant,
+} from "@patternfly/react-core";
+// Others
+import MemberOfToolbar from "src/components/MemberOf/MemberOfToolbar";
+import MemberOfTable from "src/components/MemberOf/MemberOfTable";
+// Data types
+import {
+  UserGroup,
+  Netgroup,
+  Roles,
+  HBACRules,
+  SudoRules,
+  User,
+} from "src/utils/datatypes/globalDataTypes";
+// Redux
+import { useAppDispatch, useAppSelector } from "src/store/hooks";
+import {
+  setUserGroupsRepository,
+  setNetgroupsRepository,
+  setRolesRepository,
+  setHbacRulesRepository,
+  setSudoRulesRepository,
+  setPage,
+  setPerPage,
+  setActiveTabKey,
+} from "src/store/shared/activeUsersMemberOf-slice";
+// Modals
+import MemberOfAddModal from "src/components/MemberOf/MemberOfAddModal";
+import MemberOfDeleteModal from "src/components/MemberOf/MemberOfDeleteModal";
+
+interface PropsToUserMemberOf {
+  user: User;
+}
+
+const UserMemberOf = (props: PropsToUserMemberOf) => {
+  // Set dispatch (Redux)
+  const dispatch = useAppDispatch();
+
+  // Retrieve each group list from Redux:
+  let userGroupsList = useAppSelector(
+    (state) => state.usergroups.userGroupList
+  );
+  let netgroupsList = useAppSelector((state) => state.netgroups.netgroupList);
+  let rolesList = useAppSelector((state) => state.roles.roleList);
+  let hbacRulesList = useAppSelector((state) => state.hbacrules.hbacRulesList);
+  let sudoRulesList = useAppSelector((state) => state.sudorules.sudoRulesList);
+
+  // Retrieve shared props (Redux)
+  const userGroupsRepository = useAppSelector(
+    (state) => state.activeUsersMemberOfShared.userGroupsRepository
+  );
+  const netgroupsRepository = useAppSelector(
+    (state) => state.activeUsersMemberOfShared.netgroupsRepository
+  );
+  const rolesRepository = useAppSelector(
+    (state) => state.activeUsersMemberOfShared.rolesRepository
+  );
+  const hbacRulesRepository = useAppSelector(
+    (state) => state.activeUsersMemberOfShared.hbacRulesRepository
+  );
+  const sudoRulesRepository = useAppSelector(
+    (state) => state.activeUsersMemberOfShared.sudoRulesRepository
+  );
+  const showAddModal = useAppSelector(
+    (state) => state.activeUsersMemberOfShared.showAddModal
+  );
+  const showDeleteModal = useAppSelector(
+    (state) => state.activeUsersMemberOfShared.showDeleteModal
+  );
+  const tabName = useAppSelector(
+    (state) => state.activeUsersMemberOfShared.tabName
+  );
+  const groupsNamesSelected = useAppSelector(
+    (state) => state.activeUsersMemberOfShared.groupsNamesSelected
+  );
+  const page = useAppSelector((state) => state.activeUsersMemberOfShared.page);
+  const perPage = useAppSelector(
+    (state) => state.activeUsersMemberOfShared.perPage
+  );
+  const activeTabKey = useAppSelector(
+    (state) => state.activeUsersMemberOfShared.activeTabKey
+  );
+
+  // Alter the available options list to keep the state of the recently added / removed items
+  const updateUserGroupsList = (newAvOptionsList: unknown[]) => {
+    userGroupsList = newAvOptionsList as UserGroup[];
+  };
+  const updateNetgroupsList = (newAvOptionsList: unknown[]) => {
+    netgroupsList = newAvOptionsList as Netgroup[];
+  };
+  const updateRolesList = (newAvOptionsList: unknown[]) => {
+    rolesList = newAvOptionsList as Roles[];
+  };
+  const updateHbacRulesList = (newAvOptionsList: unknown[]) => {
+    hbacRulesList = newAvOptionsList as HBACRules[];
+  };
+  const updateSudoRulesList = (newAvOptionsList: unknown[]) => {
+    sudoRulesList = newAvOptionsList as SudoRules[];
+  };
+
+  // Define column names that will be shown
+  interface ColumnNames {
+    name: string;
+    gid?: string;
+    status?: string;
+    description: string;
+  }
+
+  // Filter functions to compare the available data with the data that
+  //  the user is already member of. This is done to prevent duplicates
+  //  (e.g: adding the same element twice).
+  const filterUserGroupsData = () => {
+    // User groups
+    return userGroupsList.filter((item) => {
+      return !userGroupsRepository.some((itm) => {
+        return item.name === itm.name;
+      });
+    });
+  };
+  const filterNetgroupsData = () => {
+    // Netgroups
+    return netgroupsList.filter((item) => {
+      return !netgroupsRepository.some((itm) => {
+        return item.name === itm.name;
+      });
+    });
+  };
+  const filterRolesData = () => {
+    // Roles
+    return rolesList.filter((item) => {
+      return !rolesRepository.some((itm) => {
+        return item.name === itm.name;
+      });
+    });
+  };
+  const filterHbacRulesData = () => {
+    // HBAC rules
+    return hbacRulesList.filter((item) => {
+      return !hbacRulesRepository.some((itm) => {
+        return item.name === itm.name;
+      });
+    });
+  };
+  const filterSudoRulesData = () => {
+    // Sudo rules
+    return sudoRulesList.filter((item) => {
+      return !sudoRulesRepository.some((itm) => {
+        return item.name === itm.name;
+      });
+    });
+  };
+
+  // Available data to be added as member of
+  const userGroupsFilteredData: UserGroup[] = filterUserGroupsData();
+  const netgroupsFilteredData: Netgroup[] = filterNetgroupsData();
+  const rolesFilteredData: Roles[] = filterRolesData();
+  const hbacRulesFilteredData: HBACRules[] = filterHbacRulesData();
+  const sudoRulesFilteredData: SudoRules[] = filterSudoRulesData();
+
+  // Number of items on the list for each repository
+  const [userGroupsRepoLength, setUserGroupsRepoLength] = useState(
+    userGroupsRepository.length
+  );
+  const [netgroupsRepoLength, setNetgroupsRepoLength] = useState(
+    netgroupsRepository.length
+  );
+  const [rolesRepoLength, setRolesRepoLength] = useState(
+    rolesRepository.length
+  );
+  const [hbacRulesRepoLength, setHbacRulesRepoLength] = useState(
+    hbacRulesRepository.length
+  );
+  const [sudoRulesRepoLength, setSudoRulesRepoLength] = useState(
+    sudoRulesRepository.length
+  );
+
+  // Some data is updated when any group list is altered
+  //  - The whole list itself
+  //  - The slice of data to show (considering the pagination)
+  //  - Number of items for a specific list
+  const updateGroupRepository = (
+    groupRepository:
+      | UserGroup[]
+      | Netgroup[]
+      | Roles[]
+      | HBACRules[]
+      | SudoRules[]
+  ) => {
+    switch (tabName) {
+      case "User groups":
+        dispatch(setUserGroupsRepository(groupRepository as UserGroup[]));
+        setShownUserGroupsList(userGroupsRepository.slice(0, perPage));
+        setUserGroupsRepoLength(userGroupsRepository.length);
+        break;
+      case "Netgroups":
+        dispatch(setNetgroupsRepository(groupRepository as Netgroup[]));
+        setShownNetgroupsList(netgroupsRepository.slice(0, perPage));
+        setNetgroupsRepoLength(netgroupsRepository.length);
+        break;
+      case "Roles":
+        dispatch(setRolesRepository(groupRepository as Roles[]));
+        setShownRolesList(rolesRepository.slice(0, perPage));
+        setRolesRepoLength(rolesRepository.length);
+        break;
+      case "HBAC rules":
+        dispatch(setHbacRulesRepository(groupRepository as HBACRules[]));
+        setShownHBACRulesList(hbacRulesRepository.slice(0, perPage));
+        setHbacRulesRepoLength(hbacRulesRepository.length);
+        break;
+      case "Sudo rules":
+        dispatch(setSudoRulesRepository(groupRepository as SudoRules[]));
+        setShownSudoRulesList(sudoRulesRepository.slice(0, perPage));
+        setSudoRulesRepoLength(sudoRulesRepository.length);
+        break;
+    }
+  };
+
+  // Column names for each repository
+  const groupNameColumnNames: ColumnNames = {
+    name: "Group name",
+    gid: "GID",
+    description: "Description",
+  };
+  const netgroupsColumnNames: ColumnNames = {
+    name: "Netgroup name",
+    description: "Description",
+  };
+  const rolesColumnNames: ColumnNames = {
+    name: "Role name",
+    description: "Description",
+  };
+  const hbacRulesColumnNames: ColumnNames = {
+    name: "Rule name",
+    status: "Status",
+    description: "Description",
+  };
+  const sudoRulesColumnNames: ColumnNames = {
+    name: "Rule name",
+    status: "Status",
+    description: "Description",
+  };
+
+  // State that determines whether the row tables are displayed nor not
+  // - This helps with the reload state
+  const [showTableRows, setShowTableRows] = useState(false);
+
+  const handleTabClick = (
+    _event: React.MouseEvent<HTMLElement, MouseEvent>,
+    tabIndex: number | string
+  ) => {
+    dispatch(setActiveTabKey(tabIndex as number));
+  };
+
+  // Member groups displayed on the first page
+  const [shownUserGroupsList, setShownUserGroupsList] = useState(
+    userGroupsRepository.slice(0, perPage)
+  );
+  const [shownNetgroupsList, setShownNetgroupsList] = useState(
+    netgroupsRepository.slice(0, perPage)
+  );
+  const [shownRolesList, setShownRolesList] = useState(
+    rolesRepository.slice(0, perPage)
+  );
+  const [shownHBACRulesList, setShownHBACRulesList] = useState(
+    hbacRulesRepository.slice(0, perPage)
+  );
+  const [shownSudoRulesList, setShownSudoRulesList] = useState(
+    sudoRulesRepository.slice(0, perPage)
+  );
+
+  // Update pagination
+  const changeMemberGroupsList = (
+    value: UserGroup[] | Netgroup[] | Roles[] | HBACRules[] | SudoRules[]
+  ) => {
+    switch (activeTabKey) {
+      case 0:
+        setShownUserGroupsList(value as UserGroup[]);
+        break;
+      case 1:
+        setShownNetgroupsList(value as Netgroup[]);
+        break;
+      case 2:
+        setShownRolesList(value as Roles[]);
+        break;
+      case 3:
+        setShownHBACRulesList(value as HBACRules[]);
+        break;
+      case 4:
+        setShownSudoRulesList(value as SudoRules[]);
+        break;
+    }
+  };
+
+  // Pages setters
+  const onSetPage = (
+    _event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
+    newPage: number,
+    perPage: number | undefined,
+    startIdx: number | undefined,
+    endIdx: number | undefined
+  ) => {
+    dispatch(setPage(newPage));
+    switch (activeTabKey) {
+      case 0:
+        setShownUserGroupsList(userGroupsRepository.slice(startIdx, endIdx));
+        break;
+      case 1:
+        setShownNetgroupsList(netgroupsRepository.slice(startIdx, endIdx));
+        break;
+      case 2:
+        setShownRolesList(rolesRepository.slice(startIdx, endIdx));
+        break;
+      case 3:
+        setShownHBACRulesList(hbacRulesRepository.slice(startIdx, endIdx));
+        break;
+      case 4:
+        setShownSudoRulesList(sudoRulesRepository.slice(startIdx, endIdx));
+        break;
+    }
+  };
+
+  const onPerPageSelect = (
+    _event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
+    newPerPage: number,
+    newPage: number,
+    startIdx: number | undefined,
+    endIdx: number | undefined
+  ) => {
+    setPerPage(newPerPage);
+    switch (activeTabKey) {
+      case 0:
+        setShownUserGroupsList(userGroupsRepository.slice(startIdx, endIdx));
+        break;
+      case 1:
+        setShownNetgroupsList(netgroupsRepository.slice(startIdx, endIdx));
+        break;
+      case 2:
+        setShownRolesList(rolesRepository.slice(startIdx, endIdx));
+        break;
+      case 3:
+        setShownHBACRulesList(hbacRulesRepository.slice(startIdx, endIdx));
+        break;
+      case 4:
+        setShownSudoRulesList(sudoRulesRepository.slice(startIdx, endIdx));
+        break;
+    }
+  };
+
+  // Page setters passed as props
+  const changeSetPage = (
+    newPage: number,
+    perPage: number | undefined,
+    startIdx: number | undefined,
+    endIdx: number | undefined
+  ) => {
+    dispatch(setPage(newPage));
+    switch (activeTabKey) {
+      case 0:
+        setShownUserGroupsList(userGroupsRepository.slice(startIdx, endIdx));
+        break;
+      case 1:
+        setShownNetgroupsList(netgroupsRepository.slice(startIdx, endIdx));
+        break;
+      case 2:
+        setShownRolesList(rolesRepository.slice(startIdx, endIdx));
+        break;
+      case 3:
+        setShownHBACRulesList(hbacRulesRepository.slice(startIdx, endIdx));
+        break;
+      case 4:
+        setShownSudoRulesList(sudoRulesRepository.slice(startIdx, endIdx));
+        break;
+    }
+  };
+
+  const changePerPageSelect = (
+    newPerPage: number,
+    newPage: number,
+    startIdx: number | undefined,
+    endIdx: number | undefined
+  ) => {
+    setPerPage(newPerPage);
+    switch (activeTabKey) {
+      case 0:
+        setShownUserGroupsList(userGroupsRepository.slice(startIdx, endIdx));
+        break;
+      case 1:
+        setShownNetgroupsList(netgroupsRepository.slice(startIdx, endIdx));
+        break;
+      case 2:
+        setShownRolesList(rolesRepository.slice(startIdx, endIdx));
+        break;
+      case 3:
+        setShownHBACRulesList(hbacRulesRepository.slice(startIdx, endIdx));
+        break;
+      case 4:
+        setShownSudoRulesList(sudoRulesRepository.slice(startIdx, endIdx));
+        break;
+    }
+  };
+
+  // Different number of items will be shown depending on the 'activeTabKey'
+  const numberOfItems = () => {
+    switch (activeTabKey) {
+      case 0:
+        return userGroupsRepository.length;
+      case 1:
+        return netgroupsRepository.length;
+      case 2:
+        return rolesRepository.length;
+      case 3:
+        return hbacRulesRepository.length;
+      case 4:
+        return sudoRulesRepository.length;
+    }
+  };
+
+  // Reloads the table everytime any of the group lists are updated
+  useEffect(() => {
+    dispatch(setPage(1));
+    if (showTableRows) setShowTableRows(false);
+    setTimeout(() => {
+      switch (activeTabKey) {
+        case 0:
+          setShownUserGroupsList(userGroupsRepository.slice(0, perPage));
+          setUserGroupsRepoLength(userGroupsRepository.length);
+          break;
+        case 1:
+          setShownNetgroupsList(netgroupsRepository.slice(0, perPage));
+          setNetgroupsRepoLength(netgroupsRepository.length);
+          break;
+        case 2:
+          setShownRolesList(rolesRepository.slice(0, perPage));
+          setRolesRepoLength(rolesRepository.length);
+          break;
+        case 3:
+          setShownHBACRulesList(hbacRulesRepository.slice(0, perPage));
+          setHbacRulesRepoLength(hbacRulesRepository.length);
+          break;
+        case 4:
+          setShownSudoRulesList(sudoRulesRepository.slice(0, perPage));
+          setSudoRulesRepoLength(sudoRulesRepository.length);
+          break;
+      }
+      setShowTableRows(true);
+    }, 1000);
+  }, [
+    userGroupsRepository,
+    netgroupsRepository,
+    rolesRepository,
+    hbacRulesRepository,
+    sudoRulesRepository,
+  ]);
+
+  // Render 'ActiveUsersIsMemberOf'
+  return (
+    <Page>
+      <PageSection
+        variant={PageSectionVariants.light}
+        isFilled={false}
+        className="pf-u-m-lg"
+      >
+        <Tabs activeKey={activeTabKey} onSelect={handleTabClick} isBox={false}>
+          <Tab
+            eventKey={0}
+            name="memberof_group"
+            title={
+              <TabTitleText>
+                User groups{" "}
+                <Badge key={0} isRead>
+                  {userGroupsRepoLength}
+                </Badge>
+              </TabTitleText>
+            }
+          >
+            <MemberOfToolbar
+              pageRepo={userGroupsRepository}
+              shownItems={shownUserGroupsList}
+              toolbar="user groups"
+              changeMemberGroupsList={changeMemberGroupsList}
+              changeSetPage={changeSetPage}
+              changePerPageSelect={changePerPageSelect}
+            />
+            <MemberOfTable
+              group={shownUserGroupsList}
+              columnNames={groupNameColumnNames}
+              tableName={"User groups"}
+              activeTabKey={activeTabKey}
+              showTableRows={showTableRows}
+            />
+          </Tab>
+          <Tab
+            eventKey={1}
+            name="memberof_netgroup"
+            title={
+              <TabTitleText>
+                Netgroups{" "}
+                <Badge key={1} isRead>
+                  {netgroupsRepoLength}
+                </Badge>
+              </TabTitleText>
+            }
+          >
+            <MemberOfToolbar
+              pageRepo={netgroupsRepository}
+              shownItems={shownNetgroupsList}
+              toolbar="netgroups"
+              changeMemberGroupsList={changeMemberGroupsList}
+              changeSetPage={changeSetPage}
+              changePerPageSelect={changePerPageSelect}
+            />
+            <MemberOfTable
+              group={shownNetgroupsList}
+              columnNames={netgroupsColumnNames}
+              tableName={"Netgroups"}
+              activeTabKey={activeTabKey}
+              showTableRows={showTableRows}
+            />
+          </Tab>
+          <Tab
+            eventKey={2}
+            name="memberof_role"
+            title={
+              <TabTitleText>
+                Roles{" "}
+                <Badge key={2} isRead>
+                  {rolesRepoLength}
+                </Badge>
+              </TabTitleText>
+            }
+          >
+            <MemberOfToolbar
+              pageRepo={rolesRepository}
+              shownItems={shownRolesList}
+              toolbar="roles"
+              changeMemberGroupsList={changeMemberGroupsList}
+              changeSetPage={changeSetPage}
+              changePerPageSelect={changePerPageSelect}
+            />
+            <MemberOfTable
+              group={shownRolesList}
+              columnNames={rolesColumnNames}
+              tableName={"Roles"}
+              activeTabKey={activeTabKey}
+              showTableRows={showTableRows}
+            />
+          </Tab>
+          <Tab
+            eventKey={3}
+            name="memberof_hbacrule"
+            title={
+              <TabTitleText>
+                HBAC rules{" "}
+                <Badge key={3} isRead>
+                  {hbacRulesRepoLength}
+                </Badge>
+              </TabTitleText>
+            }
+          >
+            <MemberOfToolbar
+              pageRepo={hbacRulesRepository}
+              shownItems={shownHBACRulesList}
+              toolbar="HBAC rules"
+              changeMemberGroupsList={changeMemberGroupsList}
+              changeSetPage={changeSetPage}
+              changePerPageSelect={changePerPageSelect}
+            />
+            <MemberOfTable
+              group={shownHBACRulesList}
+              columnNames={hbacRulesColumnNames}
+              tableName={"HBAC rules"}
+              activeTabKey={activeTabKey}
+              showTableRows={showTableRows}
+            />
+          </Tab>
+          <Tab
+            eventKey={4}
+            name="memberof_sudorule"
+            title={
+              <TabTitleText>
+                Sudo rules{" "}
+                <Badge key={4} isRead>
+                  {sudoRulesRepoLength}
+                </Badge>
+              </TabTitleText>
+            }
+          >
+            <MemberOfToolbar
+              pageRepo={sudoRulesRepository}
+              shownItems={shownSudoRulesList}
+              toolbar="sudo rules"
+              changeMemberGroupsList={changeMemberGroupsList}
+              changeSetPage={changeSetPage}
+              changePerPageSelect={changePerPageSelect}
+            />
+            <MemberOfTable
+              group={shownSudoRulesList}
+              columnNames={sudoRulesColumnNames}
+              tableName={"Sudo rules"}
+              activeTabKey={activeTabKey}
+              showTableRows={showTableRows}
+            />
+          </Tab>
+        </Tabs>
+        <Pagination
+          perPageComponent="button"
+          className="pf-u-pb-0 pf-u-pr-md"
+          itemCount={numberOfItems()}
+          widgetId="pagination-options-menu-bottom"
+          perPage={perPage}
+          page={page}
+          variant={PaginationVariant.bottom}
+          onSetPage={onSetPage}
+          onPerPageSelect={onPerPageSelect}
+        />
+      </PageSection>
+      {tabName === "User groups" && (
+        <>
+          {showAddModal && (
+            <MemberOfAddModal
+              show={showAddModal}
+              availableData={userGroupsFilteredData}
+              userGroupData={userGroupsRepository}
+              updateGroupRepository={updateGroupRepository}
+              updateAvOptionsList={updateUserGroupsList}
+              userName={props.user.userLogin}
+            />
+          )}
+          {showDeleteModal && groupsNamesSelected.length !== 0 && (
+            <MemberOfDeleteModal
+              activeTabKey={activeTabKey}
+              groupRepository={userGroupsRepository}
+              updateGroupRepository={updateGroupRepository}
+            />
+          )}
+        </>
+      )}
+      {tabName === "Netgroups" && (
+        <>
+          {showAddModal && (
+            <MemberOfAddModal
+              show={showAddModal}
+              availableData={netgroupsFilteredData}
+              userGroupData={netgroupsRepository}
+              updateGroupRepository={updateGroupRepository}
+              updateAvOptionsList={updateNetgroupsList}
+              userName={props.user.userLogin}
+            />
+          )}
+          {showDeleteModal && groupsNamesSelected.length !== 0 && (
+            <MemberOfDeleteModal
+              activeTabKey={activeTabKey}
+              groupRepository={netgroupsRepository}
+              updateGroupRepository={updateGroupRepository}
+            />
+          )}
+        </>
+      )}
+      {tabName === "Roles" && (
+        <>
+          {showAddModal && (
+            <MemberOfAddModal
+              show={showAddModal}
+              availableData={rolesFilteredData}
+              userGroupData={rolesRepository}
+              updateGroupRepository={updateGroupRepository}
+              updateAvOptionsList={updateRolesList}
+              userName={props.user.userLogin}
+            />
+          )}
+          {showDeleteModal && groupsNamesSelected.length !== 0 && (
+            <MemberOfDeleteModal
+              activeTabKey={activeTabKey}
+              groupRepository={rolesRepository}
+              updateGroupRepository={updateGroupRepository}
+            />
+          )}
+        </>
+      )}
+      {tabName === "HBAC rules" && (
+        <>
+          {showAddModal && (
+            <MemberOfAddModal
+              show={showAddModal}
+              availableData={hbacRulesFilteredData}
+              userGroupData={hbacRulesRepository}
+              updateGroupRepository={updateGroupRepository}
+              updateAvOptionsList={updateHbacRulesList}
+              userName={props.user.userLogin}
+            />
+          )}
+          {showDeleteModal && groupsNamesSelected.length !== 0 && (
+            <MemberOfDeleteModal
+              activeTabKey={activeTabKey}
+              groupRepository={hbacRulesRepository}
+              updateGroupRepository={updateGroupRepository}
+            />
+          )}
+        </>
+      )}
+      {tabName === "Sudo rules" && (
+        <>
+          {showAddModal && (
+            <MemberOfAddModal
+              show={showAddModal}
+              availableData={sudoRulesFilteredData}
+              userGroupData={sudoRulesRepository}
+              updateGroupRepository={updateGroupRepository}
+              updateAvOptionsList={updateSudoRulesList}
+              userName={props.user.userLogin}
+            />
+          )}
+          {showDeleteModal && groupsNamesSelected.length !== 0 && (
+            <MemberOfDeleteModal
+              activeTabKey={activeTabKey}
+              groupRepository={sudoRulesRepository}
+              updateGroupRepository={updateGroupRepository}
+            />
+          )}
+        </>
+      )}
+    </Page>
+  );
+};
+
+export default UserMemberOf;

--- a/src/pages/ActiveUsers/tables/ActiveUsersTable.tsx
+++ b/src/pages/ActiveUsers/tables/ActiveUsersTable.tsx
@@ -18,7 +18,7 @@ import {
   setSelectedUserIds,
   setSelectedPerPage,
   setIsDeletion,
-} from "src/store/shared/shared-slice";
+} from "src/store/shared/activeUsersShared-slice";
 // Utils
 import { checkEqualStatus } from "src/utils/utils";
 // Navigation
@@ -42,16 +42,20 @@ const ActiveUsersTable = (props: PropsToTable) => {
 
   // Get shared props
   const isDisableEnableOp = useAppSelector(
-    (state) => state.shared.isDisableEnableOp
+    (state) => state.activeUsersShared.isDisableEnableOp
   );
   const selectedUserIds = useAppSelector(
-    (state) => state.shared.selectedUserIds
+    (state) => state.activeUsersShared.selectedUserIds
   );
   const selectedPerPage = useAppSelector(
-    (state) => state.shared.selectedPerPage
+    (state) => state.activeUsersShared.selectedPerPage
   );
-  const showTableRows = useAppSelector((state) => state.shared.showTableRows);
-  const isDeletion = useAppSelector((state) => state.shared.isDeletion);
+  const showTableRows = useAppSelector(
+    (state) => state.activeUsersShared.showTableRows
+  );
+  const isDeletion = useAppSelector(
+    (state) => state.activeUsersShared.isDeletion
+  );
 
   // Retrieve users data from props
   const activeUsersList = [...props.elementsList];

--- a/src/store/IPA server/roles-slice.ts
+++ b/src/store/IPA server/roles-slice.ts
@@ -1,0 +1,22 @@
+import { createSlice } from "@reduxjs/toolkit";
+import type { RootState } from "../store";
+import rolesJson from "./roles.json";
+// Data type
+import { Roles } from "src/utils/datatypes/globalDataTypes";
+
+interface RoleState {
+  roleList: Roles[];
+}
+
+const initialState: RoleState = {
+  roleList: rolesJson,
+};
+
+const rolesSlice = createSlice({
+  name: "roles",
+  initialState,
+  reducers: {},
+});
+
+export const selectNetgroups = (state: RootState) => state.roles.roleList;
+export default rolesSlice.reducer;

--- a/src/store/IPA server/roles.json
+++ b/src/store/IPA server/roles.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "Enrollment Administrator",
+    "description": "Enrollment Administrator responsible for client(host) enrollment"
+  },
+  {
+    "name": "IT Security Specialist",
+    "description": "IT Security Specialist"
+  },
+  {
+    "name": "IT Specialist",
+    "description": "IT Specialist"
+  },
+  {
+    "name": "Security Architect",
+    "description": "Security Architect"
+  },
+  {
+    "name": "User Administrator",
+    "description": "Responsible for creating Users and Groups"
+  },
+  {
+    "name": "Helpdesk",
+    "description": "Helpdesk"
+  }
+]

--- a/src/store/Identity/netgroups-slice.ts
+++ b/src/store/Identity/netgroups-slice.ts
@@ -1,0 +1,23 @@
+import { createSlice } from "@reduxjs/toolkit";
+import type { RootState } from "../store";
+import netgroupsJson from "./netgroups.json";
+// Data type
+import { Netgroup } from "src/utils/datatypes/globalDataTypes";
+
+interface NetgroupState {
+  netgroupList: Netgroup[];
+}
+
+const initialState: NetgroupState = {
+  netgroupList: netgroupsJson,
+};
+
+const netgroupsSlice = createSlice({
+  name: "netgroups",
+  initialState,
+  reducers: {},
+});
+
+export const selectNetgroups = (state: RootState) =>
+  state.netgroups.netgroupList;
+export default netgroupsSlice.reducer;

--- a/src/store/Identity/netgroups.json
+++ b/src/store/Identity/netgroups.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "netgroup1",
+    "description": "First netgroup"
+  },
+  {
+    "name": "netgroup2",
+    "description": "Second netgroup"
+  },
+  {
+    "name": "netgroup3",
+    "description": "Third netgroup"
+  }
+]

--- a/src/store/Identity/userGroups-slice.ts
+++ b/src/store/Identity/userGroups-slice.ts
@@ -1,0 +1,23 @@
+import { createSlice } from "@reduxjs/toolkit";
+import type { RootState } from "../store";
+import userGroupsJson from "./userGroups.json";
+// Data type
+import { UserGroup } from "src/utils/datatypes/globalDataTypes";
+
+interface UserGroupState {
+  userGroupList: UserGroup[];
+}
+
+const initialState: UserGroupState = {
+  userGroupList: userGroupsJson,
+};
+
+const userGroupsSlice = createSlice({
+  name: "usergroups",
+  initialState,
+  reducers: {},
+});
+
+export const selectUserGroups = (state: RootState) =>
+  state.usergroups.userGroupList;
+export default userGroupsSlice.reducer;

--- a/src/store/Identity/userGroups.json
+++ b/src/store/Identity/userGroups.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "admins",
+    "gid": "613800000",
+    "description": "Account administrators group"
+  },
+  {
+    "name": "editors",
+    "gid": "613800002",
+    "description": "Limited admins who can edit other users"
+  },
+  {
+    "name": "employees",
+    "gid": "613800005",
+    "description": "Test Employees"
+  },
+  {
+    "name": "group123",
+    "gid": "613800008",
+    "description": "The best group ever"
+  }
+]

--- a/src/store/Policy/hbacRules-slice.ts
+++ b/src/store/Policy/hbacRules-slice.ts
@@ -1,0 +1,23 @@
+import { createSlice } from "@reduxjs/toolkit";
+import type { RootState } from "../store";
+import HBACRulesJson from "./hbacRules.json";
+// Data type
+import { HBACRules } from "src/utils/datatypes/globalDataTypes";
+
+interface HBACRulesState {
+  hbacRulesList: HBACRules[];
+}
+
+const initialState: HBACRulesState = {
+  hbacRulesList: HBACRulesJson,
+};
+
+const hbacRulesSlice = createSlice({
+  name: "hbacrules",
+  initialState,
+  reducers: {},
+});
+
+export const selectHBACRules = (state: RootState) =>
+  state.hbacrules.hbacRulesList;
+export default hbacRulesSlice.reducer;

--- a/src/store/Policy/hbacRules.json
+++ b/src/store/Policy/hbacRules.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "allow_all",
+    "status": "Enabled",
+    "description": "Allow all users to access any host from any host"
+  },
+  {
+    "name": "allow_systemd-user",
+    "status": "Enabled",
+    "description": "Allow pam_systemd to run user@.service to create a system user session"
+  },
+  {
+    "name": "allow_unicorn-user",
+    "status": "Disabled",
+    "description": "Test to have a disabled rule by default"
+  }
+]

--- a/src/store/Policy/sudoRules-slice.ts
+++ b/src/store/Policy/sudoRules-slice.ts
@@ -1,0 +1,23 @@
+import { createSlice } from "@reduxjs/toolkit";
+import type { RootState } from "../store";
+import sudoRulesJson from "./sudoRules.json";
+// Data type
+import { SudoRules } from "src/utils/datatypes/globalDataTypes";
+
+interface SudoRulesState {
+  sudoRulesList: SudoRules[];
+}
+
+const initialState: SudoRulesState = {
+  sudoRulesList: sudoRulesJson,
+};
+
+const sudoRulesSlice = createSlice({
+  name: "sudorules",
+  initialState,
+  reducers: {},
+});
+
+export const selectSudoRules = (state: RootState) =>
+  state.sudorules.sudoRulesList;
+export default sudoRulesSlice.reducer;

--- a/src/store/Policy/sudoRules.json
+++ b/src/store/Policy/sudoRules.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "sudo_rule_1",
+    "status": "Enabled",
+    "description": "Description sudo_rule_1"
+  },
+  {
+    "name": "sudo_rule_2",
+    "status": "Enabled",
+    "description": "Description sudo_rule_2"
+  },
+  {
+    "name": "sudo_rule_3",
+    "status": "Disabled",
+    "description": "Description sudo_rule_3"
+  }
+]

--- a/src/store/shared/activeUsersMemberOf-slice.ts
+++ b/src/store/shared/activeUsersMemberOf-slice.ts
@@ -1,0 +1,170 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+// Data types
+import {
+  UserGroup,
+  Netgroup,
+  Roles,
+  HBACRules,
+  SudoRules,
+} from "src/utils/datatypes/globalDataTypes";
+// Repository initial data
+import {
+  userGroupsInitialData,
+  netgroupsInitialData,
+  rolesInitialData,
+  hbacRulesInitialData,
+  sudoRulesInitialData,
+} from "src/utils/data/GroupRepositories";
+
+/*
+ * This redux slice is intended for shared variables (in the 'Active
+ * users' > 'Member of' section) that are being used by different
+ * components throughout the webui app. Instead of passing the state
+ * variables via props to the components, this is done via redux to
+ * reduce the amount of variables passed by the component structure
+ * and make them more lightweight.
+ */
+
+/*
+ * - userGroupsRepository (UserGroup[])
+ *    List of user groups.
+ * - netgroupsRepository (Netgroup[])
+ *    List of netgroups.
+ * - rolesRepository (Roles[])
+ *    List of roles.
+ * - hbacRulesRepository (HBACRules[])
+ *    List of HBAC rules.
+ * - sudoRulesRepository (SudoRules[])
+ *    List of sudo rules.
+ * - showAddModal (boolean)
+ *    Flag to show/hide the 'Add' modal.
+ * - showDeleteModal (boolean)
+ *    Flag to show/hide the 'Delete' modal.
+ * - tabName (string)
+ *    Name of the actual tab. This will be displayed in the modals.
+ * - isDeleteButtonDisabled (boolean)
+ *    'Delete' button state. This button is enabled only when an
+ *     element on the table has been selected.
+ * - isDeletion (boolean)
+ *    If some entries have been deleted, restore the 'groupsNamesSelected' list.
+ * - page (number)
+ *    Actual page (pagination).
+ * - perPage (number)
+ *    Elements to show per page (pagination).
+ * - activeTabKey (number)
+ *    Number of the active tab key:
+ *      0: User groups
+ *      1: Netgroups
+ *      2: Roles
+ *      3: HBAC rules
+ *      4: Sudo rules
+ */
+
+interface ActiveUsersMemberOfSharedState {
+  userGroupsRepository: UserGroup[];
+  netgroupsRepository: Netgroup[];
+  rolesRepository: Roles[];
+  hbacRulesRepository: HBACRules[];
+  sudoRulesRepository: SudoRules[];
+  showAddModal: boolean;
+  showDeleteModal: boolean;
+  tabName: string;
+  isDeleteButtonDisabled: boolean;
+  groupsNamesSelected: string[];
+  isDeletion: boolean;
+  page: number;
+  perPage: number;
+  activeTabKey: number;
+}
+
+const initialState: ActiveUsersMemberOfSharedState = {
+  userGroupsRepository: userGroupsInitialData,
+  netgroupsRepository: netgroupsInitialData,
+  rolesRepository: rolesInitialData,
+  hbacRulesRepository: hbacRulesInitialData,
+  sudoRulesRepository: sudoRulesInitialData,
+  showAddModal: false,
+  showDeleteModal: false,
+  tabName: "user groups",
+  isDeleteButtonDisabled: true,
+  groupsNamesSelected: [],
+  isDeletion: false,
+  page: 1,
+  perPage: 10,
+  activeTabKey: 0,
+};
+
+const activeUsersMemberOfSharedSlice = createSlice({
+  name: "activeUsersMemberOfShared",
+  initialState,
+  reducers: {
+    setUserGroupsRepository: (state, action: PayloadAction<UserGroup[]>) => {
+      state.userGroupsRepository = action.payload;
+    },
+    setNetgroupsRepository: (state, action: PayloadAction<Netgroup[]>) => {
+      state.netgroupsRepository = action.payload;
+    },
+    setRolesRepository: (state, action: PayloadAction<Roles[]>) => {
+      state.rolesRepository = action.payload;
+    },
+    setHbacRulesRepository: (state, action: PayloadAction<HBACRules[]>) => {
+      state.hbacRulesRepository = action.payload;
+    },
+    setSudoRulesRepository: (state, action: PayloadAction<SudoRules[]>) => {
+      state.sudoRulesRepository = action.payload;
+    },
+    setShowAddModal: (state, action: PayloadAction<boolean>) => {
+      state.showAddModal = action.payload;
+    },
+    onClickAddHandler: (state) => {
+      state.showAddModal = true;
+    },
+    setShowDeleteModal: (state, action: PayloadAction<boolean>) => {
+      state.showDeleteModal = action.payload;
+    },
+    onClickDeleteHandler: (state) => {
+      state.showDeleteModal = true;
+    },
+    setTabName: (state, action: PayloadAction<string>) => {
+      state.tabName = action.payload;
+    },
+    setIsDeleteButtonDisabled: (state, action: PayloadAction<boolean>) => {
+      state.isDeleteButtonDisabled = action.payload;
+    },
+    setGroupsNamesSelected: (state, action: PayloadAction<string[]>) => {
+      state.groupsNamesSelected = action.payload;
+    },
+    setIsDeletion: (state, action: PayloadAction<boolean>) => {
+      state.isDeletion = action.payload;
+    },
+    setPage: (state, action: PayloadAction<number>) => {
+      state.page = action.payload;
+    },
+    setPerPage: (state, action: PayloadAction<number>) => {
+      state.perPage = action.payload;
+    },
+    setActiveTabKey: (state, action: PayloadAction<number>) => {
+      state.activeTabKey = action.payload;
+    },
+  },
+});
+
+export const {
+  setUserGroupsRepository,
+  setNetgroupsRepository,
+  setRolesRepository,
+  setHbacRulesRepository,
+  setSudoRulesRepository,
+  setShowAddModal,
+  onClickAddHandler,
+  setShowDeleteModal,
+  onClickDeleteHandler,
+  setTabName,
+  setIsDeleteButtonDisabled,
+  setGroupsNamesSelected,
+  setIsDeletion,
+  setPage,
+  setPerPage,
+  setActiveTabKey,
+} = activeUsersMemberOfSharedSlice.actions;
+export default activeUsersMemberOfSharedSlice.reducer;

--- a/src/store/shared/activeUsersShared-slice.ts
+++ b/src/store/shared/activeUsersShared-slice.ts
@@ -2,11 +2,12 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import type { RootState } from "src/store/store";
 
 /*
- * This redux slice is intended for shared variables that are being
- * used by different components throughout the webui app. Instead of
- * passing the state variables via props to the components, this is
- * done via redux to reduce the amount of variables passed by the
- * component structure and make them more lightweight.
+ * This redux slice is intended for shared variables (in the 'Active
+ * users' page) that are being used by different components throughout
+ * the webui app. Instead of passing the state variables via props to
+ * the components, this is done via redux to reduce the amount of
+ * variables passed by the component structure and make them more
+ * lightweight.
  */
 
 /*
@@ -31,7 +32,7 @@ import type { RootState } from "src/store/store";
  *    If some entries have been deleted, restore the 'selectedUsers' list.
  */
 
-interface SharedState {
+interface ActiveUsersSharedState {
   selectedUsers: string[];
   isDeleteButtonDisabled: boolean;
   isEnableButtonDisabled: boolean;
@@ -43,7 +44,7 @@ interface SharedState {
   isDeletion: boolean;
 }
 
-const initialState: SharedState = {
+const initialState: ActiveUsersSharedState = {
   selectedUsers: [],
   isDeleteButtonDisabled: true,
   isEnableButtonDisabled: true,
@@ -55,8 +56,8 @@ const initialState: SharedState = {
   isDeletion: false,
 };
 
-const sharedSlice = createSlice({
-  name: "shared",
+const activeUsersSharedSlice = createSlice({
+  name: "activeUsersShared",
   initialState,
   reducers: {
     setSelectedUsers: (state, action: PayloadAction<string[]>) => {
@@ -99,7 +100,7 @@ export const {
   setSelectedPerPage,
   setShowTableRows,
   setIsDeletion,
-} = sharedSlice.actions;
+} = activeUsersSharedSlice.actions;
 export const selectSelectedUsers = (state: RootState) =>
-  state.shared.selectedUsers;
-export default sharedSlice.reducer;
+  state.activeUsersShared.selectedUsers;
+export default activeUsersSharedSlice.reducer;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,11 +1,23 @@
 import { configureStore } from "@reduxjs/toolkit";
 import usersReducer from "./Identity/users-slice";
-import sharedReducer from "./shared/shared-slice";
+import activeUsersSharedReducer from "./shared/activeUsersShared-slice";
+import netgroupsReducer from "./Identity/netgroups-slice";
+import userGroupsReducer from "./Identity/userGroups-slice";
+import rolesReducer from "./IPA server/roles-slice";
+import hbacRulesReducer from "./Policy/hbacRules-slice";
+import sudoRulesReducer from "./Policy/sudoRules-slice";
+import activeUsersMemberOfSharedReducer from "./shared/activeUsersMemberOf-slice";
 
 const store = configureStore({
   reducer: {
     users: usersReducer,
-    shared: sharedReducer,
+    activeUsersShared: activeUsersSharedReducer,
+    netgroups: netgroupsReducer,
+    usergroups: userGroupsReducer,
+    roles: rolesReducer,
+    hbacrules: hbacRulesReducer,
+    sudorules: sudoRulesReducer,
+    activeUsersMemberOfShared: activeUsersMemberOfSharedReducer,
   },
 });
 

--- a/src/utils/data/GroupRepositories.ts
+++ b/src/utils/data/GroupRepositories.ts
@@ -1,0 +1,123 @@
+/* eslint-disable prefer-const */
+
+/*
+ * This is a temporal file to hold the repositories (aka. the intial data lists)
+ * used on the 'Active users' page > 'Is a member of' section.
+ *
+ * In the future, this must be retrieved from other source (eg.: API call, Redux, etc)
+ */
+
+import {
+  UserGroup,
+  Netgroup,
+  Roles,
+  HBACRules,
+  SudoRules,
+} from "../datatypes/globalDataTypes";
+
+// 'User groups' initial data
+export let userGroupsInitialData: UserGroup[] = [
+  {
+    name: "Initial admins",
+    gid: "12345678",
+    description: "This is a description for initial admins",
+  },
+  {
+    name: "Other admins",
+    gid: "234456567",
+    description: "This is a description for other admins",
+  },
+  {
+    name: "Other admins 1",
+    gid: "234456567",
+    description: "This is a description for other admins 1",
+  },
+  {
+    name: "Other admins 2",
+    gid: "234456567",
+    description: "This is a description for other admins 2",
+  },
+  {
+    name: "Other admins 3",
+    gid: "234456567",
+    description: "This is a description for other admins 3",
+  },
+  {
+    name: "Other admins 4",
+    gid: "234456567",
+    description: "This is a description for other admins 4",
+  },
+  {
+    name: "Other admins 5",
+    gid: "234456567",
+    description: "This is a description for other admins 5",
+  },
+  {
+    name: "Other admins 6",
+    gid: "234456567",
+    description: "This is a description for other admins 6",
+  },
+  {
+    name: "Other admins 7",
+    gid: "234456567",
+    description: "This is a description for other admins 7",
+  },
+  {
+    name: "Other admins 8",
+    gid: "234456567",
+    description: "This is a description for other admins 8",
+  },
+  {
+    name: "Other admins 9",
+    gid: "234456567",
+    description: "This is a description for other admins 9",
+  },
+  {
+    name: "Other admins 10",
+    gid: "234456567",
+    description: "This is a description for other admins 10",
+  },
+  {
+    name: "Other admins 11",
+    gid: "234456567",
+    description: "This is a description for other admins 11",
+  },
+  {
+    name: "Other admins 12",
+    gid: "234456567",
+    description: "This is a description for other admins 12",
+  },
+];
+
+// 'Netgroups' initial data
+export let netgroupsInitialData: Netgroup[] = [
+  {
+    name: "netgroup1",
+    description: "First netgroup",
+  },
+  {
+    name: "netgroup2",
+    description: "Second netgroup",
+  },
+];
+
+// 'Roles' initial data
+export let rolesInitialData: Roles[] = [];
+
+// 'HBAC rules' initial data
+export let hbacRulesInitialData: HBACRules[] = [
+  {
+    name: "allow_all",
+    status: "Enabled",
+    description: "Allow all users to access any host from any host",
+  },
+  {
+    name: "allow_systemd-user",
+    status: "Enabled",
+    description:
+      "Allow pam_systemd to run user@.service to create a system user session",
+  },
+];
+
+// 'Sudo rules' initial data
+export let sudoRulesInitialData: SudoRules[] = [];

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -9,3 +9,31 @@ export interface User {
   phone: string;
   jobTitle: string;
 }
+
+export interface UserGroup {
+  name: string;
+  gid: string;
+  description: string;
+}
+
+export interface Netgroup {
+  name: string;
+  description: string;
+}
+
+export interface Roles {
+  name: string;
+  description: string;
+}
+
+export interface HBACRules {
+  name: string;
+  status: string;
+  description: string;
+}
+
+export interface SudoRules {
+  name: string;
+  status: string;
+  description: string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "sourceMap": true,
     "jsx": "react",
     "forceConsistentCasingInFileNames": true,
-    "noImplicitReturns": true,
+    "noImplicitReturns": false,
     "noImplicitThis": true,
     "noImplicitAny": false,
     "allowJs": true,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8112750/203050279-b89418a4-8f51-4efc-a227-d7da4fe33bec.png)

The '**Is a member of**' section provides a way to manage the groups to which a specific user can be a member. These types are known as '**member groups**'.

There are five different types of member groups whose entity can be defined in different pages/sections alongside the FreeIPA page:
- **User groups** (`Identity`)
- **Netgroups** (`Identity`)
- **Roles** (`IPA server`)
- **HBAC rules** (`Policy`)
- **Sudo rules** (`Policy`)

### Redux and shared slices
To prepare the data to be used by Redux, this has been initialized as follows:
- The data types are being defined in the `globalDataTypes.ts` file.
- Assuming that the data in the tables are not empty in this specific solution, the initial data values have been defined in the `GroupRepositories.ts` file.
- The data that will be shown when assigning a new member group to the user is defined in the following files:
     - netgroups.json
     - userGroups.json
     - roles.json
     - hbacRules.json
     - sudoRules.json

The Redux slices for each of the already mentioned member groups have been defined. Redux will use the initial data taken from the JSON files to manage all the initial states by default:
- `userGroups-slice.ts` will manage the `User groups` data.
- `netgroups-slice.ts` will manage the `Netgroups` data.
- `roles-slice.ts` will manage the `Roles` data.
- `hbacRules-slice.ts` will manage the `HBAC rules` data.
- `sudoRules-slice.ts` will manage the `Sudo rules` data.

To manage the shared data among components in the `Is a member of` section, the Redux slice (`ActiveUsersMemberOf-slice.ts`) has been created and added to the store to be consumed.

Although the `shared-slice.ts` file is meant to manage the 'Active users' shared data in a centralized way, the naming of the file is not very clear and can lead to misunderstanding when creating the new 'Is a member of' slice. Thus, this file has been renamed to `ActiveUsersShared-slice.ts`. With this change, the following components that were consuming this slice have been altered:
- `DeleteUsers`
- `DisableEnableUsers`
- `BulkSelectorPrep`
- `PaginationPrep`
- `ActiveUsersTable`
- `ActiveUsers`

### 'Is a member of' child components
The main components to manage the tables, toolbar, and its action buttons ('Add' & 'Delete') have been also defined.

The 'Add' and 'Delete' functionality is given by the `MemberOfAddModal` and the `MemberOfDeleteModal` respectively. Also, similar to the main 'Active users' page behavior, the list of deleted elements is shown through the `MemberOfDeletedGroupsTable` component.

The toolbar and the table showing the member groups should be independent of the rest (i.e: each tab should have an isolated logic to show and manage all the data for that specific member group). Those have been defined in the `MemberOfTable` and `MemberOfToolbar` components. These receive the list to manage via props and all the actions are meant to be applied in this specific data list, securing the rest of the data.

### 'Is a member of' main component
Finally, the 'Is a member of' section has been added to the tab, alongside the 'Settings' one.

The `UserMemberOf` contains the main section page and only the specific member group data is passed to its children components (`MemberOfToolbar`, `MemberOfTable`, `MemberOfAddModal`, and `MemberOfDeleteModal`). Also, thanks to the shared redux slice, the number of props passed to these children's components has considerably decreased, making it leaner and more lightweight.

### Other related
Apart from the mentioned, the `TableLayout` and the `ToolbarLayout` components have been altered to add new variables that will be managed via props.

Also, the `tsconfig.json` file has been altered to fix a TypeScript-specific error that shows up in the following `UserMemberOf` code:
```ts
// Different number of items will be shown depending on the 'activeTabKey'
  const numberOfItems = () => {
    switch (activeTabKey) {
      case 0:
        return userGroupsRepository.length;
      case 1:
        return netgroupsRepository.length;
      case 2:
        return rolesRepository.length;
      case 3:
        return hbacRulesRepository.length;
      case 4:
        return sudoRulesRepository.length;
    }
  };
```

Signed-off-by: Carla Martinez <carlmart@redhat.com>