### PR TITLE
'Hosts' > 'Is a member of' section

### DIFF
--- a/src/components/MemberOf/MemberOfAddModal.tsx
+++ b/src/components/MemberOf/MemberOfAddModal.tsx
@@ -10,6 +10,7 @@ import {
   Roles,
   HBACRules,
   SudoRules,
+  HostGroup,
 } from "src/utils/datatypes/globalDataTypes";
 
 interface ModalData {
@@ -19,15 +20,27 @@ interface ModalData {
 
 interface TabData {
   tabName: string;
-  userName: string;
+  userName: string; // TODO: Change to a more generalistic name
 }
 
 export interface PropsToAdd {
   modalData: ModalData;
-  availableData: UserGroup[] | Netgroup[] | Roles[] | HBACRules[] | SudoRules[];
+  availableData:
+    | UserGroup[]
+    | Netgroup[]
+    | Roles[]
+    | HBACRules[]
+    | SudoRules[]
+    | HostGroup[];
   groupRepository: unknown[];
   updateGroupRepository: (
-    args: UserGroup[] | Netgroup[] | Roles[] | HBACRules[] | SudoRules[]
+    args:
+      | UserGroup[]
+      | Netgroup[]
+      | Roles[]
+      | HBACRules[]
+      | SudoRules[]
+      | HostGroup[]
   ) => void;
   updateAvOptionsList: (args: unknown[]) => void;
   tabData: TabData;
@@ -38,8 +51,9 @@ export interface PropsToAdd {
 // To display all the possible data types for all the tabs (and not only the mandatory ones)
 //   an extra interface 'MemberOfElement' will be defined. This will be called when assigning
 //   a new group instead of refering to each type (UserGroup | Netgroup | Roles | HBACRules |
-//   SudoRules).
+//   SudoRules | HostGroup).
 interface MemberOfElement {
+  hostGroup?: string;
   name: string;
   gid?: string;
   status?: string;
@@ -169,6 +183,16 @@ const MemberOfAddModal = (props: PropsToAdd) => {
           } as SudoRules);
           // Send updated data to table
           props.updateGroupRepository(props.groupRepository as SudoRules[]);
+        }
+        // Host groups
+        if (props.tabData.tabName === "Host groups") {
+          props.groupRepository.push({
+            name: optionData.name !== undefined && optionData.name,
+            description:
+              optionData.description !== undefined && optionData.description,
+          } as HostGroup);
+          // Send updated data to table
+          props.updateGroupRepository(props.groupRepository as HostGroup[]);
         }
       }
     });

--- a/src/components/MemberOf/MemberOfTable.tsx
+++ b/src/components/MemberOf/MemberOfTable.tsx
@@ -26,7 +26,7 @@ interface ColumnNames {
 //  its variables. Just the mandatory ones ('name' and 'description') are accessible at this point.
 // To display all the possible data types for all the tabs (and not only the mandatory ones)
 //   an extra interface 'MemberOfElement' will be defined. This will be called in the 'PropsToTable'
-//   interface instead of each type (UserGroup | Netgroup | Roles | HBACRules | SudoRules).
+//   interface instead of each type (UserGroup | Netgroup | Roles | HBACRules | SudoRules | HostGroup).
 interface MemberOfElement {
   name: string;
   gid?: string;
@@ -76,6 +76,10 @@ const MemberOfTable = (props: PropsToTable) => {
     status: "Status",
     description: "Description",
   };
+  const hostGroupsColumnNames: ColumnNames = {
+    name: "Host name",
+    description: "Description",
+  };
 
   // State for column names
   const [columnNames, setColumnNames] = useState<ColumnNames>(
@@ -109,7 +113,12 @@ const MemberOfTable = (props: PropsToTable) => {
   useEffect(() => {
     switch (props.activeTabKey) {
       case 0:
-        setColumnNames(userGroupsColumnNames);
+        if (props.tableName === "User groups") {
+          setColumnNames(userGroupsColumnNames);
+        }
+        if (props.tableName === "Host groups") {
+          setColumnNames(hostGroupsColumnNames);
+        }
         break;
       case 1:
         setColumnNames(netgroupsColumnNames);

--- a/src/components/MemberOf/MemberOfToolbar.tsx
+++ b/src/components/MemberOf/MemberOfToolbar.tsx
@@ -26,6 +26,7 @@ import {
   Roles,
   HBACRules,
   SudoRules,
+  HostGroup,
 } from "src/utils/datatypes/globalDataTypes";
 // Layout
 import SearchInputLayout from "src/components/layouts/SearchInputLayout";
@@ -55,7 +56,13 @@ interface ButtonData {
 
 interface SettersData {
   changeMemberGroupsList: (
-    arg: UserGroup[] | Netgroup[] | Roles[] | HBACRules[] | SudoRules[]
+    arg:
+      | UserGroup[]
+      | Netgroup[]
+      | Roles[]
+      | HBACRules[]
+      | SudoRules[]
+      | HostGroup[]
   ) => void;
   changeTabName: (name: string) => void;
 }
@@ -66,9 +73,27 @@ interface SearchValueData {
 }
 
 export interface PropsToToolbar {
-  pageRepo: UserGroup[] | Netgroup[] | Roles[] | HBACRules[] | SudoRules[];
-  shownItems: UserGroup[] | Netgroup[] | Roles[] | HBACRules[] | SudoRules[];
-  toolbar: "user groups" | "netgroups" | "roles" | "HBAC rules" | "sudo rules";
+  pageRepo:
+    | UserGroup[]
+    | Netgroup[]
+    | Roles[]
+    | HBACRules[]
+    | SudoRules[]
+    | HostGroup[];
+  shownItems:
+    | UserGroup[]
+    | Netgroup[]
+    | Roles[]
+    | HBACRules[]
+    | SudoRules[]
+    | HostGroup[];
+  toolbar:
+    | "user groups"
+    | "netgroups"
+    | "roles"
+    | "HBAC rules"
+    | "sudo rules"
+    | "host groups";
   settersData: SettersData;
   pageData: PageData;
   buttonData: ButtonData;
@@ -213,6 +238,28 @@ const MemberOfToolbar = (props: PropsToToolbar) => {
 
   const sudoRulesOnDeleteClickHandler = () => {
     props.settersData.changeTabName("Sudo rules");
+    props.buttonData.onClickDeleteHandler();
+  };
+
+  // - Host groups
+  const [isTGHostGroupsSelected, setIsTGHostGroupsSelected] =
+    useState("direct");
+
+  const TGHostGroupsHandler = (
+    isSelected: boolean,
+    event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent
+  ) => {
+    const id = event.currentTarget.id;
+    setIsTGHostGroupsSelected(id);
+  };
+
+  const hostGroupsOnClickAddHandler = () => {
+    props.settersData.changeTabName("Host groups");
+    props.buttonData.onClickAddHandler();
+  };
+
+  const hostGroupsOnDeleteClickHandler = () => {
+    props.settersData.changeTabName("Host groups");
     props.buttonData.onClickDeleteHandler();
   };
 
@@ -381,6 +428,39 @@ const MemberOfToolbar = (props: PropsToToolbar) => {
     paginationId: "sudoRules-pagination",
   };
 
+  // 'Host groups' toolbar elements data
+  const hostGroupsToolbarData = {
+    searchId: "hostGroups-search",
+    separator1Id: "hostGroups-separator-1",
+    refreshButton: {
+      id: "hostGroups-button-refresh",
+    },
+    deleteButton: {
+      id: "hostGroups-button-delete",
+      isDisabledHandler: props.buttonData.isDeleteButtonDisabled,
+      onClickHandler: hostGroupsOnDeleteClickHandler,
+    },
+    addButton: {
+      id: "hostGroups-button-add",
+      onClickHandler: hostGroupsOnClickAddHandler,
+    },
+    separator2Id: "hostGroups-separator-2",
+    membership: {
+      formId: "hostGroups-form",
+      toggleGroupId: "hostGroups-toggle-group",
+      isDirectSelected: isTGHostGroupsSelected === "direct",
+      onDirectChange: TGHostGroupsHandler,
+      isIndirectSelected: isTGHostGroupsSelected === "indirect",
+      onIndirectChange: TGHostGroupsHandler,
+    },
+    separator3Id: "hostGroups-separator-3",
+    helpIcon: {
+      id: "hostGroups-help-icon",
+      // href: TDB
+    },
+    paginationId: "hostGroups-pagination",
+  };
+
   // Specify which toolbar to show
   const toolbarData = () => {
     switch (props.toolbar) {
@@ -394,6 +474,8 @@ const MemberOfToolbar = (props: PropsToToolbar) => {
         return hbacRulesToolbarData;
       case "sudo rules":
         return sudoRulesToolbarData;
+      case "host groups":
+        return hostGroupsToolbarData;
     }
   };
 

--- a/src/pages/Hosts/HostsMemberOf.tsx
+++ b/src/pages/Hosts/HostsMemberOf.tsx
@@ -1,0 +1,837 @@
+import React, { useEffect, useState } from "react";
+// PatternFly
+import {
+  Badge,
+  Page,
+  PageSection,
+  PageSectionVariants,
+  Pagination,
+  PaginationVariant,
+  Tab,
+  Tabs,
+  TabTitleText,
+} from "@patternfly/react-core";
+// Others
+import MemberOfToolbar from "src/components/MemberOf/MemberOfToolbar";
+import MemberOfTable from "src/components/MemberOf/MemberOfTable";
+// Data types
+import {
+  HostGroup,
+  Netgroup,
+  Roles,
+  HBACRules,
+  SudoRules,
+  Host,
+} from "src/utils/datatypes/globalDataTypes";
+// Redux
+import { useAppSelector } from "src/store/hooks";
+
+// Repositories
+import {
+  hostsHostGroupsInitialData,
+  hostsNetgroupsInitialData,
+  hostsRolesInitialData,
+  hostsHbacRulesInitialData,
+  hostsSudoRulesInitialData,
+} from "src/utils/data/GroupRepositories";
+// Modals
+import MemberOfAddModal from "src/components/MemberOf/MemberOfAddModal";
+import MemberOfDeleteModal from "src/components/MemberOf/MemberOfDeleteModal";
+
+interface PropsToHostsMemberOf {
+  host: Host;
+}
+
+const HostsMemberOf = (props: PropsToHostsMemberOf) => {
+  // Retrieve each group list from Redux:
+  let hostGroupsList = useAppSelector(
+    (state) => state.hostGroups.hostGroupsList
+  );
+  let netgroupsList = useAppSelector((state) => state.netgroups.netgroupList);
+  let rolesList = useAppSelector((state) => state.roles.roleList);
+  let hbacRulesList = useAppSelector((state) => state.hbacrules.hbacRulesList);
+  let sudoRulesList = useAppSelector((state) => state.sudorules.sudoRulesList);
+
+  // Alter the available options list to keep the state of the recently added / removed items
+  const updateHostGroupsList = (newAvOptionsList: unknown[]) => {
+    hostGroupsList = newAvOptionsList as HostGroup[];
+  };
+  const updateNetgroupsList = (newAvOptionsList: unknown[]) => {
+    netgroupsList = newAvOptionsList as Netgroup[];
+  };
+  const updateRolesList = (newAvOptionsList: unknown[]) => {
+    rolesList = newAvOptionsList as Roles[];
+  };
+  const updateHbacRulesList = (newAvOptionsList: unknown[]) => {
+    hbacRulesList = newAvOptionsList as HBACRules[];
+  };
+  const updateSudoRulesList = (newAvOptionsList: unknown[]) => {
+    sudoRulesList = newAvOptionsList as SudoRules[];
+  };
+
+  // List of default dummy data (for each tab option)
+  const [hostGroupsRepository, setHostGroupsRepository] = useState(
+    hostsHostGroupsInitialData
+  );
+  const [netgroupsRepository, setNetgroupsRepository] = useState(
+    hostsNetgroupsInitialData
+  );
+  const [rolesRepository, setRolesRepository] = useState(hostsRolesInitialData);
+  const [hbacRulesRepository, setHbacRulesRepository] = useState(
+    hostsHbacRulesInitialData
+  );
+  const [sudoRulesRepository, setSudoRulesRepository] = useState(
+    hostsSudoRulesInitialData
+  );
+
+  // Filter (Input search)
+  const [searchValue, setSearchValue] = React.useState("");
+
+  const updateSearchValue = (value: string) => {
+    setSearchValue(value);
+  };
+
+  // Filter functions to compare the available data with the data that
+  //  the host is already member of. This is done to prevent duplicates
+  //  (e.g: adding the same element twice).
+  const filterHostGroupsData = () => {
+    // Host groups
+    return hostGroupsList.filter((item) => {
+      return !hostGroupsRepository.some((itm) => {
+        return item.name === itm.name;
+      });
+    });
+  };
+  const filterNetgroupsData = () => {
+    // Netgroups
+    return netgroupsList.filter((item) => {
+      return !netgroupsRepository.some((itm) => {
+        return item.name === itm.name;
+      });
+    });
+  };
+  const filterRolesData = () => {
+    // Roles
+    return rolesList.filter((item) => {
+      return !rolesRepository.some((itm) => {
+        return item.name === itm.name;
+      });
+    });
+  };
+  const filterHbacRulesData = () => {
+    // HBAC rules
+    return hbacRulesList.filter((item) => {
+      return !hbacRulesRepository.some((itm) => {
+        return item.name === itm.name;
+      });
+    });
+  };
+  const filterSudoRulesData = () => {
+    // Sudo rules
+    return sudoRulesList.filter((item) => {
+      return !sudoRulesRepository.some((itm) => {
+        return item.name === itm.name;
+      });
+    });
+  };
+
+  // Available data to be added as member of
+  const hostGroupsFilteredData: HostGroup[] = filterHostGroupsData();
+  const netgroupsFilteredData: Netgroup[] = filterNetgroupsData();
+  const rolesFilteredData: Roles[] = filterRolesData();
+  const hbacRulesFilteredData: HBACRules[] = filterHbacRulesData();
+  const sudoRulesFilteredData: SudoRules[] = filterSudoRulesData();
+
+  // Number of items on the list for each repository
+  const [hostGroupsRepoLength, setHostGroupsRepoLength] = useState(
+    hostGroupsRepository.length
+  );
+  const [netgroupsRepoLength, setNetgroupsRepoLength] = useState(
+    netgroupsRepository.length
+  );
+  const [rolesRepoLength, setRolesRepoLength] = useState(
+    rolesRepository.length
+  );
+  const [hbacRulesRepoLength, setHbacRulesRepoLength] = useState(
+    hbacRulesRepository.length
+  );
+  const [sudoRulesRepoLength, setSudoRulesRepoLength] = useState(
+    sudoRulesRepository.length
+  );
+
+  // Some data is updated when any group list is altered
+  //  - The whole list itself
+  //  - The slice of data to show (considering the pagination)
+  //  - Number of items for a specific list
+  const updateGroupRepository = (
+    groupRepository:
+      | HostGroup[]
+      | Netgroup[]
+      | Roles[]
+      | HBACRules[]
+      | SudoRules[]
+  ) => {
+    switch (tabName) {
+      case "Host groups":
+        setHostGroupsRepository(groupRepository as HostGroup[]);
+        setShownHostGroupsList(hostGroupsRepository.slice(0, perPage));
+        setHostGroupsRepoLength(hostGroupsRepository.length);
+        break;
+      case "Netgroups":
+        setNetgroupsRepository(groupRepository as Netgroup[]);
+        setShownNetgroupsList(netgroupsRepository.slice(0, perPage));
+        setNetgroupsRepoLength(netgroupsRepository.length);
+        break;
+      case "Roles":
+        setRolesRepository(groupRepository as Roles[]);
+        setShownRolesList(rolesRepository.slice(0, perPage));
+        setRolesRepoLength(rolesRepository.length);
+        break;
+      case "HBAC rules":
+        setHbacRulesRepository(groupRepository as HBACRules[]);
+        setShownHBACRulesList(hbacRulesRepository.slice(0, perPage));
+        setHbacRulesRepoLength(hbacRulesRepository.length);
+        break;
+      case "Sudo rules":
+        setSudoRulesRepository(groupRepository as SudoRules[]);
+        setShownSudoRulesList(sudoRulesRepository.slice(0, perPage));
+        setSudoRulesRepoLength(sudoRulesRepository.length);
+        break;
+    }
+  };
+
+  // State that determines whether the row tables are displayed nor not
+  // - This helps with the reload state
+  const [showTableRows, setShowTableRows] = useState(false);
+
+  // -- Name of the groups selected on the table (to remove)
+  const [groupsNamesSelected, setGroupsNamesSelected] = useState<string[]>([]);
+
+  const updateGroupsNamesSelected = (groups: string[]) => {
+    setGroupsNamesSelected(groups);
+  };
+
+  // -- 'Delete' button state
+  const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
+    useState<boolean>(true);
+
+  const updateIsDeleteButtonDisabled = (updatedDeleteButton: boolean) => {
+    setIsDeleteButtonDisabled(updatedDeleteButton);
+  };
+
+  // If some entries have been deleted, restore the 'groupsNamesSelected' list
+  const [isDeletion, setIsDeletion] = useState(false);
+
+  const updateIsDeletion = (option: boolean) => {
+    setIsDeletion(option);
+  };
+
+  // -- Tab
+  const [activeTabKey, setActiveTabKey] = useState(0);
+
+  const handleTabClick = (
+    _event: React.MouseEvent<HTMLElement, MouseEvent>,
+    tabIndex: number | string
+  ) => {
+    setActiveTabKey(tabIndex as number);
+  };
+
+  // -- Pagination
+  const [page, setPage] = useState(1);
+  const [perPage, setPerPage] = useState(10);
+
+  // Member groups displayed on the first page
+  const [shownHostGroupsList, setShownHostGroupsList] = useState(
+    hostGroupsRepository.slice(0, perPage)
+  );
+  const [shownNetgroupsList, setShownNetgroupsList] = useState(
+    netgroupsRepository.slice(0, perPage)
+  );
+  const [shownRolesList, setShownRolesList] = useState(
+    rolesRepository.slice(0, perPage)
+  );
+  const [shownHBACRulesList, setShownHBACRulesList] = useState(
+    hbacRulesRepository.slice(0, perPage)
+  );
+  const [shownSudoRulesList, setShownSudoRulesList] = useState(
+    sudoRulesRepository.slice(0, perPage)
+  );
+
+  // Update pagination
+  const changeMemberGroupsList = (
+    value: HostGroup[] | Netgroup[] | Roles[] | HBACRules[] | SudoRules[]
+  ) => {
+    switch (activeTabKey) {
+      case 0:
+        setShownHostGroupsList(value as HostGroup[]);
+        break;
+      case 1:
+        setShownNetgroupsList(value as Netgroup[]);
+        break;
+      case 2:
+        setShownRolesList(value as Roles[]);
+        break;
+      case 3:
+        setShownHBACRulesList(value as HBACRules[]);
+        break;
+      case 4:
+        setShownSudoRulesList(value as SudoRules[]);
+        break;
+    }
+  };
+
+  // Pages setters
+  const onSetPage = (
+    _event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
+    newPage: number,
+    perPage: number | undefined,
+    startIdx: number | undefined,
+    endIdx: number | undefined
+  ) => {
+    setPage(newPage);
+    switch (activeTabKey) {
+      case 0:
+        setShownHostGroupsList(hostGroupsRepository.slice(startIdx, endIdx));
+        break;
+      case 1:
+        setShownNetgroupsList(netgroupsRepository.slice(startIdx, endIdx));
+        break;
+      case 2:
+        setShownRolesList(rolesRepository.slice(startIdx, endIdx));
+        break;
+      case 3:
+        setShownHBACRulesList(hbacRulesRepository.slice(startIdx, endIdx));
+        break;
+      case 4:
+        setShownSudoRulesList(sudoRulesRepository.slice(startIdx, endIdx));
+        break;
+    }
+  };
+
+  const onPerPageSelect = (
+    _event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
+    newPerPage: number,
+    newPage: number,
+    startIdx: number | undefined,
+    endIdx: number | undefined
+  ) => {
+    setPerPage(newPerPage);
+    switch (activeTabKey) {
+      case 0:
+        setShownHostGroupsList(hostGroupsRepository.slice(startIdx, endIdx));
+        break;
+      case 1:
+        setShownNetgroupsList(netgroupsRepository.slice(startIdx, endIdx));
+        break;
+      case 2:
+        setShownRolesList(rolesRepository.slice(startIdx, endIdx));
+        break;
+      case 3:
+        setShownHBACRulesList(hbacRulesRepository.slice(startIdx, endIdx));
+        break;
+      case 4:
+        setShownSudoRulesList(sudoRulesRepository.slice(startIdx, endIdx));
+        break;
+    }
+  };
+
+  // Page setters passed as props
+  const changeSetPage = (
+    newPage: number,
+    perPage: number | undefined,
+    startIdx: number | undefined,
+    endIdx: number | undefined
+  ) => {
+    setPage(newPage);
+    switch (activeTabKey) {
+      case 0:
+        setShownHostGroupsList(hostGroupsRepository.slice(startIdx, endIdx));
+        break;
+      case 1:
+        setShownNetgroupsList(netgroupsRepository.slice(startIdx, endIdx));
+        break;
+      case 2:
+        setShownRolesList(rolesRepository.slice(startIdx, endIdx));
+        break;
+      case 3:
+        setShownHBACRulesList(hbacRulesRepository.slice(startIdx, endIdx));
+        break;
+      case 4:
+        setShownSudoRulesList(sudoRulesRepository.slice(startIdx, endIdx));
+        break;
+    }
+  };
+
+  const changePerPageSelect = (
+    newPerPage: number,
+    newPage: number,
+    startIdx: number | undefined,
+    endIdx: number | undefined
+  ) => {
+    setPerPage(newPerPage);
+    switch (activeTabKey) {
+      case 0:
+        setShownHostGroupsList(hostGroupsRepository.slice(startIdx, endIdx));
+        break;
+      case 1:
+        setShownNetgroupsList(netgroupsRepository.slice(startIdx, endIdx));
+        break;
+      case 2:
+        setShownRolesList(rolesRepository.slice(startIdx, endIdx));
+        break;
+      case 3:
+        setShownHBACRulesList(hbacRulesRepository.slice(startIdx, endIdx));
+        break;
+      case 4:
+        setShownSudoRulesList(sudoRulesRepository.slice(startIdx, endIdx));
+        break;
+    }
+  };
+
+  // Different number of items will be shown depending on the 'activeTabKey'
+  const numberOfItems = () => {
+    switch (activeTabKey) {
+      case 0:
+        return hostGroupsRepository.length;
+      case 1:
+        return netgroupsRepository.length;
+      case 2:
+        return rolesRepository.length;
+      case 3:
+        return hbacRulesRepository.length;
+      case 4:
+        return sudoRulesRepository.length;
+    }
+  };
+
+  // -- Modal
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  const onClickAddHandler = () => {
+    setShowAddModal(true);
+  };
+  const onModalToggle = () => {
+    setShowAddModal(!showAddModal);
+  };
+
+  const onClickDeleteHandler = () => {
+    setShowDeleteModal(true);
+  };
+
+  const onModalDeleteToggle = () => {
+    setShowDeleteModal(!showDeleteModal);
+  };
+
+  // -- Tab name
+  const [tabName, setTabName] = useState("host groups");
+
+  const updateTabName = (name: string) => {
+    setTabName(name);
+  };
+
+  // Reloads the table everytime any of the group lists are updated
+  useEffect(() => {
+    setPage(1);
+    if (showTableRows) setShowTableRows(false);
+    setTimeout(() => {
+      switch (activeTabKey) {
+        case 0:
+          setShownHostGroupsList(hostGroupsRepository.slice(0, perPage));
+          setHostGroupsRepoLength(hostGroupsRepository.length);
+          break;
+        case 1:
+          setShownNetgroupsList(netgroupsRepository.slice(0, perPage));
+          setNetgroupsRepoLength(netgroupsRepository.length);
+          break;
+        case 2:
+          setShownRolesList(rolesRepository.slice(0, perPage));
+          setRolesRepoLength(rolesRepository.length);
+          break;
+        case 3:
+          setShownHBACRulesList(hbacRulesRepository.slice(0, perPage));
+          setHbacRulesRepoLength(hbacRulesRepository.length);
+          break;
+        case 4:
+          setShownSudoRulesList(sudoRulesRepository.slice(0, perPage));
+          setSudoRulesRepoLength(sudoRulesRepository.length);
+          break;
+      }
+      setShowTableRows(true);
+    }, 1000);
+  }, [
+    hostGroupsRepository,
+    netgroupsRepository,
+    rolesRepository,
+    hbacRulesRepository,
+    sudoRulesRepository,
+  ]);
+
+  // Data wrappers
+  // - MemberOfToolbar
+  const toolbarPageData = {
+    page,
+    changeSetPage,
+    perPage,
+    changePerPageSelect,
+  };
+
+  const toolbarButtonData = {
+    onClickAddHandler,
+    onClickDeleteHandler,
+    isDeleteButtonDisabled,
+  };
+
+  const toolbarSettersData = {
+    changeMemberGroupsList,
+    changeTabName: updateTabName,
+  };
+
+  // - MemberOfTable
+  const tableButtonData = {
+    isDeletion,
+    updateIsDeletion,
+    changeIsDeleteButtonDisabled: updateIsDeleteButtonDisabled,
+  };
+
+  // - MemberOfAddModal
+  const addModalData = {
+    showModal: showAddModal,
+    handleModalToggle: onModalToggle,
+  };
+
+  const tabData = {
+    tabName,
+    userName: props.host.id,
+  };
+
+  // - MemberOfDeleteModal
+  const deleteModalData = {
+    showModal: showDeleteModal,
+    handleModalToggle: onModalDeleteToggle,
+  };
+
+  const deleteButtonData = {
+    changeIsDeleteButtonDisabled: updateIsDeleteButtonDisabled,
+    updateIsDeletion,
+  };
+
+  const deleteTabData = {
+    tabName,
+    activeTabKey,
+  };
+
+  // - 'MemberOfToolbar' > 'SearchInputLayout'
+  // SearchInputLayout
+  const searchValueData = {
+    searchValue,
+    updateSearchValue,
+  };
+
+  // Render component
+  return (
+    <Page>
+      <PageSection
+        variant={PageSectionVariants.light}
+        isFilled={false}
+        className="pf-u-m-lg"
+      >
+        <Tabs activeKey={activeTabKey} onSelect={handleTabClick} isBox={false}>
+          <Tab
+            eventKey={0}
+            name="memberof_hostgroup"
+            title={
+              <TabTitleText>
+                Host groups{" "}
+                <Badge key={0} isRead>
+                  {hostGroupsRepoLength}
+                </Badge>
+              </TabTitleText>
+            }
+          >
+            <MemberOfToolbar
+              pageRepo={hostGroupsRepository}
+              shownItems={shownHostGroupsList}
+              toolbar="host groups"
+              settersData={toolbarSettersData}
+              pageData={toolbarPageData}
+              buttonData={toolbarButtonData}
+              searchValueData={searchValueData}
+            />
+            <MemberOfTable
+              group={shownHostGroupsList}
+              tableName={"Host groups"}
+              activeTabKey={activeTabKey}
+              changeSelectedGroups={updateGroupsNamesSelected}
+              buttonData={tableButtonData}
+              showTableRows={showTableRows}
+              searchValue={searchValue}
+              fullGroupList={hostGroupsRepository}
+            />
+          </Tab>
+          <Tab
+            eventKey={1}
+            name="memberof_netgroup"
+            title={
+              <TabTitleText>
+                Netgroups{" "}
+                <Badge key={1} isRead>
+                  {netgroupsRepoLength}
+                </Badge>
+              </TabTitleText>
+            }
+          >
+            <MemberOfToolbar
+              pageRepo={netgroupsRepository}
+              shownItems={shownNetgroupsList}
+              toolbar="netgroups"
+              settersData={toolbarSettersData}
+              pageData={toolbarPageData}
+              buttonData={toolbarButtonData}
+              searchValueData={searchValueData}
+            />
+            <MemberOfTable
+              group={shownNetgroupsList}
+              tableName={"Netgroups"}
+              activeTabKey={activeTabKey}
+              changeSelectedGroups={updateGroupsNamesSelected}
+              buttonData={tableButtonData}
+              showTableRows={showTableRows}
+              searchValue={searchValue}
+              fullGroupList={netgroupsRepository}
+            />
+          </Tab>
+          <Tab
+            eventKey={2}
+            name="memberof_role"
+            title={
+              <TabTitleText>
+                Roles{" "}
+                <Badge key={2} isRead>
+                  {rolesRepoLength}
+                </Badge>
+              </TabTitleText>
+            }
+          >
+            <MemberOfToolbar
+              pageRepo={rolesRepository}
+              shownItems={shownRolesList}
+              toolbar="roles"
+              settersData={toolbarSettersData}
+              pageData={toolbarPageData}
+              buttonData={toolbarButtonData}
+              searchValueData={searchValueData}
+            />
+            <MemberOfTable
+              group={shownRolesList}
+              tableName={"Roles"}
+              activeTabKey={activeTabKey}
+              changeSelectedGroups={updateGroupsNamesSelected}
+              buttonData={tableButtonData}
+              showTableRows={showTableRows}
+              searchValue={searchValue}
+              fullGroupList={rolesRepository}
+            />
+          </Tab>
+          <Tab
+            eventKey={3}
+            name="memberof_hbacrule"
+            title={
+              <TabTitleText>
+                HBAC rules{" "}
+                <Badge key={3} isRead>
+                  {hbacRulesRepoLength}
+                </Badge>
+              </TabTitleText>
+            }
+          >
+            <MemberOfToolbar
+              pageRepo={hbacRulesRepository}
+              shownItems={shownHBACRulesList}
+              toolbar="HBAC rules"
+              settersData={toolbarSettersData}
+              pageData={toolbarPageData}
+              buttonData={toolbarButtonData}
+              searchValueData={searchValueData}
+            />
+            <MemberOfTable
+              group={shownHBACRulesList}
+              tableName={"HBAC rules"}
+              activeTabKey={activeTabKey}
+              changeSelectedGroups={updateGroupsNamesSelected}
+              buttonData={tableButtonData}
+              showTableRows={showTableRows}
+              searchValue={searchValue}
+              fullGroupList={hbacRulesRepository}
+            />
+          </Tab>
+          <Tab
+            eventKey={4}
+            name="memberof_sudorule"
+            title={
+              <TabTitleText>
+                Sudo rules{" "}
+                <Badge key={4} isRead>
+                  {sudoRulesRepoLength}
+                </Badge>
+              </TabTitleText>
+            }
+          >
+            <MemberOfToolbar
+              pageRepo={sudoRulesRepository}
+              shownItems={shownSudoRulesList}
+              toolbar="sudo rules"
+              settersData={toolbarSettersData}
+              pageData={toolbarPageData}
+              buttonData={toolbarButtonData}
+              searchValueData={searchValueData}
+            />
+            <MemberOfTable
+              group={shownSudoRulesList}
+              tableName={"Sudo rules"}
+              activeTabKey={activeTabKey}
+              changeSelectedGroups={updateGroupsNamesSelected}
+              buttonData={tableButtonData}
+              showTableRows={showTableRows}
+              searchValue={searchValue}
+              fullGroupList={sudoRulesRepository}
+            />
+          </Tab>
+        </Tabs>
+        <Pagination
+          perPageComponent="button"
+          className="pf-u-pb-0 pf-u-pr-md"
+          itemCount={numberOfItems()}
+          widgetId="pagination-options-menu-bottom"
+          perPage={perPage}
+          page={page}
+          variant={PaginationVariant.bottom}
+          onSetPage={onSetPage}
+          onPerPageSelect={onPerPageSelect}
+        />
+      </PageSection>
+      {tabName === "Host groups" && (
+        <>
+          {showAddModal && (
+            <MemberOfAddModal
+              modalData={addModalData}
+              availableData={hostGroupsFilteredData}
+              groupRepository={hostGroupsRepository}
+              updateGroupRepository={updateGroupRepository}
+              updateAvOptionsList={updateHostGroupsList}
+              tabData={tabData}
+            />
+          )}
+          {showDeleteModal && groupsNamesSelected.length !== 0 && (
+            <MemberOfDeleteModal
+              modalData={deleteModalData}
+              tabData={deleteTabData}
+              groupNamesToDelete={groupsNamesSelected}
+              groupRepository={hostGroupsRepository}
+              updateGroupRepository={updateGroupRepository}
+              buttonData={deleteButtonData}
+            />
+          )}
+        </>
+      )}
+      {tabName === "Netgroups" && (
+        <>
+          {showAddModal && (
+            <MemberOfAddModal
+              modalData={addModalData}
+              availableData={netgroupsFilteredData}
+              groupRepository={netgroupsRepository}
+              updateGroupRepository={updateGroupRepository}
+              updateAvOptionsList={updateNetgroupsList}
+              tabData={tabData}
+            />
+          )}
+          {showDeleteModal && groupsNamesSelected.length !== 0 && (
+            <MemberOfDeleteModal
+              modalData={deleteModalData}
+              tabData={deleteTabData}
+              groupNamesToDelete={groupsNamesSelected}
+              groupRepository={netgroupsRepository}
+              updateGroupRepository={updateGroupRepository}
+              buttonData={deleteButtonData}
+            />
+          )}
+        </>
+      )}
+      {tabName === "Roles" && (
+        <>
+          {showAddModal && (
+            <MemberOfAddModal
+              modalData={addModalData}
+              availableData={rolesFilteredData}
+              groupRepository={rolesRepository}
+              updateGroupRepository={updateGroupRepository}
+              updateAvOptionsList={updateRolesList}
+              tabData={tabData}
+            />
+          )}
+          {showDeleteModal && groupsNamesSelected.length !== 0 && (
+            <MemberOfDeleteModal
+              modalData={deleteModalData}
+              tabData={deleteTabData}
+              groupNamesToDelete={groupsNamesSelected}
+              groupRepository={rolesRepository}
+              updateGroupRepository={updateGroupRepository}
+              buttonData={deleteButtonData}
+            />
+          )}
+        </>
+      )}
+      {tabName === "HBAC rules" && (
+        <>
+          {showAddModal && (
+            <MemberOfAddModal
+              modalData={addModalData}
+              availableData={hbacRulesFilteredData}
+              groupRepository={hbacRulesRepository}
+              updateGroupRepository={updateGroupRepository}
+              updateAvOptionsList={updateHbacRulesList}
+              tabData={tabData}
+            />
+          )}
+          {showDeleteModal && groupsNamesSelected.length !== 0 && (
+            <MemberOfDeleteModal
+              modalData={deleteModalData}
+              tabData={deleteTabData}
+              groupNamesToDelete={groupsNamesSelected}
+              groupRepository={hbacRulesRepository}
+              updateGroupRepository={updateGroupRepository}
+              buttonData={deleteButtonData}
+            />
+          )}
+        </>
+      )}
+      {tabName === "Sudo rules" && (
+        <>
+          {showAddModal && (
+            <MemberOfAddModal
+              modalData={addModalData}
+              availableData={sudoRulesFilteredData}
+              groupRepository={sudoRulesRepository}
+              updateGroupRepository={updateGroupRepository}
+              updateAvOptionsList={updateSudoRulesList}
+              tabData={tabData}
+            />
+          )}
+          {showDeleteModal && groupsNamesSelected.length !== 0 && (
+            <MemberOfDeleteModal
+              modalData={deleteModalData}
+              tabData={deleteTabData}
+              groupNamesToDelete={groupsNamesSelected}
+              groupRepository={sudoRulesRepository}
+              updateGroupRepository={updateGroupRepository}
+              buttonData={deleteButtonData}
+            />
+          )}
+        </>
+      )}
+    </Page>
+  );
+};
+
+export default HostsMemberOf;

--- a/src/pages/Hosts/HostsTabs.tsx
+++ b/src/pages/Hosts/HostsTabs.tsx
@@ -14,6 +14,7 @@ import { useLocation } from "react-router-dom";
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 // Other
 import HostsSettings from "./HostsSettings";
+import HostsMemberOf from "./HostsMemberOf";
 // Layouts
 import BreadcrumbLayout from "src/components/layouts/BreadcrumbLayout";
 import TitleLayout from "src/components/layouts/TitleLayout";
@@ -77,6 +78,14 @@ const HostsTabs = () => {
           >
             <PageSection className="pf-u-pb-0"></PageSection>
             <HostsSettings host={hostData} />
+          </Tab>
+          <Tab
+            eventKey={1}
+            name="details"
+            title={<TabTitleText>Is a member of</TabTitleText>}
+          >
+            <PageSection className="pf-u-pb-0"></PageSection>
+            <HostsMemberOf host={hostData} />
           </Tab>
         </Tabs>
       </PageSection>

--- a/src/store/Identity/hostGroups-slice.ts
+++ b/src/store/Identity/hostGroups-slice.ts
@@ -1,0 +1,23 @@
+import { createSlice } from "@reduxjs/toolkit";
+import type { RootState } from "../store";
+import hostGroupsJson from "./hostGroups.json";
+// Data type
+import { HostGroup } from "src/utils/datatypes/globalDataTypes";
+
+interface HostGroupState {
+  hostGroupsList: HostGroup[];
+}
+
+const initialState: HostGroupState = {
+  hostGroupsList: hostGroupsJson,
+};
+
+const hostGroupsSlice = createSlice({
+  name: "hostgroups",
+  initialState,
+  reducers: {},
+});
+
+export const selectHostGroups = (state: RootState) =>
+  state.hostGroups.hostGroupsList;
+export default hostGroupsSlice.reducer;

--- a/src/store/Identity/hostGroups.json
+++ b/src/store/Identity/hostGroups.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "ipaservers",
+    "description": "IPA server hosts"
+  },
+  {
+    "name": "hostgroup1",
+    "description": "Host group 1"
+  },
+  {
+    "name": "hostgroup2",
+    "description": "Host group 2"
+  },
+  {
+    "name": "hostgroup3",
+    "description": "Host group 3"
+  }
+]

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -8,6 +8,7 @@ import sudoRulesReducer from "./Policy/sudoRules-slice";
 import stageUsersReducer from "./Identity/stageUsers-slice";
 import preservedUsersReducer from "./Identity/preservedUsers-slice";
 import hostsReducer from "./Identity/hosts-slice";
+import hostGroupsReducer from "./Identity/hostGroups-slice";
 
 const store = configureStore({
   reducer: {
@@ -20,6 +21,7 @@ const store = configureStore({
     stageUsers: stageUsersReducer,
     preservedUsers: preservedUsersReducer,
     hosts: hostsReducer,
+    hostGroups: hostGroupsReducer,
   },
 });
 

--- a/src/utils/data/GroupRepositories.ts
+++ b/src/utils/data/GroupRepositories.ts
@@ -13,8 +13,10 @@ import {
   Roles,
   HBACRules,
   SudoRules,
+  HostGroup,
 } from "../datatypes/globalDataTypes";
 
+// USERS
 // 'User groups' initial data
 export let userGroupsInitialData: UserGroup[] = [
   {
@@ -121,3 +123,40 @@ export let hbacRulesInitialData: HBACRules[] = [
 
 // 'Sudo rules' initial data
 export let sudoRulesInitialData: SudoRules[] = [];
+
+// HOSTS
+// - 'Host groups' initial data
+export let hostsHostGroupsInitialData: HostGroup[] = [];
+
+// - 'Netgroups' initial data
+export let hostsNetgroupsInitialData: Netgroup[] = [
+  {
+    name: "netgroup1",
+    description: "First netgroup",
+  },
+  {
+    name: "netgroup2",
+    description: "Second netgroup",
+  },
+];
+
+// - 'Roles' initial data
+export let hostsRolesInitialData: Roles[] = [];
+
+// - 'HBAC rules' initial data
+export let hostsHbacRulesInitialData: HBACRules[] = [
+  {
+    name: "allow_all",
+    status: "Enabled",
+    description: "Allow all users to access any host from any host",
+  },
+  {
+    name: "allow_systemd-user",
+    status: "Enabled",
+    description:
+      "Allow pam_systemd to run user@.service to create a system user session",
+  },
+];
+
+// - 'Sudo rules' initial data
+export let hostsSudoRulesInitialData: SudoRules[] = [];

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -47,3 +47,8 @@ export interface Host {
   description: string;
   enrolled: boolean;
 }
+
+export interface HostGroup {
+  name: string;
+  description: string;
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8112750/215447032-12f5214f-6d05-4ce2-9c9e-e1fbf8abd2f0.png)

### Description
The 'Is a member of' section provides a way to manage the groups to which a specific user can be a member. These types are known as 'member groups'.

There are five different types of member groups whose entity can be defined in different pages/sections alongside the FreeIPA page:

- `Host groups` (Identity)
- `Netgroups` (Identity)
- `Roles` (IPA server)
- `HBAC rules` (Policy)
- `Sudo rules` (Policy)

### Data type and initial data
The 'Is a member of' section was already defined in the 'Active users' page and most of the components created were adapted to be reusable. Although many of those existing components are also being used in this case, some modifications related to the data types need to be done. One of those is to create a new data type for `Host groups`, used by the newly-created section.

One of the first steps to adapt this new type would be to create its data type under the `globalDataTypes.ts` file. That would ensure that the right data type is being used through the components. Only then, the initial data that would be shown by default in its corresponding tab should be defined (in the `GroupRepositories.ts` file).

```ts
export interface HostGroup {
  name: string;
  description: string;
}
```

### Redux slice
The 'Is a member of' section will have the 'Host groups' tab with an initial list of data (the one that will be displayed in the table) and a list of available elements to add. This last list needs to be defined and managed via Redux with the newly-created data type: `HostGroup`.

The steps to provide Redux functionality have been the following:
- Define the list of available data (in `hostGroups.json`).
- Define the Redux slice that would manage the list of the already-defined elements (in `hostGroups-slice.ts`).
- Make this slice available via the redux store (in `store.ts`).

### Adapting existing components
The following components need have been adapted to be used with the newly-created `HostGroup` data type:
- `MemberOfToolbar`: The Toolbar that would manage the 'Hosts' > 'Is a member of' section.
- `MemberOfTable`: The table where the member associations are shown.
- `MemberOfAddModal`: This modal is shown when an 'Add' operation is performed (resulting in a new member association).

### 'Host' > 'Is a member of' component
Finally, the 'Is a member of' section has been created and added to the 'Hosts' page (next to the 'Settings' tab). This can be accessed by clicking any host entry in the 'Hosts' page table.

Signed-off-by: Carla Martinez <carlmart@redhat.com>