### PR TITLE
UI: Change 'stage users' buttons

### DIFF
--- a/src/components/BulkSelectorUsersPrep.tsx
+++ b/src/components/BulkSelectorUsersPrep.tsx
@@ -29,9 +29,9 @@ interface UsersData {
 
 interface ButtonsData {
   updateIsDeleteButtonDisabled: (value: boolean) => void;
-  updateIsEnableButtonDisabled: (value: boolean) => void;
-  updateIsDisableButtonDisabled: (value: boolean) => void;
-  updateIsDisableEnableOp: (value: boolean) => void;
+  updateIsEnableButtonDisabled?: (value: boolean) => void;
+  updateIsDisableButtonDisabled?: (value: boolean) => void;
+  updateIsDisableEnableOp?: (value: boolean) => void;
 }
 
 interface SelectedPerPageData {
@@ -131,19 +131,30 @@ const BulkSelectorPrep = (props: PropsToBulkSelectorPrep) => {
         userNamesArray.push(user.userId);
       });
       props.usersData.updateSelectedUsers(userNamesArray);
-      // Resetting 'isDisableEnableOp'
-      props.buttonsData.updateIsDisableEnableOp(false);
-      // Enable or disable buttons depending on the status
-      if (firstStatus === "Enabled") {
-        props.buttonsData.updateIsDisableButtonDisabled(false);
-        props.buttonsData.updateIsEnableButtonDisabled(true);
-      } else if (firstStatus === "Disabled") {
-        props.buttonsData.updateIsDisableButtonDisabled(true);
-        props.buttonsData.updateIsEnableButtonDisabled(false);
+      if (
+        props.buttonsData.updateIsEnableButtonDisabled !== undefined &&
+        props.buttonsData.updateIsDisableButtonDisabled !== undefined &&
+        props.buttonsData.updateIsDisableEnableOp !== undefined
+      ) {
+        // Resetting 'isDisableEnableOp'
+        props.buttonsData.updateIsDisableEnableOp(false);
+        // Enable or disable buttons depending on the status
+        if (firstStatus === "Enabled") {
+          props.buttonsData.updateIsDisableButtonDisabled(false);
+          props.buttonsData.updateIsEnableButtonDisabled(true);
+        } else if (firstStatus === "Disabled") {
+          props.buttonsData.updateIsDisableButtonDisabled(true);
+          props.buttonsData.updateIsEnableButtonDisabled(false);
+        }
       }
     } else {
-      props.buttonsData.updateIsDisableButtonDisabled(true);
-      props.buttonsData.updateIsEnableButtonDisabled(true);
+      if (
+        props.buttonsData.updateIsDisableButtonDisabled !== undefined &&
+        props.buttonsData.updateIsEnableButtonDisabled !== undefined
+      ) {
+        props.buttonsData.updateIsDisableButtonDisabled(true);
+        props.buttonsData.updateIsEnableButtonDisabled(true);
+      }
     }
 
     // Enable/disable 'Delete' button
@@ -207,19 +218,30 @@ const BulkSelectorPrep = (props: PropsToBulkSelectorPrep) => {
         userNamesArray.push(user.userId);
       });
       props.usersData.updateSelectedUsers(userNamesArray);
-      // Resetting 'isDisableEnableOp'
-      props.buttonsData.updateIsDisableEnableOp(false);
-      // Enable or disable buttons depending on the status
-      if (firstStatus === "Enabled") {
-        props.buttonsData.updateIsDisableButtonDisabled(false);
-        props.buttonsData.updateIsEnableButtonDisabled(true);
-      } else if (firstStatus === "Disabled") {
-        props.buttonsData.updateIsDisableButtonDisabled(true);
-        props.buttonsData.updateIsEnableButtonDisabled(false);
+      if (
+        props.buttonsData.updateIsDisableEnableOp !== undefined &&
+        props.buttonsData.updateIsDisableButtonDisabled !== undefined &&
+        props.buttonsData.updateIsEnableButtonDisabled !== undefined
+      ) {
+        // Resetting 'isDisableEnableOp'
+        props.buttonsData.updateIsDisableEnableOp(false);
+        // Enable or disable buttons depending on the status
+        if (firstStatus === "Enabled") {
+          props.buttonsData.updateIsDisableButtonDisabled(false);
+          props.buttonsData.updateIsEnableButtonDisabled(true);
+        } else if (firstStatus === "Disabled") {
+          props.buttonsData.updateIsDisableButtonDisabled(true);
+          props.buttonsData.updateIsEnableButtonDisabled(false);
+        }
       }
     } else {
-      props.buttonsData.updateIsDisableButtonDisabled(true);
-      props.buttonsData.updateIsEnableButtonDisabled(true);
+      if (
+        props.buttonsData.updateIsDisableButtonDisabled !== undefined &&
+        props.buttonsData.updateIsEnableButtonDisabled !== undefined
+      ) {
+        props.buttonsData.updateIsDisableButtonDisabled(true);
+        props.buttonsData.updateIsEnableButtonDisabled(true);
+      }
     }
 
     // Enable/disable 'Delete' button

--- a/src/components/modals/DeleteUsers.tsx
+++ b/src/components/modals/DeleteUsers.tsx
@@ -18,7 +18,7 @@ import { removeUser as removeStageUser } from "src/store/Identity/stageUsers-sli
 import { removeUser as removePreservedUser } from "src/store/Identity/preservedUsers-slice";
 
 interface ButtonsData {
-  updateIsDeleteButtonDisabled: (value: boolean) => void;
+  updateIsDeleteButtonDisabled?: (value: boolean) => void;
   updateIsDeletion: (value: boolean) => void;
 }
 
@@ -113,7 +113,12 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
       }
     });
     props.selectedUsersData.updateSelectedUsers([]);
-    props.buttonsData.updateIsDeleteButtonDisabled(true);
+    if (
+      props.from === "active-users" &&
+      props.buttonsData.updateIsDeleteButtonDisabled !== undefined
+    ) {
+      props.buttonsData.updateIsDeleteButtonDisabled(true);
+    }
     props.buttonsData.updateIsDeletion(true);
     closeModal();
   };

--- a/src/components/tables/UsersTable.tsx
+++ b/src/components/tables/UsersTable.tsx
@@ -27,12 +27,12 @@ interface UsersData {
 
 interface ButtonsData {
   updateIsDeleteButtonDisabled: (value: boolean) => void;
-  updateIsEnableButtonDisabled: (value: boolean) => void;
-  updateIsDisableButtonDisabled: (value: boolean) => void;
+  updateIsEnableButtonDisabled?: (value: boolean) => void;
+  updateIsDisableButtonDisabled?: (value: boolean) => void;
   isDeletion: boolean;
   updateIsDeletion: (value: boolean) => void;
-  isDisableEnableOp: boolean;
-  updateIsDisableEnableOp: (value: boolean) => void;
+  isDisableEnableOp?: boolean;
+  updateIsDisableEnableOp?: (value: boolean) => void;
 }
 
 interface PaginationData {
@@ -200,7 +200,9 @@ const UsersTable = (props: PropsToTable) => {
     setRecentSelectedRowIndex(rowIndex);
 
     // Resetting 'isDisableEnableOp'
-    props.buttonsData.updateIsDisableEnableOp(false);
+    if (props.buttonsData.updateIsDisableEnableOp !== undefined) {
+      props.buttonsData.updateIsDisableEnableOp(false);
+    }
 
     // Update userIdsSelected array
     let userIdsSelectedArray = props.usersData.selectedUserNames;
@@ -219,6 +221,7 @@ const UsersTable = (props: PropsToTable) => {
         props.paginationData.selectedPerPage - 1
       );
     }
+
     props.usersData.updateSelectedUserIds(userIdsSelectedArray);
     props.usersData.updateSelectedUsers(userIdsSelectedArray);
   };
@@ -242,37 +245,49 @@ const UsersTable = (props: PropsToTable) => {
   useEffect(() => {
     if (props.usersData.selectedUserIds.length > 0) {
       props.buttonsData.updateIsDeleteButtonDisabled(false);
+
       const selectedUsers: User[] = props.usersData.selectedUserIds.map(
         (userId) => {
           return getUserById(userId);
         }
       );
+
       // Check if selected users have the same status
-      if (selectedUsers.length > 0) {
-        const equalStatus = checkEqualStatus(
-          selectedUsers[0].status,
-          selectedUsers
-        );
-        if (equalStatus) {
-          if (selectedUsers[0].status === "Enabled") {
-            props.buttonsData.updateIsDisableButtonDisabled(false);
-            props.buttonsData.updateIsEnableButtonDisabled(true);
-          } else if (selectedUsers[0].status === "Disabled") {
+      if (
+        props.buttonsData.updateIsEnableButtonDisabled !== undefined &&
+        props.buttonsData.updateIsDisableButtonDisabled !== undefined
+      ) {
+        if (selectedUsers.length > 0) {
+          const equalStatus = checkEqualStatus(
+            selectedUsers[0].status,
+            selectedUsers
+          );
+          if (equalStatus) {
+            if (selectedUsers[0].status === "Enabled") {
+              props.buttonsData.updateIsDisableButtonDisabled(false);
+              props.buttonsData.updateIsEnableButtonDisabled(true);
+            } else if (selectedUsers[0].status === "Disabled") {
+              props.buttonsData.updateIsDisableButtonDisabled(true);
+              props.buttonsData.updateIsEnableButtonDisabled(false);
+            }
+          } else {
+            // Different status selected -> Disable all buttons
             props.buttonsData.updateIsDisableButtonDisabled(true);
-            props.buttonsData.updateIsEnableButtonDisabled(false);
+            props.buttonsData.updateIsEnableButtonDisabled(true);
           }
-        } else {
-          // Different status selected -> Disable all buttons
-          props.buttonsData.updateIsDisableButtonDisabled(true);
-          props.buttonsData.updateIsEnableButtonDisabled(true);
         }
       }
     }
 
     if (props.usersData.selectedUserIds.length === 0) {
       props.buttonsData.updateIsDeleteButtonDisabled(true);
-      props.buttonsData.updateIsDisableButtonDisabled(true);
-      props.buttonsData.updateIsEnableButtonDisabled(true);
+      if (
+        props.buttonsData.updateIsEnableButtonDisabled !== undefined &&
+        props.buttonsData.updateIsDisableButtonDisabled !== undefined
+      ) {
+        props.buttonsData.updateIsDisableButtonDisabled(true);
+        props.buttonsData.updateIsEnableButtonDisabled(true);
+      }
     }
   }, [props.usersData.selectedUserIds]);
 

--- a/src/pages/StageUsers/StageUsers.tsx
+++ b/src/pages/StageUsers/StageUsers.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 // PatternFly
 import {
-  DropdownItem,
   Page,
   PageSection,
   PageSectionVariants,
@@ -23,7 +22,6 @@ import { useAppSelector } from "src/store/hooks";
 // Layouts
 import TitleLayout from "src/components/layouts/TitleLayout";
 import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
-import KebabLayout from "src/components/layouts/KebabLayout";
 import SecondaryButton from "src/components/layouts/SecondaryButton";
 import ToolbarLayout from "src/components/layouts/ToolbarLayout";
 import SearchInputLayout from "src/components/layouts/SearchInputLayout";
@@ -33,9 +31,8 @@ import UsersTable from "../../components/tables/UsersTable";
 import PaginationPrep from "src/components/PaginationPrep";
 import BulkSelectorUsersPrep from "src/components/BulkSelectorUsersPrep";
 // Modals
-import AddUser from "src/components/modals/AddUser";
 import DeleteUsers from "src/components/modals/DeleteUsers";
-import DisableEnableUsers from "src/components/modals/DisableEnableUsers";
+import AddUser from "src/components/modals/AddUser";
 // Utils
 import { isUserSelectable } from "src/utils/utils";
 
@@ -63,29 +60,6 @@ const StageUsers = () => {
 
   const updateIsDeletion = (value: boolean) => {
     setIsDeletion(value);
-  };
-
-  // 'Enable' button state
-  const [isEnableButtonDisabled, setIsEnableButtonDisabled] =
-    useState<boolean>(true);
-
-  const updateIsEnableButtonDisabled = (value: boolean) => {
-    setIsEnableButtonDisabled(value);
-  };
-
-  // 'Disable' button state
-  const [isDisableButtonDisabled, setIsDisableButtonDisabled] =
-    useState<boolean>(true);
-
-  const updateIsDisableButtonDisabled = (value: boolean) => {
-    setIsDisableButtonDisabled(value);
-  };
-
-  // If some entries' status has been updated, unselect selected rows
-  const [isDisableEnableOp, setIsDisableEnableOp] = useState(false);
-
-  const updateIsDisableEnableOp = (value: boolean) => {
-    setIsDisableEnableOp(value);
   };
 
   // - Selected user ids state
@@ -139,36 +113,9 @@ const StageUsers = () => {
     setShowTableRows(value);
   };
 
-  // Dropdown kebab
-  const [kebabIsOpen, setKebabIsOpen] = useState(false);
-
-  const dropdownItems = [
-    <DropdownItem key="action" component="button">
-      Rebuild auto membership
-    </DropdownItem>,
-  ];
-
-  const onKebabToggle = (
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    event: any,
-    isOpen: boolean
-  ) => {
-    setKebabIsOpen(isOpen);
-  };
-
-  const onDropdownSelect = (
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    event?: React.SyntheticEvent<HTMLDivElement, Event> | undefined
-  ) => {
-    setKebabIsOpen(!kebabIsOpen);
-  };
-
   // Modals functionality
   const [showAddModal, setShowAddModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
-  const [showEnableDisableModal, setShowEnableDisableModal] = useState(false);
-  const [enableDisableOptionSelected, setEnableDisableOptionSelected] =
-    useState("");
   const onAddClickHandler = () => {
     setShowAddModal(true);
   };
@@ -181,20 +128,6 @@ const StageUsers = () => {
   };
   const onDeleteModalToggle = () => {
     setShowDeleteModal(!showDeleteModal);
-  };
-
-  const onEnableDisableHandler = (optionClicked: string) => {
-    setIsDeleteButtonDisabled(true); // prevents 'Delete' button to be enabled
-    setIsEnableButtonDisabled(true); // prevents 'Enable' button to be enabled
-    setIsDisableButtonDisabled(true); // prevents 'Disable' button to be enabled
-    setEnableDisableOptionSelected(optionClicked);
-    setShowEnableDisableModal(true);
-  };
-
-  const onEnableDisableModalToggle = () => {
-    setIsEnableButtonDisabled(true); // prevents 'Enable' button to be enabled
-    setIsDisableButtonDisabled(true); // prevents 'Disable' button to be enabled
-    setShowEnableDisableModal(!showEnableDisableModal);
   };
 
   // Table-related shared functionality
@@ -245,9 +178,6 @@ const StageUsers = () => {
 
   const buttonsData = {
     updateIsDeleteButtonDisabled,
-    updateIsEnableButtonDisabled,
-    updateIsDisableButtonDisabled,
-    updateIsDisableEnableOp,
   };
 
   const selectedPerPageData = {
@@ -266,13 +196,6 @@ const StageUsers = () => {
     updateSelectedUsers,
   };
 
-  // 'DisableEnableUsers'
-  const disableEnableButtonsData = {
-    updateIsEnableButtonDisabled,
-    updateIsDisableButtonDisabled,
-    updateIsDisableEnableOp,
-  };
-
   // 'UsersTable'
   const usersTableData = {
     isUserSelectable,
@@ -287,12 +210,8 @@ const StageUsers = () => {
 
   const usersTableButtonsData = {
     updateIsDeleteButtonDisabled,
-    updateIsEnableButtonDisabled,
-    updateIsDisableButtonDisabled,
     isDeletion,
     updateIsDeletion,
-    isDisableEnableOp,
-    updateIsDisableEnableOp,
   };
 
   // 'SearchInputLayout'
@@ -357,45 +276,14 @@ const StageUsers = () => {
     },
     {
       key: 6,
-      element: (
-        <SecondaryButton
-          isDisabled={isDisableButtonDisabled}
-          onClickHandler={() => onEnableDisableHandler("disable")}
-        >
-          Disable
-        </SecondaryButton>
-      ),
+      element: <SecondaryButton>Activate</SecondaryButton>,
     },
     {
       key: 7,
-      element: (
-        <SecondaryButton
-          isDisabled={isEnableButtonDisabled}
-          onClickHandler={() => onEnableDisableHandler("enable")}
-        >
-          Enable
-        </SecondaryButton>
-      ),
-    },
-    {
-      key: 8,
-      element: (
-        <KebabLayout
-          onDropdownSelect={onDropdownSelect}
-          onKebabToggle={onKebabToggle}
-          idKebab="main-dropdown-kebab"
-          isKebabOpen={kebabIsOpen}
-          isPlain={true}
-          dropdownItems={dropdownItems}
-        />
-      ),
-    },
-    {
-      key: 9,
       toolbarItemVariant: "separator",
     },
     {
-      key: 10,
+      key: 8,
       element: (
         <HelpTextWithIconLayout
           textComponent={TextVariants.p}
@@ -409,7 +297,7 @@ const StageUsers = () => {
       ),
     },
     {
-      key: 11,
+      key: 9,
       element: (
         <PaginationPrep
           list={stageUsersList}
@@ -478,14 +366,6 @@ const StageUsers = () => {
         handleModalToggle={onDeleteModalToggle}
         selectedUsersData={selectedUsersData}
         buttonsData={deleteUsersButtonsData}
-      />
-      <DisableEnableUsers
-        show={showEnableDisableModal}
-        from="stage-users"
-        handleModalToggle={onEnableDisableModalToggle}
-        optionSelected={enableDisableOptionSelected}
-        selectedUsersData={selectedUsersData}
-        buttonsData={disableEnableButtonsData}
       />
     </Page>
   );


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8112750/233608187-914ee654-d65a-4cf5-b7a7-035922b32aa5.png)

The action buttons from the 'Stage users' page must match the same ones in the current WebUI. Those are:
- 'Refresh'
- 'Delete'
- 'Add'
- 'Activate'

Signed-off-by: Carla Martinez <carlmart@redhat.com>