### PR TITLE
'Hosts' > 'Is managed by' section

### DIFF
--- a/src/components/ManagedBy/ManagedByAddModal.tsx
+++ b/src/components/ManagedBy/ManagedByAddModal.tsx
@@ -1,0 +1,160 @@
+import React, { ReactNode, useEffect, useState } from "react";
+// PaternFly
+import { Button, DualListSelector } from "@patternfly/react-core";
+// Data types
+import { Host } from "src/utils/datatypes/globalDataTypes";
+// Layouts
+import ModalWithFormLayout from "../layouts/ModalWithFormLayout";
+import SecondaryButton from "../layouts/SecondaryButton";
+
+interface ModalData {
+  showModal: boolean;
+  handleModalToggle: () => void;
+}
+
+interface TabData {
+  tabName: string;
+  elementName: string;
+}
+
+interface PropsToAddModal {
+  modalData: ModalData;
+  availableData: Host[];
+  groupRepository: unknown[];
+  updateGroupRepository: (args: Host[]) => void;
+  updateAvOptionsList: (args: unknown[]) => void;
+  tabData: TabData;
+}
+
+interface ManagedByElement {
+  hostName?: string;
+}
+
+const ManagedByAddModal = (props: PropsToAddModal) => {
+  // Dual list data
+  const data = props.availableData.map((d) => d.hostName);
+
+  // Dual list selector
+  const [availableOptions, setAvailableOptions] = useState<ReactNode[]>(data);
+  const [chosenOptions, setChosenOptions] = useState<ReactNode[]>([]);
+
+  const listChange = (
+    newAvailableOptions: ReactNode[],
+    newChosenOptions: ReactNode[]
+  ) => {
+    setAvailableOptions(newAvailableOptions.sort());
+    setChosenOptions(newChosenOptions.sort());
+    props.updateAvOptionsList(newAvailableOptions.sort());
+  };
+
+  const fields = [
+    {
+      id: "dual-list-selector",
+      pfComponent: (
+        <DualListSelector
+          isSearchable
+          availableOptions={availableOptions}
+          chosenOptions={chosenOptions}
+          onListChange={listChange}
+          id="basicSelectorWithSearch"
+        />
+      ),
+    },
+  ];
+
+  // When clean data, set to original values
+  const cleanData = () => {
+    setAvailableOptions(data);
+    setChosenOptions([]);
+  };
+
+  // Clean fields and close modal (To prevent data persistence when reopen modal)
+  const cleanAndCloseModal = () => {
+    cleanData();
+    props.modalData.handleModalToggle();
+  };
+
+  // Buttons are disabled until the user fills the required fields
+  const [buttonDisabled, setButtonDisabled] = useState(true);
+  useEffect(() => {
+    if (chosenOptions.length > 0) {
+      setButtonDisabled(false);
+    } else {
+      setButtonDisabled(true);
+    }
+  }, [chosenOptions]);
+
+  // Get all info from a chosen option
+  const getInfoFromGroupData = (option: unknown) => {
+    return props.availableData.find((d) => option === d.hostName);
+  };
+
+  // Add group option
+  const onClickAddGroupHandler = () => {
+    chosenOptions.map((opt) => {
+      const optionData: ManagedByElement | undefined =
+        getInfoFromGroupData(opt);
+      if (optionData !== undefined) {
+        // Host groups
+        if (props.tabData.tabName === "Hosts") {
+          props.groupRepository.push({
+            hostName: optionData.hostName !== undefined && optionData.hostName,
+          } as Host);
+          // Send updated data to table
+          props.updateGroupRepository(props.groupRepository as Host[]);
+        }
+      }
+    });
+    // Clean chosen options and close modal
+    setChosenOptions([]);
+    props.modalData.handleModalToggle();
+  };
+
+  // Utility: Convert the tab name by removing the last character and transforming into lower case
+  //  - Eg: 'Hosts' -> 'host'
+  const convertedTabName = props.tabData.tabName.slice(0, -1).toLowerCase();
+
+  // Buttons that will be shown at the end of the form
+  const modalActions = [
+    <SecondaryButton
+      key={"add-new-" + convertedTabName}
+      isDisabled={buttonDisabled}
+      form="modal-form"
+      onClickHandler={onClickAddGroupHandler}
+    >
+      Add
+    </SecondaryButton>,
+    <Button
+      key={"cancel-add-new-" + convertedTabName}
+      variant="link"
+      onClick={cleanAndCloseModal}
+    >
+      Cancel
+    </Button>,
+  ];
+
+  // Render component
+  return (
+    <ModalWithFormLayout
+      variantType="medium"
+      modalPosition="top"
+      offPosition="76px"
+      title={
+        "Add " +
+        props.tabData.tabName.toLowerCase() +
+        " managing " +
+        convertedTabName +
+        " '" +
+        props.tabData.elementName +
+        "'"
+      }
+      formId="is-managed-by-add-modal"
+      fields={fields}
+      show={props.modalData.showModal}
+      onClose={cleanAndCloseModal}
+      actions={modalActions}
+    />
+  );
+};
+
+export default ManagedByAddModal;

--- a/src/components/ManagedBy/ManagedByDeleteModal.tsx
+++ b/src/components/ManagedBy/ManagedByDeleteModal.tsx
@@ -1,0 +1,133 @@
+import React from "react";
+// PatternFly
+import {
+  TextContent,
+  Text,
+  TextVariants,
+  Button,
+} from "@patternfly/react-core";
+// Layouts
+import ModalWithFormLayout from "../layouts/ModalWithFormLayout";
+// Data type
+import { Host } from "src/utils/datatypes/globalDataTypes";
+// Tables
+import DeletedElementsTable from "../tables/DeletedElementsTable";
+
+interface ModalData {
+  showModal: boolean;
+  handleModalToggle: () => void;
+}
+
+interface ButtonData {
+  changeIsDeleteButtonDisabled: (updatedDeleteButton: boolean) => void;
+  updateIsDeletion: (option: boolean) => void;
+}
+
+interface TabData {
+  tabName: string;
+  elementName: string;
+}
+
+interface PropsToDeleteModal {
+  modalData: ModalData;
+  tabData: TabData;
+  groupNamesToDelete: string[];
+  groupRepository: Host[];
+  updateGroupRepository: (args: Host[]) => void;
+  buttonData: ButtonData;
+}
+
+const ManagedByDeleteModal = (props: PropsToDeleteModal) => {
+  // List of fields
+  const fields = [
+    {
+      id: "question-text",
+      pfComponent: (
+        <TextContent>
+          <Text component={TextVariants.p}>
+            Are you sure you want to remove the selected entries from the list?
+          </Text>
+        </TextContent>
+      ),
+    },
+    {
+      id: "deleted-users-table",
+      pfComponent: (
+        <DeletedElementsTable
+          mode="passing_id"
+          elementsToDelete={props.groupNamesToDelete}
+          columnNames={["Host"]}
+          elementType={props.tabData.tabName}
+        />
+      ),
+    },
+  ];
+
+  // Close modal
+  const closeModal = () => {
+    props.modalData.handleModalToggle();
+  };
+
+  // Delete groups
+  const deleteGroups = () => {
+    // Define function that will be reused to delete the selected entries
+    let generalUpdatedGroupList = props.groupRepository;
+    props.groupNamesToDelete.map((groupName) => {
+      const updatedGroupList = generalUpdatedGroupList.filter(
+        (grp) => grp.hostName !== groupName
+      );
+      // If not empty, replace groupList by new array
+      if (updatedGroupList) {
+        generalUpdatedGroupList = updatedGroupList;
+      }
+    });
+    props.updateGroupRepository(generalUpdatedGroupList);
+    props.buttonData.changeIsDeleteButtonDisabled(true);
+    props.buttonData.updateIsDeletion(true);
+    closeModal();
+  };
+
+  // Set the Modal and Action buttons for 'Delete' option
+  const modalActionsDelete: JSX.Element[] = [
+    <Button
+      key="delete-groups"
+      variant="danger"
+      onClick={deleteGroups}
+      form={props.tabData.tabName.toLowerCase() + "-remove-groups-modal"}
+    >
+      Delete
+    </Button>,
+    <Button key="cancel-remove-group" variant="link" onClick={closeModal}>
+      Cancel
+    </Button>,
+  ];
+
+  // Utility: Convert the tab name by removing the last character and transforming into lower case
+  //  - Eg: 'Hosts' -> 'host'
+  const convertedTabName = props.tabData.tabName.slice(0, -1).toLowerCase();
+
+  // Render component
+  return (
+    <ModalWithFormLayout
+      variantType="medium"
+      modalPosition="top"
+      offPosition="76px"
+      title={
+        "Remove " +
+        props.tabData.tabName.toLowerCase() +
+        " managing " +
+        convertedTabName +
+        " '" +
+        props.tabData.elementName +
+        "'"
+      }
+      formId="is-managed-by-remove-modal"
+      fields={fields}
+      show={props.modalData.showModal}
+      onClose={closeModal}
+      actions={modalActionsDelete}
+    />
+  );
+};
+
+export default ManagedByDeleteModal;

--- a/src/components/ManagedBy/ManagedByTable.tsx
+++ b/src/components/ManagedBy/ManagedByTable.tsx
@@ -1,0 +1,269 @@
+import React, { useEffect, useState } from "react";
+// PatternFly
+import {
+  Title,
+  Bullseye,
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  EmptyStateBody,
+  Button,
+} from "@patternfly/react-core";
+import { Td, Th, Tr } from "@patternfly/react-table";
+// Icons
+import SearchIcon from "@patternfly/react-icons/dist/esm/icons/search-icon";
+// Layouts
+import TableLayout from "../layouts/TableLayout";
+import SkeletonOnTableLayout from "../layouts/Skeleton/SkeletonOnTableLayout";
+// Data type
+import { Host } from "src/utils/datatypes/globalDataTypes";
+
+interface ColumnNames {
+  name: string;
+}
+
+interface ButtonData {
+  isDeletion: boolean;
+  updateIsDeletion: (option: boolean) => void;
+  changeIsDeleteButtonDisabled: (updatedDeleteButton: boolean) => void;
+}
+
+interface PropsToTable {
+  list: Host[];
+  tableName: string;
+  updateList: (newList: Host[]) => void;
+  showTableRows: boolean;
+  updateElementsSelected: (newElementsSelected: string[]) => void;
+  buttonData: ButtonData;
+}
+
+const ManagedByTable = (props: PropsToTable) => {
+  // Define column names
+  // - Hosts
+  const hostsColumnNames: ColumnNames = {
+    name: "Host name",
+  };
+
+  // State for column names
+  const [columnNames] = useState<ColumnNames>(hostsColumnNames);
+
+  // selected element ID state
+  const [selectedElementIds, setSelectedElementIds] = useState<string[]>([]);
+
+  // Selectable checkboxes on table
+  const isElementSelectable = (element: Host) => element.hostName !== "";
+  const selectableElements = props.list.filter(isElementSelectable);
+
+  // Selected rows are tracked. Primary key: hostName
+  const [selectedElementNames, setSelectedElementNames] = useState<string[]>(
+    []
+  );
+
+  const setElementSelected = (element: Host, isSelecting = true) =>
+    setSelectedElementNames((prevSelected) => {
+      const otherSelectedElementNames = prevSelected.filter(
+        (r) => r !== element.hostName
+      );
+      return isSelecting && isElementSelectable(element)
+        ? [...otherSelectedElementNames, element.hostName]
+        : otherSelectedElementNames;
+    });
+
+  const areAllElementsSelected =
+    selectedElementNames.length === selectableElements.length;
+
+  const isElementSelected = (element: Host) =>
+    selectedElementNames.includes(element.hostName);
+
+  // Multiple selection
+  const selectAllElements = (isSelecting = true) => {
+    setSelectedElementNames(
+      isSelecting ? selectableElements.map((g) => g.hostName) : []
+    );
+
+    // Enable/disable 'Delete' button
+    if (isSelecting) {
+      const groupsNameArray: string[] = [];
+      selectableElements.map((element) =>
+        groupsNameArray.push(element.hostName)
+      );
+      setSelectedElementIds(groupsNameArray);
+      props.updateElementsSelected(groupsNameArray);
+      props.buttonData.changeIsDeleteButtonDisabled(false);
+    } else {
+      props.updateElementsSelected([]);
+      props.buttonData.changeIsDeleteButtonDisabled(true);
+    }
+  };
+
+  // To allow shift+click to select/deselect multiple rows
+  const [recentSelectedRowIndex, setRecentSelectedRowIndex] = useState<
+    number | null
+  >(null);
+  const [shifting, setShifting] = useState(false);
+
+  // On selecting one single row
+  const onSelectElement = (
+    element: Host,
+    rowIndex: number,
+    isSelecting: boolean
+  ) => {
+    // If the group is shift + selecting the checkboxes, then all intermediate checkboxes should be selected
+    if (shifting && recentSelectedRowIndex !== null) {
+      const numberSelected = rowIndex - recentSelectedRowIndex;
+      const intermediateIndexes =
+        numberSelected > 0
+          ? Array.from(
+              new Array(numberSelected + 1),
+              (_x, i) => i + recentSelectedRowIndex
+            )
+          : Array.from(
+              new Array(Math.abs(numberSelected) + 1),
+              (_x, i) => i + rowIndex
+            );
+      intermediateIndexes.forEach((index) =>
+        setElementSelected(props.list[index], isSelecting)
+      );
+    } else {
+      setElementSelected(element, isSelecting);
+    }
+    setRecentSelectedRowIndex(rowIndex);
+
+    // Update selectedElements array
+    let selectedElementsArray = selectedElementNames;
+    if (isSelecting) {
+      selectedElementsArray.push(element.hostName);
+      setSelectedElementIds(selectedElementsArray);
+      props.updateElementsSelected(selectedElementsArray);
+    } else {
+      selectedElementsArray = selectedElementsArray.filter(
+        (elementName) => elementName !== element.hostName
+      );
+      setSelectedElementIds(selectedElementsArray);
+      props.updateElementsSelected(selectedElementsArray);
+    }
+  };
+
+  // Reset 'updateIsDeletion' when a delete operation has been done
+  useEffect(() => {
+    if (props.buttonData.isDeletion) {
+      setSelectedElementNames([]);
+      setSelectedElementIds([]);
+      props.buttonData.updateIsDeletion(false);
+    }
+  }, [props.buttonData.isDeletion]);
+
+  // Enable 'Delete' button if any group on the table is selected
+  useEffect(() => {
+    if (selectedElementIds.length > 0) {
+      props.buttonData.changeIsDeleteButtonDisabled(false);
+    }
+    if (selectedElementIds.length === 0) {
+      props.buttonData.changeIsDeleteButtonDisabled(true);
+    }
+  }, [selectedElementIds]);
+
+  // Keyboard event
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Shift") {
+        setShifting(true);
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === "Shift") {
+        setShifting(false);
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("keyup", onKeyUp);
+
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("keyup", onKeyUp);
+    };
+  }, []);
+
+  // Define body for empty tables
+  const emptyBody = (
+    <Tr>
+      <Td colSpan={8}>
+        <Bullseye>
+          <EmptyState variant={EmptyStateVariant.small}>
+            <EmptyStateIcon icon={SearchIcon} />
+            <Title headingLevel="h2" size="lg">
+              No results found
+            </Title>
+            <EmptyStateBody>Clear all filters and try again.</EmptyStateBody>
+            <Button variant="link">Clear all filters</Button>
+          </EmptyState>
+        </Bullseye>
+      </Td>
+    </Tr>
+  );
+
+  // Define table header
+  const header = (
+    <Tr>
+      <Th
+        select={{
+          onSelect: (_event, isSelecting) => selectAllElements(isSelecting),
+          isSelected: areAllElementsSelected,
+        }}
+      />
+      <Th key={columnNames.name} modifier="wrap">
+        {columnNames.name}
+      </Th>
+    </Tr>
+  );
+
+  // Define table body
+  const body = props.list.map((element, rowIndex) => (
+    <Tr key={element.hostName} id={element.hostName}>
+      <Td
+        dataLabel="checkbox"
+        select={{
+          rowIndex,
+          onSelect: (_event, isSelecting) =>
+            onSelectElement(element, rowIndex, isSelecting),
+          isSelected: isElementSelected(element),
+          disable: !isElementSelectable(element),
+        }}
+      />
+      <Td dataLabel={element.hostName}>{element.hostName}</Td>
+    </Tr>
+  ));
+
+  // Define skeleton
+  const skeleton = (
+    <SkeletonOnTableLayout
+      rows={4}
+      colSpan={9}
+      screenreaderText={"Loading table rows"}
+    />
+  );
+
+  // Render component
+  return (
+    <TableLayout
+      ariaLabel={props.tableName + " table"}
+      name="fqdn"
+      variant={"compact"}
+      hasBorders={true}
+      classes={"pf-u-mt-md"}
+      tableId={props.tableName.replace(" ", "-").toLowerCase() + "-table"}
+      isStickyHeader={true}
+      tableHeader={props.list.length === 0 ? undefined : header}
+      tableBody={
+        !props.showTableRows
+          ? skeleton
+          : props.list.length === 0
+          ? emptyBody
+          : body
+      }
+    />
+  );
+};
+
+export default ManagedByTable;

--- a/src/components/ManagedBy/ManagedByToolbar.tsx
+++ b/src/components/ManagedBy/ManagedByToolbar.tsx
@@ -1,0 +1,163 @@
+import React, { useState } from "react";
+// PatternFly
+import { Pagination, ToolbarItemVariant, Text } from "@patternfly/react-core";
+// Icons
+import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
+// Data types
+import { Host } from "src/utils/datatypes/globalDataTypes";
+// Layouts
+import SecondaryButton from "../layouts/SecondaryButton";
+import TextLayout from "src/components/layouts/TextLayout";
+import ToolbarLayout, { ToolbarItemAlignment } from "../layouts/ToolbarLayout";
+
+interface PageData {
+  page: number;
+  changeSetPage: (
+    newPage: number,
+    perPage: number | undefined,
+    startIdx: number | undefined,
+    endIdx: number | undefined
+  ) => void;
+  perPage: number;
+  changePerPageSelect: (
+    newPerPage: number,
+    newPage: number,
+    startIdx: number | undefined,
+    endIdx: number | undefined
+  ) => void;
+}
+
+interface ButtonData {
+  onClickAddHandler: () => void;
+  onClickDeleteHandler: () => void;
+  isDeleteButtonDisabled: boolean;
+}
+
+export interface PropsToToolbar {
+  pageRepo: Host[];
+  shownItems: Host[];
+  pageData: PageData;
+  buttonData: ButtonData;
+}
+
+const ManagedByToolbar = (props: PropsToToolbar) => {
+  // -- Pagination
+  const [page, setPage] = useState(1);
+  const [perPage, setPerPage] = useState(10);
+
+  // - Page setters
+  const onSetPage = (
+    _event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
+    newPage: number,
+    perPage: number | undefined,
+    startIdx: number | undefined,
+    endIdx: number | undefined
+  ) => {
+    setPage(newPage);
+    props.pageData.changeSetPage(newPage, perPage, startIdx, endIdx);
+  };
+
+  const onPerPageSelect = (
+    _event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
+    newPerPage: number,
+    newPage: number,
+    startIdx: number | undefined,
+    endIdx: number | undefined
+  ) => {
+    setPerPage(newPerPage);
+    props.pageData.changePerPageSelect(newPerPage, newPage, startIdx, endIdx);
+  };
+
+  // 'Hosts' toolbar elements data
+  const hostsToolbarData = {
+    refreshButton: {
+      id: "hosts-button-refresh",
+    },
+    deleteButton: {
+      id: "hosts-button-delete",
+      isDisabledHandler: props.buttonData.isDeleteButtonDisabled,
+      onClickHandler: props.buttonData.onClickDeleteHandler,
+    },
+    addButton: {
+      id: "hosts-button-add",
+      onClickHandler: props.buttonData.onClickAddHandler,
+    },
+    separatorId: "hosts-separator",
+    helpIcon: {
+      id: "hosts-help-icon",
+      // href: TDB
+    },
+    paginationId: "hosts-pagination",
+  };
+
+  const toolbarFields = [
+    {
+      id: hostsToolbarData.refreshButton.id,
+      key: 0,
+      element: <SecondaryButton name="refresh">Refresh</SecondaryButton>,
+    },
+    {
+      id: hostsToolbarData.deleteButton.id,
+      key: 1,
+      element: (
+        <SecondaryButton
+          name="remove"
+          isDisabled={hostsToolbarData.deleteButton.isDisabledHandler}
+          onClickHandler={hostsToolbarData.deleteButton.onClickHandler}
+        >
+          Delete
+        </SecondaryButton>
+      ),
+    },
+    {
+      id: hostsToolbarData.addButton.id,
+      key: 2,
+      element: (
+        <SecondaryButton
+          name="add"
+          onClickHandler={hostsToolbarData.addButton.onClickHandler}
+        >
+          Add
+        </SecondaryButton>
+      ),
+    },
+    {
+      id: hostsToolbarData.separatorId,
+      key: 3,
+      toolbarItemVariant: ToolbarItemVariant.separator,
+    },
+    {
+      id: hostsToolbarData.helpIcon.id,
+      key: 7,
+      element: (
+        <TextLayout component="p">
+          <OutlinedQuestionCircleIcon className="pf-u-primary-color-100 pf-u-mr-sm" />
+          <Text component="a" isVisitedLink>
+            Help
+          </Text>
+        </TextLayout>
+      ),
+    },
+    {
+      id: hostsToolbarData.paginationId,
+      key: 8,
+      element: (
+        <Pagination
+          itemCount={props.pageRepo.length}
+          perPage={perPage}
+          page={page}
+          onSetPage={onSetPage}
+          widgetId="pagination-options-menu-top"
+          onPerPageSelect={onPerPageSelect}
+          isCompact
+        />
+      ),
+      toolbarItemAlignment: { default: "alignRight" } as ToolbarItemAlignment,
+    },
+  ];
+
+  // Render component
+  return <ToolbarLayout isSticky={false} toolbarItems={toolbarFields} />;
+};
+
+export default ManagedByToolbar;

--- a/src/pages/Hosts/HostsManagedBy.tsx
+++ b/src/pages/Hosts/HostsManagedBy.tsx
@@ -1,0 +1,292 @@
+import React, { useEffect, useState } from "react";
+// PatternFly
+import {
+  Badge,
+  Page,
+  PageSection,
+  PageSectionVariants,
+  Pagination,
+  PaginationVariant,
+  Tab,
+  Tabs,
+  TabTitleText,
+} from "@patternfly/react-core";
+// Data type
+import { Host } from "src/utils/datatypes/globalDataTypes";
+// Redux
+import { useAppSelector } from "src/store/hooks";
+// Others
+import ManagedByTable from "src/components/ManagedBy/ManagedByTable";
+import ManagedByToolbar from "src/components/ManagedBy/ManagedByToolbar";
+// Modals
+import ManagedByAddModal from "src/components/ManagedBy/ManagedByAddModal";
+import ManagedByDeleteModal from "src/components/ManagedBy/ManagedByDeleteModal";
+
+interface PropsToHostsManagedBy {
+  host: Host;
+}
+
+const HostsManagedBy = (props: PropsToHostsManagedBy) => {
+  // List of currents elements on the list (Dummy data)
+  const [hostsList, setHostsList] = useState<Host[]>([props.host]);
+
+  const updateHostsList = (newHostsList: Host[]) => {
+    setHostsList(newHostsList);
+  };
+
+  // Retrieve available hosts data from Redux
+  let availableHostsData = useAppSelector((state) => state.hosts.hostsList);
+
+  // Alter the available options list to keep the state of the recently added / removed items
+  const updateAvailableHostsList = (newAvOptionsList: unknown[]) => {
+    availableHostsData = newAvOptionsList as Host[];
+  };
+
+  // Filter functions to compare the available data with the data that
+  //  the host is already member of. This is done to prevent duplicates
+  //  (e.g: adding the same element twice).
+  const filterHostsData = () => {
+    // Host groups
+    return availableHostsData.filter((item) => {
+      return !hostsList.some((itm) => {
+        return item.hostName === itm.hostName;
+      });
+    });
+  };
+
+  // Available data to be added as member of
+  const hostsFilteredData: Host[] = filterHostsData();
+
+  // State that determines whether the row tables are displayed nor not
+  // - This helps with the reload state
+  const [showTableRows, setShowTableRows] = useState(false);
+
+  // -- Pagination
+  const [page, setPage] = useState(1);
+  const [perPage, setPerPage] = useState(10);
+
+  // -- Name of the hosts selected on the table (to remove)
+  const [hostsSelected, setHostsSelected] = useState<string[]>([]);
+
+  const updateHostsSelected = (hosts: string[]) => {
+    setHostsSelected(hosts);
+  };
+
+  // -- 'Delete' button state
+  const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
+    useState<boolean>(true);
+
+  const updateIsDeleteButtonDisabled = (updatedDeleteButton: boolean) => {
+    setIsDeleteButtonDisabled(updatedDeleteButton);
+  };
+
+  // If some entries have been deleted, restore the 'groupsNamesSelected' list
+  const [isDeletion, setIsDeletion] = useState(false);
+
+  const updateIsDeletion = (option: boolean) => {
+    setIsDeletion(option);
+  };
+
+  // Member groups displayed on the first page
+  const [shownHostsList, setShownHostsList] = useState(
+    hostsList.slice(0, perPage)
+  );
+
+  // Pages setters (to manage pagination as an event)
+  const onSetPage = (
+    _event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
+    newPage: number,
+    perPage: number | undefined,
+    startIdx: number | undefined,
+    endIdx: number | undefined
+  ) => {
+    setPage(newPage);
+    setShownHostsList(hostsList.slice(startIdx, endIdx));
+  };
+
+  const onPerPageSelect = (
+    _event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
+    newPerPage: number,
+    newPage: number,
+    startIdx: number | undefined,
+    endIdx: number | undefined
+  ) => {
+    setPerPage(newPerPage);
+    setShownHostsList(hostsList.slice(startIdx, endIdx));
+  };
+
+  // Page setters passed as props
+  const changeSetPage = (
+    newPage: number,
+    perPage: number | undefined,
+    startIdx: number | undefined,
+    endIdx: number | undefined
+  ) => {
+    setPage(newPage);
+    setShownHostsList(hostsList.slice(startIdx, endIdx));
+  };
+
+  const changePerPageSelect = (
+    newPerPage: number,
+    newPage: number,
+    startIdx: number | undefined,
+    endIdx: number | undefined
+  ) => {
+    setPerPage(newPerPage);
+    setShownHostsList(hostsList.slice(startIdx, endIdx));
+  };
+
+  // -- Modal
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  const onClickAddHandler = () => {
+    setShowAddModal(true);
+  };
+  const onModalToggle = () => {
+    setShowAddModal(!showAddModal);
+  };
+
+  const onClickDeleteHandler = () => {
+    setShowDeleteModal(true);
+  };
+
+  const onModalDeleteToggle = () => {
+    setShowDeleteModal(!showDeleteModal);
+  };
+
+  // Reloads the table everytime any of the group lists are updated
+  useEffect(() => {
+    setPage(1);
+    if (showTableRows) setShowTableRows(false);
+    setTimeout(() => {
+      setShownHostsList(hostsList.slice(0, perPage));
+      setShowTableRows(true);
+    }, 1000);
+  }, [hostsList]);
+
+  // Data wrappers
+  // - ManagedByToolbar
+  const toolbarPageData = {
+    page,
+    changeSetPage,
+    perPage,
+    changePerPageSelect,
+  };
+
+  const toolbarButtonData = {
+    onClickAddHandler,
+    onClickDeleteHandler,
+    isDeleteButtonDisabled,
+  };
+
+  // - ManagedByTable
+  const tableButtonData = {
+    isDeletion,
+    updateIsDeletion,
+    changeIsDeleteButtonDisabled: updateIsDeleteButtonDisabled,
+  };
+
+  // - MemberOfAddModal
+  const addModalData = {
+    showModal: showAddModal,
+    handleModalToggle: onModalToggle,
+  };
+
+  const tabData = {
+    tabName: "Hosts",
+    elementName: props.host.hostName,
+  };
+
+  // - MemberOfDeleteModal
+  const deleteModalData = {
+    showModal: showDeleteModal,
+    handleModalToggle: onModalDeleteToggle,
+  };
+
+  const deleteButtonData = {
+    changeIsDeleteButtonDisabled: updateIsDeleteButtonDisabled,
+    updateIsDeletion,
+  };
+
+  const deleteTabData = {
+    tabName: "Hosts",
+    elementName: props.host.hostName,
+  };
+
+  // Render component
+  return (
+    <Page>
+      <PageSection
+        variant={PageSectionVariants.light}
+        isFilled={false}
+        className="pf-u-m-lg"
+      >
+        <Tabs activeKey={0} isBox={false}>
+          <Tab
+            eventKey={0}
+            name="managedby_host"
+            title={
+              <TabTitleText>
+                Hosts{" "}
+                <Badge key={0} isRead>
+                  {hostsList.length}
+                </Badge>
+              </TabTitleText>
+            }
+          >
+            <ManagedByToolbar
+              pageRepo={hostsList}
+              shownItems={shownHostsList}
+              pageData={toolbarPageData}
+              buttonData={toolbarButtonData}
+            />
+            <ManagedByTable
+              list={hostsList}
+              tableName="Hosts"
+              updateList={updateHostsList}
+              showTableRows={showTableRows}
+              updateElementsSelected={updateHostsSelected}
+              buttonData={tableButtonData}
+            />
+          </Tab>
+        </Tabs>
+        <Pagination
+          perPageComponent="button"
+          className="pf-u-pb-0 pf-u-pr-md"
+          itemCount={hostsList.length}
+          widgetId="pagination-options-menu-bottom"
+          perPage={perPage}
+          page={page}
+          variant={PaginationVariant.bottom}
+          onSetPage={onSetPage}
+          onPerPageSelect={onPerPageSelect}
+        />
+      </PageSection>
+      <>
+        {showAddModal && (
+          <ManagedByAddModal
+            modalData={addModalData}
+            availableData={hostsFilteredData}
+            groupRepository={hostsList}
+            updateGroupRepository={updateHostsList}
+            updateAvOptionsList={updateAvailableHostsList}
+            tabData={tabData}
+          />
+        )}
+        {showDeleteModal && hostsSelected.length !== 0 && (
+          <ManagedByDeleteModal
+            modalData={deleteModalData}
+            tabData={deleteTabData}
+            groupNamesToDelete={hostsSelected}
+            groupRepository={hostsList}
+            updateGroupRepository={updateHostsList}
+            buttonData={deleteButtonData}
+          />
+        )}
+      </>
+    </Page>
+  );
+};
+
+export default HostsManagedBy;

--- a/src/pages/Hosts/HostsTabs.tsx
+++ b/src/pages/Hosts/HostsTabs.tsx
@@ -15,6 +15,7 @@ import { URL_PREFIX } from "src/navigation/NavRoutes";
 // Other
 import HostsSettings from "./HostsSettings";
 import HostsMemberOf from "./HostsMemberOf";
+import HostsManagedBy from "./HostsManagedBy";
 // Layouts
 import BreadcrumbLayout from "src/components/layouts/BreadcrumbLayout";
 import TitleLayout from "src/components/layouts/TitleLayout";
@@ -86,6 +87,14 @@ const HostsTabs = () => {
           >
             <PageSection className="pf-u-pb-0"></PageSection>
             <HostsMemberOf host={hostData} />
+          </Tab>
+          <Tab
+            eventKey={2}
+            name="details"
+            title={<TabTitleText>Is managed by</TabTitleText>}
+          >
+            <PageSection className="pf-u-pb-0"></PageSection>
+            <HostsManagedBy host={hostData} />
           </Tab>
         </Tabs>
       </PageSection>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8112750/217035651-0f9e9a18-85e7-4dcf-ae61-7f1698613d6c.png)

### Description
The 'Is managed by' section provides a way to manage the entities by which a specific host can be managed. In this case, it refers to the hosts managed by other hosts.

### Data type and initial data
Since the initial data and the data type used (`Host`) were already defined in the project, there is no extra step to do here.

The data type `Host` lives under the `globalDataTypes.ts` file. 
```ts
export interface Host {
  id: string;
  hostName: string;
  dnsZone: string;
  class: string;
  ipAddress: string;
  description: string;
  enrolled: boolean;
}
```
The initial data has been defined in a JSON file (`hosts.json`) that will be taken by the Redux slice (`hosts.slice.ts`) in order to be consumed from anywhere in the project.

### 'Add' and 'Delete' modals
The 'Is managed by' section would manage the elements from a table by adding and deleting entries. This functionality has been implemented to the WebUI as modals and the components created can be reusable as well in other parts of the
page (similar to the 'Is a member of' section components).

The modals created are:
- `ManagedByAddModal`: Modal to add any new entry to the 'Is managed by' table. This is done by using a [Dual List Selector](https://www.patternfly.org/v4/components/dual-list-selector) component
- `ManagedByDeleteModal`: Modal to delete one or more entries from the 'Is managed by' table. Before performing the operation, it shows a confirmation message of the items to delete.

### Table and Toolbar components
Those are the key elements of the 'Is managed by' section. 
- The Toolbar component (`ManagedByToolbar`) provides the action buttons ('Refresh', 'Add', and 'Delete') and other functionality (such as the context help icon and the pagination) to manage the table elements.
- The table component (`ManagedByTable`) contains a list of all the hosts that can manage the actual host. Those elements can be selected by using the checkboxes.


Signed-off-by: Carla Martinez <carlmart@redhat.com>
