### PR TITLE
'Services' page

### DIFF
--- a/src/components/BulkSelectorServicesPrep.tsx
+++ b/src/components/BulkSelectorServicesPrep.tsx
@@ -1,0 +1,340 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React, { FormEvent, useEffect, useRef, useState } from "react";
+// PatternFly
+import {
+  Menu,
+  MenuContent,
+  MenuItem,
+  MenuList,
+  MenuToggle,
+  MenuToggleCheckbox,
+} from "@patternfly/react-core";
+// Data types
+import { Service } from "src/utils/datatypes/globalDataTypes";
+// Layouts
+import BulkSelectorLayout from "src/components/layouts/BulkSelectorLayout";
+
+interface ServicesData {
+  selectedServices: string[];
+  updateSelectedServices: (newSelectedServices: string[]) => void;
+  changeSelectedServiceIds: (newSelectedServiceIds: string[]) => void;
+  selectableServicesTable: Service[];
+  isServiceSelectable: (service: Service) => boolean;
+}
+
+interface ButtonsData {
+  updateIsDeleteButtonDisabled: (value: boolean) => void;
+}
+
+interface SelectedPerPageData {
+  selectedPerPage: number;
+  updateSelectedPerPage: (selected: number) => void;
+}
+
+interface PropsToBulkSelectorPrep {
+  list: Service[];
+  shownElementsList: Service[];
+  elementData: ServicesData;
+  buttonsData: ButtonsData;
+  selectedPerPageData: SelectedPerPageData;
+}
+
+const BulkSelectorServicesPrep = (props: PropsToBulkSelectorPrep) => {
+  // Table functionality (from parent component) to manage the bulk selector functionality
+  // - Menu
+  const [isOpenMenu, setIsOpenMenu] = useState(false);
+  const toggleRefMenu = useRef<any>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const containerRefMenu = useRef<HTMLDivElement>(null);
+
+  const handleMenuKeys = (event: KeyboardEvent) => {
+    if (!isOpenMenu) {
+      return;
+    }
+    if (
+      menuRef.current?.contains(event.target as Node) ||
+      toggleRefMenu.current?.contains(event.target as Node)
+    ) {
+      if (event.key === "Escape" || event.key === "Tab") {
+        setIsOpenMenu(!isOpenMenu);
+        toggleRefMenu.current?.focus();
+      }
+    }
+  };
+
+  const handleClickOutside = (event: MouseEvent) => {
+    if (isOpenMenu && !menuRef.current?.contains(event.target as Node)) {
+      setIsOpenMenu(false);
+    }
+  };
+
+  React.useEffect(() => {
+    window.addEventListener("keydown", handleMenuKeys);
+    window.addEventListener("click", handleClickOutside);
+    return () => {
+      window.removeEventListener("keydown", handleMenuKeys);
+      window.removeEventListener("click", handleClickOutside);
+    };
+  }, [isOpenMenu, menuRef]);
+
+  // - When a bulk selector element is selected, it remains highlighted
+  const onToggleClick = (ev: React.MouseEvent) => {
+    ev.stopPropagation(); // Stop handleClickOutside from handling
+    setIsOpenMenu(!isOpenMenu);
+  };
+
+  // - Selectable checkboxes on table (elements per page)
+  const selectableElementsPage = props.shownElementsList.filter(
+    props.elementData.isServiceSelectable
+  );
+
+  // - Methods to manage the Bulk selector options
+  // -- Unselect all items on the table
+  const unselectAllItems = () => {
+    props.elementData.changeSelectedServiceIds([]);
+    props.elementData.updateSelectedServices([]);
+    props.buttonsData.updateIsDeleteButtonDisabled(true);
+  };
+
+  // - Helper method: Remove duplicates in a list
+  const removeDuplicates = (servicesList: string[]) => {
+    return servicesList.filter(
+      (service, index) => servicesList.indexOf(service) === index
+    );
+  };
+
+  // Select all elements (Page)
+  const selectAllElementsPage = (
+    isSelecting = true,
+    selectableServicesList: Service[]
+  ) => {
+    props.elementData.changeSelectedServiceIds(
+      isSelecting ? selectableServicesList.map((r) => r.id) : []
+    );
+
+    // Update selected elements
+    const serviceNamesArray: string[] = [];
+    selectableServicesList.map((service) => {
+      serviceNamesArray.push(service.id);
+    });
+    props.elementData.updateSelectedServices(serviceNamesArray);
+
+    // Enable/disable 'Delete' button
+    if (isSelecting) {
+      let servicesIdArray: string[] = [];
+
+      // if all page selected, the original 'selectedServices' data is preserved
+      if (
+        selectableServicesList.length <=
+        props.elementData.selectableServicesTable.length
+      ) {
+        props.elementData.selectedServices.map((service) => {
+          servicesIdArray.push(service);
+        });
+        selectableServicesList.map((service) => {
+          servicesIdArray.push(service.id);
+        });
+      }
+
+      // Correct duplicates (if any)
+      servicesIdArray = removeDuplicates(servicesIdArray);
+      props.elementData.updateSelectedServices(servicesIdArray);
+
+      // Update data
+      props.elementData.changeSelectedServiceIds(servicesIdArray);
+      props.elementData.updateSelectedServices(servicesIdArray);
+      // Enable delete button
+      props.buttonsData.updateIsDeleteButtonDisabled(false);
+      // Update the 'selectedPerPage' counter
+      props.selectedPerPageData.updateSelectedPerPage(
+        selectableServicesList.length
+      );
+    } else {
+      props.elementData.changeSelectedServiceIds([]);
+      props.elementData.updateSelectedServices([]);
+      props.buttonsData.updateIsDeleteButtonDisabled(true);
+      // Restore the 'selectedPerPage' counter
+      props.selectedPerPageData.updateSelectedPerPage(0);
+    }
+  };
+
+  // Select all elements (Table)
+  const selectAllElementsTable = (
+    isSelecting = true,
+    selectableServicesList: Service[]
+  ) => {
+    props.elementData.changeSelectedServiceIds(
+      isSelecting ? selectableServicesList.map((r) => r.id) : []
+    );
+
+    // Update selected elements
+    const serviceNamesArray: string[] = [];
+    selectableServicesList.map((service) => {
+      serviceNamesArray.push(service.id);
+    });
+    props.elementData.updateSelectedServices(serviceNamesArray);
+
+    // Enable/disable 'Delete' button
+    if (isSelecting) {
+      const servicesIdArray: string[] = [];
+      selectableServicesList.map((service) => servicesIdArray.push(service.id));
+      props.elementData.changeSelectedServiceIds(servicesIdArray);
+      props.elementData.updateSelectedServices(servicesIdArray);
+      props.buttonsData.updateIsDeleteButtonDisabled(false);
+    } else {
+      props.elementData.changeSelectedServiceIds([]);
+      props.elementData.updateSelectedServices([]);
+      props.buttonsData.updateIsDeleteButtonDisabled(true);
+    }
+  };
+
+  // Helper method to manage the checkbox icon symbol
+  // - All rows selected: true (full check)
+  // - Some rows selected: null (-)
+  // - None selected: false (empty)
+  const areAllElementsSelected: boolean | null =
+    props.elementData.selectedServices.length ===
+    props.elementData.selectableServicesTable.length
+      ? true
+      : props.elementData.selectedServices.length > 0
+      ? null
+      : false;
+
+  // Menu toggle element with checkbox
+  const toggle = (
+    <MenuToggle
+      ref={toggleRefMenu}
+      onClick={onToggleClick}
+      isExpanded={isOpenMenu}
+      splitButtonOptions={{
+        items: [
+          <MenuToggleCheckbox
+            id="split-button-checkbox-with-text-disabled-example"
+            key="split-checkbox-with-text-disabled"
+            aria-label="Select all"
+            onChange={(
+              isSelecting: boolean | undefined,
+              event: FormEvent<HTMLInputElement>
+            ) =>
+              selectAllElementsTable(
+                isSelecting,
+                props.elementData.selectableServicesTable
+              )
+            }
+            isChecked={areAllElementsSelected}
+          >
+            {props.elementData.selectedServices.length > 0 && (
+              <p>{props.elementData.selectedServices.length + " selected"}</p>
+            )}
+          </MenuToggleCheckbox>,
+        ],
+      }}
+      aria-label="Menu toggle with checkbox split button and text"
+    />
+  );
+
+  // Checks wether all the elements on the currect page have been selected or not
+  const [currentPageAlreadySelected, setCurrentPageAlreadySelected] =
+    useState(false);
+
+  // The 'currentPageAlreadySelected' should be set when elements are selected
+  useEffect(() => {
+    const found = props.shownElementsList.every(
+      (service) => props.elementData.selectedServices.indexOf(service.id) >= 0
+    );
+
+    if (found) {
+      // All the elements on that page are been selected
+      setCurrentPageAlreadySelected(true);
+    } else {
+      // The elements on that page are not been selected (yet)
+      setCurrentPageAlreadySelected(false);
+      // If there is no elements selected on the page yet, reset 'selectedPerPage'
+      if (
+        !props.shownElementsList.some(
+          (service) =>
+            props.elementData.selectedServices.indexOf(service.id) >= 0
+        )
+      ) {
+        props.selectedPerPageData.updateSelectedPerPage(0);
+      }
+    }
+  }, [props.elementData.selectedServices.length, props.shownElementsList]);
+
+  // Set the messages displayed in the 'Select page' option (bulk selector)
+  const getSelectedElements = () => {
+    let msg =
+      "Select page (" + props.elementData.selectedServices.length + " items)";
+    const remainingElements = Math.min(
+      props.elementData.selectedServices.length +
+        props.shownElementsList.length -
+        props.selectedPerPageData.selectedPerPage,
+      props.list.length
+    );
+
+    if (
+      props.list.length > props.elementData.selectedServices.length &&
+      !currentPageAlreadySelected
+    ) {
+      msg = "Select page (" + remainingElements + " items)";
+    }
+
+    return msg;
+  };
+
+  // Menu options
+  const menuToolbar = (
+    <Menu
+      ref={menuRef}
+      style={{ minWidth: "fit-content" }}
+      onSelect={(_ev) => {
+        setIsOpenMenu(!isOpenMenu);
+        toggleRefMenu.current?.querySelector("button").focus();
+      }}
+    >
+      <MenuContent>
+        <MenuList>
+          <MenuItem itemId={0} onClick={unselectAllItems}>
+            Select none (0 items)
+          </MenuItem>
+          <MenuItem
+            itemId={1}
+            onClick={() => selectAllElementsPage(true, selectableElementsPage)}
+            // NOTE: The line below disables this BS option when all the page rows have been selected.
+            // This can benefit the user experience as it provides extra context of the already selected elements.
+            // isDisabled={currentPageAlreadySelected}
+          >
+            {getSelectedElements()}
+          </MenuItem>
+          <MenuItem
+            itemId={2}
+            onClick={() =>
+              selectAllElementsTable(
+                true,
+                props.elementData.selectableServicesTable
+              )
+            }
+          >
+            Select all ({props.list.length} items)
+          </MenuItem>
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
+
+  // Renders component with the elements' data
+  return (
+    <BulkSelectorLayout
+      menuKey="menu-all-services-table"
+      containerRefMenu={containerRefMenu}
+      toggle={toggle}
+      menuToolbar={menuToolbar}
+      appendTo={containerRefMenu.current || undefined}
+      isOpenMenu={isOpenMenu}
+      ariaLabel="Menu toggle with checkbox split button"
+    />
+  );
+};
+
+export default BulkSelectorServicesPrep;

--- a/src/components/PaginationServicesPrep.tsx
+++ b/src/components/PaginationServicesPrep.tsx
@@ -1,0 +1,102 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React from "react";
+// Data types
+import { Service } from "src/utils/datatypes/globalDataTypes";
+// Layouts
+import PaginationLayout from "src/components/layouts/PaginationLayout";
+
+interface PaginationData {
+  page: number;
+  perPage: number;
+  updatePage: (newPage: number) => void;
+  updatePerPage: (newSetPerPage: number) => void;
+  showTableRows: boolean;
+  updateShowTableRows: (value: boolean) => void;
+  updateSelectedPerPage: (selected: number) => void;
+  updateShownElementsList: (newShownElementsList: Service[]) => void;
+}
+
+interface PropsToPaginationPrep {
+  list: Service[];
+  paginationData: PaginationData;
+  variant?: "top" | "bottom";
+  widgetId?: string | undefined;
+  perPageComponent?: "div" | "button";
+  className?: string;
+  isCompact?: boolean;
+}
+
+const PaginationServicesPrep = (props: PropsToPaginationPrep) => {
+  // Refresh displayed elements every time elements list changes (from Redux or somewhere else)
+  React.useEffect(() => {
+    props.paginationData.updatePage(1);
+    if (props.paginationData.showTableRows)
+      props.paginationData.updateShowTableRows(false);
+    setTimeout(() => {
+      props.paginationData.updateShownElementsList(
+        props.list.slice(0, props.paginationData.perPage)
+      );
+      props.paginationData.updateShowTableRows(true);
+      // Reset 'selectedPerPage'
+      props.paginationData.updateSelectedPerPage(0);
+    }, 2000);
+  }, [props.list]);
+
+  // Handle content on 'setPage'
+  const handleSetPage = (
+    _event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
+    newPage: number,
+    perPage: number | undefined,
+    startIdx: number | undefined,
+    endIdx: number | undefined
+  ) => {
+    props.paginationData.updatePage(newPage);
+    props.paginationData.updateShowTableRows(false);
+    setTimeout(() => {
+      props.paginationData.updateShownElementsList(
+        props.list.slice(startIdx, endIdx)
+      );
+      props.paginationData.updateShowTableRows(true);
+      // Reset 'selectedPerPage'
+      props.paginationData.updateSelectedPerPage(0);
+    }, 2000);
+  };
+
+  // Handle content on 'perPageSelect'
+  const handlePerPageSelect = (
+    _event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
+    newPerPage: number,
+    newPage: number,
+    startIdx: number | undefined,
+    endIdx: number | undefined
+  ) => {
+    props.paginationData.updatePerPage(newPerPage);
+    props.paginationData.updatePage(newPage);
+    props.paginationData.updateShowTableRows(false);
+    setTimeout(() => {
+      props.paginationData.updateShownElementsList(
+        props.list.slice(startIdx, endIdx)
+      );
+      props.paginationData.updateShowTableRows(true);
+      // Reset 'selectedPerPage'
+      props.paginationData.updateSelectedPerPage(0);
+    }, 2000);
+  };
+
+  return (
+    <PaginationLayout
+      list={props.list}
+      perPage={props.paginationData.perPage}
+      page={props.paginationData.page}
+      handleSetPerPage={handlePerPageSelect}
+      handleSetPage={handleSetPage}
+      variant={props.variant}
+      perPageComponent={props.perPageComponent}
+      widgetId={props.widgetId}
+      className={props.className}
+      isCompact={props.isCompact}
+    />
+  );
+};
+
+export default PaginationServicesPrep;

--- a/src/components/modals/AddService.tsx
+++ b/src/components/modals/AddService.tsx
@@ -1,0 +1,382 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React, { useEffect, useState } from "react";
+// PatternFly
+import {
+  Button,
+  Checkbox,
+  HelperText,
+  HelperTextItem,
+  Select,
+  SelectOption,
+  SelectVariant,
+  ValidatedOptions,
+} from "@patternfly/react-core";
+// Layout
+import SecondaryButton from "../layouts/SecondaryButton";
+import ModalWithFormLayout from "../layouts/ModalWithFormLayout";
+// Data types
+import { Service } from "src/utils/datatypes/globalDataTypes";
+// Redux
+import { useAppDispatch, useAppSelector } from "src/store/hooks";
+import { addService } from "src/store/Identity/services-slice";
+
+interface PropsToAddService {
+  show: boolean;
+  handleModalToggle: () => void;
+}
+
+const AddService = (props: PropsToAddService) => {
+  // Set dispatch (Redux)
+  const dispatch = useAppDispatch();
+
+  // Set host names list
+  const hostsList = useAppSelector((state) => state.hosts.hostsList);
+  const hostNamesList = hostsList.map((hostName) => hostName.hostName);
+
+  // 'Service' select
+  const [isServiceOpen, setIsServiceOpen] = useState(false);
+  const [serviceSelected, setServiceSelected] = useState("");
+  const serviceOptions = [
+    "cifs",
+    "DNS",
+    "ftp",
+    "HTTP",
+    "imap",
+    "ldap",
+    "libvirt",
+    "nfs",
+    "smtp",
+    "qpidd",
+  ];
+
+  const serviceOnToggle = (isOpen: boolean) => {
+    setIsServiceOpen(isOpen);
+  };
+
+  const serviceOnSelect = (selection: any) => {
+    setServiceSelected(selection.target.textContent);
+    setServiceValidation({
+      isError: false,
+      message: "",
+      pfError: ValidatedOptions.default,
+    });
+    setIsServiceOpen(false);
+  };
+
+  // 'Host name' select
+  const [isHostNameOpen, setIsHostNameOpen] = useState(false);
+  const [hostNameSelected, setHostNameSelected] = useState("");
+  const hostNameOptions = hostNamesList;
+
+  const hostNameOnToggle = (isOpen: boolean) => {
+    setIsHostNameOpen(isOpen);
+  };
+
+  const hostNameOnSelect = (selection: any) => {
+    setHostNameSelected(selection.target.textContent);
+    setHostNameValidation({
+      isError: false,
+      message: "",
+      pfError: ValidatedOptions.default,
+    });
+    setIsHostNameOpen(false);
+  };
+
+  // 'Force' checkbox
+  const [isForceChecked, setIsForceChecked] = useState(false);
+
+  // 'Skip host check' checkbox
+  const [isSkipHostChecked, setIsSkipHostChecked] = useState(false);
+
+  // Validation fields
+  const [serviceValidation, setServiceValidation] = useState({
+    isError: false,
+    message: "",
+    pfError: ValidatedOptions.default,
+  });
+
+  const [hostNameValidation, setHostNameValidation] = useState({
+    isError: false,
+    message: "",
+    pfError: ValidatedOptions.default,
+  });
+
+  const serviceValidationHandler = () => {
+    if (serviceSelected === "") {
+      const serviceVal = {
+        isError: true,
+        message: "Required field",
+        pfError: ValidatedOptions.error,
+      };
+      setServiceValidation(serviceVal);
+      return true;
+    } else {
+      const serviceVal = {
+        isError: false,
+        message: "",
+        pfError: ValidatedOptions.default,
+      };
+      setServiceValidation(serviceVal);
+      return false;
+    }
+  };
+
+  const hostNameValidationHandler = () => {
+    if (hostNameSelected === "") {
+      const hostNameVal = {
+        isError: true,
+        message: "Required field",
+        pfError: ValidatedOptions.error,
+      };
+      setHostNameValidation(hostNameVal);
+      return true;
+    } else {
+      const hostNameVal = {
+        isError: false,
+        message: "",
+        pfError: ValidatedOptions.default,
+      };
+      setHostNameValidation(hostNameVal);
+      return false;
+    }
+  };
+
+  // Reset validation methods
+  // - Service
+  const resetServiceError = () => {
+    setHostNameValidation({
+      isError: false,
+      message: "",
+      pfError: ValidatedOptions.default,
+    });
+  };
+
+  // - Host name
+  const resetHostNameError = () => {
+    setHostNameValidation({
+      isError: false,
+      message: "",
+      pfError: ValidatedOptions.default,
+    });
+  };
+
+  // Helper method to reset validation values
+  const resetValidations = () => {
+    resetServiceError();
+    resetHostNameError();
+  };
+
+  // Add button is disabled until the user fills the required fields
+  const [buttonDisabled, setButtonDisabled] = useState(true);
+  useEffect(() => {
+    if (serviceSelected !== "" && hostNameSelected !== "") {
+      setButtonDisabled(false);
+    } else {
+      setButtonDisabled(false);
+    }
+  }, [serviceSelected, hostNameSelected]);
+
+  // List of fields
+  const fields = [
+    {
+      id: "service-select",
+      name: "Service",
+      fieldRequired: true,
+      pfComponent: (
+        <>
+          <Select
+            id="service"
+            name="service"
+            variant={SelectVariant.single}
+            placeholderText=" "
+            aria-label="Select service"
+            onToggle={serviceOnToggle}
+            onSelect={serviceOnSelect}
+            selections={serviceSelected}
+            isOpen={isServiceOpen}
+            aria-labelledby="service"
+          >
+            {serviceOptions.map((option, index) => (
+              <SelectOption key={index} value={option} />
+            ))}
+          </Select>
+          <HelperText>
+            {!serviceValidation.isError && (
+              <HelperTextItem>{serviceValidation.message}</HelperTextItem>
+            )}
+            {serviceValidation.isError && (
+              <HelperTextItem variant="error">
+                {serviceValidation.message}
+              </HelperTextItem>
+            )}
+          </HelperText>
+        </>
+      ),
+    },
+    {
+      id: "host-name-select",
+      name: "Host name",
+      fieldRequired: true,
+      pfComponent: (
+        <>
+          <Select
+            id="host-name"
+            name="host"
+            variant={SelectVariant.single}
+            placeholderText=" "
+            aria-label="Select host name"
+            onToggle={hostNameOnToggle}
+            onSelect={hostNameOnSelect}
+            selections={hostNameSelected}
+            isOpen={isHostNameOpen}
+            aria-labelledby="host name"
+          >
+            {hostNameOptions.map((option, index) => (
+              <SelectOption key={index} value={option} />
+            ))}
+          </Select>
+          <HelperText>
+            {!hostNameValidation.isError && (
+              <HelperTextItem>{hostNameValidation.message}</HelperTextItem>
+            )}
+            {hostNameValidation.isError && (
+              <HelperTextItem variant="error">
+                {hostNameValidation.message}
+              </HelperTextItem>
+            )}
+          </HelperText>
+        </>
+      ),
+    },
+    {
+      id: "force-service",
+      name: "",
+      pfComponent: (
+        <Checkbox
+          label="Force"
+          isChecked={isForceChecked}
+          aria-label="force service checkbox"
+          id="force-checkbox"
+          name="force"
+          value="force"
+        />
+      ),
+    },
+    {
+      id: "skip-host-check-service",
+      name: "",
+      pfComponent: (
+        <Checkbox
+          label="Skip host check"
+          isChecked={isSkipHostChecked}
+          aria-label="skip host check checkbox"
+          id="skip-host-check-checkbox"
+          name="skip_host_check"
+          value="skip-host-check"
+        />
+      ),
+    },
+  ];
+
+  // Helper method to clean the fields
+  const cleanAllFields = () => {
+    setServiceSelected("");
+    setHostNameSelected("");
+    setIsForceChecked(false);
+    setIsSkipHostChecked(false);
+  };
+
+  // Clean fields and close modal (To prevent data persistence when reopen modal)
+  const cleanAndCloseModal = () => {
+    cleanAllFields();
+    resetValidations();
+    props.handleModalToggle();
+  };
+
+  // List of field validations
+  const validateFields = () => {
+    resetValidations();
+    const serviceError = serviceValidationHandler();
+    const hostNameError = hostNameValidationHandler();
+    if (serviceError || hostNameError) {
+      return false;
+    } else return true;
+  };
+
+  // Add new 'Service'
+  const addServiceHandler = () => {
+    const validation = validateFields();
+    if (validation) {
+      const newService: Service = {
+        id: serviceSelected + "/" + hostNameSelected,
+        serviceType: serviceSelected,
+        host: hostNameSelected,
+      };
+      // TODO: Manage 'Force' and 'Skip host check' behaviors
+      dispatch(addService(newService));
+      cleanAndCloseModal();
+    }
+  };
+
+  const addAndAddAnotherServiceHandler = () => {
+    const validation = validateFields();
+    if (validation) {
+      const newService: Service = {
+        id: serviceSelected + "/" + hostNameSelected,
+        serviceType: serviceSelected,
+        host: hostNameSelected,
+      };
+      // TODO: Manage 'Force' and 'Skip host check' behaviors
+      dispatch(addService(newService));
+      // Do not close the modal, but clean fields & reset validations
+      cleanAllFields();
+      resetValidations();
+    }
+  };
+
+  // Buttons that will be shown at the end of the form
+  const modalActions = [
+    <SecondaryButton
+      key="add-new-service"
+      name="add"
+      isDisabled={buttonDisabled}
+      onClickHandler={addServiceHandler}
+      form="modal-form"
+    >
+      Add
+    </SecondaryButton>,
+    <SecondaryButton
+      key="add-and-add-another-new-service"
+      name="add_and_add_another"
+      isDisabled={buttonDisabled}
+      onClickHandler={addAndAddAnotherServiceHandler}
+      form="modal-form"
+    >
+      Add and add another
+    </SecondaryButton>,
+    <Button
+      key="cancel-new-service"
+      variant="link"
+      onClick={cleanAndCloseModal}
+    >
+      Cancel
+    </Button>,
+  ];
+
+  // Render component
+  return (
+    <ModalWithFormLayout
+      variantType="small"
+      modalPosition="top"
+      offPosition="76px"
+      title="Add service"
+      formId="add-service-modal"
+      fields={fields}
+      show={props.show}
+      onClose={cleanAndCloseModal}
+      actions={modalActions}
+    />
+  );
+};
+
+export default AddService;

--- a/src/components/modals/DeleteServices.tsx
+++ b/src/components/modals/DeleteServices.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+// PatternFly
+import {
+  TextContent,
+  Text,
+  TextVariants,
+  Button,
+} from "@patternfly/react-core";
+// Redux
+import { useAppDispatch, useAppSelector } from "src/store/hooks";
+import { removeService } from "src/store/Identity/services-slice";
+// Layouts
+import ModalWithFormLayout from "../layouts/ModalWithFormLayout";
+// Tables
+import DeletedElementsTable from "src/components/tables/DeletedElementsTable";
+
+interface ButtonsData {
+  updateIsDeleteButtonDisabled: (value: boolean) => void;
+  updateIsDeletion: (value: boolean) => void;
+}
+
+interface SelectedElementsData {
+  selectedElements: string[];
+  updateSelectedElements: (newSelectedElements: string[]) => void;
+}
+
+interface PropsToDeleteServices {
+  show: boolean;
+  handleModalToggle: () => void;
+  selectedElementsData: SelectedElementsData;
+  buttonsData: ButtonsData;
+}
+
+const DeleteServices = (props: PropsToDeleteServices) => {
+  // Set dispatch (Redux)
+  const dispatch = useAppDispatch();
+
+  // Retrieve all hosts list from Store and make a copy
+  const servicesList = useAppSelector((state) => state.services.servicesList);
+  const servicesListCopy = [...servicesList];
+
+  // Define the column names that will be displayed on the confirmation table.
+  // - NOTE: Camel-case should match with the property to show as it is defined in the data.
+  //    This variable will be coverted into word.
+  // TODO: Adapt to the API data
+  const deleteServicesColumnNames = ["id"];
+
+  // List of fields
+  const fields = [
+    {
+      id: "question-text",
+      pfComponent: (
+        <TextContent>
+          <Text component={TextVariants.p}>
+            Are you sure you want to remove the selected entries from Hosts?
+          </Text>
+        </TextContent>
+      ),
+    },
+    {
+      id: "deleted-users-table",
+      pfComponent: (
+        <DeletedElementsTable
+          mode="passing_full_data"
+          elementsToDelete={props.selectedElementsData.selectedElements}
+          elementsList={servicesListCopy}
+          columnNames={deleteServicesColumnNames}
+          elementType="services"
+        />
+      ),
+    },
+  ];
+
+  // Close modal
+  const closeModal = () => {
+    props.handleModalToggle();
+  };
+
+  // Redux: Delete services
+  const deleteServices = () => {
+    props.selectedElementsData.selectedElements.map((service) => {
+      dispatch(removeService(service));
+    });
+    props.selectedElementsData.updateSelectedElements([]);
+    props.buttonsData.updateIsDeleteButtonDisabled(true);
+    props.buttonsData.updateIsDeletion(true);
+    closeModal();
+  };
+
+  // Set the Modal and Action buttons for 'Delete' option
+  const modalActionsDelete: JSX.Element[] = [
+    <Button
+      key="delete-services"
+      variant="danger"
+      onClick={deleteServices}
+      form="delete-services-modal"
+    >
+      Delete
+    </Button>,
+    <Button key="cancel-delete-services" variant="link" onClick={closeModal}>
+      Cancel
+    </Button>,
+  ];
+
+  const modalDelete: JSX.Element = (
+    <ModalWithFormLayout
+      variantType="small"
+      modalPosition="top"
+      offPosition="76px"
+      title="Remove services"
+      formId="remove-services-modal"
+      fields={fields}
+      show={props.show}
+      onClose={closeModal}
+      actions={modalActionsDelete}
+    />
+  );
+
+  // Render component
+  return modalDelete;
+};
+
+export default DeleteServices;

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -15,6 +15,7 @@ import HostGroups from "src/pages/HostGroups/HostGroups";
 import Netgroups from "src/pages/Netgroups/Netgroups";
 import Hosts from "src/pages/Hosts/Hosts";
 import HostsTabs from "src/pages/Hosts/HostsTabs";
+import Services from "src/pages/Services/Services";
 
 // Navigation
 import { URL_PREFIX } from "./NavRoutes";
@@ -40,7 +41,7 @@ export const AppRoutes = (): React.ReactElement => (
         <Route path="settings" element={<HostsTabs />} />
       </Route>
       <Route path="services">
-        <Route path="" />
+        <Route path="" element={<Services />} />
       </Route>
       <Route path="user-groups">
         <Route path="" element={<UserGroups />} />

--- a/src/pages/Services/Services.tsx
+++ b/src/pages/Services/Services.tsx
@@ -1,0 +1,391 @@
+import React, { useState } from "react";
+// PatternFly
+import {
+  DropdownItem,
+  Page,
+  PageSection,
+  PageSectionVariants,
+  PaginationVariant,
+  TextVariants,
+} from "@patternfly/react-core";
+import {
+  InnerScrollContainer,
+  OuterScrollContainer,
+} from "@patternfly/react-table";
+// Layouts
+import TitleLayout from "src/components/layouts/TitleLayout";
+import ToolbarLayout, {
+  ToolbarItem,
+} from "src/components/layouts/ToolbarLayout";
+import SearchInputLayout from "src/components/layouts/SearchInputLayout";
+import SecondaryButton from "src/components/layouts/SecondaryButton";
+import KebabLayout from "src/components/layouts/KebabLayout";
+import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
+// Components
+import BulkSelectorServicesPrep from "src/components/BulkSelectorServicesPrep";
+import PaginationServicesPrep from "src/components/PaginationServicesPrep";
+// Tables
+import ServicesTable from "./ServicesTable";
+// Redux
+import { useAppSelector } from "src/store/hooks";
+// Data types
+import { Service } from "src/utils/datatypes/globalDataTypes";
+// Utils
+import { isServiceSelectable } from "src/utils/utils";
+// Icons
+import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
+// Modals
+import AddService from "src/components/modals/AddService";
+import DeleteServices from "src/components/modals/DeleteServices";
+
+const Services = () => {
+  // Initialize services list (Redux)
+  const servicesList = useAppSelector((state) => state.services.servicesList);
+
+  // Selected services state
+  const [selectedServices, setSelectedServices] = useState<string[]>([]);
+
+  const updateSelectedServices = (newSelectedServices: string[]) => {
+    setSelectedServices(newSelectedServices);
+  };
+
+  // 'Delete' button state
+  const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
+    useState<boolean>(true);
+
+  const updateIsDeleteButtonDisabled = (value: boolean) => {
+    setIsDeleteButtonDisabled(value);
+  };
+
+  // If some entries have been deleted, restore the selectedServices list
+  const [isDeletion, setIsDeletion] = useState(false);
+
+  const updateIsDeletion = (value: boolean) => {
+    setIsDeletion(value);
+  };
+
+  // Elements selected (per page)
+  //  - This will help to calculate the remaining elements on a specific page (bulk selector)
+  const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
+
+  const updateSelectedPerPage = (selected: number) => {
+    setSelectedPerPage(selected);
+  };
+
+  // Pagination
+  const [page, setPage] = useState<number>(1);
+
+  const updatePage = (newPage: number) => {
+    setPage(newPage);
+  };
+
+  const [perPage, setPerPage] = useState<number>(15);
+
+  const updatePerPage = (newSetPerPage: number) => {
+    setPerPage(newSetPerPage);
+  };
+
+  // Services displayed on the first page
+  const [shownServicesList, setShownServicesList] = useState(
+    servicesList.slice(0, perPage)
+  );
+
+  const updateShownServicesList = (newShownServicesList: Service[]) => {
+    setShownServicesList(newShownServicesList);
+  };
+
+  // Filter (Input search)
+  const [searchValue, setSearchValue] = React.useState("");
+
+  const updateSearchValue = (value: string) => {
+    setSearchValue(value);
+  };
+
+  // Show table rows
+  const [showTableRows, setShowTableRows] = useState(false);
+
+  const updateShowTableRows = (value: boolean) => {
+    setShowTableRows(value);
+  };
+
+  // Dropdown kebab
+  const [kebabIsOpen, setKebabIsOpen] = useState(false);
+
+  const dropdownItems = [
+    <DropdownItem key="rebuild auto membership" component="button">
+      Rebuild auto membership
+    </DropdownItem>,
+  ];
+
+  const onKebabToggle = (isOpen: boolean) => {
+    setKebabIsOpen(isOpen);
+  };
+
+  const onFocus = () => {
+    const element = document.getElementById("main-dropdown-kebab");
+    element?.focus();
+  };
+
+  const onDropdownSelect = (
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _event: React.SyntheticEvent<HTMLDivElement, Event> | undefined
+  ) => {
+    setKebabIsOpen(!kebabIsOpen);
+    onFocus();
+  };
+
+  // Modals functionality
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  const onAddClickHandler = () => {
+    setShowAddModal(true);
+  };
+  const onAddModalToggle = () => {
+    setShowAddModal(!showAddModal);
+  };
+
+  const onDeleteHandler = () => {
+    setShowDeleteModal(true);
+  };
+  const onDeleteModalToggle = () => {
+    setShowDeleteModal(!showDeleteModal);
+  };
+
+  // Table-related shared functionality
+  // - Selectable checkboxes on table
+  const selectableServicesTable = servicesList.filter(isServiceSelectable); // elements per Table
+
+  // - Selected rows are tracked. Primary key: service Id
+  const [selectedServiceIds, setSelectedServiceIds] = useState<string[]>([]);
+
+  const changeSelectedServiceIds = (selectedServiceIds: string[]) => {
+    setSelectedServiceIds(selectedServiceIds);
+  };
+
+  // - Helper method to set the selected services from the table
+  const setServiceSelected = (service: Service, isSelecting = true) =>
+    setSelectedServiceIds((prevSelected) => {
+      const otherSelectedServiceIds = prevSelected.filter(
+        (r) => r !== service.id
+      );
+      return isSelecting && isServiceSelectable(service)
+        ? [...otherSelectedServiceIds, service.id]
+        : otherSelectedServiceIds;
+    });
+
+  // Data wrappers
+  // - 'SearchInputLayout'
+  const searchValueData = {
+    searchValue,
+    updateSearchValue,
+  };
+
+  // - 'BulkSelectorPrep'
+  const servicesData = {
+    selectedServices,
+    updateSelectedServices,
+    changeSelectedServiceIds,
+    selectableServicesTable,
+    isServiceSelectable,
+  };
+
+  const buttonsData = {
+    updateIsDeleteButtonDisabled,
+  };
+
+  const selectedPerPageData = {
+    selectedPerPage,
+    updateSelectedPerPage,
+  };
+
+  // - 'PaginationPrep'
+  const paginationData = {
+    page,
+    perPage,
+    updatePage,
+    updatePerPage,
+    showTableRows,
+    updateShowTableRows,
+    updateSelectedPerPage,
+    updateShownElementsList: updateShownServicesList,
+  };
+
+  // - 'ServicesTable'
+  const servicesTableData = {
+    isServiceSelectable,
+    selectedServiceIds,
+    changeSelectedServiceIds,
+    selectableServicesTable,
+    setServiceSelected,
+    updateSelectedServices,
+  };
+
+  const servicesTableButtonsData = {
+    updateIsDeleteButtonDisabled,
+    isDeletion,
+    updateIsDeletion,
+  };
+
+  // - 'DeleteServices'
+  const deleteElementsButtonsData = {
+    updateIsDeleteButtonDisabled,
+    updateIsDeletion,
+  };
+
+  const selectedElementsData = {
+    selectedElements: selectedServices,
+    updateSelectedElements: updateSelectedServices,
+  };
+
+  // List of toolbar items
+  const toolbarItems: ToolbarItem[] = [
+    {
+      key: 0,
+      element: (
+        <BulkSelectorServicesPrep
+          list={servicesList}
+          shownElementsList={shownServicesList}
+          elementData={servicesData}
+          buttonsData={buttonsData}
+          selectedPerPageData={selectedPerPageData}
+        />
+      ),
+    },
+    {
+      key: 1,
+      element: (
+        <SearchInputLayout
+          name="search"
+          ariaLabel="Search services"
+          placeholder="Search"
+          searchValueData={searchValueData}
+        />
+      ),
+      toolbarItemVariant: "search-filter",
+      toolbarItemSpacer: { default: "spacerMd" },
+    },
+    {
+      key: 2,
+      toolbarItemVariant: "separator",
+    },
+    {
+      key: 3,
+      element: <SecondaryButton>Refresh</SecondaryButton>,
+    },
+    {
+      key: 4,
+      element: (
+        <SecondaryButton
+          isDisabled={isDeleteButtonDisabled}
+          onClickHandler={onDeleteHandler}
+        >
+          Delete
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 5,
+      element: (
+        <SecondaryButton onClickHandler={onAddClickHandler}>
+          Add
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 6,
+      element: (
+        <KebabLayout
+          onDropdownSelect={onDropdownSelect}
+          onKebabToggle={onKebabToggle}
+          idKebab="main-dropdown-kebab"
+          isKebabOpen={kebabIsOpen}
+          isPlain={true}
+          dropdownItems={dropdownItems}
+        />
+      ),
+    },
+    {
+      key: 7,
+      toolbarItemVariant: "separator",
+    },
+    {
+      key: 8,
+      element: (
+        <HelpTextWithIconLayout
+          textComponent={TextVariants.p}
+          subTextComponent={TextVariants.a}
+          subTextIsVisitedLink={true}
+          textContent="Help"
+          icon={
+            <OutlinedQuestionCircleIcon className="pf-u-primary-color-100 pf-u-mr-sm" />
+          }
+        />
+      ),
+    },
+    {
+      key: 9,
+      element: (
+        <PaginationServicesPrep
+          list={servicesList}
+          paginationData={paginationData}
+          widgetId="pagination-options-menu-top"
+          isCompact={true}
+        />
+      ),
+      toolbarItemAlignment: { default: "alignRight" },
+    },
+  ];
+
+  // Render component
+  return (
+    <Page>
+      <PageSection variant={PageSectionVariants.light}>
+        <TitleLayout id="Services title" headingLevel="h1" text="Services" />
+      </PageSection>
+      <PageSection
+        variant={PageSectionVariants.light}
+        isFilled={false}
+        className="pf-u-m-lg pf-u-pb-md pf-u-pl-0 pf-u-pr-0"
+      >
+        <ToolbarLayout
+          className="pf-u-pt-0 pf-u-pl-lg pf-u-pr-md"
+          contentClassName="pf-u-p-0"
+          toolbarItems={toolbarItems}
+        />
+        <div style={{ height: `calc(100vh - 350px)` }}>
+          <OuterScrollContainer>
+            <InnerScrollContainer>
+              <ServicesTable
+                elementsList={servicesList}
+                shownElementsList={shownServicesList}
+                showTableRows={showTableRows}
+                servicesData={servicesTableData}
+                buttonsData={servicesTableButtonsData}
+                paginationData={selectedPerPageData}
+                searchValue={searchValue}
+              />
+            </InnerScrollContainer>
+          </OuterScrollContainer>
+        </div>
+        <PaginationServicesPrep
+          list={servicesList}
+          paginationData={paginationData}
+          variant={PaginationVariant.bottom}
+          widgetId="pagination-options-menu-bottom"
+          perPageComponent="button"
+          className="pf-u-pb-0 pf-u-pr-md"
+        />
+      </PageSection>
+      <AddService show={showAddModal} handleModalToggle={onAddModalToggle} />
+      <DeleteServices
+        show={showDeleteModal}
+        handleModalToggle={onDeleteModalToggle}
+        selectedElementsData={selectedElementsData}
+        buttonsData={deleteElementsButtonsData}
+      />
+    </Page>
+  );
+};
+
+export default Services;

--- a/src/pages/Services/ServicesTable.tsx
+++ b/src/pages/Services/ServicesTable.tsx
@@ -1,0 +1,288 @@
+import React, { useEffect, useState } from "react";
+// PatternFly
+import { Td, Th, ThProps, Tr } from "@patternfly/react-table";
+// Tables
+import TableLayout from "src/components/layouts/TableLayout";
+// Data types
+import { Service } from "src/utils/datatypes/globalDataTypes";
+// Layouts
+import SkeletonOnTableLayout from "src/components/layouts/Skeleton/SkeletonOnTableLayout";
+// Navigation
+import { URL_PREFIX } from "src/navigation/NavRoutes";
+// React Router DOM
+import { Link } from "react-router-dom";
+
+interface ServicesData {
+  isServiceSelectable: (service: Service) => boolean;
+  selectedServiceIds: string[];
+  changeSelectedServiceIds: (newSelectedServiceIds: string[]) => void;
+  selectableServicesTable: Service[];
+  setServiceSelected: (service: Service, isSelecting?: boolean) => void;
+  updateSelectedServices: (newSelectedServices: string[]) => void;
+}
+
+interface ButtonsData {
+  updateIsDeleteButtonDisabled: (value: boolean) => void;
+  isDeletion: boolean;
+  updateIsDeletion: (value: boolean) => void;
+}
+
+interface PaginationData {
+  selectedPerPage: number;
+  updateSelectedPerPage: (selected: number) => void;
+}
+
+interface PropsToTable {
+  elementsList: Service[];
+  shownElementsList: Service[];
+  showTableRows: boolean;
+  servicesData: ServicesData;
+  buttonsData: ButtonsData;
+  paginationData: PaginationData;
+  searchValue: string;
+}
+
+const ServicesTable = (props: PropsToTable) => {
+  // Retrieve services data from props
+  const shownServicesList = [...props.shownElementsList];
+
+  // Column names
+  const columnNames = {
+    principalName: "Principal name",
+  };
+
+  // Filter (SearchInput)
+  // - When a service is search using the Search Input
+  const onFilter = (service: Service) => {
+    if (props.searchValue === "") {
+      return true;
+    }
+
+    let input: RegExp;
+    try {
+      input = new RegExp(props.searchValue, "i");
+    } catch (err) {
+      input = new RegExp(
+        props.searchValue.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
+        "i"
+      );
+    }
+    return service.id.search(input) >= 0;
+  };
+
+  const filteredShownServices =
+    props.searchValue === ""
+      ? shownServicesList
+      : props.elementsList.filter(onFilter);
+
+  // Index of the currently sorted column
+  // Note: if you intend to make columns reorderable, you may instead want to use a non-numeric key
+  // as the identifier of the sorted column. See the "Compound expandable" example.
+  const [activeSortIndex, setActiveSortIndex] = useState<number | null>(null);
+
+  // Sort direction of the currently sorted column
+  const [activeSortDirection, setActiveSortDirection] = useState<
+    "asc" | "desc" | null
+  >(null);
+
+  // Since OnSort specifies sorted columns by index, we need sortable values for our object by column index.
+  const getSortableRowValues = (service: Service): (string | number)[] => {
+    const { id } = service;
+    return [id];
+  };
+
+  let sortedServices = [...shownServicesList];
+  if (activeSortIndex !== null) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    sortedServices = shownServicesList.sort((a, b) => {
+      const aValue = getSortableRowValues(a)[activeSortIndex];
+      const bValue = getSortableRowValues(b)[activeSortIndex];
+      if (typeof aValue === "number") {
+        // Numeric sort
+        if (activeSortDirection === "asc") {
+          return (aValue as number) - (bValue as number);
+        }
+        return (bValue as number) - (aValue as number);
+      } else {
+        // String sort
+        if (activeSortDirection === "asc") {
+          return (aValue as string).localeCompare(bValue as string);
+        }
+        return (bValue as string).localeCompare(aValue as string);
+      }
+    });
+  }
+
+  // TODO: Put function in 'utils' file
+  const getSortParams = (columnIndex: number): ThProps["sort"] => ({
+    sortBy: {
+      index: activeSortIndex as number,
+      direction: activeSortDirection as "asc" | "desc",
+      // starting sort direction when first sorting a column. Defaults to 'asc'
+      defaultDirection: "asc",
+    },
+    onSort: (_event, index, direction) => {
+      setActiveSortIndex(index);
+      setActiveSortDirection(direction);
+    },
+    columnIndex,
+  });
+
+  const isServiceSelected = (service: Service) =>
+    props.servicesData.selectedServiceIds.includes(service.id);
+
+  // To allow shift+click to select/deselect multiple rows
+  const [recentSelectedRowIndex, setRecentSelectedRowIndex] = useState<
+    number | null
+  >(null);
+  const [shifting, setShifting] = useState(false);
+
+  // On selecting one single row
+  const onSelectService = (
+    service: Service,
+    rowIndex: number,
+    isSelecting: boolean
+  ) => {
+    // If the service is shift + selecting the checkboxes, then all intermediate checkboxes should be selected
+    if (shifting && recentSelectedRowIndex !== null) {
+      const numberSelected = rowIndex - recentSelectedRowIndex;
+      const intermediateIndexes =
+        numberSelected > 0
+          ? Array.from(
+              new Array(numberSelected + 1),
+              (_x, i) => i + recentSelectedRowIndex
+            )
+          : Array.from(
+              new Array(Math.abs(numberSelected) + 1),
+              (_x, i) => i + rowIndex
+            );
+      intermediateIndexes.forEach((index) =>
+        props.servicesData.setServiceSelected(
+          shownServicesList[index],
+          isSelecting
+        )
+      );
+    } else {
+      props.servicesData.setServiceSelected(service, isSelecting);
+    }
+    setRecentSelectedRowIndex(rowIndex);
+
+    // Resetting 'isDisableEnableOp'
+    props.buttonsData.updateIsDeleteButtonDisabled(false);
+
+    // Update serviceIdsSelected array
+    let serviceIdsSelectedArray = props.servicesData.selectedServiceIds;
+    if (isSelecting) {
+      serviceIdsSelectedArray.push(service.id);
+      // Increment the elements selected per page (++)
+      props.paginationData.updateSelectedPerPage(
+        props.paginationData.selectedPerPage + 1
+      );
+    } else {
+      serviceIdsSelectedArray = serviceIdsSelectedArray.filter(
+        (serviceId) => serviceId !== service.id
+      );
+      // Decrement the elements selected per page (--)
+      props.paginationData.updateSelectedPerPage(
+        props.paginationData.selectedPerPage - 1
+      );
+    }
+    props.servicesData.changeSelectedServiceIds(serviceIdsSelectedArray);
+    props.servicesData.updateSelectedServices(serviceIdsSelectedArray);
+  };
+
+  // Reset 'selectedServiceIds' array if a delete operation has been done
+  useEffect(() => {
+    if (props.buttonsData.isDeletion) {
+      props.servicesData.changeSelectedServiceIds([]);
+      props.buttonsData.updateIsDeletion(false);
+    }
+  }, [props.buttonsData.isDeletion]);
+
+  // Enable 'Delete' button (if any service selected)
+  useEffect(() => {
+    if (props.servicesData.selectedServiceIds.length > 0) {
+      props.buttonsData.updateIsDeleteButtonDisabled(false);
+    }
+
+    if (props.servicesData.selectedServiceIds.length === 0) {
+      props.buttonsData.updateIsDeleteButtonDisabled(true);
+    }
+  }, [props.servicesData.selectedServiceIds]);
+
+  // Keyboard event
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Shift") {
+        setShifting(true);
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === "Shift") {
+        setShifting(false);
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("keyup", onKeyUp);
+
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("keyup", onKeyUp);
+    };
+  }, []);
+
+  // Defining table header and body from here to avoid passing specific names to the Table Layout
+  const header = (
+    <Tr>
+      <Th modifier="wrap"></Th>
+      <Th modifier="wrap" sort={getSortParams(0)}>
+        {columnNames.principalName}
+      </Th>
+    </Tr>
+  );
+
+  const body = filteredShownServices.map((service, rowIndex) => (
+    <Tr key={service.id} id={service.id}>
+      <Td
+        dataLabel="checkbox"
+        select={{
+          rowIndex,
+          onSelect: (_event, isSelecting) =>
+            onSelectService(service, rowIndex, isSelecting),
+          isSelected: isServiceSelected(service),
+          disable: !props.servicesData.isServiceSelectable(service),
+        }}
+      />
+      <Td dataLabel={columnNames.principalName}>
+        <Link to={URL_PREFIX + "/services/settings"} state={service}>
+          {service.id}
+        </Link>
+      </Td>
+    </Tr>
+  ));
+
+  const skeleton = (
+    <SkeletonOnTableLayout
+      rows={4}
+      colSpan={9}
+      screenreaderText={"Loading table rows"}
+    />
+  );
+
+  // Render component
+  return (
+    <TableLayout
+      ariaLabel={"Services table"}
+      variant={"compact"}
+      hasBorders={true}
+      classes={"pf-u-mt-md"}
+      tableId={"services-table"}
+      isStickyHeader={true}
+      tableHeader={header}
+      tableBody={!props.showTableRows ? skeleton : body}
+    />
+  );
+};
+
+export default ServicesTable;

--- a/src/store/Identity/services-slice.ts
+++ b/src/store/Identity/services-slice.ts
@@ -1,0 +1,42 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import type { RootState } from "src/store/store";
+// User data (JSON file)
+import servicesJson from "./services.json";
+// Data types
+import { Service } from "src/utils/datatypes/globalDataTypes";
+
+interface ServicesState {
+  servicesList: Service[];
+}
+
+const initialState: ServicesState = {
+  servicesList: servicesJson,
+};
+
+const servicesSlice = createSlice({
+  name: "services",
+  initialState,
+  reducers: {
+    addService: (state, action: PayloadAction<Service>) => {
+      const newService = action.payload;
+      state.servicesList.push({
+        id: newService.id,
+        serviceType: newService.serviceType,
+        host: newService.host,
+      });
+    },
+    removeService: (state, action: PayloadAction<string>) => {
+      const serviceId = action.payload;
+      const updatedServiceList = state.servicesList.filter(
+        (service) => service.id !== serviceId
+      );
+      // If not empty, replace list by new array
+      if (updatedServiceList) {
+        state.servicesList = updatedServiceList;
+      }
+    },
+  },
+});
+
+export default servicesSlice.reducer;
+export const { addService, removeService } = servicesSlice.actions;

--- a/src/store/Identity/services.json
+++ b/src/store/Identity/services.json
@@ -1,0 +1,52 @@
+[
+  {
+    "id": "DNS/ipa.server.ipa.demo@SERVER.IPA.DEMO",
+    "serviceType": "DNS",
+    "host": "ipa.server.ipa.demo"
+  },
+  {
+    "id": "HTTP/ipa.server.ipa.demo@SERVER.IPA.DEMO",
+    "serviceType": "HTTP",
+    "host": "ipa.server.ipa.demo"
+  },
+  {
+    "id": "cifs/ipa.server.ipa.demo@SERVER.IPA.DEMO",
+    "serviceType": "cifs",
+    "host": "ipa.server.ipa.demo"
+  },
+  {
+    "id": "dogtag/ipa.server.ipa.demo@SERVER.IPA.DEMO",
+    "serviceType": "dogtag",
+    "host": "ipa.server.ipa.demo"
+  },
+  {
+    "id": "ipa-dnskeysyncd/ipa.server.ipa.demo@SERVER.IPA.DEMO",
+    "serviceType": "ipa-dnskeysyncd",
+    "host": "ipa.server.ipa.demo"
+  },
+  {
+    "id": "ldap/ipa.server.ipa.demo@SERVER.IPA.DEMO",
+    "serviceType": "ldap",
+    "host": "ipa.server.ipa.demo"
+  },
+  {
+    "id": "DNS/example.server.ipa.demo@SERVER.IPA.DEMO",
+    "serviceType": "DNS",
+    "host": "example.server.ipa.demo"
+  },
+  {
+    "id": "HTTP/example.server.ipa.demo@SERVER.IPA.DEMO",
+    "serviceType": "HTTP",
+    "host": "example.server.ipa.demo"
+  },
+  {
+    "id": "cifs/example.server.ipa.demo@SERVER.IPA.DEMO",
+    "serviceType": "cifs",
+    "host": "example.server.ipa.demo"
+  },
+  {
+    "id": "ldap/example.server.ipa.demo@SERVER.IPA.DEMO",
+    "serviceType": "ldap",
+    "host": "example.server.ipa.demo"
+  }
+]

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -9,6 +9,7 @@ import stageUsersReducer from "./Identity/stageUsers-slice";
 import preservedUsersReducer from "./Identity/preservedUsers-slice";
 import hostsReducer from "./Identity/hosts-slice";
 import hostGroupsReducer from "./Identity/hostGroups-slice";
+import servicesReducer from "./Identity/services-slice";
 
 const store = configureStore({
   reducer: {
@@ -22,6 +23,7 @@ const store = configureStore({
     preservedUsers: preservedUsersReducer,
     hosts: hostsReducer,
     hostGroups: hostGroupsReducer,
+    services: servicesReducer,
   },
 });
 

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -52,3 +52,9 @@ export interface HostGroup {
   name: string;
   description: string;
 }
+
+export interface Service {
+  id: string;
+  serviceType: string;
+  host: string;
+}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import React from "react";
 // Data type
-import { Host, User } from "./datatypes/globalDataTypes";
+import { Host, Service, User } from "./datatypes/globalDataTypes";
 
 /*
  * Functions that can be reusable and called by several components throughout the application.
@@ -20,3 +20,6 @@ export const isUserSelectable = (user: User) => user.userLogin !== "";
 
 // Determine whether a host is selectable or not
 export const isHostSelectable = (host: Host) => host.id != "";
+
+// Determine whether a service is selectable or not
+export const isServiceSelectable = (service: Service) => service.id != "";


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8112750/218709988-bf227a6c-03f2-40b2-a0a2-a3cb95c49bd1.png)

As defined in the project specs, the 'Services' page needs to be created and use the appropriate components to ensure its functionality.

### Data, Redux slice, and data type
To create the new 'Services' page, the main data has been defined in order to be used through the Redux slice. This will act as a data store ready to be used from any component. This is done in the `services.json` file.

Since TypeScript is being used in this project, the data has been associated with a specific data type. This is defined under the `globalDataTypes.ts` file.

Then, the Redux slice (`services-slice.ts`) manages the data (list of services) and the main operations to perform in this data. In order to use any slice, this has been defined in the store file.

To a lesser extent, and considering that the 'Services' page has its own table, the `isServiceSelectable` function has been defined as part of the utility file: `utils.ts`.

### Prep components for bulk Selector and pagination
The 'BulkSelector' and 'Pagination' components have been adapted to the Services page. Those are independent files as the data has been tailored to the `Service` data type (they manage the functionality of the 'Service' page only).

- The `BulkSelectorServicesPrep` will manage the bulk selector component that would allow to select and unselect table elements in bulk.
- The `PaginationServicesPrep` component is meant for managing the pagination functionality of the shown table elements.

### Routing
To access this page in the WebUI, the routing has been defined in the AppRoutes component and points directly to the 'Services' component (`Services.tsx`).

```ts
// This will be rendered under '<base-url>/<prefix>/services'
<Route path="services">
    <Route path="" element={<Services />} />
</Route>
```

### Table
The 'Services' page will have its own table to list and manage the available services (`ServicesTable`). Most of the action buttons and options in the Toolbar will affect its entries.

### Action buttons
The 'Services' page has two main action buttons located in the Toolbar: 'Add' and 'Delete'.

The functionality has been implemented in the following components:

- `AddServices` will manage any 'Add service' operation. Only one single service can be added at a time.
- `DeleteServices` will manage any 'Delete services' operation. Those should be selected using the checkboxes located in the table or by using the Bulk selector.

### Main 'Services' page
All the aforementioned components and functionality will be provided and used on the 'Services' main page (`Services` component) to retrieve, list, and perform operations via the action buttons ('Add' and 'Delete').

Signed-off-by: Carla Martinez <carlmart@redhat.com>