### PR TITLE
[CL] Create RPC wrapper

### DIFF
--- a/src/services/rpc.ts
+++ b/src/services/rpc.ts
@@ -1,0 +1,197 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// RTK Query
+import { SerializedError } from "@reduxjs/toolkit";
+import {
+  createApi,
+  fetchBaseQuery,
+  FetchBaseQueryError,
+} from "@reduxjs/toolkit/query/react";
+// Utils
+import { API_VERSION_BACKUP } from "src/utils/utils";
+
+export interface UIDType {
+  dn: string;
+  uid: string[];
+}
+
+export interface Query {
+  data: FindRPCResponse | BatchRPCResponse | undefined;
+  isLoading: boolean;
+  error: FetchBaseQueryError | SerializedError | undefined;
+}
+
+// 'FindRPCResponse' type
+//   - Has 'result' > 'result' structure
+export interface FindRPCResponse {
+  error: string;
+  id: string;
+  principal: string;
+  version: string;
+  result: {
+    result: Record<string, unknown>; // General object type
+    count: number;
+    truncated: boolean;
+    summary: string;
+  };
+}
+
+// 'BatchRPCResponse' type
+//   - Has 'result' > 'results' > 'result' structure
+//   - More data under 'result'
+export interface BatchRPCResponse {
+  error: string;
+  id: string;
+  principal: string;
+  version: string;
+  result: {
+    count: number;
+    results: {
+      result: Record<string, unknown>; // General object type
+      truncated: boolean;
+      summary: string;
+    };
+  };
+}
+
+export interface CommandWithSingleParam {
+  command: string;
+  param: string;
+}
+
+export interface Command {
+  method: string;
+  params: any[];
+}
+
+export interface BatchCommand {
+  batch: CommandWithSingleParam[];
+}
+
+// Body data to perform the calls
+export const getCommand = (commandData: Command) => {
+  const payloadWithParams = {
+    url: "ipa/session/json",
+    method: "POST",
+    body: {
+      method: commandData.method,
+      params: commandData.params,
+    },
+  };
+  return payloadWithParams;
+};
+
+export const getBatchCommand = (commandData: Command[], apiVersion: string) => {
+  const payloadBatchParams = {
+    url: "ipa/session/json",
+    method: "POST",
+    body: {
+      method: "batch",
+      params: [
+        commandData,
+        {
+          version: apiVersion,
+        },
+      ],
+    },
+  };
+  return payloadBatchParams;
+};
+
+// Endpoints that will be called from anywhere in the application.
+// Two types:
+//   - Queries: https://redux-toolkit.js.org/rtk-query/usage/queries
+//   - Mutations: https://redux-toolkit.js.org/rtk-query/usage/mutations
+// Endpoints can perform individual calls (e.g: `simpleCommand`), multiple commands
+//   (e.g: `batchCommand`), and multiple commands executed sequentially in a single
+//   endpoint (e.g: `gettingUserData`)
+export const api = createApi({
+  baseQuery: fetchBaseQuery({ baseUrl: "/" }), // TODO: Global settings!
+  endpoints: (build) => ({
+    simpleCommand: build.query<FindRPCResponse, Command | void>({
+      query: (payloadData: Command) => getCommand(payloadData),
+    }),
+    simpleMutCommand: build.mutation<BatchRPCResponse, Command>({
+      query: (payloadData: Command) => getCommand(payloadData),
+    }),
+    batchCommand: build.query<BatchRPCResponse, Command[] | void>({
+      query: (payloadData: Command[], apiVersion?: string) =>
+        getBatchCommand(payloadData, apiVersion || API_VERSION_BACKUP),
+    }),
+    batchMutCommand: build.mutation<BatchRPCResponse, Command[] | void>({
+      query: (payloadData: Command[], apiVersion?: string) =>
+        getBatchCommand(payloadData, apiVersion || API_VERSION_BACKUP),
+    }),
+    gettingUserData: build.query<BatchRPCResponse, string | void>({
+      async queryFn(apiVersion, _queryApi, _extraOptions, fetchWithBQ) {
+        // 1ST CALL - GETTING ALL UIDS
+        if (apiVersion === undefined) {
+          return {
+            error: {
+              status: "CUSTOM_ERROR",
+              data: "",
+              error: "API version not available",
+            } as FetchBaseQueryError,
+          };
+        }
+        // Prepare payload
+        const payloadDataUids: Command = {
+          method: "user_find",
+          params: [
+            [],
+            {
+              pkey_only: true,
+              sizelimit: 0,
+              version: apiVersion,
+            },
+          ],
+        };
+
+        // Make call using 'fetchWithBQ'
+        const getUidsResult = await fetchWithBQ(getCommand(payloadDataUids));
+        // Return possible errors
+        if (getUidsResult.error) {
+          return { error: getUidsResult.error as FetchBaseQueryError };
+        }
+        // If no error: cast and assign 'uids'
+        const uidResponseData = getUidsResult.data as FindRPCResponse;
+
+        const uids: string[] = [];
+        const itemsCount = uidResponseData.result.result.length as number;
+        for (let i = 0; i < itemsCount; i++) {
+          const userId = uidResponseData.result.result[i] as UIDType;
+          const { uid } = userId;
+          uids.push(uid[0] as string);
+        }
+
+        // 2ND CALL - GET PARTIAL USERS INFO
+        // Prepare payload
+        const options = { no_members: true };
+        const payloadUserDataBatch: Command[] = uids.map((uid) => ({
+          method: "user_show",
+          params: [[uid], options],
+        }));
+
+        // Make call using 'fetchWithBQ'
+        const partialUsersInfoResult = await fetchWithBQ(
+          getBatchCommand(payloadUserDataBatch as Command[], apiVersion)
+        );
+
+        // Return results
+        return partialUsersInfoResult.data
+          ? { data: partialUsersInfoResult.data as BatchRPCResponse }
+          : {
+              error:
+                partialUsersInfoResult.error as unknown as FetchBaseQueryError,
+            };
+      },
+    }),
+  }),
+});
+
+export const {
+  useSimpleCommandQuery,
+  useSimpleMutCommandMutation,
+  useBatchCommandQuery,
+  useBatchMutCommandMutation,
+  useGettingUserDataQuery,
+} = api;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,4 +1,5 @@
 import { configureStore } from "@reduxjs/toolkit";
+import { setupListeners } from "@reduxjs/toolkit/query";
 import activeUsersReducer from "./Identity/activeUsers-slice";
 import netgroupsReducer from "./Identity/netgroups-slice";
 import userGroupsReducer from "./Identity/userGroups-slice";
@@ -10,9 +11,11 @@ import preservedUsersReducer from "./Identity/preservedUsers-slice";
 import hostsReducer from "./Identity/hosts-slice";
 import hostGroupsReducer from "./Identity/hostGroups-slice";
 import servicesReducer from "./Identity/services-slice";
+import { api } from "../services/rpc";
 
 const store = configureStore({
   reducer: {
+    api: api.reducer,
     activeUsers: activeUsersReducer,
     netgroups: netgroupsReducer,
     usergroups: userGroupsReducer,
@@ -25,7 +28,15 @@ const store = configureStore({
     hostGroups: hostGroupsReducer,
     services: servicesReducer,
   },
+  // Adding the api middleware enables caching, invalidation, polling,
+  // and other useful features of `rtk-query`.
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat(api.middleware),
 });
+
+// optional, but required for refetchOnFocus/refetchOnReconnect behaviors
+// see `setupListeners` docs - takes an optional callback as the 2nd arg for customization
+setupListeners(store.dispatch);
 
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -7,6 +7,9 @@ import { Host, Service, User } from "./datatypes/globalDataTypes";
  * Functions that can be reusable and called by several components throughout the application.
  */
 
+// Default API version (in case this is not available in Redux ATM)
+export const API_VERSION_BACKUP = "2.251";
+
 // Helper method: Given an users list and status, check if some entry has different status
 export const checkEqualStatus = (status: boolean, usersList: User[]) => {
   const usersWithOtherStatus = usersList.filter(


### PR DESCRIPTION
### RTK Query in a nutshell
The main goal of the communication layer is to perform API calls to retrieve and mutate data from the IPA server via JSON-RPC. The [RTK Query library](https://redux-toolkit.js.org/rtk-query/overview) is an optional add-on included in the Redux Toolkit package and it is designed to simplify common cases for loading data in a web application. Also, it is very versatile and can be adapted to any type of API protocol.

### RPC wrapper
Following the [guidelines](https://redux-toolkit.js.org/rtk-query/overview#basic-usage), a wrapper file has been created to manage the different API calls and define the endpoints. Later on, those endpoints can be consumed by other components in order to perform the API calls. 

Considering that the endpoints can be defined as [Queries](https://redux-toolkit.js.org/rtk-query/usage/queries) or [Mutations](https://redux-toolkit.js.org/rtk-query/usage/mutations) basic types, the solution uses that logic to define a set of endpoints and manage three types of operations:
- Individual calls.
- Multiple calls (batch).
- Sequential calls: When two different calls are executed in a single endpoint to perform an operation and the second call could not start until the first one has finished. This type of operation can be created anytime if needed in a specific context.

### API version
The API version should be passed as a parameter to make the API calls.

Ideally, this variable is retrieved from an API call to get the global and environmental data (`method: "env"`). But there are some circumstances where this variable is still not available (e.g.: to make the aforementioned call you still need a valid API version).

To prevent these cases, a provisional API version has been defined (set by default as "2.251") in the `utils` file.

### Configure the store for the RPC wrapper
According to the [guidelines](https://redux-toolkit.js.org/rtk-query/overview#configure-the-store), the created API slice (our RPC wrapper) can be set as a Redux slice to track which calls have been made (and its responses) on which endpoint.


Signed-off-by: Carla Martinez <carlmart@redhat.com>