### PR TITLE
Checkboxes disabled when shift-focus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@patternfly/patternfly": "^4.202.1",
         "@patternfly/react-core": "^4.250.1",
-        "@patternfly/react-table": "^4.93.1",
+        "@patternfly/react-table": "^4.112.39",
         "@reduxjs/toolkit": "^1.8.6",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -2038,13 +2038,13 @@
       "integrity": "sha512-cQiiPqmwJOm9onuTfLPQNRlpAZwDIJ/zVfDQeaFqMQyPJtxtKn3lkphz5xErY5dPs9rR4X94ytQ1I9pkVzaPJQ=="
     },
     "node_modules/@patternfly/react-core": {
-      "version": "4.250.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.250.1.tgz",
-      "integrity": "sha512-vAOZPQdZzYXl/vkHnHMIt1eC3nrPDdsuuErPatkNPwmSvilXuXmWP5wxoJ36FbSNRRURkprFwx52zMmWS3iHJA==",
+      "version": "4.276.6",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.276.6.tgz",
+      "integrity": "sha512-G0K+378jf9jw9g+hCAoKnsAe/UGTRspqPeuAYypF2FgNr+dC7dUpc7/VkNhZBVqSJzUWVEK8NyXcqkfi0IemIg==",
       "dependencies": {
-        "@patternfly/react-icons": "^4.92.6",
-        "@patternfly/react-styles": "^4.91.6",
-        "@patternfly/react-tokens": "^4.93.6",
+        "@patternfly/react-icons": "^4.93.6",
+        "@patternfly/react-styles": "^4.92.6",
+        "@patternfly/react-tokens": "^4.94.6",
         "focus-trap": "6.9.2",
         "react-dropzone": "9.0.0",
         "tippy.js": "5.1.2",
@@ -2056,40 +2056,40 @@
       }
     },
     "node_modules/@patternfly/react-icons": {
-      "version": "4.92.6",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.92.6.tgz",
-      "integrity": "sha512-UdMSDqJ7fCxi/E6vlsFHuDZ3L0+kqBZ4ujRi4mjokrsvzOR4WFdaMhC+7iRy4aPNjT0DpHVjVUUUoWwKID9VqA==",
+      "version": "4.93.6",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.93.6.tgz",
+      "integrity": "sha512-ZrXegc/81oiuTIeWvoHb3nG/eZODbB4rYmekBEsrbiysyO7m/sUFoi/RLvgFINrRoh6YCJqL5fj06Jg6d7jX1g==",
       "peerDependencies": {
         "react": "^16.8 || ^17 || ^18",
         "react-dom": "^16.8 || ^17 || ^18"
       }
     },
     "node_modules/@patternfly/react-styles": {
-      "version": "4.91.6",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.91.6.tgz",
-      "integrity": "sha512-3wCYkvGRgbx6u5JrCaUNcpDvyTOrgvXU/Mh2hs8s/njBUDpyuyRb+gkFoE3l3Ro3Lk0DnRLYpIjCSjl38Bd0iA=="
+      "version": "4.92.6",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.92.6.tgz",
+      "integrity": "sha512-b8uQdEReMyeoMzjpMri845QxqtupY/tIFFYfVeKoB2neno8gkcW1RvDdDe62LF88q45OktCwAe/8A99ker10Iw=="
     },
     "node_modules/@patternfly/react-table": {
-      "version": "4.93.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.93.1.tgz",
-      "integrity": "sha512-N/zHkNsY3X3yUXPg6COwdZKAFmTCbWm25qCY2aHjrXlIlE2OKWaYvVag0CcTwPiQhIuCumztr9Y2Uw9uvv0Fsw==",
+      "version": "4.112.39",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.112.39.tgz",
+      "integrity": "sha512-U+hOMgYlbghGH4M5MX+qt0GkVi/ocrGnxDnm11YiS3CtEGsd6Rr0NeqMmk0uoR46Od4Pr5tKuXxZhPP32sCL/w==",
       "dependencies": {
-        "@patternfly/react-core": "^4.224.1",
-        "@patternfly/react-icons": "^4.75.1",
-        "@patternfly/react-styles": "^4.74.1",
-        "@patternfly/react-tokens": "^4.76.1",
+        "@patternfly/react-core": "^4.276.6",
+        "@patternfly/react-icons": "^4.93.6",
+        "@patternfly/react-styles": "^4.92.6",
+        "@patternfly/react-tokens": "^4.94.6",
         "lodash": "^4.17.19",
         "tslib": "^2.0.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
+        "react": "^16.8 || ^17 || ^18",
+        "react-dom": "^16.8 || ^17 || ^18"
       }
     },
     "node_modules/@patternfly/react-tokens": {
-      "version": "4.93.6",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.93.6.tgz",
-      "integrity": "sha512-rf4q5NoJNX7oBpRvGrWSjfK6sLA4yHSBgm6Rh5/2Uw1cgp47VaBY3XrErjT5YTu9uZCcvThGqBk8jiXI7tIRxw=="
+      "version": "4.94.6",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.94.6.tgz",
+      "integrity": "sha512-tm7C6nat+uKMr1hrapis7hS3rN9cr41tpcCKhx6cod6FLU8KwF2Yt5KUxakhIOCEcE/M/EhXhAw/qejp8w0r7Q=="
     },
     "node_modules/@reduxjs/toolkit": {
       "version": "1.8.6",
@@ -11934,13 +11934,13 @@
       "integrity": "sha512-cQiiPqmwJOm9onuTfLPQNRlpAZwDIJ/zVfDQeaFqMQyPJtxtKn3lkphz5xErY5dPs9rR4X94ytQ1I9pkVzaPJQ=="
     },
     "@patternfly/react-core": {
-      "version": "4.250.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.250.1.tgz",
-      "integrity": "sha512-vAOZPQdZzYXl/vkHnHMIt1eC3nrPDdsuuErPatkNPwmSvilXuXmWP5wxoJ36FbSNRRURkprFwx52zMmWS3iHJA==",
+      "version": "4.276.6",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.276.6.tgz",
+      "integrity": "sha512-G0K+378jf9jw9g+hCAoKnsAe/UGTRspqPeuAYypF2FgNr+dC7dUpc7/VkNhZBVqSJzUWVEK8NyXcqkfi0IemIg==",
       "requires": {
-        "@patternfly/react-icons": "^4.92.6",
-        "@patternfly/react-styles": "^4.91.6",
-        "@patternfly/react-tokens": "^4.93.6",
+        "@patternfly/react-icons": "^4.93.6",
+        "@patternfly/react-styles": "^4.92.6",
+        "@patternfly/react-tokens": "^4.94.6",
         "focus-trap": "6.9.2",
         "react-dropzone": "9.0.0",
         "tippy.js": "5.1.2",
@@ -11948,33 +11948,33 @@
       }
     },
     "@patternfly/react-icons": {
-      "version": "4.92.6",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.92.6.tgz",
-      "integrity": "sha512-UdMSDqJ7fCxi/E6vlsFHuDZ3L0+kqBZ4ujRi4mjokrsvzOR4WFdaMhC+7iRy4aPNjT0DpHVjVUUUoWwKID9VqA==",
+      "version": "4.93.6",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.93.6.tgz",
+      "integrity": "sha512-ZrXegc/81oiuTIeWvoHb3nG/eZODbB4rYmekBEsrbiysyO7m/sUFoi/RLvgFINrRoh6YCJqL5fj06Jg6d7jX1g==",
       "requires": {}
     },
     "@patternfly/react-styles": {
-      "version": "4.91.6",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.91.6.tgz",
-      "integrity": "sha512-3wCYkvGRgbx6u5JrCaUNcpDvyTOrgvXU/Mh2hs8s/njBUDpyuyRb+gkFoE3l3Ro3Lk0DnRLYpIjCSjl38Bd0iA=="
+      "version": "4.92.6",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.92.6.tgz",
+      "integrity": "sha512-b8uQdEReMyeoMzjpMri845QxqtupY/tIFFYfVeKoB2neno8gkcW1RvDdDe62LF88q45OktCwAe/8A99ker10Iw=="
     },
     "@patternfly/react-table": {
-      "version": "4.93.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.93.1.tgz",
-      "integrity": "sha512-N/zHkNsY3X3yUXPg6COwdZKAFmTCbWm25qCY2aHjrXlIlE2OKWaYvVag0CcTwPiQhIuCumztr9Y2Uw9uvv0Fsw==",
+      "version": "4.112.39",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.112.39.tgz",
+      "integrity": "sha512-U+hOMgYlbghGH4M5MX+qt0GkVi/ocrGnxDnm11YiS3CtEGsd6Rr0NeqMmk0uoR46Od4Pr5tKuXxZhPP32sCL/w==",
       "requires": {
-        "@patternfly/react-core": "^4.224.1",
-        "@patternfly/react-icons": "^4.75.1",
-        "@patternfly/react-styles": "^4.74.1",
-        "@patternfly/react-tokens": "^4.76.1",
+        "@patternfly/react-core": "^4.276.6",
+        "@patternfly/react-icons": "^4.93.6",
+        "@patternfly/react-styles": "^4.92.6",
+        "@patternfly/react-tokens": "^4.94.6",
         "lodash": "^4.17.19",
         "tslib": "^2.0.0"
       }
     },
     "@patternfly/react-tokens": {
-      "version": "4.93.6",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.93.6.tgz",
-      "integrity": "sha512-rf4q5NoJNX7oBpRvGrWSjfK6sLA4yHSBgm6Rh5/2Uw1cgp47VaBY3XrErjT5YTu9uZCcvThGqBk8jiXI7tIRxw=="
+      "version": "4.94.6",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.94.6.tgz",
+      "integrity": "sha512-tm7C6nat+uKMr1hrapis7hS3rN9cr41tpcCKhx6cod6FLU8KwF2Yt5KUxakhIOCEcE/M/EhXhAw/qejp8w0r7Q=="
     },
     "@reduxjs/toolkit": {
       "version": "1.8.6",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@patternfly/patternfly": "^4.202.1",
     "@patternfly/react-core": "^4.250.1",
-    "@patternfly/react-table": "^4.93.1",
+    "@patternfly/react-table": "^4.112.39",
     "@reduxjs/toolkit": "^1.8.6",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/components/layouts/SearchInputLayout.tsx
+++ b/src/components/layouts/SearchInputLayout.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import React, { FormEvent, SyntheticEvent } from "react";
 // PatternFly
 import { SearchInput } from "@patternfly/react-core";
 
@@ -15,8 +16,15 @@ interface PropsToSearchInput {
 }
 
 const SearchInputLayout = (props: PropsToSearchInput) => {
-  const onSearchChange = (value: string) => {
+  const onSearchChange = (
+    _event: FormEvent<HTMLInputElement>,
+    value: string
+  ) => {
     props.searchValueData.updateSearchValue(value);
+  };
+
+  const onSearchClean = (_event: SyntheticEvent<HTMLButtonElement, Event>) => {
+    props.searchValueData.updateSearchValue("");
   };
 
   return (
@@ -26,7 +34,7 @@ const SearchInputLayout = (props: PropsToSearchInput) => {
       placeholder={props.placeholder}
       value={props.searchValueData.searchValue}
       onChange={onSearchChange}
-      onClear={() => onSearchChange("")}
+      onClear={onSearchClean}
     />
   );
 };

--- a/src/components/tables/HostsSettings/CreateKeytabHostGroupsTable.tsx
+++ b/src/components/tables/HostsSettings/CreateKeytabHostGroupsTable.tsx
@@ -163,6 +163,7 @@ const CreateKeytabHostGroupsTable = (props: PropsToTable) => {
         select={{
           onSelect: (_event, isSelecting) => selectAllHostGroups(isSelecting),
           isSelected: areAllHostGroupsSelected,
+          isDisabled: tableHostGroupsList.length === 0 ? true : false,
         }}
       />
       <Th width={10}>{hostGroupsColumnNamesArray[0]}</Th>

--- a/src/components/tables/HostsSettings/CreateKeytabHostsTable.tsx
+++ b/src/components/tables/HostsSettings/CreateKeytabHostsTable.tsx
@@ -148,6 +148,7 @@ const CreateKeytabHostsTable = (props: PropsToTable) => {
         select={{
           onSelect: (_event, isSelecting) => selectAllHosts(isSelecting),
           isSelected: areAllHostsSelected,
+          isDisabled: tableHostsList.length === 0 ? true : false,
         }}
       />
       <Th width={10}>{hostsColumnNamesArray[0]}</Th>

--- a/src/components/tables/HostsSettings/CreateKeytabUserGroupsTable.tsx
+++ b/src/components/tables/HostsSettings/CreateKeytabUserGroupsTable.tsx
@@ -164,6 +164,7 @@ const CreateKeytabUserGroupsTable = (props: PropsToTable) => {
         select={{
           onSelect: (_event, isSelecting) => selectAllUserGroups(isSelecting),
           isSelected: areAllUserGroupsSelected,
+          isDisabled: tableUserGroupsList.length === 0 ? true : false,
         }}
       />
       <Th width={10}>{userGroupsColumnNamesArray[0]}</Th>

--- a/src/components/tables/HostsSettings/CreateKeytabUsersTable.tsx
+++ b/src/components/tables/HostsSettings/CreateKeytabUsersTable.tsx
@@ -148,9 +148,9 @@ const CreateKeytabUsersTable = (props: PropsToTable) => {
         select={{
           onSelect: (_event, isSelecting) => selectAllUsers(isSelecting),
           isSelected: areAllUsersSelected,
+          isDisabled: tableUsersList.length === 0 ? true : false,
         }}
       />
-      {/* <Th width={10}>{usersColumnNames.user}</Th> */}
       <Th width={10}>{usersColumnNamesArray[0]}</Th>
     </Tr>
   );
@@ -168,7 +168,6 @@ const CreateKeytabUsersTable = (props: PropsToTable) => {
           disable: false,
         }}
       />
-      {/* <Td dataLabel={usersColumnNames.user}>{user}</Td> */}
       <Td dataLabel={usersColumnNamesArray[0]}>{user}</Td>
     </Tr>
   ));

--- a/src/components/tables/HostsSettings/RetrieveKeytabHostGroupTable.tsx
+++ b/src/components/tables/HostsSettings/RetrieveKeytabHostGroupTable.tsx
@@ -161,6 +161,7 @@ const RetrieveKeytabHostGroupsTable = (props: PropsToTable) => {
         select={{
           onSelect: (_event, isSelecting) => selectAllHostGroups(isSelecting),
           isSelected: areAllHostGroupsSelected,
+          isDisabled: tableHostGroupsList.length === 0 ? true : false,
         }}
       />
       <Th width={10}>{hostGroupsColumnNamesArray[0]}</Th>

--- a/src/components/tables/HostsSettings/RetrieveKeytabHostsTable.tsx
+++ b/src/components/tables/HostsSettings/RetrieveKeytabHostsTable.tsx
@@ -148,6 +148,7 @@ const RetrieveKeytabHostsTable = (props: PropsToTable) => {
         select={{
           onSelect: (_event, isSelecting) => selectAllHosts(isSelecting),
           isSelected: areAllHostsSelected,
+          isDisabled: tableHostsList.length === 0 ? true : false,
         }}
       />
       <Th width={10}>{hostsColumnNamesArray[0]}</Th>

--- a/src/components/tables/HostsSettings/RetrieveKeytabUserGroupsTable.tsx
+++ b/src/components/tables/HostsSettings/RetrieveKeytabUserGroupsTable.tsx
@@ -164,6 +164,7 @@ const RetrieveKeytabUserGroupsTable = (props: PropsToTable) => {
         select={{
           onSelect: (_event, isSelecting) => selectAllUserGroups(isSelecting),
           isSelected: areAllUserGroupsSelected,
+          isDisabled: tableUserGroupsList.length === 0 ? true : false,
         }}
       />
       <Th width={10}>{userGroupsColumnNamesArray[0]}</Th>

--- a/src/components/tables/HostsSettings/RetrieveKeytabUsersTable.tsx
+++ b/src/components/tables/HostsSettings/RetrieveKeytabUsersTable.tsx
@@ -148,9 +148,9 @@ const RetrieveKeytabUsersTable = (props: PropsToTable) => {
         select={{
           onSelect: (_event, isSelecting) => selectAllUsers(isSelecting),
           isSelected: areAllUsersSelected,
+          isDisabled: tableUsersList.length === 0 ? true : false,
         }}
       />
-      {/* <Th width={10}>{usersColumnNames.user}</Th> */}
       <Th width={10}>{usersColumnNamesArray[0]}</Th>
     </Tr>
   );


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/8112750/217241251-55934ab0-2da9-4219-ac16-1f50b7fff8f3.png" width="450px">

### Description
In the 'Settings' section, when the user scrolls through all the page elements by pressing the 'shift' key, the checkboxes should be omitted from the 'focus' event on all those tables that do not contain any elements. This behavior must be adapted in all 'Create' and 'Retrieve keytab' tables.

### Solution
The `isDisabled` parameter of PatternFly's `react-table` library should manage the state of the checkbox (enabled|disabled) depending on whether there is something in the table or not. That would also determine whether the checkbox is selectable or 'skipped' by the focus event.

In order to use the `isDisabled` parameter (as part of the `ThSelectType` [component](https://www.patternfly.org/v4/components/table/#thselecttype)), Patternfly's `react-table` library has been updated to the latest version (`4.112.39`).


Signed-off-by: Carla Martinez <carlmart@redhat.com>