### PR TITLE
Fix: not updating managed groups

### DIFF
--- a/src/components/ManagedBy/ManagedByTable.tsx
+++ b/src/components/ManagedBy/ManagedByTable.tsx
@@ -31,7 +31,6 @@ interface ButtonData {
 interface PropsToTable {
   list: Host[];
   tableName: string;
-  updateList: (newList: Host[]) => void;
   showTableRows: boolean;
   updateElementsSelected: (newElementsSelected: string[]) => void;
   buttonData: ButtonData;

--- a/src/components/ManagedBy/ManagedByToolbar.tsx
+++ b/src/components/ManagedBy/ManagedByToolbar.tsx
@@ -36,6 +36,7 @@ interface ButtonData {
 export interface PropsToToolbar {
   pageRepo: Host[];
   shownItems: Host[];
+  updateShownElementsList: (newShownElementsList: Host[]) => void;
   pageData: PageData;
   buttonData: ButtonData;
 }
@@ -54,6 +55,7 @@ const ManagedByToolbar = (props: PropsToToolbar) => {
     endIdx: number | undefined
   ) => {
     setPage(newPage);
+    props.updateShownElementsList(props.pageRepo.slice(startIdx, endIdx));
     props.pageData.changeSetPage(newPage, perPage, startIdx, endIdx);
   };
 
@@ -65,6 +67,7 @@ const ManagedByToolbar = (props: PropsToToolbar) => {
     endIdx: number | undefined
   ) => {
     setPerPage(newPerPage);
+    props.updateShownElementsList(props.pageRepo.slice(startIdx, endIdx));
     props.pageData.changePerPageSelect(newPerPage, newPage, startIdx, endIdx);
   };
 

--- a/src/pages/Hosts/HostsManagedBy.tsx
+++ b/src/pages/Hosts/HostsManagedBy.tsx
@@ -30,8 +30,13 @@ const HostsManagedBy = (props: PropsToHostsManagedBy) => {
   // List of currents elements on the list (Dummy data)
   const [hostsList, setHostsList] = useState<Host[]>([props.host]);
 
-  const updateHostsList = (newHostsList: Host[]) => {
+  // Some data is updated when any group list is altered
+  //  - The whole list itself
+  //  - The slice of data to show (considering the pagination)
+  //  - Number of items for a specific list
+  const updateGroupRepository = (newHostsList: Host[]) => {
     setHostsList(newHostsList);
+    setShownHostsList(hostsList.slice(0, perPage));
   };
 
   // Retrieve available hosts data from Redux
@@ -43,7 +48,7 @@ const HostsManagedBy = (props: PropsToHostsManagedBy) => {
   };
 
   // Filter functions to compare the available data with the data that
-  //  the host is already member of. This is done to prevent duplicates
+  //  the host is already managed by. This is done to prevent duplicates
   //  (e.g: adding the same element twice).
   const filterHostsData = () => {
     // Host groups
@@ -54,7 +59,7 @@ const HostsManagedBy = (props: PropsToHostsManagedBy) => {
     });
   };
 
-  // Available data to be added as member of
+  // Available data to be added as managed by
   const hostsFilteredData: Host[] = filterHostsData();
 
   // State that determines whether the row tables are displayed nor not
@@ -91,6 +96,10 @@ const HostsManagedBy = (props: PropsToHostsManagedBy) => {
   const [shownHostsList, setShownHostsList] = useState(
     hostsList.slice(0, perPage)
   );
+
+  const updateShownHostsList = (newShownHostsList: Host[]) => {
+    setShownHostsList(newShownHostsList);
+  };
 
   // Pages setters (to manage pagination as an event)
   const onSetPage = (
@@ -238,13 +247,13 @@ const HostsManagedBy = (props: PropsToHostsManagedBy) => {
             <ManagedByToolbar
               pageRepo={hostsList}
               shownItems={shownHostsList}
+              updateShownElementsList={updateShownHostsList}
               pageData={toolbarPageData}
               buttonData={toolbarButtonData}
             />
             <ManagedByTable
-              list={hostsList}
+              list={shownHostsList}
               tableName="Hosts"
-              updateList={updateHostsList}
               showTableRows={showTableRows}
               updateElementsSelected={updateHostsSelected}
               buttonData={tableButtonData}
@@ -269,7 +278,7 @@ const HostsManagedBy = (props: PropsToHostsManagedBy) => {
             modalData={addModalData}
             availableData={hostsFilteredData}
             groupRepository={hostsList}
-            updateGroupRepository={updateHostsList}
+            updateGroupRepository={updateGroupRepository}
             updateAvOptionsList={updateAvailableHostsList}
             tabData={tabData}
           />
@@ -280,7 +289,7 @@ const HostsManagedBy = (props: PropsToHostsManagedBy) => {
             tabData={deleteTabData}
             groupNamesToDelete={hostsSelected}
             groupRepository={hostsList}
-            updateGroupRepository={updateHostsList}
+            updateGroupRepository={updateGroupRepository}
             buttonData={deleteButtonData}
           />
         )}


### PR DESCRIPTION
When adding elements in the 'Is managed by' section of the 'Hosts' page and the number of the list exceeded the page size, the list elements was not been updated correctly when moving to the next pages.

The fix has been applied by referencing the right list in the table (`shownHostsList`), passing the function to update the elements that will be shown per page (`updateShownHostsList`), and updating some data that will be needed every time new elements are added (`updateGroupRepository`). Also, some misleading comments have been adapted to the
page as well.


Signed-off-by: Carla Martinez <carlmart@redhat.com>