### PR TITLE
Hosts settings section

### DIFF
--- a/src/components/HostsSections/AllowedCreateKeytab.tsx
+++ b/src/components/HostsSections/AllowedCreateKeytab.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+// PatternFly
+import { Flex, FlexItem } from "@patternfly/react-core";
+// Tables
+import CreateKeytabUsersTable from "../tables/HostsSettings/CreateKeytabUsersTable";
+import CreateKeytabUserGroupsTable from "../tables/HostsSettings/CreateKeytabUserGroupsTable";
+import CreateKeytabHostsTable from "../tables/HostsSettings/CreateKeytabHostsTable";
+import CreateKeytabHostGroupsTable from "../tables/HostsSettings/CreateKeytabHostGroupsTable";
+// Data types
+import { Host } from "src/utils/datatypes/globalDataTypes";
+
+interface PropsToAllowCreateKeytab {
+  host: Host;
+}
+
+const AllowedCreateKeytab = (props: PropsToAllowCreateKeytab) => {
+  return (
+    <Flex direction={{ default: "column", lg: "row" }}>
+      <FlexItem flex={{ default: "flex_1" }}>
+        <CreateKeytabUsersTable host={props.host.hostName} />
+        <CreateKeytabHostsTable host={props.host.hostName} />
+      </FlexItem>
+      <FlexItem flex={{ default: "flex_1" }}>
+        <CreateKeytabUserGroupsTable host={props.host.hostName} />
+        <CreateKeytabHostGroupsTable host={props.host.hostName} />
+      </FlexItem>
+    </Flex>
+  );
+};
+
+export default AllowedCreateKeytab;

--- a/src/components/HostsSections/AllowedRetrieveKeytab.tsx
+++ b/src/components/HostsSections/AllowedRetrieveKeytab.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+// PatternFly
+import { Flex, FlexItem } from "@patternfly/react-core";
+// Tables
+import RetrieveKeytabUsersTable from "../tables/HostsSettings/RetrieveKeytabUsersTable";
+import RetrieveKeytabUserGroupsTable from "../tables/HostsSettings/RetrieveKeytabUserGroupsTable";
+import RetrieveKeytabHostsTable from "../tables/HostsSettings/RetrieveKeytabHostsTable";
+import RetrieveKeytabHostGroupsTable from "../tables/HostsSettings/RetrieveKeytabHostGroupTable";
+// Data types
+import { Host } from "src/utils/datatypes/globalDataTypes";
+
+interface PropsToAllowRetrieveKeytab {
+  host: Host;
+}
+
+const AllowedRetrieveKeytab = (props: PropsToAllowRetrieveKeytab) => {
+  return (
+    <Flex direction={{ default: "column", lg: "row" }}>
+      <FlexItem flex={{ default: "flex_1" }}>
+        <RetrieveKeytabUsersTable host={props.host.hostName} />
+        <RetrieveKeytabHostsTable host={props.host.hostName} />
+      </FlexItem>
+      <FlexItem flex={{ default: "flex_1" }}>
+        <RetrieveKeytabUserGroupsTable host={props.host.hostName} />
+        <RetrieveKeytabHostGroupsTable host={props.host.hostName} />
+      </FlexItem>
+    </Flex>
+  );
+};
+
+export default AllowedRetrieveKeytab;

--- a/src/components/HostsSections/Enrollment.tsx
+++ b/src/components/HostsSections/Enrollment.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+// PatternFly
+import { Flex, FlexItem, Form, FormGroup, Icon } from "@patternfly/react-core";
+// Layouts
+import TextLayout from "../layouts/TextLayout";
+// Icons
+import CheckIcon from "@patternfly/react-icons/dist/esm/icons/check-icon";
+import ExclamationTriangleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon";
+
+const Enrollment = () => {
+  // TODO: This needs to be adapted to real data. The text and icons might change due to that.
+  // Icons
+  const kerberusKeyIcon = (
+    <Icon>
+      <CheckIcon />
+    </Icon>
+  );
+
+  const oneTimePwd = (
+    <Icon>
+      <ExclamationTriangleIcon />
+    </Icon>
+  );
+
+  return (
+    <Flex direction={{ default: "column", lg: "row" }}>
+      <FlexItem flex={{ default: "flex_1" }}>
+        <Form>
+          <FormGroup label="Kerberos key" fieldId="kerberos-key">
+            <Flex>
+              <FlexItem>{kerberusKeyIcon}</FlexItem>
+              <FlexItem>
+                <TextLayout>Kerberos key present, Host provisioned</TextLayout>
+              </FlexItem>
+            </Flex>
+          </FormGroup>
+        </Form>
+      </FlexItem>
+      <FlexItem flex={{ default: "flex_1" }}>
+        <Form>
+          <FormGroup label="One-time password" fieldId="one-time-password">
+            <Flex>
+              <FlexItem>{oneTimePwd}</FlexItem>
+              <FlexItem>
+                <TextLayout>One-Time Password Not Present</TextLayout>
+              </FlexItem>
+            </Flex>
+          </FormGroup>
+        </Form>
+      </FlexItem>
+    </Flex>
+  );
+};
+
+export default Enrollment;

--- a/src/components/HostsSections/HostCertificate.tsx
+++ b/src/components/HostsSections/HostCertificate.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from "react";
+// PatternFly
+import { Flex, FlexItem, Form, FormGroup } from "@patternfly/react-core";
+// Layouts
+import SecondaryButton from "../layouts/SecondaryButton";
+
+interface Certificate {
+  id: string | number;
+  certificate: string;
+}
+
+const HostCertificate = () => {
+  // Certificates
+  const [certificatesList] = useState<Certificate[]>([]);
+
+  return (
+    <Flex direction={{ default: "column", lg: "row" }}>
+      <FlexItem flex={{ default: "flex_1" }}>
+        <Form className="pf-u-mb-lg">
+          <FormGroup label="Certificates" fieldId="certificates">
+            {certificatesList.length > 0 ? (
+              certificatesList.map((cert) => {
+                return (
+                  <>
+                    {cert.certificate}
+                    <SecondaryButton>Show</SecondaryButton>
+                    <SecondaryButton>Delete</SecondaryButton>
+                  </>
+                );
+              })
+            ) : (
+              <SecondaryButton>Add</SecondaryButton>
+            )}
+          </FormGroup>
+        </Form>
+      </FlexItem>
+    </Flex>
+  );
+};
+
+export default HostCertificate;

--- a/src/components/HostsSections/HostSettings.tsx
+++ b/src/components/HostsSections/HostSettings.tsx
@@ -1,0 +1,521 @@
+import React, { useState } from "react";
+// PatternFly
+import {
+  Button,
+  Checkbox,
+  Flex,
+  FlexItem,
+  Form,
+  FormGroup,
+  TextArea,
+  TextInput,
+} from "@patternfly/react-core";
+// Data types
+import { Host } from "src/utils/datatypes/globalDataTypes";
+// Layouts
+import SecondaryButton from "../layouts/SecondaryButton";
+import PopoverWithIconLayout from "../layouts/PopoverWithIconLayout";
+// Modals
+import PrincipalAliasAddModal from "../modals/PrincipalAliasAddModal";
+import PrincipalAliasDeleteModal from "../modals/PrincipalAliasDeleteModal";
+
+interface PrincipalAlias {
+  id: number | string;
+  alias: string;
+}
+
+interface SshPublicKey {
+  key: string;
+}
+
+interface MacAddress {
+  id: number | string;
+  address: string;
+}
+
+interface PropsToHostSettings {
+  host: Host;
+}
+
+const HostSettings = (props: PropsToHostSettings) => {
+  const REALM = "@SERVER.IPA.DEMO";
+  // Host name - textbox (mandatory field)
+  const [hostName] = useState(props.host.hostName);
+
+  // Principal alias - textbox
+  const [principalAliasList, setPrincipalAliasList] = useState<
+    PrincipalAlias[]
+  >([
+    {
+      id: 0,
+      alias: "host/" + props.host.hostName + REALM, // TODO: The realm (@SERVER.IPA.DEMO) should adapt to context
+    },
+  ]);
+
+  // Description - textbox
+  const [hostDescription, setHostDescription] = useState(
+    props.host.description
+  );
+  const onChangeDescriptionHandler = (newDescription: string) => {
+    setHostDescription(newDescription);
+  };
+
+  // Class - textbox
+  const [hostClass, setHostClass] = useState(props.host.class);
+  const updateHostClass = (newHostClass: string) => {
+    setHostClass(newHostClass);
+  };
+
+  // Locality - textbox
+  const [locality, setLocality] = useState("");
+  const updateLocality = (newLocality: string) => {
+    setLocality(newLocality);
+  };
+  const [location, setLocation] = useState("");
+  const updateLocation = (newLocation: string) => {
+    setLocation(newLocation);
+  };
+  const [platform, setPlatform] = useState("");
+  const updatePlatform = (newPlatform: string) => {
+    setPlatform(newPlatform);
+  };
+  const [operatingSystem, setOperatingSystem] = useState("");
+  const updateOperatingSystem = (newOperatingSystem: string) => {
+    setOperatingSystem(newOperatingSystem);
+  };
+
+  // SSH public keys
+  const [sshPublicKeys] = useState<SshPublicKey[]>([]);
+
+  // MAC address
+  const [macAddressList, setMacAddressList] = useState<MacAddress[]>([]);
+
+  // - 'Add MAC address' handler
+  const onAddMacAddressFieldHandler = () => {
+    const macAddressListCopy = [...macAddressList];
+    macAddressListCopy.push({
+      id: Date.now.toString(),
+      address: "",
+    });
+    setMacAddressList(macAddressListCopy);
+  };
+
+  // - 'Change MAC address' handler
+  const onHandleMacAddressChange = (
+    value: string,
+    event: React.FormEvent<HTMLInputElement>,
+    idx: number
+  ) => {
+    const macAddressListCopy = [...macAddressList];
+    macAddressListCopy[idx]["element"] = (
+      event.target as HTMLInputElement
+    ).value;
+    setMacAddressList(macAddressListCopy);
+  };
+
+  // - 'Remove MAC address' handler
+  const onRemoveMacAddressHandler = (idx: number) => {
+    const macAddressListCopy = [...macAddressList];
+    macAddressListCopy.splice(idx, 1);
+    setMacAddressList(macAddressListCopy);
+  };
+
+  // Authentication indicators - checkboxes
+  const [radiusCheckbox] = useState(false);
+  const [tpaCheckbox] = useState(false);
+  const [pkinitCheckbox] = useState(false);
+  const [hardenedPassCheckbox] = useState(false);
+
+  const AuthIndicatorsTypesMessage = () => (
+    <div>
+      <p>
+        Defines an allow list for Authentication indicators. Use <b>otp</b> to
+        allow OTP-based 2FA authentications. Use <b>radius</b> to allow
+        RADIUS-based 2FA authentications. Use <b>pkinit</b> to allow
+        PKINIT-based 2FA authentications. Use <b>hardened</b> to allow
+        brute-force hardened password authentication by SPAKE or FAST. With{" "}
+        <b>no indicator</b> specified, all authentication mechanisms are
+        allowed.
+      </p>
+    </div>
+  );
+
+  // Trusted for delegation - checkbox
+  const [trustedForDelegationCheckbox] = useState(false);
+
+  // Trusted to authenticate as a user - checkbox
+  const [trustedAuthAsUserCheckbox] = useState(false);
+
+  // Assigned ID view - data type unknown, treated as string from now
+  const [assignedIDView] = useState("");
+
+  // Principal alias - Add Modal
+  const [isPrincipalAliasAddModalOpen, setIsPrincipalAliasAddModalOpen] =
+    useState(false);
+
+  // - Modal fields data
+  // -- New kerberos principal alias - textbox
+  const [newKrbAlias, setNewKrbAlias] = useState("");
+
+  const onChangeNewKrbAlias = (newAlias: string) => {
+    setNewKrbAlias(newAlias);
+  };
+
+  // - Close modal
+  const onClosePrincipalAliasAddModal = () => {
+    // Reset values
+    setNewKrbAlias("");
+    setIsPrincipalAliasAddModalOpen(false);
+  };
+
+  // - Open modal
+  const onOpenPrincipalAliasAddModal = () => {
+    setIsPrincipalAliasAddModalOpen(true);
+  };
+
+  // - Add new kerberos principal alias
+  const addNewKrbPrincipalAlias = (newKrbAlias: string) => {
+    // Process new krb alias
+    // (whether a single name or a complete name with realm is provided, this needs to be checked)
+    if (!newKrbAlias.includes(REALM)) {
+      newKrbAlias = newKrbAlias + REALM;
+    }
+    const principalAliasListCopy = [...principalAliasList];
+    principalAliasListCopy.push({
+      id: Date.now.toString(),
+      alias: newKrbAlias,
+    });
+    setPrincipalAliasList(principalAliasListCopy);
+    // Reset values and close modal
+    onClosePrincipalAliasAddModal();
+  };
+
+  // - Modal actions
+  const principalAliasAddModalActions = [
+    <SecondaryButton
+      key="add"
+      onClickHandler={() => addNewKrbPrincipalAlias(newKrbAlias)}
+    >
+      Add
+    </SecondaryButton>,
+    <Button key="cancel" variant="link" onClick={onClosePrincipalAliasAddModal}>
+      Cancel
+    </Button>,
+  ];
+
+  // - Data to modal
+  const dataToModal = {
+    newKrbAlias,
+    onChangeNewKrbAlias,
+    onClosePrincipalAliasAddModal,
+    onOpenPrincipalAliasAddModal,
+    addNewKrbPrincipalAlias,
+  };
+
+  // Principal alias - Delete Modal
+  const [isPrincipalAliasDeleteModalOpen, setIsPrincipalAliasDeleteModalOpen] =
+    useState(false);
+
+  // - Alias to delete
+  const [aliasToDelete, setAliasToDelete] = useState("");
+
+  // - Close modal
+  const onClosePrincipalAliasDeleteModal = () => {
+    setIsPrincipalAliasDeleteModalOpen(false);
+  };
+
+  // - Open modal
+  const onOpenPrincipalAliasDeleteModal = () => {
+    setIsPrincipalAliasDeleteModalOpen(true);
+  };
+
+  const openModalAndSetAlias = (krbAliasToDelete: string) => {
+    setAliasToDelete(krbAliasToDelete);
+    onOpenPrincipalAliasDeleteModal();
+  };
+
+  // - Delete new kerberos principal alias
+  const deleteNewKrbPrincipalAlias = () => {
+    const principalAliasUpdatedList: PrincipalAlias[] = [];
+    principalAliasList.map((krbAlias) => {
+      if (krbAlias.alias !== aliasToDelete) {
+        principalAliasUpdatedList.push(krbAlias);
+      }
+    });
+    setPrincipalAliasList(principalAliasUpdatedList);
+    // Reset delete variable
+    setAliasToDelete("");
+    // Close modal
+    onClosePrincipalAliasDeleteModal();
+  };
+
+  // - Modal actions
+  const principalAliasDeleteModalActions = [
+    <SecondaryButton key="delete" onClickHandler={deleteNewKrbPrincipalAlias}>
+      Delete
+    </SecondaryButton>,
+    <Button
+      key="cancel"
+      variant="link"
+      onClick={onClosePrincipalAliasDeleteModal}
+    >
+      Cancel
+    </Button>,
+  ];
+
+  return (
+    <>
+      <Flex direction={{ default: "column", lg: "row" }}>
+        <FlexItem flex={{ default: "flex_1" }}>
+          <Form className="pf-u-mb-lg">
+            <FormGroup label="Host name" fieldId="host-name">
+              <TextInput
+                id="host-name"
+                name="hostname"
+                value={hostName}
+                type="text"
+                aria-label="host name"
+                isDisabled
+              />
+            </FormGroup>
+            <FormGroup label="Principal alias" fieldId="principal-alias">
+              {principalAliasList.map((alias, idx) => (
+                <Flex key={idx} className={idx !== 0 ? "pf-u-mt-sm" : ""}>
+                  <FlexItem>{alias.alias}</FlexItem>
+                  <FlexItem>
+                    <SecondaryButton
+                      onClickHandler={() => openModalAndSetAlias(alias.alias)}
+                    >
+                      Delete
+                    </SecondaryButton>
+                  </FlexItem>
+                </Flex>
+              ))}
+            </FormGroup>
+            <FormGroup>
+              <SecondaryButton onClickHandler={onOpenPrincipalAliasAddModal}>
+                Add
+              </SecondaryButton>
+            </FormGroup>
+            <FormGroup label="Description" fieldId="host-description">
+              <TextArea
+                value={hostDescription}
+                name="description"
+                onChange={onChangeDescriptionHandler}
+                aria-label="host description"
+                resizeOrientation="vertical"
+              />
+            </FormGroup>
+            <FormGroup label="Class" fieldId="host-class">
+              <TextInput
+                id="host-class"
+                name="userclass"
+                onChange={updateHostClass}
+                value={hostClass}
+                type="text"
+                aria-label="host class"
+              />
+            </FormGroup>
+            <FormGroup label="Locality" fieldId="locality">
+              <TextInput
+                id="locality"
+                name="l"
+                onChange={updateLocality}
+                value={locality}
+                type="text"
+                aria-label="locality"
+              />
+            </FormGroup>
+            <FormGroup label="Location" fieldId="location">
+              <TextInput
+                id="location"
+                name="nshostlocation"
+                onChange={updateLocation}
+                value={location}
+                type="text"
+                aria-label="location"
+              />
+            </FormGroup>
+            <FormGroup label="Platform" fieldId="platform">
+              <TextInput
+                id="platform"
+                name="nshardwareplatform"
+                onChange={updatePlatform}
+                value={platform}
+                type="text"
+                aria-label="platform"
+              />
+            </FormGroup>
+            <FormGroup label="Operating system" fieldId="operating-system">
+              <TextInput
+                id="operating-system"
+                name="nsosversion"
+                onChange={updateOperatingSystem}
+                value={operatingSystem}
+                type="text"
+                aria-label="operating-system"
+              />
+            </FormGroup>
+          </Form>
+        </FlexItem>
+        <FlexItem flex={{ default: "flex_1" }}>
+          <Form>
+            <FormGroup label="SSH public keys" fieldId="ssh-public-keys">
+              {sshPublicKeys.length === 0 ? (
+                <SecondaryButton>Add</SecondaryButton>
+              ) : (
+                <>
+                  {sshPublicKeys.map((publicKey) => {
+                    return (
+                      <>
+                        {publicKey.key}
+                        <SecondaryButton>Show/Set key</SecondaryButton>
+                        <SecondaryButton>Delete</SecondaryButton>
+                      </>
+                    );
+                  })}
+                  <SecondaryButton>Add</SecondaryButton>
+                </>
+              )}
+            </FormGroup>
+            <FormGroup label="MAC address" fieldId="mac-address">
+              <Flex direction={{ default: "column" }} name="macaddress">
+                {macAddressList.map((macAddress, idx) => (
+                  <Flex
+                    direction={{ default: "row" }}
+                    key={macAddress.id + "-" + idx + "-div"}
+                    name={"macaddress-" + idx}
+                  >
+                    <FlexItem
+                      key={macAddress.id + "-textbox"}
+                      flex={{ default: "flex_1" }}
+                    >
+                      <TextInput
+                        id="mac-address-text"
+                        value={macAddress.address}
+                        type="text"
+                        name={"macaddress-" + idx}
+                        aria-label="mac address"
+                        onChange={(value, event) =>
+                          onHandleMacAddressChange(value, event, idx)
+                        }
+                      />
+                    </FlexItem>
+                    <FlexItem key={macAddress.id + "-delete-button"}>
+                      <SecondaryButton
+                        name="remove"
+                        onClickHandler={() => onRemoveMacAddressHandler(idx)}
+                      >
+                        Delete
+                      </SecondaryButton>
+                    </FlexItem>
+                  </Flex>
+                ))}
+              </Flex>
+              <SecondaryButton
+                classname={macAddressList.length !== 0 ? "pf-u-mt-md" : ""}
+                name="add"
+                onClickHandler={onAddMacAddressFieldHandler}
+              >
+                Add
+              </SecondaryButton>
+            </FormGroup>
+            <FormGroup
+              label="Authentication indicators"
+              fieldId="authentication-indicators"
+              labelIcon={
+                <PopoverWithIconLayout message={AuthIndicatorsTypesMessage} />
+              }
+            >
+              <Checkbox
+                label="Two-factor authentication (password + OTP)"
+                isChecked={tpaCheckbox}
+                aria-label="two factor authentication from authentication indicators checkbox"
+                id="tpaCheckbox"
+                name="ipauserauthtype"
+                value="otp"
+                className="pf-u-mt-xs pf-u-mb-sm"
+              />
+              <Checkbox
+                label="RADIUS"
+                isChecked={radiusCheckbox}
+                aria-label="radius from authentication indicators checkbox"
+                id="radiusCheckbox"
+                name="ipauserauthtype"
+                value="radius"
+                className="pf-u-mt-xs pf-u-mb-sm"
+              />
+              <Checkbox
+                label="PKINIT"
+                isChecked={pkinitCheckbox}
+                aria-label="pkinit from authentication indicators checkbox"
+                id="pkinitCheckbox"
+                name="ipauserauthtype"
+                value="pkinit"
+                className="pf-u-mt-xs pf-u-mb-sm"
+              />
+              <Checkbox
+                label="Hardened password (by SPAKE or FAST)"
+                isChecked={hardenedPassCheckbox}
+                aria-label="hardened password from authentication indicators checkbox"
+                id="hardenedPassCheckbox"
+                name="ipauserauthtype"
+                value="hardened"
+              />
+            </FormGroup>
+            <FormGroup
+              label="Trusted for delegation"
+              fieldId="trusted-delegation"
+            >
+              <Checkbox
+                label="Trusted for delegation"
+                isChecked={trustedForDelegationCheckbox}
+                aria-label="trusted for delegation checkbox"
+                id="trustedForDelegationCheckbox"
+                name="ipakrbokasdelegate"
+                value="trustedForDelegation"
+              />
+            </FormGroup>
+            <FormGroup
+              label="Trusted to authenticate as a user"
+              fieldId="trusted-auth-as-user"
+            >
+              <Checkbox
+                label="Trusted to authenticate as a user"
+                isChecked={trustedAuthAsUserCheckbox}
+                aria-label="trusted to authenticate as a user checkbox"
+                id="trustedAuthAsUserCheckbox"
+                name="ipakrboktoauthasdelegate"
+                value="trustedAuthAsUser"
+              />
+            </FormGroup>
+            <FormGroup label="Assigned ID view" fieldId="assigned-id-view">
+              <TextInput
+                id="assigned-id-view"
+                name="ipaassignedidview"
+                value={assignedIDView}
+                type="text"
+                aria-label="assigned id view"
+                isDisabled
+              />
+            </FormGroup>
+          </Form>
+        </FlexItem>
+      </Flex>
+      <PrincipalAliasAddModal
+        isOpen={isPrincipalAliasAddModalOpen}
+        onClose={onClosePrincipalAliasAddModal}
+        actions={principalAliasAddModalActions}
+        data={dataToModal}
+      />
+      <PrincipalAliasDeleteModal
+        isOpen={isPrincipalAliasDeleteModalOpen}
+        onClose={onClosePrincipalAliasDeleteModal}
+        actions={principalAliasDeleteModalActions}
+        hostToRemove={aliasToDelete}
+      />
+    </>
+  );
+};
+
+export default HostSettings;

--- a/src/components/layouts/BreadcrumbLayout.tsx
+++ b/src/components/layouts/BreadcrumbLayout.tsx
@@ -8,8 +8,9 @@ export interface PagesVisited {
 }
 
 export interface PropsToBreadcrumb {
-  userId: string;
+  userId: string; // TODO: Replace 'userId' to a more reusable name
   className?: string;
+  preText?: string;
   pagesVisited: PagesVisited[];
 }
 
@@ -21,7 +22,10 @@ const BreadcrumbLayout = (props: PropsToBreadcrumb) => {
           {page.name}
         </BreadcrumbItem>
       ))}
-      <BreadcrumbItem isActive>User login: {props.userId}</BreadcrumbItem>
+      <BreadcrumbItem isActive>
+        {props.preText !== undefined ? props.preText : "User login:"}{" "}
+        {props.userId}
+      </BreadcrumbItem>
     </Breadcrumb>
   );
 };

--- a/src/components/layouts/TableWithButtonsLayout.tsx
+++ b/src/components/layouts/TableWithButtonsLayout.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+// PatternFly
+import { Flex, FlexItem } from "@patternfly/react-core";
+import { TableVariant } from "@patternfly/react-table";
+// Layout
+import SecondaryButton from "./SecondaryButton";
+import TableLayout from "./TableLayout";
+
+export interface PropsToTableWithButtons {
+  // Table
+  ariaLabel: string;
+  name?: string;
+  variant: TableVariant | "compact";
+  hasBorders: boolean;
+  tableClasses?: string;
+  tableId: string;
+  isStickyHeader: boolean;
+  tableHeader?: JSX.Element;
+  tableBody: JSX.Element[] | JSX.Element;
+  // Buttons
+  deleteButtonClasses?: string;
+  onDeleteModal: () => void;
+  isDeleteDisabled?: boolean;
+  addButtonClasses?: string;
+  onAddModal: () => void;
+}
+
+const TableWithButtonsLayout = (props: PropsToTableWithButtons) => {
+  return (
+    <>
+      <Flex>
+        <FlexItem>
+          <SecondaryButton
+            classname={props.deleteButtonClasses}
+            isDisabled={props.isDeleteDisabled}
+            onClickHandler={props.onDeleteModal}
+          >
+            Delete
+          </SecondaryButton>
+          <SecondaryButton
+            classname={props.addButtonClasses}
+            onClickHandler={props.onAddModal}
+          >
+            Add
+          </SecondaryButton>
+        </FlexItem>
+      </Flex>
+      <TableLayout
+        ariaLabel={props.ariaLabel}
+        name={props.name}
+        variant={props.variant}
+        hasBorders={props.hasBorders}
+        classes={props.tableClasses}
+        tableId={props.tableId}
+        isStickyHeader={props.isStickyHeader}
+        tableHeader={props.tableHeader}
+        tableBody={props.tableBody}
+      />
+    </>
+  );
+};
+
+export default TableWithButtonsLayout;

--- a/src/components/layouts/TextLayout.tsx
+++ b/src/components/layouts/TextLayout.tsx
@@ -1,0 +1,49 @@
+// For further information, visit the PatternFly page: https://www.patternfly.org/v4/components/text
+import { TextContent, Text } from "@patternfly/react-core";
+import React from "react";
+
+interface PropsToTextLayout {
+  // 'TextContent' props
+  textContentClassName?: string;
+  textContentIsVisited?: boolean;
+  textContentChildren?: React.ReactNode;
+  // Text
+  className?: string;
+  component?:
+    | "h1"
+    | "h2"
+    | "h3"
+    | "h4"
+    | "h5"
+    | "h6"
+    | "p"
+    | "a"
+    | "small"
+    | "blockquote"
+    | "pre";
+  isvisitedLink?: boolean;
+  ouiaId?: string | number;
+  ouiaSafe?: boolean;
+  children: React.ReactNode;
+}
+
+const TextLayout = (props: PropsToTextLayout) => {
+  return (
+    <TextContent
+      className={props.textContentClassName}
+      isVisited={props.textContentIsVisited}
+    >
+      {props.textContentChildren}
+      <Text
+        component={props.component}
+        isVisitedLink={props.isvisitedLink}
+        ouiaId={props.ouiaId}
+        ouiaSafe={props.ouiaSafe}
+      >
+        {props.children}
+      </Text>
+    </TextContent>
+  );
+};
+
+export default TextLayout;

--- a/src/components/modals/DeleteHosts.tsx
+++ b/src/components/modals/DeleteHosts.tsx
@@ -60,6 +60,7 @@ const DeleteHosts = (props: PropsToDeleteHosts) => {
       id: "deleted-users-table",
       pfComponent: (
         <DeletedElementsTable
+          mode="passing_full_data"
           elementsToDelete={props.selectedHostsData.selectedHosts}
           elementsList={hostsListCopy}
           columnNames={deleteHostsColumnNames}

--- a/src/components/modals/HostsSettings/CreateKeytabElementsAddModal.tsx
+++ b/src/components/modals/HostsSettings/CreateKeytabElementsAddModal.tsx
@@ -1,0 +1,138 @@
+import React, { ReactNode, useEffect, useState } from "react";
+// PatternFly
+import { Button, DualListSelector } from "@patternfly/react-core";
+// Layout
+import SecondaryButton from "src/components/layouts/SecondaryButton";
+import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
+
+interface PropsToAddModal {
+  host: string;
+  elementType: string;
+  operationType: string;
+  showModal: boolean;
+  onCloseModal: () => void;
+  onOpenModal: () => void;
+  availableData: string[];
+  updateAvailableData: (newAvailableData: unknown[]) => void;
+  updateSelectedElements: (newSelectedElements: string[]) => void;
+  tableElementsList: string[];
+  updateTableElementsList: (newTableElementsList: string[]) => void;
+}
+
+const CreateKeytabElementsAddModal = (props: PropsToAddModal) => {
+  // Dual list data
+  const data = props.availableData;
+
+  // Dual list selector
+  const [availableOptions, setAvailableOptions] = useState<ReactNode[]>(
+    data.sort()
+  );
+  const [chosenOptions, setChosenOptions] = useState<ReactNode[]>([]);
+
+  const listChange = (
+    newAvailableOptions: ReactNode[],
+    newChosenOptions: ReactNode[]
+  ) => {
+    setAvailableOptions(newAvailableOptions.sort());
+    setChosenOptions(newChosenOptions.sort());
+    // The recently added entries are removed from the available data options
+    props.updateAvailableData(newAvailableOptions.sort());
+  };
+
+  const fields = [
+    {
+      id: "dual-list-selector",
+      pfComponent: (
+        <DualListSelector
+          isSearchable
+          availableOptions={availableOptions}
+          chosenOptions={chosenOptions}
+          onListChange={listChange}
+          id="basicSelectorWithSearch"
+        />
+      ),
+    },
+  ];
+
+  // When clean data, set to original values
+  const cleanData = () => {
+    setAvailableOptions(data);
+    setChosenOptions([]);
+    props.updateSelectedElements([]);
+  };
+
+  // Clean fields and close modal (To prevent data persistence when reopen modal)
+  const cleanAndCloseModal = () => {
+    cleanData();
+    props.onCloseModal();
+  };
+
+  // Buttons are disabled until all the required fields are filled
+  const [buttonDisabled, setButtonDisabled] = useState(true);
+  useEffect(() => {
+    if (chosenOptions.length > 0) {
+      setButtonDisabled(false);
+    } else {
+      setButtonDisabled(true);
+    }
+  }, [chosenOptions]);
+
+  // Add element to the list
+  const addElementToList = () => {
+    const itemsToAdd: string[] = [];
+    const newTableElementsList = props.tableElementsList;
+    chosenOptions.map((opt) => {
+      if (opt !== undefined && opt !== null) {
+        itemsToAdd.push(opt.toString());
+        newTableElementsList.push(opt.toString());
+      }
+    });
+    props.updateTableElementsList(newTableElementsList);
+    props.updateSelectedElements([]);
+    cleanAndCloseModal();
+  };
+
+  // Buttons that will be shown at the end of the form
+  const modalActions = [
+    <SecondaryButton
+      key={"add-new-" + props.elementType}
+      isDisabled={buttonDisabled}
+      form="modal-form"
+      onClickHandler={addElementToList}
+    >
+      Add
+    </SecondaryButton>,
+    <Button
+      key={"cancel-new-" + props.elementType}
+      variant="link"
+      onClick={cleanAndCloseModal}
+    >
+      Cancel
+    </Button>,
+  ];
+
+  // Render component
+  return (
+    <ModalWithFormLayout
+      variantType="medium"
+      modalPosition="top"
+      title={
+        "Allow " +
+        props.elementType +
+        "s to " +
+        props.operationType +
+        " keytab of " +
+        props.host
+      }
+      formId={
+        props.operationType + "-keytab-" + props.elementType + "s-add-modal"
+      }
+      fields={fields}
+      show={props.showModal}
+      onClose={cleanAndCloseModal}
+      actions={modalActions}
+    />
+  );
+};
+
+export default CreateKeytabElementsAddModal;

--- a/src/components/modals/HostsSettings/CreateKeytabElementsDeleteModal.tsx
+++ b/src/components/modals/HostsSettings/CreateKeytabElementsDeleteModal.tsx
@@ -1,0 +1,128 @@
+import React from "react";
+// PatternFly
+import {
+  Button,
+  TextContent,
+  Text,
+  TextVariants,
+} from "@patternfly/react-core";
+// Layouts
+import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
+import SecondaryButton from "src/components/layouts/SecondaryButton";
+// Tables
+import DeletedElementsTable from "src/components/tables/DeletedElementsTable";
+
+interface PropsToDelete {
+  host: string;
+  elementType: string;
+  operationType: string;
+  columnNames: string[];
+  showModal: boolean;
+  closeModal: () => void;
+  elementsToDelete: string[];
+  updateIsDeleteButtonDisabled: (newValue: boolean) => void;
+  updateSelectedElements: (newSelectedElements: string[]) => void;
+  tableElementsList: string[];
+  updateTableElementsList: (newElementsList: string[]) => void;
+  availableData: string[];
+  updateAvailableData: (newFilteredElements: unknown[]) => void;
+}
+
+const CreateKeytabElementsDeleteModal = (props: PropsToDelete) => {
+  // Modal fields
+  const fields = [
+    {
+      id: "question-text",
+      pfComponent: (
+        <TextContent>
+          <Text component={TextVariants.p}>
+            Are you sure you want to delete the selected entries?
+          </Text>
+        </TextContent>
+      ),
+    },
+    {
+      id: "deleted-" + props.elementType + "s-table",
+      pfComponent: (
+        <DeletedElementsTable
+          mode="passing_id"
+          elementsList={props.elementsToDelete.sort()}
+          elementsToDelete={props.elementsToDelete.sort()}
+          columnNames={props.columnNames}
+          elementType={props.elementType}
+        />
+      ),
+    },
+  ];
+
+  // Remove element from the list
+  const removeElementFromList = () => {
+    // Define function that will be reused to delete the selected entries
+    let generalUpdatedElementsList = props.tableElementsList;
+    const dataBackToBeAvailable = props.availableData;
+    props.elementsToDelete.map((element) => {
+      dataBackToBeAvailable.push(element);
+      const updatedElementsList = generalUpdatedElementsList.filter(
+        (elm) => elm !== element
+      );
+      // If not empty, replace element list by new array
+      if (updatedElementsList) {
+        generalUpdatedElementsList = updatedElementsList;
+      }
+    });
+    props.updateTableElementsList(generalUpdatedElementsList);
+    props.updateIsDeleteButtonDisabled(true);
+    // Add removed items back to the option list (to be added again)
+    props.updateAvailableData(dataBackToBeAvailable.sort());
+    // Clean selected elements & close modal
+    props.updateSelectedElements([]);
+    closeModal();
+  };
+
+  const closeModal = () => {
+    props.closeModal();
+  };
+
+  // Buttons that will be shown at the end of the form
+  const modalActions = [
+    <SecondaryButton
+      key={"delete-" + props.elementType}
+      form="modal-form"
+      onClickHandler={removeElementFromList}
+    >
+      Delete
+    </SecondaryButton>,
+    <Button
+      key={"cancel-delete-" + props.elementType}
+      variant="link"
+      onClick={closeModal}
+    >
+      Cancel
+    </Button>,
+  ];
+
+  // Render component
+  return (
+    <ModalWithFormLayout
+      variantType="medium"
+      modalPosition="top"
+      title={
+        "Disallow " +
+        props.elementType +
+        "s to " +
+        props.operationType +
+        " keytab of " +
+        props.host
+      }
+      formId={
+        props.operationType + "-keytab-" + props.elementType + "s-delete-modal"
+      }
+      fields={fields}
+      show={props.showModal}
+      onClose={closeModal}
+      actions={modalActions}
+    />
+  );
+};
+
+export default CreateKeytabElementsDeleteModal;

--- a/src/components/modals/HostsSettings/RetrieveKeytabElementsAddModal.tsx
+++ b/src/components/modals/HostsSettings/RetrieveKeytabElementsAddModal.tsx
@@ -1,0 +1,138 @@
+import React, { ReactNode, useEffect, useState } from "react";
+// PatternFly
+import { Button, DualListSelector } from "@patternfly/react-core";
+// Layout
+import SecondaryButton from "src/components/layouts/SecondaryButton";
+import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
+
+interface PropsToAddModal {
+  host: string;
+  elementType: string;
+  operationType: string;
+  showModal: boolean;
+  onCloseModal: () => void;
+  onOpenModal: () => void;
+  availableData: string[];
+  updateAvailableData: (newAvailableData: unknown[]) => void;
+  updateSelectedElements: (newSelectedElements: string[]) => void;
+  tableElementsList: string[];
+  updateTableElementsList: (newTableElementsList: string[]) => void;
+}
+
+const RetrieveKeytabElementsAddModal = (props: PropsToAddModal) => {
+  // Dual list data
+  const data = props.availableData;
+
+  // Dual list selector
+  const [availableOptions, setAvailableOptions] = useState<ReactNode[]>(
+    data.sort()
+  );
+  const [chosenOptions, setChosenOptions] = useState<ReactNode[]>([]);
+
+  const listChange = (
+    newAvailableOptions: ReactNode[],
+    newChosenOptions: ReactNode[]
+  ) => {
+    setAvailableOptions(newAvailableOptions.sort());
+    setChosenOptions(newChosenOptions.sort());
+    // The recently added entries are removed from the available data options
+    props.updateAvailableData(newAvailableOptions.sort());
+  };
+
+  const fields = [
+    {
+      id: "dual-list-selector",
+      pfComponent: (
+        <DualListSelector
+          isSearchable
+          availableOptions={availableOptions}
+          chosenOptions={chosenOptions}
+          onListChange={listChange}
+          id="basicSelectorWithSearch"
+        />
+      ),
+    },
+  ];
+
+  // When clean data, set to original values
+  const cleanData = () => {
+    setAvailableOptions(data);
+    setChosenOptions([]);
+    props.updateSelectedElements([]);
+  };
+
+  // Clean fields and close modal (To prevent data persistence when reopen modal)
+  const cleanAndCloseModal = () => {
+    cleanData();
+    props.onCloseModal();
+  };
+
+  // Buttons are disabled until all the required fields are filled
+  const [buttonDisabled, setButtonDisabled] = useState(true);
+  useEffect(() => {
+    if (chosenOptions.length > 0) {
+      setButtonDisabled(false);
+    } else {
+      setButtonDisabled(true);
+    }
+  }, [chosenOptions]);
+
+  // Add element to the list
+  const addElementToList = () => {
+    const itemsToAdd: string[] = [];
+    const newTableElementsList = props.tableElementsList;
+    chosenOptions.map((opt) => {
+      if (opt !== undefined && opt !== null) {
+        itemsToAdd.push(opt.toString());
+        newTableElementsList.push(opt.toString());
+      }
+    });
+    props.updateTableElementsList(newTableElementsList);
+    props.updateSelectedElements([]);
+    cleanAndCloseModal();
+  };
+
+  // Buttons that will be shown at the end of the form
+  const modalActions = [
+    <SecondaryButton
+      key={"add-new-" + props.elementType}
+      isDisabled={buttonDisabled}
+      form="modal-form"
+      onClickHandler={addElementToList}
+    >
+      Add
+    </SecondaryButton>,
+    <Button
+      key={"cancel-new-" + props.elementType}
+      variant="link"
+      onClick={cleanAndCloseModal}
+    >
+      Cancel
+    </Button>,
+  ];
+
+  // Render component
+  return (
+    <ModalWithFormLayout
+      variantType="medium"
+      modalPosition="top"
+      title={
+        "Allow " +
+        props.elementType +
+        "s to " +
+        props.operationType +
+        " keytab of " +
+        props.host
+      }
+      formId={
+        props.operationType + "-keytab-" + props.elementType + "s-add-modal"
+      }
+      fields={fields}
+      show={props.showModal}
+      onClose={cleanAndCloseModal}
+      actions={modalActions}
+    />
+  );
+};
+
+export default RetrieveKeytabElementsAddModal;

--- a/src/components/modals/HostsSettings/RetrieveKeytabElementsDeleteModal.tsx
+++ b/src/components/modals/HostsSettings/RetrieveKeytabElementsDeleteModal.tsx
@@ -1,0 +1,128 @@
+import React from "react";
+// PatternFly
+import {
+  Button,
+  TextContent,
+  Text,
+  TextVariants,
+} from "@patternfly/react-core";
+// Layouts
+import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
+import SecondaryButton from "src/components/layouts/SecondaryButton";
+// Tables
+import DeletedElementsTable from "src/components/tables/DeletedElementsTable";
+
+interface PropsToDelete {
+  host: string;
+  elementType: string;
+  operationType: string;
+  columnNames: string[];
+  showModal: boolean;
+  closeModal: () => void;
+  elementsToDelete: string[];
+  updateIsDeleteButtonDisabled: (newValue: boolean) => void;
+  updateSelectedElements: (newSelectedElements: string[]) => void;
+  tableElementsList: string[];
+  updateTableElementsList: (newElementsList: string[]) => void;
+  availableData: string[];
+  updateAvailableData: (newFilteredElements: unknown[]) => void;
+}
+
+const RetrieveKeytabElementsDeleteModal = (props: PropsToDelete) => {
+  // Modal fields
+  const fields = [
+    {
+      id: "question-text",
+      pfComponent: (
+        <TextContent>
+          <Text component={TextVariants.p}>
+            Are you sure you want to delete the selected entries?
+          </Text>
+        </TextContent>
+      ),
+    },
+    {
+      id: "deleted-" + props.elementType + "s-table",
+      pfComponent: (
+        <DeletedElementsTable
+          mode="passing_id"
+          elementsList={props.elementsToDelete.sort()}
+          elementsToDelete={props.elementsToDelete.sort()}
+          columnNames={props.columnNames}
+          elementType={props.elementType}
+        />
+      ),
+    },
+  ];
+
+  // Remove element from the list
+  const removeElementFromList = () => {
+    // Define function that will be reused to delete the selected entries
+    let generalUpdatedElementsList = props.tableElementsList;
+    const dataBackToBeAvailable = props.availableData;
+    props.elementsToDelete.map((element) => {
+      dataBackToBeAvailable.push(element);
+      const updatedElementsList = generalUpdatedElementsList.filter(
+        (elm) => elm !== element
+      );
+      // If not empty, replace element list by new array
+      if (updatedElementsList) {
+        generalUpdatedElementsList = updatedElementsList;
+      }
+    });
+    props.updateTableElementsList(generalUpdatedElementsList);
+    props.updateIsDeleteButtonDisabled(true);
+    // Add removed items back to the option list (to be added again)
+    props.updateAvailableData(dataBackToBeAvailable.sort());
+    // Clean selected elements & close modal
+    props.updateSelectedElements([]);
+    closeModal();
+  };
+
+  const closeModal = () => {
+    props.closeModal();
+  };
+
+  // Buttons that will be shown at the end of the form
+  const modalActions = [
+    <SecondaryButton
+      key={"delete-" + props.elementType}
+      form="modal-form"
+      onClickHandler={removeElementFromList}
+    >
+      Delete
+    </SecondaryButton>,
+    <Button
+      key={"cancel-delete-" + props.elementType}
+      variant="link"
+      onClick={closeModal}
+    >
+      Cancel
+    </Button>,
+  ];
+
+  // Render component
+  return (
+    <ModalWithFormLayout
+      variantType="medium"
+      modalPosition="top"
+      title={
+        "Disallow " +
+        props.elementType +
+        "s to " +
+        props.operationType +
+        " keytab of " +
+        props.host
+      }
+      formId={
+        props.operationType + "-keytab-" + props.elementType + "s-delete-modal"
+      }
+      fields={fields}
+      show={props.showModal}
+      onClose={closeModal}
+      actions={modalActions}
+    />
+  );
+};
+
+export default RetrieveKeytabElementsDeleteModal;

--- a/src/components/modals/PrincipalAliasAddModal.tsx
+++ b/src/components/modals/PrincipalAliasAddModal.tsx
@@ -1,0 +1,48 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React from "react";
+// PatternFly
+import { TextInput } from "@patternfly/react-core";
+// Layouts
+import ModalWithFormLayout from "../layouts/ModalWithFormLayout";
+
+interface PropsToPrincipalAliasModal {
+  isOpen: boolean;
+  onClose: () => void;
+  actions: JSX.Element[];
+  data: any; // Data agnostic on passed props
+}
+
+const PrincipalAliasAddModal = (props: PropsToPrincipalAliasModal) => {
+  // Fields
+  const fieldsToModal = [
+    {
+      id: "new-kerberos-alias",
+      name: "New kerberos principal alias",
+      pfComponent: (
+        <TextInput
+          id="new-kerberos-alias"
+          name="krbprincalname"
+          value={props.data.newKrbAlias}
+          onChange={props.data.onChangeNewKrbAlias}
+          type="text"
+          aria-label="new kerberos alias"
+        />
+      ),
+    },
+  ];
+
+  return (
+    <ModalWithFormLayout
+      variantType="small"
+      modalPosition="top"
+      title="Add Kerberos Principal Alias"
+      formId="principal-alias"
+      fields={fieldsToModal}
+      show={props.isOpen}
+      onClose={props.onClose}
+      actions={props.actions}
+    />
+  );
+};
+
+export default PrincipalAliasAddModal;

--- a/src/components/modals/PrincipalAliasDeleteModal.tsx
+++ b/src/components/modals/PrincipalAliasDeleteModal.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+// PatternFly
+import { TextInput } from "@patternfly/react-core";
+// Layouts
+import ModalWithFormLayout from "../layouts/ModalWithFormLayout";
+import TextLayout from "../layouts/TextLayout";
+
+interface PropsToPrincipalAliasModal {
+  isOpen: boolean;
+  onClose: () => void;
+  actions: JSX.Element[];
+  hostToRemove: string;
+}
+
+const PrincipalAliasDeleteModal = (props: PropsToPrincipalAliasModal) => {
+  // Fields
+  const fieldsToModal = [
+    {
+      id: "confirmation-question",
+      pfComponent: (
+        <TextLayout>
+          Do you want to remove kerberos alias {props.hostToRemove}
+        </TextLayout>
+      ),
+    },
+  ];
+
+  return (
+    <ModalWithFormLayout
+      variantType="small"
+      modalPosition="top"
+      title="Remove Kerberos Principal Alias"
+      formId="principal-alias"
+      fields={fieldsToModal}
+      show={props.isOpen}
+      onClose={props.onClose}
+      actions={props.actions}
+    />
+  );
+};
+
+export default PrincipalAliasDeleteModal;

--- a/src/components/tables/HostsSettings/CreateKeytabHostGroupsTable.tsx
+++ b/src/components/tables/HostsSettings/CreateKeytabHostGroupsTable.tsx
@@ -1,0 +1,272 @@
+import React, { useEffect, useState } from "react";
+// PatternFly
+import { Td, Th, Tr } from "@patternfly/react-table";
+// Layout
+import TableWithButtonsLayout from "src/components/layouts/TableWithButtonsLayout";
+// Modals
+import CreateKeytabElementsAddModal from "src/components/modals/HostsSettings/CreateKeytabElementsAddModal";
+import CreateKeytabElementsDeleteModal from "src/components/modals/HostsSettings/CreateKeytabElementsDeleteModal";
+
+interface PropsToTable {
+  host: string;
+}
+
+const CreateKeytabHostGroupsTable = (props: PropsToTable) => {
+  // TODO: Retrieve data from Redux when available
+  // Full host groups list -> Initial data
+  const fullHostGroupsIdsList = [
+    "hostGroup1",
+    "hostGroup2",
+    "hostGroup3",
+    "hostGroup4",
+    "hostGroup5",
+    "hostGroup6",
+    "hostGroup7",
+    "hostGroup8",
+  ];
+
+  // Host groups on the table
+  const [tableHostGroupsList, setTableHostGroupsList] = useState<string[]>([]);
+
+  const updateTableHostGroupsList = (newTableHostGroupsList: string[]) => {
+    setTableHostGroupsList(newTableHostGroupsList);
+  };
+
+  // Filter function to compare the available data with the data that
+  //  is in the table already. This is done to prevent duplicates
+  //  (e.g: adding the same element twice).
+  const filterHostGroupsData = () => {
+    return fullHostGroupsIdsList.filter((item) => {
+      return !tableHostGroupsList.some((itm) => {
+        return item === itm;
+      });
+    });
+  };
+
+  const [hostGroupsFilteredData, setHostGroupsFilteredData] = useState(
+    filterHostGroupsData()
+  );
+
+  const updateHostGroupsFilteredData = (newFilteredHostGroups: unknown[]) => {
+    setHostGroupsFilteredData(newFilteredHostGroups as string[]);
+  };
+
+  // 'Delete' button is disabled if no row is selected
+  const [isDeleteDisabled, setIsDeleteDisabled] = useState(true);
+
+  // Column names
+  const hostGroupsColumnNamesArray = ["Host group"];
+
+  // - Selected rows are tracked
+  const [selectedHostGroups, setSelectedHostGroups] = useState<string[]>([]);
+
+  const updateSelectedHostGroups = (newSelectedHostGroups: string[]) => {
+    setSelectedHostGroups(newSelectedHostGroups);
+  };
+
+  // - To allow shift+click to select/deselect multiple rows
+  const [recentSelectedRowIndex, setRecentSelectedRowIndex] = useState<
+    number | null
+  >(null);
+  const [shifting, setShifting] = useState(false);
+
+  // Keyboard event
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Shift") {
+        setShifting(true);
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === "Shift") {
+        setShifting(false);
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("keyup", onKeyUp);
+
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("keyup", onKeyUp);
+    };
+  }, []);
+
+  // - Returns 'True' if a specific table host group has been selected
+  const isHostGroupSelected = (hostGroup: string) =>
+    selectedHostGroups.includes(hostGroup);
+
+  const areAllHostGroupsSelected =
+    selectedHostGroups.length === tableHostGroupsList.length &&
+    tableHostGroupsList.length !== 0;
+
+  // - Select all host groups
+  const selectAllHostGroups = (isSelecting = true) => {
+    setSelectedHostGroups(
+      isSelecting ? tableHostGroupsList.map((elem) => elem) : []
+    );
+    setIsDeleteDisabled(false);
+  };
+
+  // - Helper method to set the selected hosts from the table
+  const setHostGroupSelected = (hostGroup: string, isSelecting = true) =>
+    setSelectedHostGroups((prevSelected) => {
+      const otherSelectedHostGroups = prevSelected.filter(
+        (r) => r !== hostGroup
+      );
+      return isSelecting
+        ? [...otherSelectedHostGroups, hostGroup]
+        : otherSelectedHostGroups;
+    });
+
+  // - On selecting one single row
+  const onSelectHostGroup = (
+    hostGroup: string,
+    rowIndex: number,
+    isSelecting: boolean
+  ) => {
+    // If the element is shift + selecting the checkboxes, then all intermediate checkboxes should be selected
+    if (shifting && recentSelectedRowIndex !== null) {
+      const numberSelected = rowIndex - recentSelectedRowIndex;
+      const intermediateIndexes =
+        numberSelected > 0
+          ? Array.from(
+              new Array(numberSelected + 1),
+              (_x, i) => i + recentSelectedRowIndex
+            )
+          : Array.from(
+              new Array(Math.abs(numberSelected) + 1),
+              (_x, i) => i + rowIndex
+            );
+      intermediateIndexes.forEach((index) =>
+        setHostGroupSelected(selectedHostGroups[index], isSelecting)
+      );
+    } else {
+      setHostGroupSelected(hostGroup, isSelecting);
+    }
+    setRecentSelectedRowIndex(rowIndex);
+    // Enable 'Delete' button
+    setIsDeleteDisabled(false);
+  };
+
+  // Disable 'Delete' button when no elements selected
+  useEffect(() => {
+    if (selectedHostGroups.length === 0) {
+      setIsDeleteDisabled(true);
+    }
+  }, [selectedHostGroups]);
+
+  // Header
+  const hostGroupsHeader = (
+    <Tr>
+      <Th
+        select={{
+          onSelect: (_event, isSelecting) => selectAllHostGroups(isSelecting),
+          isSelected: areAllHostGroupsSelected,
+        }}
+      />
+      <Th width={10}>{hostGroupsColumnNamesArray[0]}</Th>
+    </Tr>
+  );
+
+  const hostGroupsBody = tableHostGroupsList.map((hostGroup, rowIndex) => (
+    <Tr key={hostGroup} id={hostGroup}>
+      <Td
+        dataLabel="checkbox"
+        select={{
+          rowIndex,
+          onSelect: (_event, isSelecting) =>
+            onSelectHostGroup(hostGroup, rowIndex, isSelecting),
+          isSelected: isHostGroupSelected(hostGroup),
+          disable: false,
+        }}
+      />
+      <Td dataLabel={hostGroupsColumnNamesArray[0]}>{hostGroup}</Td>
+    </Tr>
+  ));
+
+  // Modal functionality
+  // - Show modals
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  // - Close 'Add' modal
+  const onCloseAddHandler = () => {
+    setShowAddModal(false);
+  };
+
+  // - close 'Delete' button
+  const onCloseDeleteHandler = () => {
+    setShowDeleteModal(false);
+  };
+
+  // - 'Add' button -> Open modal
+  const onClickAddHandler = () => {
+    setShowAddModal(true);
+  };
+
+  // - 'Delete' button -> Remove table entry
+  const onClickDeleteHandler = () => {
+    setShowDeleteModal(true);
+  };
+
+  // - Update 'Delete' button
+  const updateIsDeleteButtonDisabled = (newValue: boolean) => {
+    setIsDeleteDisabled(newValue);
+  };
+
+  return (
+    <>
+      <TableWithButtonsLayout
+        ariaLabel="hosts table in host settings"
+        variant="compact"
+        hasBorders={true}
+        name="ipaallowedtoperform_write_keys_host"
+        tableId="host-settings-hosts-table"
+        isStickyHeader={false}
+        tableHeader={hostGroupsHeader}
+        tableBody={hostGroupsBody}
+        tableClasses="pf-u-mb-2xl"
+        deleteButtonClasses="pf-u-mr-sm"
+        onDeleteModal={onClickDeleteHandler}
+        isDeleteDisabled={isDeleteDisabled}
+        addButtonClasses="pf-u-mr-sm"
+        onAddModal={onClickAddHandler}
+      />
+      {showAddModal && (
+        <CreateKeytabElementsAddModal
+          host={props.host}
+          elementType="host"
+          operationType="create"
+          showModal={showAddModal}
+          onCloseModal={onCloseAddHandler}
+          onOpenModal={onClickAddHandler}
+          availableData={hostGroupsFilteredData}
+          updateAvailableData={updateHostGroupsFilteredData}
+          updateSelectedElements={updateSelectedHostGroups}
+          tableElementsList={tableHostGroupsList}
+          updateTableElementsList={updateTableHostGroupsList}
+        />
+      )}
+      {showDeleteModal && (
+        <CreateKeytabElementsDeleteModal
+          host={props.host}
+          elementType="host"
+          operationType="create"
+          columnNames={hostGroupsColumnNamesArray}
+          showModal={showDeleteModal}
+          closeModal={onCloseDeleteHandler}
+          elementsToDelete={selectedHostGroups}
+          updateIsDeleteButtonDisabled={updateIsDeleteButtonDisabled}
+          updateSelectedElements={updateSelectedHostGroups}
+          tableElementsList={tableHostGroupsList}
+          updateTableElementsList={updateTableHostGroupsList}
+          availableData={hostGroupsFilteredData}
+          updateAvailableData={updateHostGroupsFilteredData}
+        />
+      )}
+    </>
+  );
+};
+
+export default CreateKeytabHostGroupsTable;

--- a/src/components/tables/HostsSettings/CreateKeytabHostsTable.tsx
+++ b/src/components/tables/HostsSettings/CreateKeytabHostsTable.tsx
@@ -1,0 +1,257 @@
+import React, { useEffect, useState } from "react";
+// PatternFly
+import { Td, Th, Tr } from "@patternfly/react-table";
+// Layout
+import TableWithButtonsLayout from "src/components/layouts/TableWithButtonsLayout";
+// Modals
+import CreateKeytabElementsAddModal from "src/components/modals/HostsSettings/CreateKeytabElementsAddModal";
+import CreateKeytabElementsDeleteModal from "src/components/modals/HostsSettings/CreateKeytabElementsDeleteModal";
+// Redux
+import { useAppSelector } from "src/store/hooks";
+
+interface PropsToTable {
+  host: string;
+}
+
+const CreateKeytabHostsTable = (props: PropsToTable) => {
+  // Full elements list -> Initial data
+  const fullHostsList = useAppSelector((state) => state.hosts.hostsList);
+  const fullHostIdsList = fullHostsList.map((host) => host.hostName);
+
+  // Elements on the table
+  const [tableHostsList, setTableHostsList] = useState<string[]>([]);
+
+  const updateTableHostsList = (newTableHostsList: string[]) => {
+    setTableHostsList(newTableHostsList);
+  };
+
+  // Filter function to compare the available data with the data that
+  //  is in the table already. This is done to prevent duplicates
+  //  (e.g: adding the same element twice).
+  const filterHostsData = () => {
+    return fullHostIdsList.filter((item) => {
+      return !tableHostsList.some((itm) => {
+        return item === itm;
+      });
+    });
+  };
+
+  // const usersFilteredData = filterUsersData();
+  const [hostsFilteredData, setHostsFilteredData] = useState(filterHostsData());
+
+  const updateHostsFilteredData = (newFilteredHosts: unknown[]) => {
+    setHostsFilteredData(newFilteredHosts as string[]);
+  };
+
+  // 'Delete' button is disabled if no row is selected
+  const [isDeleteDisabled, setIsDeleteDisabled] = useState(true);
+
+  // Column names (Array)
+  const hostsColumnNamesArray = ["Host"];
+
+  // - Selected rows are tracked
+  const [selectedHosts, setSelectedHosts] = useState<string[]>([]);
+
+  const updateSelectedHosts = (newSelectedHosts: string[]) => {
+    setSelectedHosts(newSelectedHosts);
+  };
+
+  // - To allow shift+click to select/deselect multiple rows
+  const [recentSelectedRowIndex, setRecentSelectedRowIndex] = useState<
+    number | null
+  >(null);
+  const [shifting, setShifting] = useState(false);
+
+  // Keyboard event
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Shift") {
+        setShifting(true);
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === "Shift") {
+        setShifting(false);
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("keyup", onKeyUp);
+
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("keyup", onKeyUp);
+    };
+  }, []);
+
+  // - Returns 'True' if a specific table host has been selected
+  const isHostSelected = (host: string) => selectedHosts.includes(host);
+
+  const areAllHostsSelected =
+    selectedHosts.length === tableHostsList.length &&
+    tableHostsList.length !== 0;
+
+  // - Select all elements
+  const selectAllHosts = (isSelecting = true) => {
+    setSelectedHosts(isSelecting ? tableHostsList.map((elem) => elem) : []);
+    setIsDeleteDisabled(false);
+  };
+
+  // - Helper method to set the selected elements from the table
+  const setHostSelected = (host: string, isSelecting = true) =>
+    setSelectedHosts((prevSelected) => {
+      const otherSelectedHosts = prevSelected.filter((r) => r !== host);
+      return isSelecting ? [...otherSelectedHosts, host] : otherSelectedHosts;
+    });
+
+  // - On selecting one single row
+  const onSelectHost = (
+    host: string,
+    rowIndex: number,
+    isSelecting: boolean
+  ) => {
+    // If the element is shift + selecting the checkboxes, then all intermediate checkboxes should be selected
+    if (shifting && recentSelectedRowIndex !== null) {
+      const numberSelected = rowIndex - recentSelectedRowIndex;
+      const intermediateIndexes =
+        numberSelected > 0
+          ? Array.from(
+              new Array(numberSelected + 1),
+              (_x, i) => i + recentSelectedRowIndex
+            )
+          : Array.from(
+              new Array(Math.abs(numberSelected) + 1),
+              (_x, i) => i + rowIndex
+            );
+      intermediateIndexes.forEach((index) =>
+        setHostSelected(selectedHosts[index], isSelecting)
+      );
+    } else {
+      setHostSelected(host, isSelecting);
+    }
+    setRecentSelectedRowIndex(rowIndex);
+    // Enable 'Delete' button
+    setIsDeleteDisabled(false);
+  };
+
+  // Disable 'Delete' button when no elements selected
+  useEffect(() => {
+    if (selectedHosts.length === 0) {
+      setIsDeleteDisabled(true);
+    }
+  }, [selectedHosts]);
+
+  // Header
+  const hostsHeader = (
+    <Tr>
+      <Th
+        select={{
+          onSelect: (_event, isSelecting) => selectAllHosts(isSelecting),
+          isSelected: areAllHostsSelected,
+        }}
+      />
+      <Th width={10}>{hostsColumnNamesArray[0]}</Th>
+    </Tr>
+  );
+
+  const hostsBody = tableHostsList.map((host, rowIndex) => (
+    <Tr key={host} id={host}>
+      <Td
+        dataLabel="checkbox"
+        select={{
+          rowIndex,
+          onSelect: (_event, isSelecting) =>
+            onSelectHost(host, rowIndex, isSelecting),
+          isSelected: isHostSelected(host),
+          disable: false,
+        }}
+      />
+      <Td dataLabel={hostsColumnNamesArray[0]}>{host}</Td>
+    </Tr>
+  ));
+
+  // Modal functionality
+  // - Show modals
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  // - Close 'Add' modal
+  const onCloseAddHandler = () => {
+    setShowAddModal(false);
+  };
+
+  // - close 'Delete' button
+  const onCloseDeleteHandler = () => {
+    setShowDeleteModal(false);
+  };
+
+  // - 'Add' button -> Open modal
+  const onClickAddHandler = () => {
+    setShowAddModal(true);
+  };
+
+  // - 'Delete' button -> Remove table entry
+  const onClickDeleteHandler = () => {
+    setShowDeleteModal(true);
+  };
+
+  // - Update 'Delete' button
+  const updateIsDeleteButtonDisabled = (newValue: boolean) => {
+    setIsDeleteDisabled(newValue);
+  };
+
+  return (
+    <>
+      <TableWithButtonsLayout
+        ariaLabel="hosts table in host settings"
+        variant="compact"
+        hasBorders={true}
+        name="ipaallowedtoperform_write_keys_host"
+        tableId="host-settings-hosts-table"
+        isStickyHeader={false}
+        tableHeader={hostsHeader}
+        tableBody={hostsBody}
+        tableClasses="pf-u-mb-2xl"
+        deleteButtonClasses="pf-u-mr-sm"
+        onDeleteModal={onClickDeleteHandler}
+        isDeleteDisabled={isDeleteDisabled}
+        addButtonClasses="pf-u-mr-sm"
+        onAddModal={onClickAddHandler}
+      />
+      {showAddModal && (
+        <CreateKeytabElementsAddModal
+          host={props.host}
+          elementType="host"
+          operationType="create"
+          showModal={showAddModal}
+          onCloseModal={onCloseAddHandler}
+          onOpenModal={onClickAddHandler}
+          availableData={hostsFilteredData}
+          updateAvailableData={updateHostsFilteredData}
+          updateSelectedElements={updateSelectedHosts}
+          tableElementsList={tableHostsList}
+          updateTableElementsList={updateTableHostsList}
+        />
+      )}
+      {showDeleteModal && (
+        <CreateKeytabElementsDeleteModal
+          host={props.host}
+          elementType="host"
+          operationType="create"
+          columnNames={hostsColumnNamesArray}
+          showModal={showDeleteModal}
+          closeModal={onCloseDeleteHandler}
+          elementsToDelete={selectedHosts}
+          updateIsDeleteButtonDisabled={updateIsDeleteButtonDisabled}
+          updateSelectedElements={updateSelectedHosts}
+          tableElementsList={tableHostsList}
+          updateTableElementsList={updateTableHostsList}
+          availableData={hostsFilteredData}
+          updateAvailableData={updateHostsFilteredData}
+        />
+      )}
+    </>
+  );
+};
+
+export default CreateKeytabHostsTable;

--- a/src/components/tables/HostsSettings/CreateKeytabUserGroupsTable.tsx
+++ b/src/components/tables/HostsSettings/CreateKeytabUserGroupsTable.tsx
@@ -1,0 +1,273 @@
+import React, { useEffect, useState } from "react";
+// PatternFly
+import { Td, Th, Tr } from "@patternfly/react-table";
+// Layout
+import TableWithButtonsLayout from "src/components/layouts/TableWithButtonsLayout";
+// Modals
+import CreateKeytabElementsAddModal from "src/components/modals/HostsSettings/CreateKeytabElementsAddModal";
+import CreateKeytabElementsDeleteModal from "src/components/modals/HostsSettings/CreateKeytabElementsDeleteModal";
+
+interface PropsToTable {
+  host: string;
+}
+
+const CreateKeytabUserGroupsTable = (props: PropsToTable) => {
+  // TODO: Retrieve data from Redux when available
+  // Full user groups list -> Initial data
+  const fullUserGroupsIdsList = [
+    "userGroup1",
+    "userGroup2",
+    "userGroup3",
+    "userGroup4",
+    "userGroup5",
+    "userGroup6",
+    "userGroup7",
+    "userGroup8",
+  ];
+
+  // User groups on the table
+  const [tableUserGroupsList, setTableUserGroupsList] = useState<string[]>([]);
+
+  const updateTableUserGroupsList = (newTableUserGroupsList: string[]) => {
+    setTableUserGroupsList(newTableUserGroupsList);
+  };
+
+  // Filter function to compare the available data with the data that
+  //  is in the table already. This is done to prevent duplicates
+  //  (e.g: adding the same element twice).
+  const filterUserGroupsData = () => {
+    return fullUserGroupsIdsList.filter((item) => {
+      return !tableUserGroupsList.some((itm) => {
+        return item === itm;
+      });
+    });
+  };
+
+  // const usersFilteredData = filterUsersData();
+  const [userGroupsFilteredData, setUserGroupsFilteredData] = useState(
+    filterUserGroupsData()
+  );
+
+  const updateUserGroupsFilteredData = (newFilteredUsers: unknown[]) => {
+    setUserGroupsFilteredData(newFilteredUsers as string[]);
+  };
+
+  // 'Delete' button is disabled if no row is selected
+  const [isDeleteDisabled, setIsDeleteDisabled] = useState(true);
+
+  // Column names (Array)
+  const userGroupsColumnNamesArray = ["User groups"];
+
+  // - Selected rows are tracked
+  const [selectedUserGroups, setSelectedUserGroups] = useState<string[]>([]);
+
+  const updateSelectedUserGroups = (newSelectedUserGroups: string[]) => {
+    setSelectedUserGroups(newSelectedUserGroups);
+  };
+
+  // - To allow shift+click to select/deselect multiple rows
+  const [recentSelectedRowIndex, setRecentSelectedRowIndex] = useState<
+    number | null
+  >(null);
+  const [shifting, setShifting] = useState(false);
+
+  // Keyboard event
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Shift") {
+        setShifting(true);
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === "Shift") {
+        setShifting(false);
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("keyup", onKeyUp);
+
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("keyup", onKeyUp);
+    };
+  }, []);
+
+  // - Returns 'True' if a specific table user group has been selected
+  const isUserGroupSelected = (userGroup: string) =>
+    selectedUserGroups.includes(userGroup);
+
+  const areAllUserGroupsSelected =
+    selectedUserGroups.length === tableUserGroupsList.length &&
+    tableUserGroupsList.length !== 0;
+
+  // - Select all user groups
+  const selectAllUserGroups = (isSelecting = true) => {
+    setSelectedUserGroups(
+      isSelecting ? tableUserGroupsList.map((elem) => elem) : []
+    );
+    setIsDeleteDisabled(false);
+  };
+
+  // - Helper method to set the selected users from the table
+  const setUserGroupSelected = (userGroup: string, isSelecting = true) =>
+    setSelectedUserGroups((prevSelected) => {
+      const otherSelectedUserGroups = prevSelected.filter(
+        (r) => r !== userGroup
+      );
+      return isSelecting
+        ? [...otherSelectedUserGroups, userGroup]
+        : otherSelectedUserGroups;
+    });
+
+  // - On selecting one single row
+  const onSelectUserGroup = (
+    userGroup: string,
+    rowIndex: number,
+    isSelecting: boolean
+  ) => {
+    // If the element is shift + selecting the checkboxes, then all intermediate checkboxes should be selected
+    if (shifting && recentSelectedRowIndex !== null) {
+      const numberSelected = rowIndex - recentSelectedRowIndex;
+      const intermediateIndexes =
+        numberSelected > 0
+          ? Array.from(
+              new Array(numberSelected + 1),
+              (_x, i) => i + recentSelectedRowIndex
+            )
+          : Array.from(
+              new Array(Math.abs(numberSelected) + 1),
+              (_x, i) => i + rowIndex
+            );
+      intermediateIndexes.forEach((index) =>
+        setUserGroupSelected(selectedUserGroups[index], isSelecting)
+      );
+    } else {
+      setUserGroupSelected(userGroup, isSelecting);
+    }
+    setRecentSelectedRowIndex(rowIndex);
+    // Enable 'Delete' button
+    setIsDeleteDisabled(false);
+  };
+
+  // Disable 'Delete' button when no elements selected
+  useEffect(() => {
+    if (selectedUserGroups.length === 0) {
+      setIsDeleteDisabled(true);
+    }
+  }, [selectedUserGroups]);
+
+  // Header
+  const userGroupsHeader = (
+    <Tr>
+      <Th
+        select={{
+          onSelect: (_event, isSelecting) => selectAllUserGroups(isSelecting),
+          isSelected: areAllUserGroupsSelected,
+        }}
+      />
+      <Th width={10}>{userGroupsColumnNamesArray[0]}</Th>
+    </Tr>
+  );
+
+  const userGroupsBody = tableUserGroupsList.map((userGroup, rowIndex) => (
+    <Tr key={userGroup} id={userGroup}>
+      <Td
+        dataLabel="checkbox"
+        select={{
+          rowIndex,
+          onSelect: (_event, isSelecting) =>
+            onSelectUserGroup(userGroup, rowIndex, isSelecting),
+          isSelected: isUserGroupSelected(userGroup),
+          disable: false,
+        }}
+      />
+      <Td dataLabel={userGroupsColumnNamesArray[0]}>{userGroup}</Td>
+    </Tr>
+  ));
+
+  // Modal functionality
+  // - Show modals
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  // - Close 'Add' modal
+  const onCloseAddHandler = () => {
+    setShowAddModal(false);
+  };
+
+  // - close 'Delete' button
+  const onCloseDeleteHandler = () => {
+    setShowDeleteModal(false);
+  };
+
+  // - 'Add' button -> Open modal
+  const onClickAddHandler = () => {
+    setShowAddModal(true);
+  };
+
+  // - 'Delete' button -> Remove table entry
+  const onClickDeleteHandler = () => {
+    setShowDeleteModal(true);
+  };
+
+  // - Update 'Delete' button
+  const updateIsDeleteButtonDisabled = (newValue: boolean) => {
+    setIsDeleteDisabled(newValue);
+  };
+
+  return (
+    <>
+      <TableWithButtonsLayout
+        ariaLabel="user groups table in host settings"
+        variant="compact"
+        hasBorders={true}
+        name="ipaallowedtoperform_write_keys_group"
+        tableId="host-settings-user-groups-table"
+        isStickyHeader={false}
+        tableHeader={userGroupsHeader}
+        tableBody={userGroupsBody}
+        tableClasses="pf-u-mb-3xl"
+        deleteButtonClasses="pf-u-mr-sm"
+        onDeleteModal={onClickDeleteHandler}
+        isDeleteDisabled={isDeleteDisabled}
+        addButtonClasses="pf-u-mr-sm"
+        onAddModal={onClickAddHandler}
+      />
+      {showAddModal && (
+        <CreateKeytabElementsAddModal
+          host={props.host}
+          elementType="user group"
+          operationType="create"
+          showModal={showAddModal}
+          onCloseModal={onCloseAddHandler}
+          onOpenModal={onClickAddHandler}
+          availableData={userGroupsFilteredData}
+          updateAvailableData={updateUserGroupsFilteredData}
+          updateSelectedElements={updateSelectedUserGroups}
+          tableElementsList={tableUserGroupsList}
+          updateTableElementsList={updateTableUserGroupsList}
+        />
+      )}
+      {showDeleteModal && (
+        <CreateKeytabElementsDeleteModal
+          host={props.host}
+          elementType="user group"
+          operationType="create"
+          columnNames={userGroupsColumnNamesArray}
+          showModal={showDeleteModal}
+          closeModal={onCloseDeleteHandler}
+          elementsToDelete={selectedUserGroups}
+          updateIsDeleteButtonDisabled={updateIsDeleteButtonDisabled}
+          updateSelectedElements={updateSelectedUserGroups}
+          tableElementsList={tableUserGroupsList}
+          updateTableElementsList={updateTableUserGroupsList}
+          availableData={userGroupsFilteredData}
+          updateAvailableData={updateUserGroupsFilteredData}
+        />
+      )}
+    </>
+  );
+};
+
+export default CreateKeytabUserGroupsTable;

--- a/src/components/tables/HostsSettings/CreateKeytabUsersTable.tsx
+++ b/src/components/tables/HostsSettings/CreateKeytabUsersTable.tsx
@@ -1,0 +1,260 @@
+import React, { useEffect, useState } from "react";
+// PatternFly
+import { Td, Th, Tr } from "@patternfly/react-table";
+// Layout
+import TableWithButtonsLayout from "src/components/layouts/TableWithButtonsLayout";
+// Modals
+import CreateKeytabElementsAddModal from "src/components/modals/HostsSettings/CreateKeytabElementsAddModal";
+import CreateKeytabElementsDeleteModal from "src/components/modals/HostsSettings/CreateKeytabElementsDeleteModal";
+// Redux
+import { useAppSelector } from "src/store/hooks";
+
+interface PropsToTable {
+  host: string;
+}
+
+const CreateKeytabUsersTable = (props: PropsToTable) => {
+  // Full users list -> Initial data
+  const fullUsersList = useAppSelector((state) => state.activeUsers.usersList);
+  const fullUserIdsList = fullUsersList.map((user) => user.userLogin);
+
+  // Users list on the table
+  const [tableUsersList, setTableUsersList] = useState<string[]>([]);
+
+  const updateTableUsersList = (newTableUsersList: string[]) => {
+    setTableUsersList(newTableUsersList);
+  };
+
+  // Filter function to compare the available data with the data that
+  //  is in the table already. This is done to prevent duplicates
+  //  (e.g: adding the same element twice).
+  const filterUsersData = () => {
+    return fullUserIdsList.filter((item) => {
+      return !tableUsersList.some((itm) => {
+        return item === itm;
+      });
+    });
+  };
+
+  // const usersFilteredData = filterUsersData();
+  const [usersFilteredData, setUsersFilteredData] = useState(filterUsersData());
+
+  const updateUsersFilteredData = (newFilteredUsers: unknown[]) => {
+    setUsersFilteredData(newFilteredUsers as string[]);
+  };
+
+  // 'Delete' button is disabled if no row is selected
+  const [isDeleteDisabled, setIsDeleteDisabled] = useState(true);
+
+  // Column names (String)
+  const usersColumnNamesArray = ["User"];
+
+  // Selected rows are tracked
+  const [selectedUsers, setSelectedUsers] = useState<string[]>([]);
+
+  const updateSelectedUsers = (newSelectedUsers: string[]) => {
+    setSelectedUsers(newSelectedUsers);
+  };
+
+  // To allow shift+click to select/deselect multiple rows
+  const [recentSelectedRowIndex, setRecentSelectedRowIndex] = useState<
+    number | null
+  >(null);
+  const [shifting, setShifting] = useState(false);
+
+  // Keyboard event to select rows
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Shift") {
+        setShifting(true);
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === "Shift") {
+        setShifting(false);
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("keyup", onKeyUp);
+
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("keyup", onKeyUp);
+    };
+  }, []);
+
+  // - Returns 'True' if a specific table user has been selected
+  const isUserSelected = (user: string) => selectedUsers.includes(user);
+
+  const areAllUsersSelected =
+    selectedUsers.length === tableUsersList.length &&
+    tableUsersList.length !== 0;
+
+  // - Select all users
+  const selectAllUsers = (isSelecting = true) => {
+    setSelectedUsers(isSelecting ? tableUsersList.map((elem) => elem) : []);
+    setIsDeleteDisabled(false);
+  };
+
+  // - Helper method to set the selected users from the table
+  const setUserSelected = (user: string, isSelecting = true) =>
+    setSelectedUsers((prevSelected) => {
+      const otherSelectedUsers = prevSelected.filter((r) => r !== user);
+      return isSelecting ? [...otherSelectedUsers, user] : otherSelectedUsers;
+    });
+
+  // - On selecting one single row
+  const onSelectUser = (
+    user: string,
+    rowIndex: number,
+    isSelecting: boolean
+  ) => {
+    // If the element is shift + selecting the checkboxes, then all intermediate checkboxes should be selected
+    if (shifting && recentSelectedRowIndex !== null) {
+      const numberSelected = rowIndex - recentSelectedRowIndex;
+      const intermediateIndexes =
+        numberSelected > 0
+          ? Array.from(
+              new Array(numberSelected + 1),
+              (_x, i) => i + recentSelectedRowIndex
+            )
+          : Array.from(
+              new Array(Math.abs(numberSelected) + 1),
+              (_x, i) => i + rowIndex
+            );
+      intermediateIndexes.forEach((index) =>
+        setUserSelected(tableUsersList[index], isSelecting)
+      );
+    } else {
+      setUserSelected(user, isSelecting);
+    }
+    setRecentSelectedRowIndex(rowIndex);
+    // Enable 'Delete' button
+    setIsDeleteDisabled(false);
+  };
+
+  // Disable 'Delete' button when no elements selected
+  useEffect(() => {
+    if (selectedUsers.length === 0) {
+      setIsDeleteDisabled(true);
+    }
+  }, [selectedUsers]);
+
+  // Header
+  const usersHeader = (
+    <Tr>
+      <Th
+        select={{
+          onSelect: (_event, isSelecting) => selectAllUsers(isSelecting),
+          isSelected: areAllUsersSelected,
+        }}
+      />
+      {/* <Th width={10}>{usersColumnNames.user}</Th> */}
+      <Th width={10}>{usersColumnNamesArray[0]}</Th>
+    </Tr>
+  );
+
+  // Body
+  const usersBody = tableUsersList.map((user, rowIndex) => (
+    <Tr key={user} id={user}>
+      <Td
+        dataLabel="checkbox"
+        select={{
+          rowIndex,
+          onSelect: (_event, isSelecting) =>
+            onSelectUser(user, rowIndex, isSelecting),
+          isSelected: isUserSelected(user),
+          disable: false,
+        }}
+      />
+      {/* <Td dataLabel={usersColumnNames.user}>{user}</Td> */}
+      <Td dataLabel={usersColumnNamesArray[0]}>{user}</Td>
+    </Tr>
+  ));
+
+  // Modal functionality
+  // - Show modals
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  // - Close 'Add' modal
+  const onCloseAddHandler = () => {
+    setShowAddModal(false);
+  };
+
+  // - close 'Delete' button
+  const onCloseDeleteHandler = () => {
+    setShowDeleteModal(false);
+  };
+
+  // - 'Add' button -> Open modal
+  const onClickAddHandler = () => {
+    setShowAddModal(true);
+  };
+
+  // - 'Delete' button -> Remove table entry
+  const onClickDeleteHandler = () => {
+    setShowDeleteModal(true);
+  };
+
+  // - Update 'Delete' button
+  const updateIsDeleteButtonDisabled = (newValue: boolean) => {
+    setIsDeleteDisabled(newValue);
+  };
+
+  return (
+    <>
+      <TableWithButtonsLayout
+        ariaLabel="user table in host settings"
+        variant="compact"
+        hasBorders={true}
+        name="ipaallowedtoperform_write_keys_user"
+        tableId="host-settings-user-table"
+        isStickyHeader={false}
+        tableHeader={usersHeader}
+        tableBody={usersBody}
+        tableClasses="pf-u-mb-3xl"
+        deleteButtonClasses="pf-u-mr-sm"
+        onDeleteModal={onClickDeleteHandler}
+        isDeleteDisabled={isDeleteDisabled}
+        addButtonClasses="pf-u-mr-sm"
+        onAddModal={onClickAddHandler}
+      />
+      {showAddModal && (
+        <CreateKeytabElementsAddModal
+          host={props.host}
+          elementType="user"
+          operationType="create"
+          showModal={showAddModal}
+          onCloseModal={onCloseAddHandler}
+          onOpenModal={onClickAddHandler}
+          availableData={usersFilteredData}
+          updateAvailableData={updateUsersFilteredData}
+          updateSelectedElements={updateSelectedUsers}
+          tableElementsList={tableUsersList}
+          updateTableElementsList={updateTableUsersList}
+        />
+      )}
+      {showDeleteModal && (
+        <CreateKeytabElementsDeleteModal
+          host={props.host}
+          elementType="user"
+          operationType="create"
+          columnNames={usersColumnNamesArray}
+          showModal={showDeleteModal}
+          closeModal={onCloseDeleteHandler}
+          elementsToDelete={selectedUsers}
+          updateIsDeleteButtonDisabled={updateIsDeleteButtonDisabled}
+          updateSelectedElements={updateSelectedUsers}
+          tableElementsList={tableUsersList}
+          updateTableElementsList={updateTableUsersList}
+          availableData={usersFilteredData}
+          updateAvailableData={updateUsersFilteredData}
+        />
+      )}
+    </>
+  );
+};
+
+export default CreateKeytabUsersTable;

--- a/src/components/tables/HostsSettings/RetrieveKeytabHostGroupTable.tsx
+++ b/src/components/tables/HostsSettings/RetrieveKeytabHostGroupTable.tsx
@@ -1,0 +1,270 @@
+import React, { useEffect, useState } from "react";
+// PatternFly
+import { Td, Th, Tr } from "@patternfly/react-table";
+// Layout
+import TableWithButtonsLayout from "src/components/layouts/TableWithButtonsLayout";
+// Modals
+import RetrieveKeytabElementsAddModal from "src/components/modals/HostsSettings/RetrieveKeytabElementsAddModal";
+import RetrieveKeytabElementsDeleteModal from "src/components/modals/HostsSettings/RetrieveKeytabElementsDeleteModal";
+
+interface PropsToTable {
+  host: string;
+}
+
+const RetrieveKeytabHostGroupsTable = (props: PropsToTable) => {
+  // TODO: Retrieve data from Redux when available
+  // Full host groups list -> Initial data
+  const fullHostGroupsIdsList = [
+    "hostGroup3",
+    "hostGroup4",
+    "hostGroup5",
+    "hostGroup6",
+    "hostGroup7",
+    "hostGroup8",
+  ];
+
+  // Host groups on the table
+  const [tableHostGroupsList, setTableHostGroupsList] = useState<string[]>([]);
+
+  const updateTableHostGroupsList = (newTableHostGroupsList: string[]) => {
+    setTableHostGroupsList(newTableHostGroupsList);
+  };
+
+  // Filter function to compare the available data with the data that
+  //  is in the table already. This is done to prevent duplicates
+  //  (e.g: adding the same element twice).
+  const filterHostGroupsData = () => {
+    return fullHostGroupsIdsList.filter((item) => {
+      return !tableHostGroupsList.some((itm) => {
+        return item === itm;
+      });
+    });
+  };
+
+  const [hostGroupsFilteredData, setHostGroupsFilteredData] = useState(
+    filterHostGroupsData()
+  );
+
+  const updateHostGroupsFilteredData = (newFilteredHostGroups: unknown[]) => {
+    setHostGroupsFilteredData(newFilteredHostGroups as string[]);
+  };
+
+  // 'Delete' button is disabled if no row is selected
+  const [isDeleteDisabled, setIsDeleteDisabled] = useState(true);
+
+  // Column names
+  const hostGroupsColumnNamesArray = ["Host group"];
+
+  // - Selected rows are tracked
+  const [selectedHostGroups, setSelectedHostGroups] = useState<string[]>([]);
+
+  const updateSelectedHostGroups = (newSelectedHostGroups: string[]) => {
+    setSelectedHostGroups(newSelectedHostGroups);
+  };
+
+  // - To allow shift+click to select/deselect multiple rows
+  const [recentSelectedRowIndex, setRecentSelectedRowIndex] = useState<
+    number | null
+  >(null);
+  const [shifting, setShifting] = useState(false);
+
+  // Keyboard event
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Shift") {
+        setShifting(true);
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === "Shift") {
+        setShifting(false);
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("keyup", onKeyUp);
+
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("keyup", onKeyUp);
+    };
+  }, []);
+
+  // - Returns 'True' if a specific table host group has been selected
+  const isHostGroupSelected = (hostGroup: string) =>
+    selectedHostGroups.includes(hostGroup);
+
+  const areAllHostGroupsSelected =
+    selectedHostGroups.length === tableHostGroupsList.length &&
+    tableHostGroupsList.length !== 0;
+
+  // - Select all host groups
+  const selectAllHostGroups = (isSelecting = true) => {
+    setSelectedHostGroups(
+      isSelecting ? tableHostGroupsList.map((elem) => elem) : []
+    );
+    setIsDeleteDisabled(false);
+  };
+
+  // - Helper method to set the selected hosts from the table
+  const setHostGroupSelected = (hostGroup: string, isSelecting = true) =>
+    setSelectedHostGroups((prevSelected) => {
+      const otherSelectedHostGroups = prevSelected.filter(
+        (r) => r !== hostGroup
+      );
+      return isSelecting
+        ? [...otherSelectedHostGroups, hostGroup]
+        : otherSelectedHostGroups;
+    });
+
+  // - On selecting one single row
+  const onSelectHostGroup = (
+    hostGroup: string,
+    rowIndex: number,
+    isSelecting: boolean
+  ) => {
+    // If the element is shift + selecting the checkboxes, then all intermediate checkboxes should be selected
+    if (shifting && recentSelectedRowIndex !== null) {
+      const numberSelected = rowIndex - recentSelectedRowIndex;
+      const intermediateIndexes =
+        numberSelected > 0
+          ? Array.from(
+              new Array(numberSelected + 1),
+              (_x, i) => i + recentSelectedRowIndex
+            )
+          : Array.from(
+              new Array(Math.abs(numberSelected) + 1),
+              (_x, i) => i + rowIndex
+            );
+      intermediateIndexes.forEach((index) =>
+        setHostGroupSelected(selectedHostGroups[index], isSelecting)
+      );
+    } else {
+      setHostGroupSelected(hostGroup, isSelecting);
+    }
+    setRecentSelectedRowIndex(rowIndex);
+    // Enable 'Delete' button
+    setIsDeleteDisabled(false);
+  };
+
+  // Disable 'Delete' button when no elements selected
+  useEffect(() => {
+    if (selectedHostGroups.length === 0) {
+      setIsDeleteDisabled(true);
+    }
+  }, [selectedHostGroups]);
+
+  // Header
+  const hostGroupsHeader = (
+    <Tr>
+      <Th
+        select={{
+          onSelect: (_event, isSelecting) => selectAllHostGroups(isSelecting),
+          isSelected: areAllHostGroupsSelected,
+        }}
+      />
+      <Th width={10}>{hostGroupsColumnNamesArray[0]}</Th>
+    </Tr>
+  );
+
+  const hostGroupsBody = tableHostGroupsList.map((hostGroup, rowIndex) => (
+    <Tr key={hostGroup} id={hostGroup}>
+      <Td
+        dataLabel="checkbox"
+        select={{
+          rowIndex,
+          onSelect: (_event, isSelecting) =>
+            onSelectHostGroup(hostGroup, rowIndex, isSelecting),
+          isSelected: isHostGroupSelected(hostGroup),
+          disable: false,
+        }}
+      />
+      <Td dataLabel={hostGroupsColumnNamesArray[0]}>{hostGroup}</Td>
+    </Tr>
+  ));
+
+  // Modal functionality
+  // - Show modals
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  // - Close 'Add' modal
+  const onCloseAddHandler = () => {
+    setShowAddModal(false);
+  };
+
+  // - close 'Delete' button
+  const onCloseDeleteHandler = () => {
+    setShowDeleteModal(false);
+  };
+
+  // - 'Add' button -> Open modal
+  const onClickAddHandler = () => {
+    setShowAddModal(true);
+  };
+
+  // - 'Delete' button -> Remove table entry
+  const onClickDeleteHandler = () => {
+    setShowDeleteModal(true);
+  };
+
+  // - Update 'Delete' button
+  const updateIsDeleteButtonDisabled = (newValue: boolean) => {
+    setIsDeleteDisabled(newValue);
+  };
+
+  return (
+    <>
+      <TableWithButtonsLayout
+        ariaLabel="host groups table in host settings"
+        variant="compact"
+        hasBorders={true}
+        name="ipaallowedtoperform_read_keys_hostgroup"
+        tableId="host-settings-host-groups-table"
+        isStickyHeader={false}
+        tableHeader={hostGroupsHeader}
+        tableBody={hostGroupsBody}
+        tableClasses="pf-u-mb-2xl"
+        deleteButtonClasses="pf-u-mr-sm"
+        onDeleteModal={onClickDeleteHandler}
+        isDeleteDisabled={isDeleteDisabled}
+        addButtonClasses="pf-u-mr-sm"
+        onAddModal={onClickAddHandler}
+      />
+      {showAddModal && (
+        <RetrieveKeytabElementsAddModal
+          host={props.host}
+          elementType="host"
+          operationType="retrieve"
+          showModal={showAddModal}
+          onCloseModal={onCloseAddHandler}
+          onOpenModal={onClickAddHandler}
+          availableData={hostGroupsFilteredData}
+          updateAvailableData={updateHostGroupsFilteredData}
+          updateSelectedElements={updateSelectedHostGroups}
+          tableElementsList={tableHostGroupsList}
+          updateTableElementsList={updateTableHostGroupsList}
+        />
+      )}
+      {showDeleteModal && (
+        <RetrieveKeytabElementsDeleteModal
+          host={props.host}
+          elementType="host"
+          operationType="retrieve"
+          columnNames={hostGroupsColumnNamesArray}
+          showModal={showDeleteModal}
+          closeModal={onCloseDeleteHandler}
+          elementsToDelete={selectedHostGroups}
+          updateIsDeleteButtonDisabled={updateIsDeleteButtonDisabled}
+          updateSelectedElements={updateSelectedHostGroups}
+          tableElementsList={tableHostGroupsList}
+          updateTableElementsList={updateTableHostGroupsList}
+          availableData={hostGroupsFilteredData}
+          updateAvailableData={updateHostGroupsFilteredData}
+        />
+      )}
+    </>
+  );
+};
+
+export default RetrieveKeytabHostGroupsTable;

--- a/src/components/tables/HostsSettings/RetrieveKeytabHostsTable.tsx
+++ b/src/components/tables/HostsSettings/RetrieveKeytabHostsTable.tsx
@@ -1,0 +1,257 @@
+import React, { useEffect, useState } from "react";
+// PatternFly
+import { Td, Th, Tr } from "@patternfly/react-table";
+// Layout
+import TableWithButtonsLayout from "src/components/layouts/TableWithButtonsLayout";
+// Modals
+import RetrieveKeytabElementsAddModal from "src/components/modals/HostsSettings/RetrieveKeytabElementsAddModal";
+import RetrieveKeytabElementsDeleteModal from "src/components/modals/HostsSettings/RetrieveKeytabElementsDeleteModal";
+// Redux
+import { useAppSelector } from "src/store/hooks";
+
+interface PropsToTable {
+  host: string;
+}
+
+const RetrieveKeytabHostsTable = (props: PropsToTable) => {
+  // Full elements list -> Initial data
+  const fullHostsList = useAppSelector((state) => state.hosts.hostsList);
+  const fullHostIdsList = fullHostsList.map((host) => host.hostName);
+
+  // Elements on the table
+  const [tableHostsList, setTableHostsList] = useState<string[]>([]);
+
+  const updateTableHostsList = (newTableHostsList: string[]) => {
+    setTableHostsList(newTableHostsList);
+  };
+
+  // Filter function to compare the available data with the data that
+  //  is in the table already. This is done to prevent duplicates
+  //  (e.g: adding the same element twice).
+  const filterHostsData = () => {
+    return fullHostIdsList.filter((item) => {
+      return !tableHostsList.some((itm) => {
+        return item === itm;
+      });
+    });
+  };
+
+  // const usersFilteredData = filterUsersData();
+  const [hostsFilteredData, setHostsFilteredData] = useState(filterHostsData());
+
+  const updateHostsFilteredData = (newFilteredHosts: unknown[]) => {
+    setHostsFilteredData(newFilteredHosts as string[]);
+  };
+
+  // 'Delete' button is disabled if no row is selected
+  const [isDeleteDisabled, setIsDeleteDisabled] = useState(true);
+
+  // Column names (Array)
+  const hostsColumnNamesArray = ["Host"];
+
+  // - Selected rows are tracked
+  const [selectedHosts, setSelectedHosts] = useState<string[]>([]);
+
+  const updateSelectedHosts = (newSelectedHosts: string[]) => {
+    setSelectedHosts(newSelectedHosts);
+  };
+
+  // - To allow shift+click to select/deselect multiple rows
+  const [recentSelectedRowIndex, setRecentSelectedRowIndex] = useState<
+    number | null
+  >(null);
+  const [shifting, setShifting] = useState(false);
+
+  // Keyboard event
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Shift") {
+        setShifting(true);
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === "Shift") {
+        setShifting(false);
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("keyup", onKeyUp);
+
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("keyup", onKeyUp);
+    };
+  }, []);
+
+  // - Returns 'True' if a specific table host has been selected
+  const isHostSelected = (host: string) => selectedHosts.includes(host);
+
+  const areAllHostsSelected =
+    selectedHosts.length === tableHostsList.length &&
+    tableHostsList.length !== 0;
+
+  // - Select all elements
+  const selectAllHosts = (isSelecting = true) => {
+    setSelectedHosts(isSelecting ? tableHostsList.map((elem) => elem) : []);
+    setIsDeleteDisabled(false);
+  };
+
+  // - Helper method to set the selected elements from the table
+  const setHostSelected = (host: string, isSelecting = true) =>
+    setSelectedHosts((prevSelected) => {
+      const otherSelectedHosts = prevSelected.filter((r) => r !== host);
+      return isSelecting ? [...otherSelectedHosts, host] : otherSelectedHosts;
+    });
+
+  // - On selecting one single row
+  const onSelectHost = (
+    host: string,
+    rowIndex: number,
+    isSelecting: boolean
+  ) => {
+    // If the element is shift + selecting the checkboxes, then all intermediate checkboxes should be selected
+    if (shifting && recentSelectedRowIndex !== null) {
+      const numberSelected = rowIndex - recentSelectedRowIndex;
+      const intermediateIndexes =
+        numberSelected > 0
+          ? Array.from(
+              new Array(numberSelected + 1),
+              (_x, i) => i + recentSelectedRowIndex
+            )
+          : Array.from(
+              new Array(Math.abs(numberSelected) + 1),
+              (_x, i) => i + rowIndex
+            );
+      intermediateIndexes.forEach((index) =>
+        setHostSelected(selectedHosts[index], isSelecting)
+      );
+    } else {
+      setHostSelected(host, isSelecting);
+    }
+    setRecentSelectedRowIndex(rowIndex);
+    // Enable 'Delete' button
+    setIsDeleteDisabled(false);
+  };
+
+  // Disable 'Delete' button when no elements selected
+  useEffect(() => {
+    if (selectedHosts.length === 0) {
+      setIsDeleteDisabled(true);
+    }
+  }, [selectedHosts]);
+
+  // Header
+  const hostsHeader = (
+    <Tr>
+      <Th
+        select={{
+          onSelect: (_event, isSelecting) => selectAllHosts(isSelecting),
+          isSelected: areAllHostsSelected,
+        }}
+      />
+      <Th width={10}>{hostsColumnNamesArray[0]}</Th>
+    </Tr>
+  );
+
+  const hostsBody = tableHostsList.map((host, rowIndex) => (
+    <Tr key={host} id={host}>
+      <Td
+        dataLabel="checkbox"
+        select={{
+          rowIndex,
+          onSelect: (_event, isSelecting) =>
+            onSelectHost(host, rowIndex, isSelecting),
+          isSelected: isHostSelected(host),
+          disable: false,
+        }}
+      />
+      <Td dataLabel={hostsColumnNamesArray[0]}>{host}</Td>
+    </Tr>
+  ));
+
+  // Modal functionality
+  // - Show modals
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  // - Close 'Add' modal
+  const onCloseAddHandler = () => {
+    setShowAddModal(false);
+  };
+
+  // - close 'Delete' button
+  const onCloseDeleteHandler = () => {
+    setShowDeleteModal(false);
+  };
+
+  // - 'Add' button -> Open modal
+  const onClickAddHandler = () => {
+    setShowAddModal(true);
+  };
+
+  // - 'Delete' button -> Remove table entry
+  const onClickDeleteHandler = () => {
+    setShowDeleteModal(true);
+  };
+
+  // - Update 'Delete' button
+  const updateIsDeleteButtonDisabled = (newValue: boolean) => {
+    setIsDeleteDisabled(newValue);
+  };
+
+  return (
+    <>
+      <TableWithButtonsLayout
+        ariaLabel="hosts table in host settings"
+        variant="compact"
+        hasBorders={true}
+        name="ipaallowedtoperform_read_keys_host"
+        tableId="host-settings-host-table"
+        isStickyHeader={false}
+        tableHeader={hostsHeader}
+        tableBody={hostsBody}
+        tableClasses="pf-u-mb-2xl"
+        deleteButtonClasses="pf-u-mr-sm"
+        onDeleteModal={onClickDeleteHandler}
+        isDeleteDisabled={isDeleteDisabled}
+        addButtonClasses="pf-u-mr-sm"
+        onAddModal={onClickAddHandler}
+      />
+      {showAddModal && (
+        <RetrieveKeytabElementsAddModal
+          host={props.host}
+          elementType="host"
+          operationType="retrieve"
+          showModal={showAddModal}
+          onCloseModal={onCloseAddHandler}
+          onOpenModal={onClickAddHandler}
+          availableData={hostsFilteredData}
+          updateAvailableData={updateHostsFilteredData}
+          updateSelectedElements={updateSelectedHosts}
+          tableElementsList={tableHostsList}
+          updateTableElementsList={updateTableHostsList}
+        />
+      )}
+      {showDeleteModal && (
+        <RetrieveKeytabElementsDeleteModal
+          host={props.host}
+          elementType="host"
+          operationType="retrieve"
+          columnNames={hostsColumnNamesArray}
+          showModal={showDeleteModal}
+          closeModal={onCloseDeleteHandler}
+          elementsToDelete={selectedHosts}
+          updateIsDeleteButtonDisabled={updateIsDeleteButtonDisabled}
+          updateSelectedElements={updateSelectedHosts}
+          tableElementsList={tableHostsList}
+          updateTableElementsList={updateTableHostsList}
+          availableData={hostsFilteredData}
+          updateAvailableData={updateHostsFilteredData}
+        />
+      )}
+    </>
+  );
+};
+
+export default RetrieveKeytabHostsTable;

--- a/src/components/tables/HostsSettings/RetrieveKeytabUserGroupsTable.tsx
+++ b/src/components/tables/HostsSettings/RetrieveKeytabUserGroupsTable.tsx
@@ -1,0 +1,273 @@
+import React, { useEffect, useState } from "react";
+// PatternFly
+import { Td, Th, Tr } from "@patternfly/react-table";
+// Layout
+import TableWithButtonsLayout from "src/components/layouts/TableWithButtonsLayout";
+// Modals
+import RetrieveKeytabElementsAddModal from "src/components/modals/HostsSettings/RetrieveKeytabElementsAddModal";
+import RetrieveKeytabElementsDeleteModal from "src/components/modals/HostsSettings/RetrieveKeytabElementsDeleteModal";
+
+interface PropsToTable {
+  host: string;
+}
+
+const RetrieveKeytabUserGroupsTable = (props: PropsToTable) => {
+  // TODO: Retrieve data from Redux when available
+  // Full user groups list -> Initial data
+  const fullUserGroupsIdsList = [
+    "userGroup1",
+    "userGroup2",
+    "userGroup3",
+    "userGroup4",
+    "userGroup5",
+    "userGroup6",
+    "userGroup7",
+    "userGroup8",
+  ];
+
+  // User groups on the table
+  const [tableUserGroupsList, setTableUserGroupsList] = useState<string[]>([]);
+
+  const updateTableUserGroupsList = (newTableUserGroupsList: string[]) => {
+    setTableUserGroupsList(newTableUserGroupsList);
+  };
+
+  // Filter function to compare the available data with the data that
+  //  is in the table already. This is done to prevent duplicates
+  //  (e.g: adding the same element twice).
+  const filterUserGroupsData = () => {
+    return fullUserGroupsIdsList.filter((item) => {
+      return !tableUserGroupsList.some((itm) => {
+        return item === itm;
+      });
+    });
+  };
+
+  // const usersFilteredData = filterUsersData();
+  const [userGroupsFilteredData, setUserGroupsFilteredData] = useState(
+    filterUserGroupsData()
+  );
+
+  const updateUserGroupsFilteredData = (newFilteredUsers: unknown[]) => {
+    setUserGroupsFilteredData(newFilteredUsers as string[]);
+  };
+
+  // 'Delete' button is disabled if no row is selected
+  const [isDeleteDisabled, setIsDeleteDisabled] = useState(true);
+
+  // Column names (Array)
+  const userGroupsColumnNamesArray = ["User groups"];
+
+  // - Selected rows are tracked
+  const [selectedUserGroups, setSelectedUserGroups] = useState<string[]>([]);
+
+  const updateSelectedUserGroups = (newSelectedUserGroups: string[]) => {
+    setSelectedUserGroups(newSelectedUserGroups);
+  };
+
+  // - To allow shift+click to select/deselect multiple rows
+  const [recentSelectedRowIndex, setRecentSelectedRowIndex] = useState<
+    number | null
+  >(null);
+  const [shifting, setShifting] = useState(false);
+
+  // Keyboard event
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Shift") {
+        setShifting(true);
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === "Shift") {
+        setShifting(false);
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("keyup", onKeyUp);
+
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("keyup", onKeyUp);
+    };
+  }, []);
+
+  // - Returns 'True' if a specific table user group has been selected
+  const isUserGroupSelected = (userGroup: string) =>
+    selectedUserGroups.includes(userGroup);
+
+  const areAllUserGroupsSelected =
+    selectedUserGroups.length === tableUserGroupsList.length &&
+    tableUserGroupsList.length !== 0;
+
+  // - Select all user groups
+  const selectAllUserGroups = (isSelecting = true) => {
+    setSelectedUserGroups(
+      isSelecting ? tableUserGroupsList.map((elem) => elem) : []
+    );
+    setIsDeleteDisabled(false);
+  };
+
+  // - Helper method to set the selected users from the table
+  const setUserGroupSelected = (userGroup: string, isSelecting = true) =>
+    setSelectedUserGroups((prevSelected) => {
+      const otherSelectedUserGroups = prevSelected.filter(
+        (r) => r !== userGroup
+      );
+      return isSelecting
+        ? [...otherSelectedUserGroups, userGroup]
+        : otherSelectedUserGroups;
+    });
+
+  // - On selecting one single row
+  const onSelectUserGroup = (
+    userGroup: string,
+    rowIndex: number,
+    isSelecting: boolean
+  ) => {
+    // If the element is shift + selecting the checkboxes, then all intermediate checkboxes should be selected
+    if (shifting && recentSelectedRowIndex !== null) {
+      const numberSelected = rowIndex - recentSelectedRowIndex;
+      const intermediateIndexes =
+        numberSelected > 0
+          ? Array.from(
+              new Array(numberSelected + 1),
+              (_x, i) => i + recentSelectedRowIndex
+            )
+          : Array.from(
+              new Array(Math.abs(numberSelected) + 1),
+              (_x, i) => i + rowIndex
+            );
+      intermediateIndexes.forEach((index) =>
+        setUserGroupSelected(selectedUserGroups[index], isSelecting)
+      );
+    } else {
+      setUserGroupSelected(userGroup, isSelecting);
+    }
+    setRecentSelectedRowIndex(rowIndex);
+    // Enable 'Delete' button
+    setIsDeleteDisabled(false);
+  };
+
+  // Disable 'Delete' button when no elements selected
+  useEffect(() => {
+    if (selectedUserGroups.length === 0) {
+      setIsDeleteDisabled(true);
+    }
+  }, [selectedUserGroups]);
+
+  // Header
+  const userGroupsHeader = (
+    <Tr>
+      <Th
+        select={{
+          onSelect: (_event, isSelecting) => selectAllUserGroups(isSelecting),
+          isSelected: areAllUserGroupsSelected,
+        }}
+      />
+      <Th width={10}>{userGroupsColumnNamesArray[0]}</Th>
+    </Tr>
+  );
+
+  const userGroupsBody = tableUserGroupsList.map((userGroup, rowIndex) => (
+    <Tr key={userGroup} id={userGroup}>
+      <Td
+        dataLabel="checkbox"
+        select={{
+          rowIndex,
+          onSelect: (_event, isSelecting) =>
+            onSelectUserGroup(userGroup, rowIndex, isSelecting),
+          isSelected: isUserGroupSelected(userGroup),
+          disable: false,
+        }}
+      />
+      <Td dataLabel={userGroupsColumnNamesArray[0]}>{userGroup}</Td>
+    </Tr>
+  ));
+
+  // Modal functionality
+  // - Show modals
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  // - Close 'Add' modal
+  const onCloseAddHandler = () => {
+    setShowAddModal(false);
+  };
+
+  // - close 'Delete' button
+  const onCloseDeleteHandler = () => {
+    setShowDeleteModal(false);
+  };
+
+  // - 'Add' button -> Open modal
+  const onClickAddHandler = () => {
+    setShowAddModal(true);
+  };
+
+  // - 'Delete' button -> Remove table entry
+  const onClickDeleteHandler = () => {
+    setShowDeleteModal(true);
+  };
+
+  // - Update 'Delete' button
+  const updateIsDeleteButtonDisabled = (newValue: boolean) => {
+    setIsDeleteDisabled(newValue);
+  };
+
+  return (
+    <>
+      <TableWithButtonsLayout
+        ariaLabel="user group table in host settings"
+        variant="compact"
+        hasBorders={true}
+        name="ipaallowedtoperform_read_keys_group"
+        tableId="host-settings-user-group-table"
+        isStickyHeader={false}
+        tableHeader={userGroupsHeader}
+        tableBody={userGroupsBody}
+        tableClasses="pf-u-mb-3xl"
+        deleteButtonClasses="pf-u-mr-sm"
+        onDeleteModal={onClickDeleteHandler}
+        isDeleteDisabled={isDeleteDisabled}
+        addButtonClasses="pf-u-mr-sm"
+        onAddModal={onClickAddHandler}
+      />
+      {showAddModal && (
+        <RetrieveKeytabElementsAddModal
+          host={props.host}
+          elementType="user group"
+          operationType="retrieve"
+          showModal={showAddModal}
+          onCloseModal={onCloseAddHandler}
+          onOpenModal={onClickAddHandler}
+          availableData={userGroupsFilteredData}
+          updateAvailableData={updateUserGroupsFilteredData}
+          updateSelectedElements={updateSelectedUserGroups}
+          tableElementsList={tableUserGroupsList}
+          updateTableElementsList={updateTableUserGroupsList}
+        />
+      )}
+      {showDeleteModal && (
+        <RetrieveKeytabElementsDeleteModal
+          host={props.host}
+          elementType="user group"
+          operationType="retrieve"
+          columnNames={userGroupsColumnNamesArray}
+          showModal={showDeleteModal}
+          closeModal={onCloseDeleteHandler}
+          elementsToDelete={selectedUserGroups}
+          updateIsDeleteButtonDisabled={updateIsDeleteButtonDisabled}
+          updateSelectedElements={updateSelectedUserGroups}
+          tableElementsList={tableUserGroupsList}
+          updateTableElementsList={updateTableUserGroupsList}
+          availableData={userGroupsFilteredData}
+          updateAvailableData={updateUserGroupsFilteredData}
+        />
+      )}
+    </>
+  );
+};
+
+export default RetrieveKeytabUserGroupsTable;

--- a/src/components/tables/HostsSettings/RetrieveKeytabUsersTable.tsx
+++ b/src/components/tables/HostsSettings/RetrieveKeytabUsersTable.tsx
@@ -1,0 +1,261 @@
+import React, { useEffect, useState } from "react";
+// PatternFly
+import { Td, Th, Tr } from "@patternfly/react-table";
+// Layouts
+import TableWithButtonsLayout from "src/components/layouts/TableWithButtonsLayout";
+// Modals
+import RetrieveKeytabElementsAddModal from "src/components/modals/HostsSettings/RetrieveKeytabElementsAddModal";
+import RetrieveKeytabElementsDeleteModal from "src/components/modals/HostsSettings/RetrieveKeytabElementsDeleteModal";
+// Redux
+import { useAppSelector } from "src/store/hooks";
+
+interface PropsToTable {
+  host: string;
+}
+
+const RetrieveKeytabUsersTable = (props: PropsToTable) => {
+  // Full users list -> Initial data
+  const fullUsersList = useAppSelector((state) => state.activeUsers.usersList);
+  const fullUserIdsList = fullUsersList.map((user) => user.userLogin);
+
+  // Users list on the table
+  const [tableUsersList, setTableUsersList] = useState<string[]>([]);
+
+  const updateTableUsersList = (newTableUsersList: string[]) => {
+    setTableUsersList(newTableUsersList);
+  };
+
+  // Filter function to compare the available data with the data that
+  //  is in the table already. This is done to prevent duplicates
+  //  (e.g: adding the same element twice).
+  const filterUsersData = () => {
+    return fullUserIdsList.filter((item) => {
+      return !tableUsersList.some((itm) => {
+        return item === itm;
+      });
+    });
+  };
+
+  // const usersFilteredData = filterUsersData();
+  const [usersFilteredData, setUsersFilteredData] = useState(filterUsersData());
+
+  const updateUsersFilteredData = (newFilteredUsers: unknown[]) => {
+    setUsersFilteredData(newFilteredUsers as string[]);
+  };
+
+  // 'Delete' button is disabled if no row is selected
+  const [isDeleteDisabled, setIsDeleteDisabled] = useState(true);
+
+  // Column names (String)
+  const usersColumnNamesArray = ["User"];
+
+  // Selected rows are tracked
+  const [selectedUsers, setSelectedUsers] = useState<string[]>([]);
+
+  const updateSelectedUsers = (newSelectedUsers: string[]) => {
+    setSelectedUsers(newSelectedUsers);
+  };
+
+  // To allow shift+click to select/deselect multiple rows
+  const [recentSelectedRowIndex, setRecentSelectedRowIndex] = useState<
+    number | null
+  >(null);
+  const [shifting, setShifting] = useState(false);
+
+  // Keyboard event to select rows
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Shift") {
+        setShifting(true);
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === "Shift") {
+        setShifting(false);
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("keyup", onKeyUp);
+
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("keyup", onKeyUp);
+    };
+  }, []);
+
+  // - Returns 'True' if a specific table user has been selected
+  const isUserSelected = (user: string) => selectedUsers.includes(user);
+
+  const areAllUsersSelected =
+    selectedUsers.length === tableUsersList.length &&
+    tableUsersList.length !== 0;
+
+  // - Select all users
+  const selectAllUsers = (isSelecting = true) => {
+    setSelectedUsers(isSelecting ? tableUsersList.map((elem) => elem) : []);
+    setIsDeleteDisabled(false);
+  };
+
+  // - Helper method to set the selected users from the table
+  const setUserSelected = (user: string, isSelecting = true) =>
+    setSelectedUsers((prevSelected) => {
+      const otherSelectedUsers = prevSelected.filter((r) => r !== user);
+      return isSelecting ? [...otherSelectedUsers, user] : otherSelectedUsers;
+    });
+
+  // - On selecting one single row
+  const onSelectUser = (
+    user: string,
+    rowIndex: number,
+    isSelecting: boolean
+  ) => {
+    // If the element is shift + selecting the checkboxes, then all intermediate checkboxes should be selected
+    if (shifting && recentSelectedRowIndex !== null) {
+      const numberSelected = rowIndex - recentSelectedRowIndex;
+      const intermediateIndexes =
+        numberSelected > 0
+          ? Array.from(
+              new Array(numberSelected + 1),
+              (_x, i) => i + recentSelectedRowIndex
+            )
+          : Array.from(
+              new Array(Math.abs(numberSelected) + 1),
+              (_x, i) => i + rowIndex
+            );
+      intermediateIndexes.forEach((index) =>
+        setUserSelected(tableUsersList[index], isSelecting)
+      );
+    } else {
+      setUserSelected(user, isSelecting);
+    }
+    setRecentSelectedRowIndex(rowIndex);
+    // Enable 'Delete' button
+    setIsDeleteDisabled(false);
+  };
+
+  // Disable 'Delete' button when no elements selected
+  useEffect(() => {
+    if (selectedUsers.length === 0) {
+      setIsDeleteDisabled(true);
+    }
+  }, [selectedUsers]);
+
+  // Header
+  const usersHeader = (
+    <Tr>
+      <Th
+        select={{
+          onSelect: (_event, isSelecting) => selectAllUsers(isSelecting),
+          isSelected: areAllUsersSelected,
+        }}
+      />
+      {/* <Th width={10}>{usersColumnNames.user}</Th> */}
+      <Th width={10}>{usersColumnNamesArray[0]}</Th>
+    </Tr>
+  );
+
+  // Body
+  const usersBody = tableUsersList.map((user, rowIndex) => (
+    <Tr key={user} id={user}>
+      <Td
+        dataLabel="checkbox"
+        select={{
+          rowIndex,
+          onSelect: (_event, isSelecting) =>
+            onSelectUser(user, rowIndex, isSelecting),
+          isSelected: isUserSelected(user),
+          disable: false,
+        }}
+      />
+      {/* <Td dataLabel={usersColumnNames.user}>{user}</Td> */}
+      <Td dataLabel={usersColumnNamesArray[0]}>{user}</Td>
+    </Tr>
+  ));
+
+  // Modal functionality
+  // - Show modals
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  // - Close 'Add' modal
+  const onCloseAddHandler = () => {
+    setShowAddModal(false);
+  };
+
+  // - close 'Delete' button
+  const onCloseDeleteHandler = () => {
+    setShowDeleteModal(false);
+  };
+
+  // - 'Add' button -> Open modal
+  const onClickAddHandler = () => {
+    setShowAddModal(true);
+  };
+
+  // - 'Delete' button -> Remove table entry
+  const onClickDeleteHandler = () => {
+    setShowDeleteModal(true);
+  };
+
+  // - Update 'Delete' button
+  const updateIsDeleteButtonDisabled = (newValue: boolean) => {
+    setIsDeleteDisabled(newValue);
+  };
+
+  // Render component
+  return (
+    <>
+      <TableWithButtonsLayout
+        ariaLabel="user table in host settings"
+        variant="compact"
+        hasBorders={true}
+        name="ipaallowedtoperform_read_keys_user"
+        tableId="host-settings-user-table"
+        isStickyHeader={false}
+        tableHeader={usersHeader}
+        tableBody={usersBody}
+        tableClasses="pf-u-mb-3xl"
+        deleteButtonClasses="pf-u-mr-sm"
+        onDeleteModal={onClickDeleteHandler}
+        isDeleteDisabled={isDeleteDisabled}
+        addButtonClasses="pf-u-mr-sm"
+        onAddModal={onClickAddHandler}
+      />
+      {showAddModal && (
+        <RetrieveKeytabElementsAddModal
+          host={props.host}
+          elementType="user"
+          operationType="retrieve"
+          showModal={showAddModal}
+          onCloseModal={onCloseAddHandler}
+          onOpenModal={onClickAddHandler}
+          availableData={usersFilteredData}
+          updateAvailableData={updateUsersFilteredData}
+          updateSelectedElements={updateSelectedUsers}
+          tableElementsList={tableUsersList}
+          updateTableElementsList={updateTableUsersList}
+        />
+      )}
+      {showDeleteModal && (
+        <RetrieveKeytabElementsDeleteModal
+          host={props.host}
+          elementType="user"
+          operationType="retrieve"
+          columnNames={usersColumnNamesArray}
+          showModal={showDeleteModal}
+          closeModal={onCloseDeleteHandler}
+          elementsToDelete={selectedUsers}
+          updateIsDeleteButtonDisabled={updateIsDeleteButtonDisabled}
+          updateSelectedElements={updateSelectedUsers}
+          tableElementsList={tableUsersList}
+          updateTableElementsList={updateTableUsersList}
+          availableData={usersFilteredData}
+          updateAvailableData={updateUsersFilteredData}
+        />
+      )}
+    </>
+  );
+};
+
+export default RetrieveKeytabUsersTable;

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -14,6 +14,7 @@ import UserGroups from "src/pages/UserGroups/UserGroups";
 import HostGroups from "src/pages/HostGroups/HostGroups";
 import Netgroups from "src/pages/Netgroups/Netgroups";
 import Hosts from "src/pages/Hosts/Hosts";
+import HostsTabs from "src/pages/Hosts/HostsTabs";
 
 // Navigation
 import { URL_PREFIX } from "./NavRoutes";
@@ -36,6 +37,7 @@ export const AppRoutes = (): React.ReactElement => (
       </Route>
       <Route path="hosts">
         <Route path="" element={<Hosts />} />
+        <Route path="settings" element={<HostsTabs />} />
       </Route>
       <Route path="services">
         <Route path="" />

--- a/src/pages/Hosts/HostsSettings.tsx
+++ b/src/pages/Hosts/HostsSettings.tsx
@@ -1,0 +1,189 @@
+import React, { SyntheticEvent, useState } from "react";
+// PatternFly
+import {
+  DropdownDirection,
+  DropdownItem,
+  Flex,
+  JumpLinks,
+  JumpLinksItem,
+  PageSection,
+  PageSectionVariants,
+  Sidebar,
+  SidebarContent,
+  SidebarPanel,
+  TextVariants,
+} from "@patternfly/react-core";
+// Icons
+import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
+// Data types
+import { Host } from "src/utils/datatypes/globalDataTypes";
+// Layouts
+import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
+import TitleLayout from "src/components/layouts/TitleLayout";
+import SecondaryButton from "src/components/layouts/SecondaryButton";
+import KebabLayout from "src/components/layouts/KebabLayout";
+import ToolbarLayout from "src/components/layouts/ToolbarLayout";
+// Field sections
+import HostSettings from "src/components/HostsSections/HostSettings";
+import Enrollment from "src/components/HostsSections/Enrollment";
+import HostCertificate from "src/components/HostsSections/HostCertificate";
+import AllowedRetrieveKeytab from "src/components/HostsSections/AllowedRetrieveKeytab";
+import AllowedCreateKeytab from "src/components/HostsSections/AllowedCreateKeytab";
+
+interface PropsToHostsSettings {
+  host: Host;
+}
+
+const HostsSettings = (props: PropsToHostsSettings) => {
+  // Kebab
+  const [isKebabOpen, setIsKebabOpen] = useState(false);
+
+  const dropdownItems = [
+    <DropdownItem key="rebuild auto membership">
+      Rebuild auto membership
+    </DropdownItem>,
+    <DropdownItem key="unprovision">Unprovision</DropdownItem>,
+    <DropdownItem key="set-one-time-password">
+      Set one-time password
+    </DropdownItem>,
+    <DropdownItem key="new certificate">New certificate</DropdownItem>,
+  ];
+
+  const onKebabToggle = (isOpen: boolean) => {
+    setIsKebabOpen(isOpen);
+  };
+
+  const onKebabSelect = (
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _event: SyntheticEvent<HTMLDivElement, Event> | undefined
+  ) => {
+    setIsKebabOpen(!isKebabOpen);
+  };
+  // Toolbar
+  const toolbarFields = [
+    {
+      key: 0,
+      element: <SecondaryButton>Refresh</SecondaryButton>,
+    },
+    {
+      key: 1,
+      element: <SecondaryButton isDisabled={true}>Revert</SecondaryButton>,
+    },
+    {
+      key: 2,
+      element: <SecondaryButton isDisabled={true}>Save</SecondaryButton>,
+    },
+    {
+      key: 3,
+      element: (
+        <KebabLayout
+          direction={DropdownDirection.up}
+          onDropdownSelect={onKebabSelect}
+          onKebabToggle={onKebabToggle}
+          idKebab="toggle-action-buttons"
+          isKebabOpen={isKebabOpen}
+          isPlain={true}
+          dropdownItems={dropdownItems}
+        />
+      ),
+    },
+  ];
+  return (
+    <>
+      <PageSection
+        id="settings-page"
+        variant={PageSectionVariants.light}
+        className="pf-u-pr-0 pf-u-ml-lg pf-u-mr-sm"
+        style={{ overflowY: "scroll", height: `calc(100vh - 319px)` }}
+      >
+        <Sidebar isPanelRight className="pf-u-mt-lg">
+          <SidebarPanel variant="sticky">
+            <HelpTextWithIconLayout
+              textComponent={TextVariants.p}
+              textClassName="pf-u-mb-md"
+              subTextComponent={TextVariants.a}
+              subTextIsVisitedLink={true}
+              textContent="Help"
+              icon={
+                <OutlinedQuestionCircleIcon className="pf-u-primary-color-100 pf-u-mr-sm" />
+              }
+            />
+            <JumpLinks
+              isVertical
+              label="Jump to section"
+              scrollableSelector="#settings-page"
+              offset={220} // for masthead
+              expandable={{ default: "expandable", md: "nonExpandable" }}
+            >
+              <JumpLinksItem key={0} href="#host-settings">
+                Host settings
+              </JumpLinksItem>
+              <JumpLinksItem key={1} href="#enrollment">
+                Enrollment
+              </JumpLinksItem>
+              <JumpLinksItem key={2} href="#host-certificate">
+                Host certificate
+              </JumpLinksItem>
+              <JumpLinksItem key={3} href="#allow-retrieve-keytab">
+                Allow to retrieve keytab
+              </JumpLinksItem>
+              <JumpLinksItem key={4} href="#allow-create-keytab">
+                Allow to create keytab
+              </JumpLinksItem>
+            </JumpLinks>
+          </SidebarPanel>
+
+          <SidebarContent className="pf-u-mr-xl">
+            <Flex
+              direction={{ default: "column" }}
+              flex={{ default: "flex_1" }}
+            >
+              <TitleLayout
+                key={0}
+                headingLevel="h2"
+                id="host-settings"
+                text="Host settings"
+              />
+              <HostSettings host={props.host} />
+              <TitleLayout
+                key={1}
+                headingLevel="h2"
+                id="enrollment"
+                text="Enrollment"
+              />
+              <Enrollment />
+              <TitleLayout
+                key={2}
+                headingLevel="h2"
+                id="host-certificate"
+                text="Host certificate"
+              />
+              <HostCertificate />
+              <TitleLayout
+                key={3}
+                headingLevel="h2"
+                id="allow-retrieve-keytab"
+                text="Allow to retrieve keytab"
+              />
+              <AllowedRetrieveKeytab host={props.host} />
+              <TitleLayout
+                key={4}
+                headingLevel="h2"
+                id="allow-create-keytab"
+                text="Allow to create keytab"
+              />
+              <AllowedCreateKeytab host={props.host} />
+            </Flex>
+          </SidebarContent>
+        </Sidebar>
+      </PageSection>
+      <ToolbarLayout
+        isSticky={true}
+        className={"pf-u-p-md pf-u-ml-lg pf-u-mr-lg"}
+        toolbarItems={toolbarFields}
+      />
+    </>
+  );
+};
+
+export default HostsSettings;

--- a/src/pages/Hosts/HostsTabs.tsx
+++ b/src/pages/Hosts/HostsTabs.tsx
@@ -1,0 +1,87 @@
+import React, { useState } from "react";
+// PatternFly
+import {
+  Page,
+  PageSection,
+  PageSectionVariants,
+  Tabs,
+  Tab,
+  TabTitleText,
+} from "@patternfly/react-core";
+// React Router DOM
+import { useLocation } from "react-router-dom";
+// Navigation
+import { URL_PREFIX } from "src/navigation/NavRoutes";
+// Other
+import HostsSettings from "./HostsSettings";
+// Layouts
+import BreadcrumbLayout from "src/components/layouts/BreadcrumbLayout";
+import TitleLayout from "src/components/layouts/TitleLayout";
+// Data types
+import { Host } from "src/utils/datatypes/globalDataTypes";
+
+const HostsTabs = () => {
+  // TODO: Make the 'Tabs' component data-agnostic and more reusable,
+  //   getting the data via props.
+
+  // Get location (React Router DOM) and get state data
+  const location = useLocation();
+  const hostData: Host = location.state as Host;
+
+  // Tab
+  const [activeTabKey, setActiveTabKey] = useState(0);
+
+  const handleTabClick = (
+    _event: React.MouseEvent<HTMLElement, MouseEvent>,
+    tabIndex: number | string
+  ) => {
+    setActiveTabKey(tabIndex as number);
+  };
+
+  // 'pagesVisited' array will contain the visited pages.
+  // - Those will be passed to the 'BreadcrumbLayout' component.
+  const pagesVisited = [
+    {
+      name: "Hosts",
+      url: URL_PREFIX + "/hosts",
+    },
+  ];
+
+  return (
+    <Page>
+      <PageSection variant={PageSectionVariants.light} className="pf-u-pr-0">
+        <BreadcrumbLayout
+          className="pf-u-mb-md"
+          preText="Host:"
+          userId={hostData.id}
+          pagesVisited={pagesVisited}
+        />
+        <TitleLayout
+          id={hostData.hostName}
+          text={hostData.hostName}
+          headingLevel="h1"
+        />
+      </PageSection>
+      <PageSection type="tabs" variant={PageSectionVariants.light} isFilled>
+        <Tabs
+          activeKey={activeTabKey}
+          onSelect={handleTabClick}
+          variant="light300"
+          isBox
+          className="pf-u-ml-lg"
+        >
+          <Tab
+            eventKey={0}
+            name="details"
+            title={<TabTitleText>Settings</TabTitleText>}
+          >
+            <PageSection className="pf-u-pb-0"></PageSection>
+            <HostsSettings host={hostData} />
+          </Tab>
+        </Tabs>
+      </PageSection>
+    </Page>
+  );
+};
+
+export default HostsTabs;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8112750/214341913-b1749a9c-30ae-40cb-abdc-3b79914e6d80.png)

### Description
The 'Host' > 'Settings' section contains the main configuration for a specific host (accessed by clicking on the main table). This can be reached under `<BASE-URL>/Hosts/Settings`.

### Routing
To access this page in the WebUI, the routing has been defined in the `AppRoutes` component. As this is a Host's section, it should be dependent on it.  The routing points directly to the `HostsSettings` component.

```ts
      <Route path="hosts">
          <Route path="" element={<Hosts />} />
          <Route path="settings" element={<HostsTabs />} />
      </Route>
```

### 'Settings' section
The Host settings page contains the main following subsections:
- 'Host settings' (`HostSettings` component)
   - Related to the host's main settings.
- 'Enrollment' (`Enrollment` component)
   - Related to the Kerberos authentication settings.
- 'Host certificate' (`HostCertificate` component)
   - Related to the certificates associated with that specific host.
- 'Allow to retrieve keytab' (`AllowedRetrieveKeytab` component)
   - Related to the permissions for retrieving keytabs.
- 'Allow to create keyTab' (`AllowedCreateKeytab` component)
   - Related to the permissions for creating keytabs.

Also, the `HostsSettings` component is set under a layout called `HostsTabs`. This structure makes the code leaner and more scalable.

### 'Allow to create/retrieve' subsections
'Allow to create keytab' and 'Allow to retrieve keytab' are two sections contained in the Hosts' settings page.

These are made up of four different tables for each section: `Users`, `Hosts`, `User groups`, and `Host groups`. Each of them has two action buttons to manage the tables: `Add` and `Delete`. When clicking any of them, a modal will be shown to help perform the specific operation.

The tables created are:
- `RetrieveKeytabUsersTable`
- `RetrieveKeytabHostsTable`
- `RetrieveKeytabUserGroupsTable`
- `RetrieveKeytabHostGroupsTable`
- `CreateKeytabUsersTable`
- `CreateKeytabHostsTable`
- `CreateKeytabUserGroupsTable`
- `CreateKeytabHostGroupsTable`

In order to make use of a reusable component for the button's actions, the following modal components have been defined:
- `CreateKeytabElementsAddModal`
- `CreateKeytabElementsDeleteModal`
- `RetrieveKeytabElementsAddModal`
- `RetrieveKeytabElementsDeleteModal`

The reason behind creating two different types of modals (`Retrieve-` and `Create-`) is to prepare those types for possible
changes that can occur when performing those operations via API calls.

### Other components
Some components have been created or altered to enhance their reusability in the project. Those are:
- `BreadCrumbLayout`: Simple [breadcrumb](https://www.patternfly.org/v4/components/breadcrumb) layout component
- `TableWithButtonsLayout`: Table that contains the 'Add' and 'Delete' buttons. 
- `TextLayout`: Layout for the [text component](https://www.patternfly.org/v4/components/text/).
- `DeletedElementsTable`: Table to list the deleted elements. Used normally as part of the 'Delete' action button.

Signed-off-by: Carla Martinez <carlmart@redhat.com>