### PR TITLE
'Stage users' page

### DIFF
--- a/src/components/modals/AddUser.tsx
+++ b/src/components/modals/AddUser.tsx
@@ -21,6 +21,7 @@ import { User } from "src/utils/datatypes/globalDataTypes";
 // Redux
 import { useAppDispatch } from "src/store/hooks";
 import { addUser as addActiveUser } from "src/store/Identity/activeUsers-slice";
+import { addUser as addStageUser } from "src/store/Identity/stageUsers-slice";
 
 export interface PropsToAddUser {
   show: boolean;
@@ -418,6 +419,8 @@ const AddUser = (props: PropsToAddUser) => {
       };
       if (props.from === "active-users") {
         dispatch(addActiveUser(newUser));
+      } else if (props.from === "stage-users") {
+        dispatch(addStageUser(newUser));
       }
       cleanAndCloseModal();
     }
@@ -468,6 +471,8 @@ const AddUser = (props: PropsToAddUser) => {
       };
       if (props.from === "active-users") {
         dispatch(addActiveUser(newUser));
+      } else if (props.from === "stage-users") {
+        dispatch(addStageUser(newUser));
       }
       // Do not close the modal, but clean fields & reset validations
       cleanAllFields();

--- a/src/components/modals/DeleteUsers.tsx
+++ b/src/components/modals/DeleteUsers.tsx
@@ -14,6 +14,7 @@ import DeletedUsersTable from "src/components/tables/DeletedUsersTable";
 // Redux
 import { useAppDispatch } from "src/store/hooks";
 import { removeUser as removeActiveUser } from "src/store/Identity/activeUsers-slice";
+import { removeUser as removeStageUser } from "src/store/Identity/stageUsers-slice";
 
 interface ButtonsData {
   updateIsDeleteButtonDisabled: (value: boolean) => void;
@@ -104,6 +105,8 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
     props.selectedUsersData.selectedUsers.map((user) => {
       if (props.from === "active-users") {
         dispatch(removeActiveUser(user));
+      } else if (props.from === "stage-users") {
+        dispatch(removeStageUser(user));
       }
     });
     props.selectedUsersData.updateSelectedUsers([]);

--- a/src/components/modals/DisableEnableUsers.tsx
+++ b/src/components/modals/DisableEnableUsers.tsx
@@ -10,6 +10,7 @@ import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
 // Redux
 import { useAppDispatch } from "src/store/hooks";
 import { changeStatus as changeStatusActiveUser } from "src/store/Identity/activeUsers-slice";
+import { changeStatus as changeStatusStageUser } from "src/store/Identity/stageUsers-slice";
 
 interface ButtonsData {
   updateIsEnableButtonDisabled: (value: boolean) => void;
@@ -17,12 +18,17 @@ interface ButtonsData {
   updateIsDisableEnableOp: (value: boolean) => void;
 }
 
+interface SelectedUsersData {
+  selectedUsers: string[];
+  updateSelectedUsers: (newSelectedUsers: string[]) => void;
+}
+
 export interface PropsToDisableEnableUsers {
   show: boolean;
   from: "active-users" | "stage-users" | "preserved-users";
   handleModalToggle: () => void;
   optionSelected: string; // 'enable' | 'disable'
-  selectedUsers: string[];
+  selectedUsersData: SelectedUsersData;
   buttonsData: ButtonsData;
 }
 
@@ -57,6 +63,13 @@ const DisableEnableUsers = (props: PropsToDisableEnableUsers) => {
           selectedUsers,
         })
       );
+    } else if (props.from === "stage-users") {
+      dispatch(
+        changeStatusStageUser({
+          newStatus,
+          selectedUsers,
+        })
+      );
     }
     // Update 'isDisbleEnableOp' to notify table that an updating operation is performed
     props.buttonsData.updateIsDisableEnableOp(true);
@@ -68,6 +81,8 @@ const DisableEnableUsers = (props: PropsToDisableEnableUsers) => {
       props.buttonsData.updateIsEnableButtonDisabled(false);
       props.buttonsData.updateIsDisableButtonDisabled(true);
     }
+
+    props.selectedUsersData.updateSelectedUsers([]);
     closeModal();
   };
 
@@ -76,7 +91,12 @@ const DisableEnableUsers = (props: PropsToDisableEnableUsers) => {
     <Button
       key="disable-users"
       variant="primary"
-      onClick={() => modifyStatus(props.optionSelected, props.selectedUsers)}
+      onClick={() =>
+        modifyStatus(
+          props.optionSelected,
+          props.selectedUsersData.selectedUsers
+        )
+      }
       form="users-enable-disable-users-modal"
     >
       Disable
@@ -105,7 +125,12 @@ const DisableEnableUsers = (props: PropsToDisableEnableUsers) => {
     <Button
       key="enable-users"
       variant="primary"
-      onClick={() => modifyStatus(props.optionSelected, props.selectedUsers)}
+      onClick={() =>
+        modifyStatus(
+          props.optionSelected,
+          props.selectedUsersData.selectedUsers
+        )
+      }
       form="active-users-enable-disable-users-modal"
     >
       Enable

--- a/src/components/tables/DeletedUsersTable.tsx
+++ b/src/components/tables/DeletedUsersTable.tsx
@@ -21,11 +21,24 @@ const DeletedUsersTable = (props: PropsToDeletedUsersTable) => {
   );
   const activeUsersListCopy = [...activeUsersList];
 
+  // - Stage users
+  const stageUsersList = useAppSelector((state) => state.stageUsers.usersList);
+  const stageUsersListCopy = [...stageUsersList];
+
   // Given userIds, retrieve full user info to display into table
   const usersToDelete: User[] = [];
   switch (props.from) {
     case "active-users":
       activeUsersListCopy.map((user) => {
+        props.usersToDelete.map((selected) => {
+          if (user.userId === selected) {
+            usersToDelete.push(user);
+          }
+        });
+      });
+      break;
+    case "stage-users":
+      stageUsersListCopy.map((user) => {
         props.usersToDelete.map((selected) => {
           if (user.userId === selected) {
             usersToDelete.push(user);

--- a/src/pages/ActiveUsers/ActiveUsers.tsx
+++ b/src/pages/ActiveUsers/ActiveUsers.tsx
@@ -465,7 +465,7 @@ const ActiveUsers = () => {
         from="active-users"
         handleModalToggle={onEnableDisableModalToggle}
         optionSelected={enableDisableOptionSelected}
-        selectedUsers={selectedUsers}
+        selectedUsersData={selectedUsersData}
         buttonsData={disableEnableButtonsData}
       />
     </Page>

--- a/src/pages/StageUsers/StageUsers.tsx
+++ b/src/pages/StageUsers/StageUsers.tsx
@@ -1,9 +1,475 @@
-import React from "react";
-// React router dom
-import { NavLink } from "react-router-dom";
+import React, { useState } from "react";
+// PatternFly
+import {
+  DropdownItem,
+  Page,
+  PageSection,
+  PageSectionVariants,
+  SearchInput,
+  TextVariants,
+  PaginationVariant,
+} from "@patternfly/react-core";
+// PatternFly table
+import {
+  InnerScrollContainer,
+  OuterScrollContainer,
+} from "@patternfly/react-table";
+// Icons
+import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
+// Data types
+import { User } from "src/utils/datatypes/globalDataTypes";
+import { ToolbarItem } from "src/components/layouts/ToolbarLayout";
+// Redux
+import { useAppSelector } from "src/store/hooks";
+// Layouts
+import TitleLayout from "src/components/layouts/TitleLayout";
+import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
+import KebabLayout from "src/components/layouts/KebabLayout";
+import SecondaryButton from "src/components/layouts/SecondaryButton";
+import ToolbarLayout from "src/components/layouts/ToolbarLayout";
+// Tables
+import UsersTable from "../../components/tables/UsersTable";
+// Components
+import PaginationPrep from "src/components/PaginationPrep";
+import BulkSelectorPrep from "src/components/BulkSelectorPrep";
+// Modals
+import AddUser from "src/components/modals/AddUser";
+import DeleteUsers from "src/components/modals/DeleteUsers";
+import DisableEnableUsers from "src/components/modals/DisableEnableUsers";
+// Utils
+import { isUserSelectable } from "src/utils/utils";
 
 const StageUsers = () => {
-  return <NavLink to="settings">Stage Users Page</NavLink>;
+  // Initialize stage users list (Redux)
+  const stageUsersList = useAppSelector((state) => state.stageUsers.usersList);
+
+  // Selected users state
+  const [selectedUsers, setSelectedUsers] = useState<string[]>([]);
+
+  const updateSelectedUsers = (newSelectedUsers: string[]) => {
+    setSelectedUsers(newSelectedUsers);
+  };
+
+  // 'Delete' button state
+  const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
+    useState<boolean>(true);
+
+  const updateIsDeleteButtonDisabled = (value: boolean) => {
+    setIsDeleteButtonDisabled(value);
+  };
+
+  // If some entries have been deleted, restore the selectedUsers list
+  const [isDeletion, setIsDeletion] = useState(false);
+
+  const updateIsDeletion = (value: boolean) => {
+    setIsDeletion(value);
+  };
+
+  // 'Enable' button state
+  const [isEnableButtonDisabled, setIsEnableButtonDisabled] =
+    useState<boolean>(true);
+
+  const updateIsEnableButtonDisabled = (value: boolean) => {
+    setIsEnableButtonDisabled(value);
+  };
+
+  // 'Disable' button state
+  const [isDisableButtonDisabled, setIsDisableButtonDisabled] =
+    useState<boolean>(true);
+
+  const updateIsDisableButtonDisabled = (value: boolean) => {
+    setIsDisableButtonDisabled(value);
+  };
+
+  // If some entries' status has been updated, unselect selected rows
+  const [isDisableEnableOp, setIsDisableEnableOp] = useState(false);
+
+  const updateIsDisableEnableOp = (value: boolean) => {
+    setIsDisableEnableOp(value);
+  };
+
+  // - Selected user ids state
+  const [selectedUserIds, setSelectedUserIds] = useState<string[]>([]);
+
+  const updateSelectedUserIds = (newSelectedUserIds: string[]) => {
+    setSelectedUserIds(newSelectedUserIds);
+  };
+
+  // Elements selected (per page)
+  //  - This will help to calculate the remaining elements on a specific page (bulk selector)
+  const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
+
+  const updateSelectedPerPage = (selected: number) => {
+    setSelectedPerPage(selected);
+  };
+
+  // Pagination
+  const [page, setPage] = useState<number>(1);
+
+  const updatePage = (newPage: number) => {
+    setPage(newPage);
+  };
+
+  const [perPage, setPerPage] = useState<number>(15);
+
+  const updatePerPage = (newSetPerPage: number) => {
+    setPerPage(newSetPerPage);
+  };
+
+  // Users displayed on the first page
+  const [shownUsersList, setShownUsersList] = useState(
+    stageUsersList.slice(0, perPage)
+  );
+
+  const updateShownUsersList = (newShownUsersList: User[]) => {
+    setShownUsersList(newShownUsersList);
+  };
+
+  // Show table rows
+  const [showTableRows, setShowTableRows] = useState(false);
+
+  const updateShowTableRows = (value: boolean) => {
+    setShowTableRows(value);
+  };
+
+  // Dropdown kebab
+  const [kebabIsOpen, setKebabIsOpen] = useState(false);
+
+  const dropdownItems = [
+    <DropdownItem key="action" component="button">
+      Rebuild auto membership
+    </DropdownItem>,
+  ];
+
+  const onKebabToggle = (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    event: any,
+    isOpen: boolean
+  ) => {
+    setKebabIsOpen(isOpen);
+  };
+
+  const onDropdownSelect = (
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    event?: React.SyntheticEvent<HTMLDivElement, Event> | undefined
+  ) => {
+    setKebabIsOpen(!kebabIsOpen);
+  };
+
+  // Modals functionality
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [showEnableDisableModal, setShowEnableDisableModal] = useState(false);
+  const [enableDisableOptionSelected, setEnableDisableOptionSelected] =
+    useState("");
+  const onAddClickHandler = () => {
+    setShowAddModal(true);
+  };
+  const onAddModalToggle = () => {
+    setShowAddModal(!showAddModal);
+  };
+
+  const onDeleteHandler = () => {
+    setShowDeleteModal(true);
+  };
+  const onDeleteModalToggle = () => {
+    setShowDeleteModal(!showDeleteModal);
+  };
+
+  const onEnableDisableHandler = (optionClicked: string) => {
+    setIsDeleteButtonDisabled(true); // prevents 'Delete' button to be enabled
+    setIsEnableButtonDisabled(true); // prevents 'Enable' button to be enabled
+    setIsDisableButtonDisabled(true); // prevents 'Disable' button to be enabled
+    setEnableDisableOptionSelected(optionClicked);
+    setShowEnableDisableModal(true);
+  };
+
+  const onEnableDisableModalToggle = () => {
+    setIsEnableButtonDisabled(true); // prevents 'Enable' button to be enabled
+    setIsDisableButtonDisabled(true); // prevents 'Disable' button to be enabled
+    setShowEnableDisableModal(!showEnableDisableModal);
+  };
+
+  // Table-related shared functionality
+  // - Selectable checkboxes on table
+  const selectableUsersTable = stageUsersList.filter(isUserSelectable); // elements per Table
+
+  // - Selected rows are tracked. Primary key: userLogin
+  const [selectedUserNames, setSelectedUserNames] = useState<string[]>([]);
+
+  const changeSelectedUserNames = (selectedUsernames: string[]) => {
+    setSelectedUserNames(selectedUsernames);
+  };
+
+  // - Helper method to set the selected users from the table
+  const setUserSelected = (user: User, isSelecting = true) =>
+    setSelectedUserNames((prevSelected) => {
+      const otherSelectedUserNames = prevSelected.filter(
+        (r) => r !== user.userLogin
+      );
+      return isSelecting && isUserSelectable(user)
+        ? [...otherSelectedUserNames, user.userLogin]
+        : otherSelectedUserNames;
+    });
+
+  // Data wrappers
+  // - 'PaginationPrep'
+  const paginationData = {
+    page,
+    perPage,
+    updatePage,
+    updatePerPage,
+    showTableRows,
+    updateShowTableRows,
+    updateSelectedPerPage,
+    updateShownUsersList,
+  };
+
+  // - 'BulkSelectorPrep'
+  const usersData = {
+    selectedUsers,
+    updateSelectedUsers,
+    updateSelectedUserIds,
+    selectedUserNames,
+    changeSelectedUserNames,
+    selectableUsersTable,
+    isUserSelectable,
+  };
+
+  const buttonsData = {
+    // isDeleteButtonDisabled, //
+    updateIsDeleteButtonDisabled,
+    // isEnableButtonDisabled, //
+    updateIsEnableButtonDisabled,
+    updateIsDisableButtonDisabled,
+    updateIsDisableEnableOp,
+  };
+
+  const selectedPerPageData = {
+    selectedPerPage,
+    updateSelectedPerPage,
+  };
+
+  // 'DeleteUsers'
+  const deleteUsersButtonsData = {
+    updateIsDeleteButtonDisabled,
+    updateIsDeletion,
+  };
+
+  const selectedUsersData = {
+    selectedUsers,
+    updateSelectedUsers,
+  };
+
+  // 'DisableEnableUsers'
+  const disableEnableButtonsData = {
+    updateIsEnableButtonDisabled,
+    updateIsDisableButtonDisabled,
+    updateIsDisableEnableOp,
+  };
+
+  // 'UsersTable'
+  const usersTableData = {
+    isUserSelectable,
+    selectedUserNames,
+    changeSelectedUserNames,
+    selectedUserIds,
+    updateSelectedUserIds,
+    selectableUsersTable,
+    setUserSelected,
+    updateSelectedUsers,
+  };
+
+  const usersTableButtonsData = {
+    updateIsDeleteButtonDisabled,
+    updateIsEnableButtonDisabled,
+    updateIsDisableButtonDisabled,
+    isDeletion,
+    updateIsDeletion,
+    isDisableEnableOp,
+    updateIsDisableEnableOp,
+  };
+
+  // List of Toolbar items
+  const toolbarItems: ToolbarItem[] = [
+    {
+      key: 0,
+      element: (
+        <BulkSelectorPrep
+          list={stageUsersList}
+          shownElementsList={shownUsersList}
+          usersData={usersData}
+          buttonsData={buttonsData}
+          selectedPerPageData={selectedPerPageData}
+        />
+      ),
+    },
+    {
+      key: 1,
+      element: <SearchInput aria-label="Search user" placeholder="Search" />,
+      toolbarItemVariant: "search-filter",
+      toolbarItemSpacer: { default: "spacerMd" },
+    },
+    {
+      key: 2,
+      toolbarItemVariant: "separator",
+    },
+    {
+      key: 3,
+      element: <SecondaryButton>Refresh</SecondaryButton>,
+    },
+    {
+      key: 4,
+      element: (
+        <SecondaryButton
+          isDisabled={isDeleteButtonDisabled}
+          onClickHandler={onDeleteHandler}
+        >
+          Delete
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 5,
+      element: (
+        <SecondaryButton onClickHandler={onAddClickHandler}>
+          Add
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 6,
+      element: (
+        <SecondaryButton
+          isDisabled={isDisableButtonDisabled}
+          onClickHandler={() => onEnableDisableHandler("disable")}
+        >
+          Disable
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 7,
+      element: (
+        <SecondaryButton
+          isDisabled={isEnableButtonDisabled}
+          onClickHandler={() => onEnableDisableHandler("enable")}
+        >
+          Enable
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 8,
+      element: (
+        <KebabLayout
+          onDropdownSelect={onDropdownSelect}
+          onKebabToggle={onKebabToggle}
+          idKebab="main-dropdown-kebab"
+          isKebabOpen={kebabIsOpen}
+          isPlain={true}
+          dropdownItems={dropdownItems}
+        />
+      ),
+    },
+    {
+      key: 9,
+      toolbarItemVariant: "separator",
+    },
+    {
+      key: 10,
+      element: (
+        <HelpTextWithIconLayout
+          textComponent={TextVariants.p}
+          subTextComponent={TextVariants.a}
+          subTextIsVisitedLink={true}
+          textContent="Help"
+          icon={
+            <OutlinedQuestionCircleIcon className="pf-u-primary-color-100 pf-u-mr-sm" />
+          }
+        />
+      ),
+    },
+    {
+      key: 11,
+      element: (
+        <PaginationPrep
+          list={stageUsersList}
+          paginationData={paginationData}
+          widgetId="pagination-options-menu-top"
+          isCompact={true}
+        />
+      ),
+      toolbarItemAlignment: { default: "alignRight" },
+    },
+  ];
+
+  // Render 'Stage users'
+  return (
+    <Page>
+      <PageSection variant={PageSectionVariants.light}>
+        <TitleLayout
+          id="stage users title"
+          headingLevel="h1"
+          text="Stage users"
+        />
+      </PageSection>
+      <PageSection
+        variant={PageSectionVariants.light}
+        isFilled={false}
+        className="pf-u-m-lg pf-u-pb-md pf-u-pl-0 pf-u-pr-0"
+      >
+        <ToolbarLayout
+          className="pf-u-pt-0 pf-u-pl-lg pf-u-pr-md"
+          contentClassName="pf-u-p-0"
+          toolbarItems={toolbarItems}
+        />
+        <div style={{ height: `calc(100vh - 352.2px)` }}>
+          <OuterScrollContainer>
+            <InnerScrollContainer>
+              <UsersTable
+                elementsList={stageUsersList}
+                shownElementsList={shownUsersList}
+                from="stage-users"
+                showTableRows={showTableRows}
+                usersData={usersTableData}
+                buttonsData={usersTableButtonsData}
+                paginationData={selectedPerPageData}
+              />
+            </InnerScrollContainer>
+          </OuterScrollContainer>
+        </div>
+        <PaginationPrep
+          list={stageUsersList}
+          paginationData={paginationData}
+          variant={PaginationVariant.bottom}
+          widgetId="pagination-options-menu-bottom"
+          perPageComponent="button"
+          className="pf-u-pb-0 pf-u-pr-md"
+        />
+      </PageSection>
+      <AddUser
+        show={showAddModal}
+        from="stage-users"
+        handleModalToggle={onAddModalToggle}
+      />
+      <DeleteUsers
+        show={showDeleteModal}
+        from="stage-users"
+        handleModalToggle={onDeleteModalToggle}
+        selectedUsersData={selectedUsersData}
+        buttonsData={deleteUsersButtonsData}
+      />
+      <DisableEnableUsers
+        show={showEnableDisableModal}
+        from="stage-users"
+        handleModalToggle={onEnableDisableModalToggle}
+        optionSelected={enableDisableOptionSelected}
+        selectedUsersData={selectedUsersData}
+        buttonsData={disableEnableButtonsData}
+      />
+    </Page>
+  );
 };
 
 export default StageUsers;

--- a/src/pages/StageUsers/StageUsersTabs.tsx
+++ b/src/pages/StageUsers/StageUsersTabs.tsx
@@ -1,9 +1,85 @@
-import React from "react";
-// React router dom
-import { Link } from "react-router-dom";
+import React, { useState } from "react";
+// PatternFly
+import {
+  Title,
+  Page,
+  PageSection,
+  PageSectionVariants,
+  TextContent,
+  Text,
+  Tabs,
+  Tab,
+  TabTitleText,
+} from "@patternfly/react-core";
+// React Router DOM
+import { useLocation } from "react-router-dom";
+// Navigation
+import { URL_PREFIX } from "src/navigation/NavRoutes";
+// Data types
+import { User } from "src/utils/datatypes/globalDataTypes";
+// Other
+import UserSettings from "src/components/UserSettings";
+// Layouts
+import BreadcrumbLayout from "src/components/layouts/BreadcrumbLayout";
 
 const StageUsersTabs = () => {
-  return <Link to="third-level-page-stage">This is Stage users tabs!</Link>;
+  // Get location (React Router DOM) and get state data
+  const location = useLocation();
+  const userData: User = location.state as User;
+
+  // Tab
+  const [activeTabKey, setActiveTabKey] = useState(0);
+
+  const handleTabClick = (
+    _event: React.MouseEvent<HTMLElement, MouseEvent>,
+    tabIndex: number | string
+  ) => {
+    setActiveTabKey(tabIndex as number);
+  };
+
+  // 'pagesVisited' array will contain the visited pages.
+  // - Those will be passed to the BreadcrumbLayout component.
+  const pagesVisited = [
+    {
+      name: "Stage users",
+      url: URL_PREFIX + "/stage-users",
+    },
+  ];
+
+  return (
+    <Page>
+      <PageSection variant={PageSectionVariants.light} className="pf-u-pr-0">
+        <BreadcrumbLayout
+          className="pf-u-mb-md"
+          userId={userData.userId}
+          pagesVisited={pagesVisited}
+        />
+        <TextContent>
+          <Title headingLevel="h1">
+            <Text>{userData.userId}</Text>
+          </Title>
+        </TextContent>
+      </PageSection>
+      <PageSection type="tabs" variant={PageSectionVariants.light} isFilled>
+        <Tabs
+          activeKey={activeTabKey}
+          onSelect={handleTabClick}
+          variant="light300"
+          isBox
+          className="pf-u-ml-lg"
+        >
+          <Tab
+            eventKey={0}
+            name="details"
+            title={<TabTitleText>Settings</TabTitleText>}
+          >
+            <PageSection className="pf-u-pb-0"></PageSection>
+            <UserSettings user={userData} from="stage-users" />
+          </Tab>
+        </Tabs>
+      </PageSection>
+    </Page>
+  );
 };
 
 export default StageUsersTabs;

--- a/src/store/Identity/stageUsers-slice.ts
+++ b/src/store/Identity/stageUsers-slice.ts
@@ -1,0 +1,94 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import type { RootState } from "src/store/store";
+// User data (JSON file)
+import stageUsersJson from "./stageUsers.json";
+// Data types
+import { User } from "src/utils/datatypes/globalDataTypes";
+
+interface StageUsersState {
+  usersList: User[];
+}
+
+interface ChangeStatusData {
+  newStatus: string;
+  selectedUsers: string[];
+}
+
+const initialState: StageUsersState = {
+  usersList: stageUsersJson,
+};
+
+const stageUsersSlice = createSlice({
+  name: "stageUsers",
+  initialState,
+  reducers: {
+    addUser: (state, action: PayloadAction<User>) => {
+      const newUser = action.payload;
+      state.usersList.push({
+        userId: newUser.userId,
+        userLogin: newUser.userLogin,
+        firstName: newUser.firstName,
+        lastName: newUser.lastName,
+        status: newUser.status,
+        uid: newUser.uid,
+        emailAddress: newUser.emailAddress,
+        phone: newUser.phone,
+        jobTitle: newUser.jobTitle,
+      });
+      // Update json file
+    },
+    removeUser: (state, action: PayloadAction<string>) => {
+      const userId = action.payload;
+      const updatedUserList = state.usersList.filter(
+        (user) => user.userId !== userId
+      );
+      // If not empty, replace userList by new array
+      if (updatedUserList) {
+        state.usersList = updatedUserList;
+        // Update json file
+      }
+    },
+    changeStatus: (state, action: PayloadAction<ChangeStatusData>) => {
+      const newStatus =
+        action.payload.newStatus.charAt(0).toUpperCase() +
+        action.payload.newStatus.slice(1) +
+        "d";
+      const selectedUsersIds = action.payload.selectedUsers;
+      let selectedUsersCount = selectedUsersIds.length;
+
+      // Retrieve users
+      for (let i = 0; i < selectedUsersIds.length; i++) {
+        for (let j = 0; j < state.usersList.length; j++) {
+          if (selectedUsersCount > 0) {
+            // Find User by userId
+            if (selectedUsersIds[i] === state.usersList[j].userId) {
+              // Update the status only
+              const updatedUser = {
+                userId: state.usersList[j].userId,
+                userLogin: state.usersList[j].userLogin,
+                firstName: state.usersList[j].firstName,
+                lastName: state.usersList[j].lastName,
+                status: newStatus,
+                uid: state.usersList[j].uid,
+                emailAddress: state.usersList[j].emailAddress,
+                phone: state.usersList[j].phone,
+                jobTitle: state.usersList[j].jobTitle,
+              };
+              // Replace entry
+              state.usersList[j] = updatedUser;
+              selectedUsersCount--;
+            }
+          } else {
+            // When all ocurrences in selectedUsers array are found, nothing else to search
+            break;
+          }
+        }
+      }
+    },
+  },
+});
+
+export const { addUser, removeUser, changeStatus } = stageUsersSlice.actions;
+export const selectUsers = (state: RootState) =>
+  state.stageUsers.usersList as User[];
+export default stageUsersSlice.reducer;

--- a/src/store/Identity/stageUsers.json
+++ b/src/store/Identity/stageUsers.json
@@ -1,0 +1,233 @@
+[
+  {
+    "userId": "admin",
+    "userLogin": "admin",
+    "firstName": "",
+    "lastName": "Administrator",
+    "status": "Enabled",
+    "uid": "1151000000",
+    "emailAddress": "",
+    "phone": "",
+    "jobTitle": ""
+  },
+  {
+    "userId": "jdoe",
+    "userLogin": "jdoe",
+    "firstName": "John",
+    "lastName": "Doe",
+    "status": "Enabled",
+    "uid": "1151000001",
+    "emailAddress": "jdoe@ipaexample.test",
+    "phone": "",
+    "jobTitle": ""
+  },
+  {
+    "userId": "sother",
+    "userLogin": "sother",
+    "firstName": "Some",
+    "lastName": "Other",
+    "status": "Disabled",
+    "uid": "1151000003",
+    "emailAddress": "sother@ipaexample.test",
+    "phone": "",
+    "jobTitle": ""
+  },
+  {
+    "userId": "employee",
+    "userLogin": "employee",
+    "firstName": "Test",
+    "lastName": "Employee",
+    "status": "Enabled",
+    "uid": "1151000004",
+    "emailAddress": "employee@ipaexample.test",
+    "phone": "",
+    "jobTitle": ""
+  },
+  {
+    "userId": "helpDesk",
+    "userLogin": "helpDesk",
+    "firstName": "Test",
+    "lastName": "HelpDesk",
+    "status": "Enabled",
+    "uid": "1151000005",
+    "emailAddress": "helpDesk@ipaexample.test",
+    "phone": "",
+    "jobTitle": ""
+  },
+  {
+    "userId": "manager",
+    "userLogin": "manager",
+    "firstName": "Test",
+    "lastName": "Manager",
+    "status": "Enabled",
+    "uid": "1151000006",
+    "emailAddress": "manager@ipaexample.test",
+    "phone": "",
+    "jobTitle": ""
+  },
+  {
+    "userId": "sother5",
+    "userLogin": "sother5",
+    "firstName": "Some",
+    "lastName": "Other",
+    "status": "Enabled",
+    "uid": "1151000007",
+    "emailAddress": "sother5@ipaexample.test",
+    "phone": "",
+    "jobTitle": ""
+  },
+  {
+    "userId": "sother6",
+    "userLogin": "sother6",
+    "firstName": "Some",
+    "lastName": "Other",
+    "status": "Enabled",
+    "uid": "1151000008",
+    "emailAddress": "sother6@ipaexample.test",
+    "phone": "",
+    "jobTitle": ""
+  },
+  {
+    "userId": "sother7",
+    "userLogin": "sother7",
+    "firstName": "Some",
+    "lastName": "Other",
+    "status": "Enabled",
+    "uid": "1151000009",
+    "emailAddress": "sother7@ipaexample.test",
+    "phone": "",
+    "jobTitle": ""
+  },
+  {
+    "userId": "sother8",
+    "userLogin": "sother8",
+    "firstName": "Some",
+    "lastName": "Other",
+    "status": "Enabled",
+    "uid": "1151000010",
+    "emailAddress": "sother8@ipaexample.test",
+    "phone": "",
+    "jobTitle": ""
+  },
+  {
+    "userId": "sother9",
+    "userLogin": "sother9",
+    "firstName": "Some",
+    "lastName": "Other",
+    "status": "Enabled",
+    "uid": "1151000011",
+    "emailAddress": "sother9@ipaexample.test",
+    "phone": "",
+    "jobTitle": ""
+  },
+  {
+    "userId": "sother10",
+    "userLogin": "sother10",
+    "firstName": "Some",
+    "lastName": "Other",
+    "status": "Enabled",
+    "uid": "1151000012",
+    "emailAddress": "sother10@ipaexample.test",
+    "phone": "",
+    "jobTitle": ""
+  },
+  {
+    "userId": "sother11",
+    "userLogin": "sother11",
+    "firstName": "Some",
+    "lastName": "Other",
+    "status": "Enabled",
+    "uid": "1151000013",
+    "emailAddress": "sother11@ipaexample.test",
+    "phone": "",
+    "jobTitle": ""
+  },
+  {
+    "userId": "sother12",
+    "userLogin": "sother12",
+    "firstName": "Some",
+    "lastName": "Other",
+    "status": "Enabled",
+    "uid": "1151000014",
+    "emailAddress": "sother12@ipaexample.test",
+    "phone": "",
+    "jobTitle": ""
+  },
+  {
+    "userId": "sother13",
+    "userLogin": "sother13",
+    "firstName": "Some",
+    "lastName": "Other",
+    "status": "Enabled",
+    "uid": "1151000015",
+    "emailAddress": "sother13@ipaexample.test",
+    "phone": "",
+    "jobTitle": ""
+  },
+  {
+    "userId": "sother14",
+    "userLogin": "sother14",
+    "firstName": "Some",
+    "lastName": "Other",
+    "status": "Enabled",
+    "uid": "1151000016",
+    "emailAddress": "sother14@ipaexample.test",
+    "phone": "",
+    "jobTitle": ""
+  },
+  {
+    "userId": "sother15",
+    "userLogin": "sother15",
+    "firstName": "Some",
+    "lastName": "Other",
+    "status": "Disabled",
+    "uid": "1151000017",
+    "emailAddress": "sother15@ipaexample.test",
+    "phone": "",
+    "jobTitle": ""
+  },
+  {
+    "userId": "sother16",
+    "userLogin": "sother16",
+    "firstName": "Some",
+    "lastName": "Other",
+    "status": "Enabled",
+    "uid": "1151000018",
+    "emailAddress": "sother16@ipaexample.test",
+    "phone": "",
+    "jobTitle": ""
+  },
+  {
+    "userId": "sother17",
+    "userLogin": "sother17",
+    "firstName": "Some",
+    "lastName": "Other",
+    "status": "Enabled",
+    "uid": "1151000019",
+    "emailAddress": "sother17@ipaexample.test",
+    "phone": "",
+    "jobTitle": ""
+  },
+  {
+    "userId": "sother18",
+    "userLogin": "sother18",
+    "firstName": "Some",
+    "lastName": "Other",
+    "status": "Enabled",
+    "uid": "1151000020",
+    "emailAddress": "sother18@ipaexample.test",
+    "phone": "",
+    "jobTitle": ""
+  },
+  {
+    "userId": "sother19",
+    "userLogin": "sother19",
+    "firstName": "Some",
+    "lastName": "Other",
+    "status": "Enabled",
+    "uid": "1151000021",
+    "emailAddress": "sother19@ipaexample.test",
+    "phone": "",
+    "jobTitle": ""
+  }
+]

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -5,6 +5,7 @@ import userGroupsReducer from "./Identity/userGroups-slice";
 import rolesReducer from "./IPA server/roles-slice";
 import hbacRulesReducer from "./Policy/hbacRules-slice";
 import sudoRulesReducer from "./Policy/sudoRules-slice";
+import stageUsersReducer from "./Identity/stageUsers-slice";
 
 const store = configureStore({
   reducer: {
@@ -14,6 +15,7 @@ const store = configureStore({
     roles: rolesReducer,
     hbacrules: hbacRulesReducer,
     sudorules: sudoRulesReducer,
+    stageUsers: stageUsersReducer,
   },
 });
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8112750/205001863-95dbec89-7038-4ecc-a444-5af2b28e8b8b.png)

### Context
The 'Stage users' page has been defined as part of the users' pages, under the 'Identity' section.

### Data and Redux slice
The first step has been defining the list of stage users that will be shown in the table. This should be an independent JSON file to simulate different data being retrieved from an external source (i.e: API call).

Then, the Redux slice for the 'Stage users' page is defined to manage the list items (i.e: add, delete, enable, and disable). This change should be also reflected in the `store.ts` file.

### Shared components with 'Stage users' data
The 'Stage users' page will have the same functionality (given by the action buttons) as the 'Active users' one.
The following components have been adapted to work with the 'Stage users' data:
- `AddUser`
- `DeleteUsers`
- `DisableEnableUsers`
- `DeletedUsersTable`

To ensure the components are reusable for all user types, the specific data related to each one has been filtered to be used depending on the `from` property.

Example for adding user (`AddUser`):

```ts
if (props.from === "active-users") {
    dispatch(addActiveUser(newUser));
} else if (props.from === "stage-users") {  // <--------
    dispatch(addStageUser(newUser));
}
```

### Main 'Stage users' page and 'Settings' section
The `StageUsers` component has been added to hold the main functionality of the 'Stage users' page.

Related to this, the 'Settings' section has been added to this page as required. This is done via the `StageUsersTabs` component.

### Fixing bug: Bulk selector
(Related to the 'Active users' page)
When the state of a set of users is changed, the bulk selector keeps showing the previously selected users (in number format) after performing the operation and the table values are reset. This happens in 'Enable' and 'Disable' indistinctively.

This is caused by the selected users' list (`selectedUsers`) not being reset to empty.

This is solved by passing the `selectedUsersData` structure to the `DisableEnableUsers` as a prop. The `selectedUsersData` structure contains the selected users' list and its setter method:

```ts
const selectedUsersData = {
    selectedUsers,          // <-- List of selected users
    updateSelectedUsers,    // <-- Setter
};
```

Now, inside the `DisableEnableUsers` component this is processed to update the `selectedUsers` list back to empty (`[]`) when the operation is completed.

Signed-off-by: Carla Martinez <carlmart@redhat.com>