### PR TITLE
'Active users' > kebab options ('Rebuild auto membership')

### DIFF
--- a/src/components/layouts/AlertGroupLayout.tsx
+++ b/src/components/layouts/AlertGroupLayout.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+// PatternFly
+import { AlertGroup } from "@patternfly/react-core";
+
+interface PropsToAlertGroup {
+  alerts: JSX.Element[];
+  setAlerts: (newAlertsList: JSX.Element[]) => void;
+}
+
+const AlertGroupLayout = (props: PropsToAlertGroup) => {
+  // Remove all alerts
+  const removeAllAlerts = () => {
+    props.setAlerts([]);
+  };
+
+  return (
+    <>
+      {props.alerts !== undefined && (
+        <AlertGroup isToast isLiveRegion onOverflowClick={removeAllAlerts}>
+          {props.alerts}
+        </AlertGroup>
+      )}
+    </>
+  );
+};
+
+export default AlertGroupLayout;

--- a/src/components/layouts/AlertLayout.tsx
+++ b/src/components/layouts/AlertLayout.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+// PatternFly
+import { Alert, AlertActionCloseButton } from "@patternfly/react-core";
+
+interface PropsToAlert {
+  key: string | number;
+  variant?: "default" | "success" | "danger" | "warning" | "info";
+  title: React.ReactNode;
+  onCloseHandler: () => void;
+}
+
+const AlertLayout = (props: PropsToAlert) => {
+  return (
+    <Alert
+      key={props.key}
+      variant={props.variant}
+      title={props.title}
+      timeout
+      isLiveRegion
+      actionClose={
+        <AlertActionCloseButton
+          variantLabel={`${props.variant} alert`}
+          onClose={props.onCloseHandler}
+        />
+      }
+    />
+  );
+};
+
+export default AlertLayout;


### PR DESCRIPTION
### Description
According to the [documentation](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/linux_domain_identity_authentication_and_policy_guide/automember)[1], the 'Rebuild auto membership' option applies auto member rules to users' and hosts' entries created after the rules were added. They are not applied retrospectively to entries that existed before the rules were added. 

This option inside the kebab element has been implemented, reproducing the same behavior as in the current WebUI and applying the [alert](https://www.patternfly.org/v4/components/alert) and [alert group](https://www.patternfly.org/v4/components/alert-group) PatternFly UI elements to determine whether the operation has been successful or not. Those are shown as floating elements that would automatically disappear within 8 seconds if the user doesn't click on the close icon.



[1] - Applying Automember Rules to Existing Users and Hosts - https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/linux_domain_identity_authentication_and_policy_guide/automember

Signed-off-by: Carla Martinez <carlmart@redhat.com>