### PR TITLE
Add external IdP checkbox

### DIFF
--- a/src/components/UsersSections/UsersAccountSettings.tsx
+++ b/src/components/UsersSections/UsersAccountSettings.tsx
@@ -363,6 +363,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
   const [tpaCheckbox] = useState(false);
   const [pkinitCheckbox] = useState(false);
   const [hardenedPassCheckbox] = useState(false);
+  const [extIdentityProvCheckbox] = useState(false);
 
   // Date and time picker (Calendar)
   const [isCalendarOpen, setIsCalendarOpen] = React.useState(false);
@@ -717,6 +718,15 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
                 id="hardenedPassCheckbox"
                 name="ipauserauthtype"
                 value="hardened"
+                className="pf-u-mt-xs pf-u-mb-sm"
+              />
+              <Checkbox
+                label="External Identity Provider"
+                isChecked={extIdentityProvCheckbox}
+                aria-label="external identity provider from user authentication types"
+                id="extIdentityProvCheckbox"
+                name="ipauserauthtype"
+                value="idp"
               />
             </FormGroup>
             <FormGroup


### PR DESCRIPTION
The `External Identity Provider` checkbox is available in the current WebUI, but not in the new WebUI. This needs to be amended to reproduce the same UI & functionality.

Signed-off-by: Carla Martinez <carlmart@redhat.com>