### PR TITLE
[Fix] 'Stage' and 'Preserved' lists not showing

### DIFF
--- a/src/pages/PreservedUsers/PreservedUsers.tsx
+++ b/src/pages/PreservedUsers/PreservedUsers.tsx
@@ -144,6 +144,18 @@ const PreservedUsers = () => {
         : otherSelectedUserNames;
     });
 
+  // Refresh displayed elements every time elements list changes (from Redux or somewhere else)
+  React.useEffect(() => {
+    updatePage(1);
+    if (showTableRows) updateShowTableRows(false);
+    setTimeout(() => {
+      updateShownUsersList(preservedUsersList.slice(0, perPage));
+      updateShowTableRows(true);
+      // Reset 'selectedPerPage'
+      updateSelectedPerPage(0);
+    }, 2000);
+  }, [preservedUsersList]);
+
   // Data wrappers
   // - 'PaginationPrep'
   const paginationData = {
@@ -152,7 +164,6 @@ const PreservedUsers = () => {
     updatePage,
     updatePerPage,
     showTableRows,
-    updateShowTableRows,
     updateSelectedPerPage,
     updateShownElementsList: updateShownUsersList,
   };

--- a/src/pages/StageUsers/StageUsers.tsx
+++ b/src/pages/StageUsers/StageUsers.tsx
@@ -150,6 +150,18 @@ const StageUsers = () => {
         : otherSelectedUserNames;
     });
 
+  // Refresh displayed elements every time elements list changes (from Redux or somewhere else)
+  React.useEffect(() => {
+    updatePage(1);
+    if (showTableRows) updateShowTableRows(false);
+    setTimeout(() => {
+      updateShownUsersList(stageUsersList.slice(0, perPage));
+      updateShowTableRows(true);
+      // Reset 'selectedPerPage'
+      updateSelectedPerPage(0);
+    }, 2000);
+  }, [stageUsersList]);
+
   // Data wrappers
   // - 'PaginationPrep'
   const paginationData = {
@@ -158,7 +170,6 @@ const StageUsers = () => {
     updatePage,
     updatePerPage,
     showTableRows,
-    updateShowTableRows,
     updateSelectedPerPage,
     updateShownElementsList: updateShownUsersList,
   };


### PR DESCRIPTION
In previous changes, the `PaginationPrep` component has been adapted to work with the 'Active users' page and the RPC wrapper. Thus, some functionality has been altered.

As a consequence of adapting those changes, some functionality related to updating the table data when the users' list is altered was deleted by mistake. That makes the data is showing fine for 'Active users' but not for 'Stage-' and 'Preserved users'.

In order to fix that, a new `useEffect` has been defined in `StageUsers` and `PreservedUsers` components to refresh the elements on the table every time the list of elements changes:

```ts
// E.g.: Preserved users
React.useEffect(() => {
  updatePage(1);
  if (showTableRows) updateShowTableRows(false);
  setTimeout(() => {
    updateShownUsersList(preservedUsersList.slice(0, perPage));
    updateShowTableRows(true);
    // Reset 'selectedPerPage'
    updateSelectedPerPage(0);
  }, 2000);
}, [preservedUsersList]);
```

Signed-off-by: Carla Martinez <carlmart@redhat.com>