### PR TITLE
Enable direct access to react routes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,6 +56,9 @@ Vagrant.configure("2") do |config|
       AllowOverride None
       Satisfy Any
       Require all granted
+      RewriteEngine On
+      RewriteCond %{REQUEST_FILENAME} !-f
+      RewriteRule ^ index.html [QSA,L]
     </Directory>
     EOF
 


### PR DESCRIPTION
If the requested path is not a regular file, rewrite the request to index.html while keeping any query string from the original request.
