### PR TITLE
Active users > 'Settings': 'Refresh' button

### DIFF
--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -65,6 +65,10 @@ const UserSettings = (props: PropsToUserSettings) => {
     useState<Record<string, unknown>>();
   const [idpData, setIdpData] = useState<Record<string, unknown>>();
   const [uidsData, setUidsData] = useState<Record<string, unknown>>();
+  // Attribute level rights
+  // - Some fields are hidden for some users and can have different
+  //   read/write permissions.
+  const [attrLevelRights, setAttrLevelRights] = useState<any>("");
 
   // [API call] Get full user information
   const userShowCommand: Command = {
@@ -133,6 +137,9 @@ const UserSettings = (props: PropsToUserSettings) => {
       setPwpolicyShowData(batchResponse.result.results[1].result);
       setKrbtpolicyShowData(batchResponse.result.results[2].result);
       setCertFindData(batchResponse.result.results[3].result);
+      setAttrLevelRights(
+        batchResponse.result.results[0].result.attributelevelrights
+      );
     }
   }, [isBatchLoading]);
 
@@ -297,7 +304,10 @@ const UserSettings = (props: PropsToUserSettings) => {
                   id="identity-settings"
                   text="Identity settings"
                 />
-                <UsersIdentity userData={userShowData} />
+                <UsersIdentity
+                  userData={userShowData}
+                  attrLevelRights={attrLevelRights}
+                />
                 <TitleLayout
                   key={1}
                   headingLevel="h2"

--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -1,4 +1,5 @@
-import React, { SyntheticEvent, useState } from "react";
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React, { SyntheticEvent, useEffect, useState } from "react";
 // PatternFly
 import {
   PageSection,
@@ -12,6 +13,7 @@ import {
   SidebarPanel,
   SidebarContent,
   DropdownDirection,
+  Spinner,
 } from "@patternfly/react-core";
 // Icons
 import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
@@ -32,6 +34,14 @@ import UsersContactSettings from "src/components/UsersSections/UsersContactSetti
 import UsersMailingAddress from "src/components/UsersSections/UsersMailingAddress";
 import UsersEmployeeInfo from "src/components/UsersSections/UsersEmployeeInfo";
 import UsersAttributesSMB from "src/components/UsersSections/UsersAttributesSMB";
+// Redux
+import { useAppSelector } from "src/store/hooks";
+// RPC
+import {
+  Command,
+  useBatchCommandQuery,
+  useSimpleCommandQuery,
+} from "src/services/rpc";
 
 export interface PropsToUserSettings {
   user: User;
@@ -39,6 +49,114 @@ export interface PropsToUserSettings {
 }
 
 const UserSettings = (props: PropsToUserSettings) => {
+  // Retrieve API version from environment data
+  const apiVersion = useAppSelector(
+    (state) => state.global.environment.api_version
+  ) as string;
+
+  // Initialize data
+  const [userShowData, setUserShowData] = useState<Record<string, unknown>>();
+  const [pwpolicyShowData, setPwpolicyShowData] =
+    useState<Record<string, unknown>>();
+  const [krbtpolicyShowData, setKrbtpolicyShowData] =
+    useState<Record<string, unknown>>();
+  const [certFindData, setCertFindData] = useState<Record<string, unknown>>();
+  const [radiusProxyData, setRadiusProxyData] =
+    useState<Record<string, unknown>>();
+  const [idpData, setIdpData] = useState<Record<string, unknown>>();
+  const [uidsData, setUidsData] = useState<Record<string, unknown>>();
+
+  // [API call] Get full user information
+  const userShowCommand: Command = {
+    method: "user_show",
+    params: [props.user.uid, { all: true, rights: true }],
+  };
+
+  const pwpolicyShowCommand: Command = {
+    method: "pwpolicy_show",
+    params: [[], { user: props.user.uid[0], all: true, rights: true }],
+  };
+
+  const krbtpolicyShowCommand: Command = {
+    method: "krbtpolicy_show",
+    params: [props.user.uid, { all: true, rights: true }],
+  };
+
+  const certFindCommand: Command = {
+    method: "cert_find",
+    params: [[], { user: props.user.uid[0], sizelimit: 0, all: true }],
+  };
+
+  const batchPayload: Command[] = [
+    userShowCommand,
+    pwpolicyShowCommand,
+    krbtpolicyShowCommand,
+    certFindCommand,
+  ];
+
+  const { data: batchResponse, isLoading: isBatchLoading } =
+    useBatchCommandQuery(batchPayload);
+
+  // [API calls] Get context information
+  // - RADIUS Proxy
+  const radiusproxyPayload: Command = {
+    method: "radiusproxy_find",
+    params: [[], { version: apiVersion }],
+  };
+
+  const { data: radiusProxyResponse, isLoading: isRadiusProxyLoading } =
+    useSimpleCommandQuery(radiusproxyPayload);
+
+  // - External IPD
+  const idpPayload: Command = {
+    method: "idp_find",
+    params: [[], { version: apiVersion }],
+  };
+
+  const { data: idpResponse, isLoading: isIdpLoading } =
+    useSimpleCommandQuery(idpPayload);
+
+  // - User IDs
+  const userIdsPayload: Command = {
+    method: "user_find",
+    params: [[], { no_members: true, version: apiVersion }],
+  };
+
+  const { data: uidsResponse, isLoading: isUidsLoading } =
+    useSimpleCommandQuery(userIdsPayload);
+
+  // Update batch data when available
+  useEffect(() => {
+    // Batch
+    if (batchResponse !== undefined) {
+      setUserShowData(batchResponse.result.results[0].result);
+      setPwpolicyShowData(batchResponse.result.results[1].result);
+      setKrbtpolicyShowData(batchResponse.result.results[2].result);
+      setCertFindData(batchResponse.result.results[3].result);
+    }
+  }, [isBatchLoading]);
+
+  // Update RADIUS proxy data when available
+  useEffect(() => {
+    if (radiusProxyResponse !== undefined) {
+      setRadiusProxyData(radiusProxyResponse.result.result);
+    }
+  }, [isRadiusProxyLoading]);
+
+  // Update External IdP data when available
+  useEffect(() => {
+    if (idpResponse !== undefined) {
+      setIdpData(idpResponse.result.result);
+    }
+  }, [isIdpLoading]);
+
+  // Update User IDs data when available
+  useEffect(() => {
+    if (uidsResponse !== undefined) {
+      setUidsData(uidsResponse.result.result);
+    }
+  }, [isUidsLoading]);
+
   // Kebab
   const [isKebabOpen, setIsKebabOpen] = useState(false);
 
@@ -69,6 +187,15 @@ const UserSettings = (props: PropsToUserSettings) => {
   ) => {
     setIsKebabOpen(!isKebabOpen);
   };
+
+  // Spinner UI
+  const spinner = (
+    <Spinner
+      isSVG
+      style={{ alignSelf: "center", marginLeft: "45%", marginTop: "5%" }}
+      aria-label="Loading contents of user settings"
+    />
+  );
 
   // Toolbar
   const toolbarFields = [
@@ -109,116 +236,131 @@ const UserSettings = (props: PropsToUserSettings) => {
         className="pf-u-pr-0 pf-u-ml-lg pf-u-mr-sm"
         style={{ overflowY: "scroll", height: `calc(100vh - 319.2px)` }}
       >
-        <Sidebar isPanelRight className="pf-u-mt-lg">
-          <SidebarPanel variant="sticky">
-            <HelpTextWithIconLayout
-              textComponent={TextVariants.p}
-              textClassName="pf-u-mb-md"
-              subTextComponent={TextVariants.a}
-              subTextIsVisitedLink={true}
-              textContent="Help"
-              icon={
-                <OutlinedQuestionCircleIcon className="pf-u-primary-color-100 pf-u-mr-sm" />
-              }
-            />
-            <JumpLinks
-              isVertical
-              label="Jump to section"
-              scrollableSelector="#settings-page"
-              offset={220} // for masthead
-              expandable={{ default: "expandable", md: "nonExpandable" }}
-            >
-              <JumpLinksItem key={0} href="#identity-settings">
-                Identity settings
-              </JumpLinksItem>
-              <JumpLinksItem key={1} href="#account-settings">
-                Account settings
-              </JumpLinksItem>
-              <JumpLinksItem key={2} href="#password-policy">
-                Password policy
-              </JumpLinksItem>
-              <JumpLinksItem key={3} href="#kerberos-ticket">
-                Kerberos ticket policy
-              </JumpLinksItem>
-              <JumpLinksItem key={4} href="#contact-settings">
-                Contact settings
-              </JumpLinksItem>
-              <JumpLinksItem key={5} href="#mailing-address">
-                Mailing address
-              </JumpLinksItem>
-              <JumpLinksItem key={6} href="#employee-information">
-                Employee information
-              </JumpLinksItem>
-              <JumpLinksItem key={7} href="#smb-services">
-                User attributes for SMB services
-              </JumpLinksItem>
-            </JumpLinks>
-          </SidebarPanel>
+        {!isBatchLoading &&
+        !isRadiusProxyLoading &&
+        !isIdpLoading &&
+        !isUidsLoading ? (
+          <Sidebar isPanelRight className="pf-u-mt-lg">
+            <SidebarPanel variant="sticky">
+              <HelpTextWithIconLayout
+                textComponent={TextVariants.p}
+                textClassName="pf-u-mb-md"
+                subTextComponent={TextVariants.a}
+                subTextIsVisitedLink={true}
+                textContent="Help"
+                icon={
+                  <OutlinedQuestionCircleIcon className="pf-u-primary-color-100 pf-u-mr-sm" />
+                }
+              />
+              <JumpLinks
+                isVertical
+                label="Jump to section"
+                scrollableSelector="#settings-page"
+                offset={220} // for masthead
+                expandable={{ default: "expandable", md: "nonExpandable" }}
+              >
+                <JumpLinksItem key={0} href="#identity-settings">
+                  Identity settings
+                </JumpLinksItem>
+                <JumpLinksItem key={1} href="#account-settings">
+                  Account settings
+                </JumpLinksItem>
+                <JumpLinksItem key={2} href="#password-policy">
+                  Password policy
+                </JumpLinksItem>
+                <JumpLinksItem key={3} href="#kerberos-ticket">
+                  Kerberos ticket policy
+                </JumpLinksItem>
+                <JumpLinksItem key={4} href="#contact-settings">
+                  Contact settings
+                </JumpLinksItem>
+                <JumpLinksItem key={5} href="#mailing-address">
+                  Mailing address
+                </JumpLinksItem>
+                <JumpLinksItem key={6} href="#employee-information">
+                  Employee information
+                </JumpLinksItem>
+                <JumpLinksItem key={7} href="#smb-services">
+                  User attributes for SMB services
+                </JumpLinksItem>
+              </JumpLinks>
+            </SidebarPanel>
 
-          <SidebarContent className="pf-u-mr-xl">
-            <Flex
-              direction={{ default: "column" }}
-              flex={{ default: "flex_1" }}
-            >
-              <TitleLayout
-                key={0}
-                headingLevel="h2"
-                id="identity-settings"
-                text="Identity settings"
-              />
-              <UsersIdentity user={props.user} />
-              <TitleLayout
-                key={1}
-                headingLevel="h2"
-                id="account-settings"
-                text="Account settings"
-              />
-              <UsersAccountSettings user={props.user} />
-              <TitleLayout
-                key={2}
-                headingLevel="h2"
-                id="password-policy"
-                text="Password policy"
-              />
-              <UsersPasswordPolicy />
-              <TitleLayout
-                key={3}
-                headingLevel="h2"
-                id="kerberos-ticket"
-                text="Kerberos ticket"
-              />
-              <UsersKerberosTicket />
-              <TitleLayout
-                key={4}
-                headingLevel="h2"
-                id="contact-settings"
-                text="Contact settings"
-              />
-              <UsersContactSettings user={props.user} />
-              <TitleLayout
-                key={5}
-                headingLevel="h2"
-                id="mailing-address"
-                text="Mailing address"
-              />
-              <UsersMailingAddress />
-              <TitleLayout
-                key={6}
-                headingLevel="h2"
-                id="employee-information"
-                text="Employee information"
-              />
-              <UsersEmployeeInfo />
-              <TitleLayout
-                key={7}
-                headingLevel="h2"
-                id="smb-services"
-                text="User attributes for SMB services"
-              />
-              <UsersAttributesSMB />
-            </Flex>
-          </SidebarContent>
-        </Sidebar>
+            <SidebarContent className="pf-u-mr-xl">
+              <Flex
+                direction={{ default: "column" }}
+                flex={{ default: "flex_1" }}
+              >
+                <TitleLayout
+                  key={0}
+                  headingLevel="h2"
+                  id="identity-settings"
+                  text="Identity settings"
+                />
+                <UsersIdentity userData={userShowData} />
+                <TitleLayout
+                  key={1}
+                  headingLevel="h2"
+                  id="account-settings"
+                  text="Account settings"
+                />
+                <UsersAccountSettings
+                  userData={userShowData}
+                  certData={certFindData}
+                  radiusProxyData={radiusProxyData}
+                  idpData={idpData}
+                />
+                <TitleLayout
+                  key={2}
+                  headingLevel="h2"
+                  id="password-policy"
+                  text="Password policy"
+                />
+                <UsersPasswordPolicy pwpolicyData={pwpolicyShowData} />
+                <TitleLayout
+                  key={3}
+                  headingLevel="h2"
+                  id="kerberos-ticket"
+                  text="Kerberos ticket"
+                />
+                <UsersKerberosTicket krbtpolicyData={krbtpolicyShowData} />
+                <TitleLayout
+                  key={4}
+                  headingLevel="h2"
+                  id="contact-settings"
+                  text="Contact settings"
+                />
+                <UsersContactSettings userData={userShowData} />
+                <TitleLayout
+                  key={5}
+                  headingLevel="h2"
+                  id="mailing-address"
+                  text="Mailing address"
+                />
+                <UsersMailingAddress userData={userShowData} />
+                <TitleLayout
+                  key={6}
+                  headingLevel="h2"
+                  id="employee-information"
+                  text="Employee information"
+                />
+                <UsersEmployeeInfo
+                  uidsData={uidsData}
+                  userData={userShowData}
+                />
+                <TitleLayout
+                  key={7}
+                  headingLevel="h2"
+                  id="smb-services"
+                  text="User attributes for SMB services"
+                />
+                <UsersAttributesSMB userData={userShowData} />
+              </Flex>
+            </SidebarContent>
+          </Sidebar>
+        ) : (
+          spinner
+        )}
       </PageSection>
       <ToolbarLayout
         isSticky={true}

--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -357,7 +357,10 @@ const UserSettings = (props: PropsToUserSettings) => {
                   id="mailing-address"
                   text="Mailing address"
                 />
-                <UsersMailingAddress userData={userShowData} />
+                <UsersMailingAddress
+                  userData={userShowData}
+                  attrLevelRights={attrLevelRights}
+                />
                 <TitleLayout
                   key={6}
                   headingLevel="h2"

--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -378,7 +378,10 @@ const UserSettings = (props: PropsToUserSettings) => {
                   id="smb-services"
                   text="User attributes for SMB services"
                 />
-                <UsersAttributesSMB userData={userShowData} />
+                <UsersAttributesSMB
+                  userData={userShowData}
+                  attrLevelRights={attrLevelRights}
+                />
               </Flex>
             </SidebarContent>
           </Sidebar>

--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -370,6 +370,7 @@ const UserSettings = (props: PropsToUserSettings) => {
                 <UsersEmployeeInfo
                   uidsData={uidsData}
                   userData={userShowData}
+                  attrLevelRights={attrLevelRights}
                 />
                 <TitleLayout
                   key={7}

--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -319,6 +319,7 @@ const UserSettings = (props: PropsToUserSettings) => {
                   certData={certFindData}
                   radiusProxyData={radiusProxyData}
                   idpData={idpData}
+                  attrLevelRights={attrLevelRights}
                 />
                 <TitleLayout
                   key={2}

--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -337,7 +337,10 @@ const UserSettings = (props: PropsToUserSettings) => {
                   id="kerberos-ticket"
                   text="Kerberos ticket"
                 />
-                <UsersKerberosTicket krbtpolicyData={krbtpolicyShowData} />
+                <UsersKerberosTicket
+                  krbtpolicyData={krbtpolicyShowData}
+                  attrLevelRights={attrLevelRights}
+                />
                 <TitleLayout
                   key={4}
                   headingLevel="h2"

--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -347,7 +347,10 @@ const UserSettings = (props: PropsToUserSettings) => {
                   id="contact-settings"
                   text="Contact settings"
                 />
-                <UsersContactSettings userData={userShowData} />
+                <UsersContactSettings
+                  userData={userShowData}
+                  attrLevelRights={attrLevelRights}
+                />
                 <TitleLayout
                   key={5}
                   headingLevel="h2"

--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -327,7 +327,10 @@ const UserSettings = (props: PropsToUserSettings) => {
                   id="password-policy"
                   text="Password policy"
                 />
-                <UsersPasswordPolicy pwpolicyData={pwpolicyShowData} />
+                <UsersPasswordPolicy
+                  pwpolicyData={pwpolicyShowData}
+                  attrLevelRights={attrLevelRights}
+                />
                 <TitleLayout
                   key={3}
                   headingLevel="h2"

--- a/src/components/UsersSections/UsersAccountSettings.tsx
+++ b/src/components/UsersSections/UsersAccountSettings.tsx
@@ -31,13 +31,19 @@ import ModalWithTextAreaLayout from "src/components/layouts/ModalWithTextAreaLay
 // Modals
 import CertificateMappingDataModal from "src/components/modals/CertificateMappingDataModal";
 // Utils
-import { parseStringToUTCFormat } from "src/utils/utils";
+import {
+  isFieldWritable,
+  isFieldReadable,
+  parseStringToUTCFormat,
+} from "src/utils/utils";
+import FieldWrapper from "src/utils/FieldWrapper";
 
 interface PropsToUsersAccountSettings {
   userData: any;
   certData: any;
   radiusProxyData: any;
   idpData: any;
+  attrLevelRights: any;
 }
 
 const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
@@ -618,26 +624,39 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
                 isDisabled
               />
             </FormGroup>
-            <FormGroup label="UID" fieldId="uid-number">
-              <TextInput
-                id="uid-number"
-                name="uidnumber"
-                value={uidNumber}
-                type="text"
-                onChange={uidNumberInputHandler}
-                aria-label="uid number"
-              />
-            </FormGroup>
-            <FormGroup label="GID" fieldId="gid">
-              <TextInput
-                id="gid"
-                name="gidnumber"
-                value={gid}
-                type="text"
-                onChange={gidInputHandler}
-                aria-label="gid"
-              />
-            </FormGroup>
+
+            <FieldWrapper
+              isWritable={isFieldWritable(props.attrLevelRights.uidnumber)}
+              isReadable={isFieldReadable(props.attrLevelRights.uidnumber)}
+            >
+              <FormGroup label="UID" fieldId="uid-number">
+                <TextInput
+                  id="uid-number"
+                  name="uidnumber"
+                  value={uidNumber}
+                  type="text"
+                  onChange={uidNumberInputHandler}
+                  aria-label="uid number"
+                />
+              </FormGroup>
+            </FieldWrapper>
+
+            <FieldWrapper
+              isWritable={isFieldWritable(props.attrLevelRights.gidnumber)}
+              isReadable={isFieldReadable(props.attrLevelRights.gidnumber)}
+            >
+              <FormGroup label="GID" fieldId="gid">
+                <TextInput
+                  id="gid"
+                  name="gidnumber"
+                  value={gid}
+                  type="text"
+                  onChange={gidInputHandler}
+                  aria-label="gid"
+                />
+              </FormGroup>
+            </FieldWrapper>
+
             <FormGroup label="Principal alias" fieldId="principal-alias">
               <Flex direction={{ default: "column" }} name="krbprincipalname">
                 {principalAliasList.map((principalAlias, idx) => (
@@ -659,29 +678,44 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
                         onChange={(value, event) =>
                           onHandlePrincipalAliasChange(value, event, idx)
                         }
+                        isDisabled={
+                          !isFieldWritable(
+                            props.attrLevelRights.krbprincipalname
+                          )
+                        }
                       />
                     </FlexItem>
-                    <FlexItem key={principalAlias + "-delete-button"}>
-                      <SecondaryButton
-                        name="remove"
-                        onClickHandler={() =>
-                          onRemovePrincipalAliasHandler(idx)
-                        }
-                      >
-                        Delete
-                      </SecondaryButton>
-                    </FlexItem>
+                    {isFieldWritable(
+                      props.attrLevelRights.krbprincipalname
+                    ) && (
+                      <FlexItem key={principalAlias + "-delete-button"}>
+                        <SecondaryButton
+                          name="remove"
+                          onClickHandler={() =>
+                            onRemovePrincipalAliasHandler(idx)
+                          }
+                        >
+                          Delete
+                        </SecondaryButton>
+                      </FlexItem>
+                    )}
                   </Flex>
                 ))}
               </Flex>
-              <SecondaryButton
-                classname="pf-u-mt-md"
-                name="add"
-                onClickHandler={onAddPrincipalAliasFieldHandler}
-              >
-                Add
-              </SecondaryButton>
+              {isFieldWritable(props.attrLevelRights.krbprincipalname) && (
+                <SecondaryButton
+                  classname="pf-u-mt-md"
+                  name="add"
+                  onClickHandler={onAddPrincipalAliasFieldHandler}
+                  isDisabled={
+                    !isFieldWritable(props.attrLevelRights.krbprincipalname)
+                  }
+                >
+                  Add
+                </SecondaryButton>
+              )}
             </FormGroup>
+
             <FormGroup
               label="Kerberos principal expiration (UTC)"
               fieldId="kerberos-principal-expiration"
@@ -697,45 +731,78 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
                 textInputId="date-time"
                 textInputAriaLabel="date and time picker"
                 textInputValue={valueDate + " " + valueTime}
+                isDisable={
+                  !isFieldWritable(props.attrLevelRights.krbprincipalexpiration)
+                }
               >
-                {calendarButton}
-                {time}
+                {isFieldWritable(
+                  props.attrLevelRights.krbprincipalexpiration
+                ) ? (
+                  calendarButton
+                ) : (
+                  <></>
+                )}
+                {isFieldWritable(
+                  props.attrLevelRights.krbprincipalexpiration
+                ) ? (
+                  time
+                ) : (
+                  <></>
+                )}
               </CalendarLayout>
             </FormGroup>
-            <FormGroup label="Login shell" fieldId="login-shell">
-              <TextInput
-                id="login-shell"
-                name="loginshell"
-                value={loginShell}
-                type="text"
-                onChange={loginShellInputHandler}
-                aria-label="login shell"
-              />
-            </FormGroup>
+
+            <FieldWrapper
+              isWritable={isFieldWritable(props.attrLevelRights.loginshell)}
+              isReadable={isFieldReadable(props.attrLevelRights.loginshell)}
+            >
+              <FormGroup label="Login shell" fieldId="login-shell">
+                <TextInput
+                  id="login-shell"
+                  name="loginshell"
+                  value={loginShell}
+                  type="text"
+                  onChange={loginShellInputHandler}
+                  aria-label="login shell"
+                />
+              </FormGroup>
+            </FieldWrapper>
           </Form>
         </FlexItem>
         <FlexItem flex={{ default: "flex_1" }}>
           <Form className="pf-u-mb-lg">
-            <FormGroup label="Home directory" fieldId="home-directory">
-              <TextInput
-                id="home-directory"
-                name="homedirectory"
-                value={homeDirectory}
-                type="text"
-                onChange={homeDirectoryInputHandler}
-                aria-label="home directory"
-              />
-            </FormGroup>
+            <FieldWrapper
+              isWritable={isFieldWritable(props.attrLevelRights.homedirectory)}
+              isReadable={isFieldReadable(props.attrLevelRights.homedirectory)}
+            >
+              <FormGroup label="Home directory" fieldId="home-directory">
+                <TextInput
+                  id="home-directory"
+                  name="homedirectory"
+                  value={homeDirectory}
+                  type="text"
+                  onChange={homeDirectoryInputHandler}
+                  aria-label="home directory"
+                />
+              </FormGroup>
+            </FieldWrapper>
+
             <FormGroup label="SSH public keys" fieldId="ssh-public-keys">
-              <SecondaryButton onClickHandler={openSshPublicKeysModal}>
-                Add
-              </SecondaryButton>
+              {isFieldWritable(props.attrLevelRights.ipasshpubkey) && (
+                <SecondaryButton onClickHandler={openSshPublicKeysModal}>
+                  Add
+                </SecondaryButton>
+              )}
             </FormGroup>
+
             <FormGroup label="Certificates" fieldId="certificates">
-              <SecondaryButton onClickHandler={openCertificatesModal}>
-                Add
-              </SecondaryButton>
+              {isFieldWritable(props.attrLevelRights.usercertificate) && (
+                <SecondaryButton onClickHandler={openCertificatesModal}>
+                  Add
+                </SecondaryButton>
+              )}
             </FormGroup>
+
             <FormGroup
               label="Certificate mapping data"
               fieldId="certificate-mapping-data"
@@ -745,144 +812,196 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
                 />
               }
             >
-              <SecondaryButton
-                onClickHandler={openCertificatesMappingDataModal}
+              {isFieldWritable(props.attrLevelRights.ipacertmapdata) && (
+                <SecondaryButton
+                  onClickHandler={openCertificatesMappingDataModal}
+                >
+                  Add
+                </SecondaryButton>
+              )}
+            </FormGroup>
+
+            <FieldWrapper
+              isWritable={isFieldWritable(
+                props.attrLevelRights.ipauserauthtype,
+                props.attrLevelRights.objectclass,
+                "w_if_no_aci"
+              )}
+              isReadable={isFieldReadable(
+                props.attrLevelRights.ipauserauthtype,
+                "r_if_no_aci"
+              )}
+            >
+              <FormGroup
+                label="User authentication types"
+                fieldId="user-authentication-types"
+                labelIcon={
+                  <PopoverWithIconLayout message={userAuthTypesMessage} />
+                }
               >
-                Add
-              </SecondaryButton>
-            </FormGroup>
-            <FormGroup
-              label="User authentication types"
-              fieldId="user-authentication-types"
-              labelIcon={
-                <PopoverWithIconLayout message={userAuthTypesMessage} />
-              }
+                <Checkbox
+                  label="Password"
+                  isChecked={passwordCheckbox}
+                  aria-label="password from user authentication types"
+                  id="passwordCheckbox"
+                  name="ipauserauthtype"
+                  value="password"
+                  className="pf-u-mt-xs pf-u-mb-sm"
+                />
+                <Checkbox
+                  label="RADIUS"
+                  isChecked={radiusCheckbox}
+                  aria-label="radius from user authentication types"
+                  id="radiusCheckbox"
+                  name="ipauserauthtype"
+                  value="radius"
+                  className="pf-u-mt-xs pf-u-mb-sm"
+                />
+                <Checkbox
+                  label="Two-factor authentication (password + OTP)"
+                  isChecked={tpaCheckbox}
+                  aria-label="two factor authentication from user authentication types"
+                  id="tpaCheckbox"
+                  name="ipauserauthtype"
+                  value="otp"
+                  className="pf-u-mt-xs pf-u-mb-sm"
+                />
+                <Checkbox
+                  label="PKINIT"
+                  isChecked={pkinitCheckbox}
+                  aria-label="pkinit from user authentication types"
+                  id="pkinitCheckbox"
+                  name="ipauserauthtype"
+                  value="pkinit"
+                  className="pf-u-mt-xs pf-u-mb-sm"
+                />
+                <Checkbox
+                  label="Hardened password (by SPAKE or FAST)"
+                  isChecked={hardenedPassCheckbox}
+                  aria-label="hardened password from user authentication types"
+                  id="hardenedPassCheckbox"
+                  name="ipauserauthtype"
+                  value="hardened"
+                  className="pf-u-mt-xs pf-u-mb-sm"
+                />
+                <Checkbox
+                  label="External Identity Provider"
+                  isChecked={extIdentityProvCheckbox}
+                  aria-label="external identity provider from user authentication types"
+                  id="extIdentityProvCheckbox"
+                  name="ipauserauthtype"
+                  value="idp"
+                />
+              </FormGroup>
+            </FieldWrapper>
+
+            <FieldWrapper
+              isWritable={isFieldWritable(
+                props.attrLevelRights.ipatokenradiusconfiglink
+              )}
+              isReadable={isFieldReadable(
+                props.attrLevelRights.ipatokenradiusconfiglink
+              )}
             >
-              <Checkbox
-                label="Password"
-                isChecked={passwordCheckbox}
-                aria-label="password from user authentication types"
-                id="passwordCheckbox"
-                name="ipauserauthtype"
-                value="password"
-                className="pf-u-mt-xs pf-u-mb-sm"
-              />
-              <Checkbox
-                label="RADIUS"
-                isChecked={radiusCheckbox}
-                aria-label="radius from user authentication types"
-                id="radiusCheckbox"
-                name="ipauserauthtype"
-                value="radius"
-                className="pf-u-mt-xs pf-u-mb-sm"
-              />
-              <Checkbox
-                label="Two-factor authentication (password + OTP)"
-                isChecked={tpaCheckbox}
-                aria-label="two factor authentication from user authentication types"
-                id="tpaCheckbox"
-                name="ipauserauthtype"
-                value="otp"
-                className="pf-u-mt-xs pf-u-mb-sm"
-              />
-              <Checkbox
-                label="PKINIT"
-                isChecked={pkinitCheckbox}
-                aria-label="pkinit from user authentication types"
-                id="pkinitCheckbox"
-                name="ipauserauthtype"
-                value="pkinit"
-                className="pf-u-mt-xs pf-u-mb-sm"
-              />
-              <Checkbox
-                label="Hardened password (by SPAKE or FAST)"
-                isChecked={hardenedPassCheckbox}
-                aria-label="hardened password from user authentication types"
-                id="hardenedPassCheckbox"
-                name="ipauserauthtype"
-                value="hardened"
-                className="pf-u-mt-xs pf-u-mb-sm"
-              />
-              <Checkbox
-                label="External Identity Provider"
-                isChecked={extIdentityProvCheckbox}
-                aria-label="external identity provider from user authentication types"
-                id="extIdentityProvCheckbox"
-                name="ipauserauthtype"
-                value="idp"
-              />
-            </FormGroup>
-            <FormGroup
-              label="Radius proxy configuration"
-              fieldId="radius-proxy-configuration"
-            >
-              <Select
-                id="radius-proxy-configuration"
-                name="ipatokenradiusconfiglink"
-                variant={SelectVariant.single}
-                placeholderText=" "
-                aria-label="Select Input with descriptions"
-                onToggle={radiusConfOnToggle}
-                onSelect={radiusConfOnSelect}
-                selections={radiusConfSelected}
-                isOpen={isRadiusConfOpen}
-                aria-labelledby="radius-proxy-conf"
+              <FormGroup
+                label="Radius proxy configuration"
+                fieldId="radius-proxy-configuration"
               >
-                {radiusConfOptions.map((option, index) => (
-                  <SelectOption key={index} value={option.cn} />
-                ))}
-              </Select>
-            </FormGroup>
-            <FormGroup
-              label="Radius proxy username"
-              fieldId="radius-proxy-username"
+                <Select
+                  id="radius-proxy-configuration"
+                  name="ipatokenradiusconfiglink"
+                  variant={SelectVariant.single}
+                  placeholderText=" "
+                  aria-label="Select Input with descriptions"
+                  onToggle={radiusConfOnToggle}
+                  onSelect={radiusConfOnSelect}
+                  selections={radiusConfSelected}
+                  isOpen={isRadiusConfOpen}
+                  aria-labelledby="radius-proxy-conf"
+                >
+                  {radiusConfOptions.map((option, index) => (
+                    <SelectOption key={index} value={option.cn} />
+                  ))}
+                </Select>
+              </FormGroup>
+            </FieldWrapper>
+
+            <FieldWrapper
+              isWritable={isFieldWritable(
+                props.attrLevelRights.ipatokenradiususername
+              )}
+              isReadable={isFieldReadable(
+                props.attrLevelRights.ipatokenradiususername
+              )}
             >
-              <TextInput
-                id="radius-proxy-username"
-                name="ipatokenradiususername"
-                value={radiusUsername}
-                type="text"
-                onChange={radiusUsernameInputHandler}
-                aria-label="radius proxy username"
-              />
-            </FormGroup>
-            <FormGroup
-              label="External IdP configuration"
-              fieldId="external-idp-configuration"
-            >
-              <Select
-                id="external-idp-configuration"
-                name="ipaidpconfiglink"
-                variant={SelectVariant.single}
-                placeholderText=" "
-                aria-label="Select Input with descriptions"
-                onToggle={idpConfOnToggle}
-                onSelect={idpConfOnSelect}
-                selections={idpConfSelected}
-                isOpen={isIdpConfOpen}
-                aria-labelledby="external-idp-conf"
+              <FormGroup
+                label="Radius proxy username"
+                fieldId="radius-proxy-username"
               >
-                {idpConfOptions.map((option, index) => (
-                  <SelectOption key={index} value={option} />
-                ))}
-              </Select>
-            </FormGroup>
-            <FormGroup
-              label="External IdP user identifier"
-              fieldId="external-idp-user-identifier"
+                <TextInput
+                  id="radius-proxy-username"
+                  name="ipatokenradiususername"
+                  value={radiusUsername}
+                  type="text"
+                  onChange={radiusUsernameInputHandler}
+                  aria-label="radius proxy username"
+                />
+              </FormGroup>
+            </FieldWrapper>
+
+            <FieldWrapper
+              isWritable={isFieldWritable(
+                props.attrLevelRights.ipaidpconfiglink
+              )}
+              isReadable={isFieldReadable(
+                props.attrLevelRights.ipaidpconfiglink
+              )}
             >
-              <TextInput
-                id="external-idp-user-identifier"
-                name="ipaidpsub"
-                value={idpIdentifier}
-                type="text"
-                onChange={idpIdentifierInputHandler}
-                aria-label="idp user identifier"
-              />
-            </FormGroup>
+              <FormGroup
+                label="External IdP configuration"
+                fieldId="external-idp-configuration"
+              >
+                <Select
+                  id="external-idp-configuration"
+                  name="ipaidpconfiglink"
+                  variant={SelectVariant.single}
+                  placeholderText=" "
+                  aria-label="Select Input with descriptions"
+                  onToggle={idpConfOnToggle}
+                  onSelect={idpConfOnSelect}
+                  selections={idpConfSelected}
+                  isOpen={isIdpConfOpen}
+                  aria-labelledby="external-idp-conf"
+                >
+                  {idpConfOptions.map((option, index) => (
+                    <SelectOption key={index} value={option} />
+                  ))}
+                </Select>
+              </FormGroup>
+            </FieldWrapper>
+
+            <FieldWrapper
+              isWritable={isFieldWritable(props.attrLevelRights.ipaidpsub)}
+              isReadable={isFieldReadable(props.attrLevelRights.ipaidpsub)}
+            >
+              <FormGroup
+                label="External IdP user identifier"
+                fieldId="external-idp-user-identifier"
+              >
+                <TextInput
+                  id="external-idp-user-identifier"
+                  name="ipaidpsub"
+                  value={idpIdentifier}
+                  type="text"
+                  onChange={idpIdentifierInputHandler}
+                  aria-label="idp user identifier"
+                />
+              </FormGroup>
+            </FieldWrapper>
           </Form>
         </FlexItem>
       </Flex>
+
       <ModalWithTextAreaLayout
         value={textAreaSshPublicKeysValue}
         onChange={onChangeTextAreaSshPublicKeysValue}

--- a/src/components/UsersSections/UsersAttributesSMB.tsx
+++ b/src/components/UsersSections/UsersAttributesSMB.tsx
@@ -15,9 +15,13 @@ import {
 import PopoverWithIconLayout from "../layouts/PopoverWithIconLayout";
 // Data types
 import { User } from "src/utils/datatypes/globalDataTypes";
+// Utils
+import { isFieldReadable, isFieldWritable } from "src/utils/utils";
+import FieldWrapper from "src/utils/FieldWrapper";
 
 interface PropsToUsersAttributesSMB {
   userData: any;
+  attrLevelRights: any;
 }
 
 const UsersAttributesSMB = (props: PropsToUsersAttributesSMB) => {
@@ -119,90 +123,120 @@ const UsersAttributesSMB = (props: PropsToUsersAttributesSMB) => {
     <Flex direction={{ default: "column", md: "row" }}>
       <FlexItem flex={{ default: "flex_1" }}>
         <Form className="pf-u-mb-lg">
-          <FormGroup
-            label="SMB logon script path"
-            fieldId="smb-logon-script-path"
-            labelIcon={
-              <PopoverWithIconLayout message={SBMLogonScriptPathMessage} />
-            }
+          <FieldWrapper
+            isWritable={isFieldWritable(props.attrLevelRights.ipantlogonscript)}
+            isReadable={isFieldReadable(props.attrLevelRights.ipantlogonscript)}
           >
-            <TextInput
-              id="smb-logon-script-path"
-              name="ipantlogonscript"
-              value={SMBLogonScriptPath}
-              type="text"
-              aria-label="smb logon script path"
-              onChange={onChangeSMBLogonScriptPath}
-            />
-          </FormGroup>
-          <FormGroup
-            label="SMB profile path"
-            fieldId="smb-profile-path"
-            labelIcon={
-              <PopoverWithIconLayout message={SMBProfilePathMessage} />
-            }
+            <FormGroup
+              label="SMB logon script path"
+              fieldId="smb-logon-script-path"
+              labelIcon={
+                <PopoverWithIconLayout message={SBMLogonScriptPathMessage} />
+              }
+            >
+              <TextInput
+                id="smb-logon-script-path"
+                name="ipantlogonscript"
+                value={SMBLogonScriptPath}
+                type="text"
+                aria-label="smb logon script path"
+                onChange={onChangeSMBLogonScriptPath}
+              />
+            </FormGroup>
+          </FieldWrapper>
+
+          <FieldWrapper
+            isWritable={isFieldWritable(props.attrLevelRights.ipantprofilepath)}
+            isReadable={isFieldReadable(props.attrLevelRights.ipantprofilepath)}
           >
-            <TextInput
-              id="smb-profile-path"
-              name="ipantprofilepath"
-              value={SMBProfilePath}
-              type="text"
-              aria-label="smb profile path"
-              onChange={onChangeSMBProfilePath}
-            />
-          </FormGroup>
+            <FormGroup
+              label="SMB profile path"
+              fieldId="smb-profile-path"
+              labelIcon={
+                <PopoverWithIconLayout message={SMBProfilePathMessage} />
+              }
+            >
+              <TextInput
+                id="smb-profile-path"
+                name="ipantprofilepath"
+                value={SMBProfilePath}
+                type="text"
+                aria-label="smb profile path"
+                onChange={onChangeSMBProfilePath}
+              />
+            </FormGroup>
+          </FieldWrapper>
         </Form>
       </FlexItem>
       <FlexItem flex={{ default: "flex_1" }}>
         <Form className="pf-u-mb-lg">
-          <FormGroup
-            label="SMB home directory"
-            fieldId="smb-home-directory"
-            labelIcon={
-              <PopoverWithIconLayout
-                message={SMBHomeDirectoryMessage}
-                hasAutoWidth={true}
-              />
-            }
+          <FieldWrapper
+            isWritable={isFieldWritable(
+              props.attrLevelRights.ipanthomedirectory
+            )}
+            isReadable={isFieldReadable(
+              props.attrLevelRights.ipanthomedirectory
+            )}
           >
-            <TextInput
-              id="smb-home-directory"
-              name="ipanthomedirectory"
-              value={SMBHomeDirectory}
-              type="text"
-              aria-label="smb home directory"
-              onChange={onChangeSMBHomeDirectory}
-            />
-          </FormGroup>
-          <FormGroup
-            label="SMB home directory drive"
-            fieldId="smb-home-directory-drive"
-            labelIcon={
-              <PopoverWithIconLayout
-                message={SMBHomeDirectoryDriveMessage}
-                hasAutoWidth={true}
-              />
-            }
-          >
-            <Select
-              id="smb-home-directory-drive"
-              name="ipanthomedirectorydrive"
-              variant={SelectVariant.single}
-              direction={"up"}
-              placeholderText=" "
-              aria-label="Select samba home directory drive"
-              onToggle={SMBHomeDirectoryDriveOnToggle}
-              onSelect={SMBHomeDirectoryDriveOnSelect}
-              selections={SMBHomeDirectoryDriveSelected}
-              isOpen={isSMBHomeDirectoryDriveOpen}
-              aria-labelledby="smb-directory-drive"
-              maxHeight="280px"
+            <FormGroup
+              label="SMB home directory"
+              fieldId="smb-home-directory"
+              labelIcon={
+                <PopoverWithIconLayout
+                  message={SMBHomeDirectoryMessage}
+                  hasAutoWidth={true}
+                />
+              }
             >
-              {SMBHomeDirectoryDriveOptions.map((option, index) => (
-                <SelectOption key={index} value={option} />
-              ))}
-            </Select>
-          </FormGroup>
+              <TextInput
+                id="smb-home-directory"
+                name="ipanthomedirectory"
+                value={SMBHomeDirectory}
+                type="text"
+                aria-label="smb home directory"
+                onChange={onChangeSMBHomeDirectory}
+              />
+            </FormGroup>
+          </FieldWrapper>
+
+          <FieldWrapper
+            isWritable={isFieldWritable(
+              props.attrLevelRights.ipanthomedirectorydrive
+            )}
+            isReadable={isFieldReadable(
+              props.attrLevelRights.ipanthomedirectorydrive
+            )}
+          >
+            <FormGroup
+              label="SMB home directory drive"
+              fieldId="smb-home-directory-drive"
+              labelIcon={
+                <PopoverWithIconLayout
+                  message={SMBHomeDirectoryDriveMessage}
+                  hasAutoWidth={true}
+                />
+              }
+            >
+              <Select
+                id="smb-home-directory-drive"
+                name="ipanthomedirectorydrive"
+                variant={SelectVariant.single}
+                direction={"up"}
+                placeholderText=" "
+                aria-label="Select samba home directory drive"
+                onToggle={SMBHomeDirectoryDriveOnToggle}
+                onSelect={SMBHomeDirectoryDriveOnSelect}
+                selections={SMBHomeDirectoryDriveSelected}
+                isOpen={isSMBHomeDirectoryDriveOpen}
+                aria-labelledby="smb-directory-drive"
+                maxHeight="280px"
+              >
+                {SMBHomeDirectoryDriveOptions.map((option, index) => (
+                  <SelectOption key={index} value={option} />
+                ))}
+              </Select>
+            </FormGroup>
+          </FieldWrapper>
         </Form>
       </FlexItem>
     </Flex>

--- a/src/components/UsersSections/UsersAttributesSMB.tsx
+++ b/src/components/UsersSections/UsersAttributesSMB.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React, { useEffect, useState } from "react";
 // PatternFly
 import {
   SelectVariant,
@@ -12,12 +13,37 @@ import {
 } from "@patternfly/react-core";
 // Layout
 import PopoverWithIconLayout from "../layouts/PopoverWithIconLayout";
+// Data types
+import { User } from "src/utils/datatypes/globalDataTypes";
 
-const UsersAttributesSMB = () => {
+interface PropsToUsersAttributesSMB {
+  userData: any;
+}
+
+const UsersAttributesSMB = (props: PropsToUsersAttributesSMB) => {
   // TODO: This state variables should update the user data via the IPA API
   const [SMBLogonScriptPath, setSMBLogonScriptPath] = useState("");
   const [SMBProfilePath, setSMBProfilePath] = useState("");
   const [SMBHomeDirectory, setSMBHomeDirectory] = useState("");
+
+  // Updates data on 'userData' changes
+  useEffect(() => {
+    if (props.userData !== undefined) {
+      const userData = props.userData as User;
+      if (userData.ipantlogonscript !== undefined) {
+        setSMBLogonScriptPath(userData.ipantlogonscript);
+      }
+      if (userData.ipantprofilepath !== undefined) {
+        setSMBProfilePath(userData.ipantprofilepath);
+      }
+      if (userData.ipanthomedirectory !== undefined) {
+        setSMBHomeDirectory(userData.ipanthomedirectory);
+      }
+      if (userData.ipanthomedirectorydrive !== undefined) {
+        setSMBHomeDirectoryDriveSelected(userData.ipanthomedirectorydrive);
+      }
+    }
+  }, [props.userData]);
 
   const onChangeSMBLogonScriptPath = (value: string) => {
     setSMBLogonScriptPath(value);
@@ -49,32 +75,33 @@ const UsersAttributesSMB = () => {
   const [SMBHomeDirectoryDriveSelected, setSMBHomeDirectoryDriveSelected] =
     useState("");
   const SMBHomeDirectoryDriveOptions = [
-    { value: "A:", disabled: false },
-    { value: "B:", disabled: false },
-    { value: "C:", disabled: false },
-    { value: "D:", disabled: false },
-    { value: "E:", disabled: false },
-    { value: "F:", disabled: false },
-    { value: "G:", disabled: false },
-    { value: "H:", disabled: false },
-    { value: "I:", disabled: false },
-    { value: "J:", disabled: false },
-    { value: "K:", disabled: false },
-    { value: "L:", disabled: false },
-    { value: "M:", disabled: false },
-    { value: "N:", disabled: false },
-    { value: "O:", disabled: false },
-    { value: "P:", disabled: false },
-    { value: "Q:", disabled: false },
-    { value: "R:", disabled: false },
-    { value: "S:", disabled: false },
-    { value: "T:", disabled: false },
-    { value: "U:", disabled: false },
-    { value: "V:", disabled: false },
-    { value: "W:", disabled: false },
-    { value: "X:", disabled: false },
-    { value: "Y:", disabled: false },
-    { value: "Z:", disabled: false },
+    "",
+    "A:",
+    "B:",
+    "C:",
+    "D:",
+    "E:",
+    "F:",
+    "G:",
+    "H:",
+    "I:",
+    "J:",
+    "K:",
+    "L:",
+    "M:",
+    "N:",
+    "O:",
+    "P:",
+    "Q:",
+    "R:",
+    "S:",
+    "T:",
+    "U:",
+    "V:",
+    "W:",
+    "X:",
+    "Y:",
+    "Z:",
   ];
   const SMBHomeDirectoryDriveOnToggle = (isOpen: boolean) => {
     setIsSMBHomeDirectoryDriveOpen(isOpen);
@@ -172,11 +199,7 @@ const UsersAttributesSMB = () => {
               maxHeight="280px"
             >
               {SMBHomeDirectoryDriveOptions.map((option, index) => (
-                <SelectOption
-                  isDisabled={option.disabled}
-                  key={index}
-                  value={option.value}
-                />
+                <SelectOption key={index} value={option} />
               ))}
             </Select>
           </FormGroup>

--- a/src/components/UsersSections/UsersContactSettings.tsx
+++ b/src/components/UsersSections/UsersContactSettings.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React, { useEffect, useState } from "react";
 // PatternFly
 import {
   Flex,
@@ -13,49 +14,39 @@ import { User } from "src/utils/datatypes/globalDataTypes";
 import SecondaryButton from "src/components/layouts/SecondaryButton";
 
 interface PropsToUsersContactSettings {
-  user: User;
-}
-
-interface EmailData {
-  id: number | string;
-  email: string;
-}
-
-interface TelephoneData {
-  id: number | string;
-  telephone: string;
-}
-
-interface PagerData {
-  id: number | string;
-  pager: string;
-}
-
-interface MobilePhoneData {
-  id: number | string;
-  mobile: string;
-}
-
-interface FaxData {
-  id: number | string;
-  fax: string;
+  userData: any;
 }
 
 const UsersContactSettings = (props: PropsToUsersContactSettings) => {
   // TODO: This state variables should update the user data via the IPA API (`user_mod`)
-  const [emailList, setEmailList] = useState<EmailData[]>([
-    { id: 0, email: props.user.mail[0] },
-  ]);
-  const [telephoneList, setTelephoneList] = useState<TelephoneData[]>([]);
-  const [pagerList, setPagerList] = useState<PagerData[]>([]);
-  const [mobilePhoneList, setMobilePhoneList] = useState<MobilePhoneData[]>([]);
-  const [faxList, setFaxList] = useState<FaxData[]>([]);
+  const [emailList, setEmailList] = useState<string[]>([]);
+  const [telephoneList, setTelephoneList] = useState<string[]>([]);
+  const [pagerList, setPagerList] = useState<string[]>([]);
+  const [mobilePhoneList, setMobilePhoneList] = useState<string[]>([]);
+  const [faxList, setFaxList] = useState<string[]>([]);
+
+  // Updates data on 'userData' changes
+  useEffect(() => {
+    if (props.userData !== undefined) {
+      const userData = props.userData as User;
+
+      if (userData.mail !== undefined) setEmailList(userData.mail);
+      if (userData.telephonenumber !== undefined) {
+        setTelephoneList(userData.telephonenumber);
+      }
+      if (userData.pager !== undefined) setPagerList(userData.pager);
+      if (userData.mobile !== undefined) setMobilePhoneList(userData.mobile);
+      if (userData.facsimiletelephonenumber !== undefined) {
+        setFaxList(userData.facsimiletelephonenumber);
+      }
+    }
+  }, [props.userData]);
 
   // Email
   // - 'Add email field' handler
   const onAddEmailFieldHandler = () => {
     const emailListCopy = [...emailList];
-    emailListCopy.push({ id: Date.now.toString(), email: "" });
+    emailListCopy.push("");
     setEmailList(emailListCopy);
   };
 
@@ -66,7 +57,7 @@ const UsersContactSettings = (props: PropsToUsersContactSettings) => {
     idx: number
   ) => {
     const emailListCopy = [...emailList];
-    emailListCopy[idx]["email"] = (event.target as HTMLInputElement).value;
+    emailListCopy[idx] = (event.target as HTMLInputElement).value;
     setEmailList(emailListCopy);
   };
 
@@ -81,7 +72,7 @@ const UsersContactSettings = (props: PropsToUsersContactSettings) => {
   // - 'Add telephone number' handler
   const onAddTelephoneFieldHandler = () => {
     const telephoneListCopy = [...telephoneList];
-    telephoneListCopy.push({ id: Date.now.toString(), telephone: "" });
+    telephoneListCopy.push("");
     setTelephoneList(telephoneListCopy);
   };
 
@@ -109,7 +100,7 @@ const UsersContactSettings = (props: PropsToUsersContactSettings) => {
   // - 'Add pager number' handler
   const onAddPagerFieldHandler = () => {
     const pagerListCopy = [...pagerList];
-    pagerListCopy.push({ id: Date.now.toString(), pager: "" });
+    pagerListCopy.push("");
     setPagerList(pagerListCopy);
   };
 
@@ -135,7 +126,7 @@ const UsersContactSettings = (props: PropsToUsersContactSettings) => {
   // - 'Add mobile phone' handler
   const onAddMobilePhoneFieldHandler = () => {
     const mobilePhoneListCopy = [...mobilePhoneList];
-    mobilePhoneListCopy.push({ id: Date.now.toString(), mobile: "" });
+    mobilePhoneListCopy.push("");
     setMobilePhoneList(mobilePhoneListCopy);
   };
 
@@ -163,7 +154,7 @@ const UsersContactSettings = (props: PropsToUsersContactSettings) => {
   // - 'Add fax' handler
   const onAddFaxFieldHandler = () => {
     const faxListCopy = [...faxList];
-    faxListCopy.push({ id: Date.now.toString(), fax: "" });
+    faxListCopy.push("");
     setFaxList(faxListCopy);
   };
 
@@ -194,16 +185,16 @@ const UsersContactSettings = (props: PropsToUsersContactSettings) => {
               {emailList.map((userEmail, idx) => (
                 <Flex
                   direction={{ default: "row" }}
-                  key={userEmail.id + "-" + idx + "-div"}
+                  key={"mail-" + idx + "-div"}
                   name="value"
                 >
                   <FlexItem
-                    key={userEmail.id + "-textbox"}
+                    key={"mail-" + idx + "-textbox"}
                     flex={{ default: "flex_1" }}
                   >
                     <TextInput
                       id="user-email"
-                      value={userEmail.email}
+                      value={userEmail}
                       type="email"
                       name={"mail-" + idx}
                       aria-label="user email"
@@ -212,7 +203,7 @@ const UsersContactSettings = (props: PropsToUsersContactSettings) => {
                       }
                     />
                   </FlexItem>
-                  <FlexItem key={userEmail.id + "-delete-button"}>
+                  <FlexItem key={"mail-" + idx + "-delete-button"}>
                     <SecondaryButton
                       name="remove"
                       onClickHandler={() => onRemoveEmailHandler(idx)}
@@ -233,37 +224,38 @@ const UsersContactSettings = (props: PropsToUsersContactSettings) => {
           </FormGroup>
           <FormGroup label="Telephone number" fieldId="telephone-number">
             <Flex direction={{ default: "column" }} name="telephonenumber">
-              {telephoneList.map((userTelephone, idx) => (
-                <Flex
-                  direction={{ default: "row" }}
-                  key={userTelephone.id + "-" + idx + "-div"}
-                  name="value"
-                >
-                  <FlexItem
-                    key={userTelephone.id + "-textbox"}
-                    flex={{ default: "flex_1" }}
+              {telephoneList !== undefined &&
+                telephoneList.map((userTelephone, idx) => (
+                  <Flex
+                    direction={{ default: "row" }}
+                    key={"telephonenumber-" + idx + "-div"}
+                    name="value"
                   >
-                    <TextInput
-                      id="user-telephone"
-                      value={userTelephone.telephone}
-                      type="tel"
-                      name={"telephonenumber-" + idx}
-                      aria-label="user telephone"
-                      onChange={(value, event) =>
-                        onHandleTelephoneChange(value, event, idx)
-                      }
-                    />
-                  </FlexItem>
-                  <FlexItem key={userTelephone.id + "-delete-button"}>
-                    <SecondaryButton
-                      name="remove"
-                      onClickHandler={() => onRemoveTelephoneHandler(idx)}
+                    <FlexItem
+                      key={"telephonenumber-" + idx + "-textbox"}
+                      flex={{ default: "flex_1" }}
                     >
-                      Delete
-                    </SecondaryButton>
-                  </FlexItem>
-                </Flex>
-              ))}
+                      <TextInput
+                        id="user-telephone"
+                        value={userTelephone}
+                        type="tel"
+                        name={"telephonenumber-" + idx}
+                        aria-label="user telephone"
+                        onChange={(value, event) =>
+                          onHandleTelephoneChange(value, event, idx)
+                        }
+                      />
+                    </FlexItem>
+                    <FlexItem key={"telephonenumber-" + idx + "-delete-button"}>
+                      <SecondaryButton
+                        name="remove"
+                        onClickHandler={() => onRemoveTelephoneHandler(idx)}
+                      >
+                        Delete
+                      </SecondaryButton>
+                    </FlexItem>
+                  </Flex>
+                ))}
             </Flex>
             <SecondaryButton
               classname="pf-u-mt-sm"
@@ -275,37 +267,38 @@ const UsersContactSettings = (props: PropsToUsersContactSettings) => {
           </FormGroup>
           <FormGroup label="Pager number" fieldId="pager-number">
             <Flex direction={{ default: "column" }} name="pager">
-              {pagerList.map((userPager, idx) => (
-                <Flex
-                  direction={{ default: "row" }}
-                  key={userPager.id + "-" + idx + "-div"}
-                  name="value"
-                >
-                  <FlexItem
-                    key={userPager.id + "-textbox"}
-                    flex={{ default: "flex_1" }}
+              {pagerList !== undefined &&
+                pagerList.map((userPager, idx) => (
+                  <Flex
+                    direction={{ default: "row" }}
+                    key={"pager-" + idx + "-div"}
+                    name="value"
                   >
-                    <TextInput
-                      id="user-pager"
-                      value={userPager.pager}
-                      type="text"
-                      name={"pager-" + idx}
-                      aria-label="user pager"
-                      onChange={(value, event) =>
-                        onHandlePagerChange(value, event, idx)
-                      }
-                    />
-                  </FlexItem>
-                  <FlexItem key={userPager.id + "-delete-button"}>
-                    <SecondaryButton
-                      name="remove"
-                      onClickHandler={() => onRemovePagerHandler(idx)}
+                    <FlexItem
+                      key={"pager-" + idx + "-textbox"}
+                      flex={{ default: "flex_1" }}
                     >
-                      Delete
-                    </SecondaryButton>
-                  </FlexItem>
-                </Flex>
-              ))}
+                      <TextInput
+                        id="user-pager"
+                        value={userPager}
+                        type="text"
+                        name={"pager-" + idx}
+                        aria-label="user pager"
+                        onChange={(value, event) =>
+                          onHandlePagerChange(value, event, idx)
+                        }
+                      />
+                    </FlexItem>
+                    <FlexItem key={"pager-" + idx + "-delete-button"}>
+                      <SecondaryButton
+                        name="remove"
+                        onClickHandler={() => onRemovePagerHandler(idx)}
+                      >
+                        Delete
+                      </SecondaryButton>
+                    </FlexItem>
+                  </Flex>
+                ))}
             </Flex>
             <SecondaryButton
               classname="pf-u-mt-sm"
@@ -321,37 +314,38 @@ const UsersContactSettings = (props: PropsToUsersContactSettings) => {
         <Form className="pf-u-mb-lg">
           <FormGroup label="Mobile phone number" fieldId="mobile-phone-number">
             <Flex direction={{ default: "column" }} name="mobile">
-              {mobilePhoneList.map((userMobilePhone, idx) => (
-                <Flex
-                  direction={{ default: "row" }}
-                  key={userMobilePhone.id + "-" + idx + "-div"}
-                  name="value"
-                >
-                  <FlexItem
-                    key={userMobilePhone.id + "-textbox"}
-                    flex={{ default: "flex_1" }}
+              {mobilePhoneList !== undefined &&
+                mobilePhoneList.map((userMobilePhone, idx) => (
+                  <Flex
+                    direction={{ default: "row" }}
+                    key={"mobile-" + idx + "-div"}
+                    name="value"
                   >
-                    <TextInput
-                      id="user-mobile-phone"
-                      value={userMobilePhone.mobile}
-                      type="tel"
-                      name={"mobile-" + idx}
-                      aria-label="user mobile phone"
-                      onChange={(value, event) =>
-                        onHandleMobilePhoneChange(value, event, idx)
-                      }
-                    />
-                  </FlexItem>
-                  <FlexItem key={userMobilePhone.id + "-delete-button"}>
-                    <SecondaryButton
-                      name="remove"
-                      onClickHandler={() => onRemoveMobilePhoneHandler(idx)}
+                    <FlexItem
+                      key={"mobile-" + idx + "-textbox"}
+                      flex={{ default: "flex_1" }}
                     >
-                      Delete
-                    </SecondaryButton>
-                  </FlexItem>
-                </Flex>
-              ))}
+                      <TextInput
+                        id="user-mobile-phone"
+                        value={userMobilePhone}
+                        type="tel"
+                        name={"mobile-" + idx}
+                        aria-label="user mobile phone"
+                        onChange={(value, event) =>
+                          onHandleMobilePhoneChange(value, event, idx)
+                        }
+                      />
+                    </FlexItem>
+                    <FlexItem key={"mobile-" + idx + "-delete-button"}>
+                      <SecondaryButton
+                        name="remove"
+                        onClickHandler={() => onRemoveMobilePhoneHandler(idx)}
+                      >
+                        Delete
+                      </SecondaryButton>
+                    </FlexItem>
+                  </Flex>
+                ))}
             </Flex>
             <SecondaryButton
               classname="pf-u-mt-sm"
@@ -366,37 +360,40 @@ const UsersContactSettings = (props: PropsToUsersContactSettings) => {
               direction={{ default: "column" }}
               name="facsimiletelephonenumber"
             >
-              {faxList.map((userFax, idx) => (
-                <Flex
-                  direction={{ default: "row" }}
-                  key={userFax.id + "-" + idx + "-div"}
-                  name="value"
-                >
-                  <FlexItem
-                    key={userFax.id + "-textbox"}
-                    flex={{ default: "flex_1" }}
+              {faxList !== undefined &&
+                faxList.map((userFax, idx) => (
+                  <Flex
+                    direction={{ default: "row" }}
+                    key={"facsimiletelephonenumber-" + idx + "-div"}
+                    name="value"
                   >
-                    <TextInput
-                      id="user-fax"
-                      value={userFax.fax}
-                      type="tel"
-                      name={"mobile-" + idx}
-                      aria-label="user fax"
-                      onChange={(value, event) =>
-                        onHandleFaxChange(value, event, idx)
-                      }
-                    />
-                  </FlexItem>
-                  <FlexItem key={userFax.id + "-delete-button"}>
-                    <SecondaryButton
-                      name="remove"
-                      onClickHandler={() => onRemoveFaxHandler(idx)}
+                    <FlexItem
+                      key={"facsimiletelephonenumber-" + idx + "-textbox"}
+                      flex={{ default: "flex_1" }}
                     >
-                      Delete
-                    </SecondaryButton>
-                  </FlexItem>
-                </Flex>
-              ))}
+                      <TextInput
+                        id="user-fax"
+                        value={userFax}
+                        type="tel"
+                        name={"facsimiletelephonenumber-" + idx}
+                        aria-label="user fax"
+                        onChange={(value, event) =>
+                          onHandleFaxChange(value, event, idx)
+                        }
+                      />
+                    </FlexItem>
+                    <FlexItem
+                      key={"facsimiletelephonenumber-" + idx + "-delete-button"}
+                    >
+                      <SecondaryButton
+                        name="remove"
+                        onClickHandler={() => onRemoveFaxHandler(idx)}
+                      >
+                        Delete
+                      </SecondaryButton>
+                    </FlexItem>
+                  </Flex>
+                ))}
             </Flex>
             <SecondaryButton
               classname="pf-u-mt-sm"

--- a/src/components/UsersSections/UsersContactSettings.tsx
+++ b/src/components/UsersSections/UsersContactSettings.tsx
@@ -12,9 +12,12 @@ import {
 import { User } from "src/utils/datatypes/globalDataTypes";
 // Layouts
 import SecondaryButton from "src/components/layouts/SecondaryButton";
+// Utils
+import { isFieldWritable } from "src/utils/utils";
 
 interface PropsToUsersContactSettings {
   userData: any;
+  attrLevelRights: any;
 }
 
 const UsersContactSettings = (props: PropsToUsersContactSettings) => {
@@ -201,27 +204,33 @@ const UsersContactSettings = (props: PropsToUsersContactSettings) => {
                       onChange={(value, event) =>
                         onHandleEmailChange(value, event, idx)
                       }
+                      isDisabled={!isFieldWritable(props.attrLevelRights.mail)}
                     />
                   </FlexItem>
-                  <FlexItem key={"mail-" + idx + "-delete-button"}>
-                    <SecondaryButton
-                      name="remove"
-                      onClickHandler={() => onRemoveEmailHandler(idx)}
-                    >
-                      Delete
-                    </SecondaryButton>
-                  </FlexItem>
+                  {isFieldWritable(props.attrLevelRights.mail) && (
+                    <FlexItem key={"mail-" + idx + "-delete-button"}>
+                      <SecondaryButton
+                        name="remove"
+                        onClickHandler={() => onRemoveEmailHandler(idx)}
+                      >
+                        Delete
+                      </SecondaryButton>
+                    </FlexItem>
+                  )}
                 </Flex>
               ))}
             </Flex>
-            <SecondaryButton
-              classname="pf-u-mt-sm"
-              name="add"
-              onClickHandler={onAddEmailFieldHandler}
-            >
-              Add
-            </SecondaryButton>
+            {isFieldWritable(props.attrLevelRights.mail) && (
+              <SecondaryButton
+                classname="pf-u-mt-sm"
+                name="add"
+                onClickHandler={onAddEmailFieldHandler}
+              >
+                Add
+              </SecondaryButton>
+            )}
           </FormGroup>
+
           <FormGroup label="Telephone number" fieldId="telephone-number">
             <Flex direction={{ default: "column" }} name="telephonenumber">
               {telephoneList !== undefined &&
@@ -244,27 +253,39 @@ const UsersContactSettings = (props: PropsToUsersContactSettings) => {
                         onChange={(value, event) =>
                           onHandleTelephoneChange(value, event, idx)
                         }
+                        isDisabled={
+                          !isFieldWritable(
+                            props.attrLevelRights.telephonenumber
+                          )
+                        }
                       />
                     </FlexItem>
-                    <FlexItem key={"telephonenumber-" + idx + "-delete-button"}>
-                      <SecondaryButton
-                        name="remove"
-                        onClickHandler={() => onRemoveTelephoneHandler(idx)}
+                    {isFieldWritable(props.attrLevelRights.telephonenumber) && (
+                      <FlexItem
+                        key={"telephonenumber-" + idx + "-delete-button"}
                       >
-                        Delete
-                      </SecondaryButton>
-                    </FlexItem>
+                        <SecondaryButton
+                          name="remove"
+                          onClickHandler={() => onRemoveTelephoneHandler(idx)}
+                        >
+                          Delete
+                        </SecondaryButton>
+                      </FlexItem>
+                    )}
                   </Flex>
                 ))}
             </Flex>
-            <SecondaryButton
-              classname="pf-u-mt-sm"
-              name="add"
-              onClickHandler={onAddTelephoneFieldHandler}
-            >
-              Add
-            </SecondaryButton>
+            {isFieldWritable(props.attrLevelRights.telephonenumber) && (
+              <SecondaryButton
+                classname="pf-u-mt-sm"
+                name="add"
+                onClickHandler={onAddTelephoneFieldHandler}
+              >
+                Add
+              </SecondaryButton>
+            )}
           </FormGroup>
+
           <FormGroup label="Pager number" fieldId="pager-number">
             <Flex direction={{ default: "column" }} name="pager">
               {pagerList !== undefined &&
@@ -287,26 +308,33 @@ const UsersContactSettings = (props: PropsToUsersContactSettings) => {
                         onChange={(value, event) =>
                           onHandlePagerChange(value, event, idx)
                         }
+                        isDisabled={
+                          !isFieldWritable(props.attrLevelRights.pager)
+                        }
                       />
                     </FlexItem>
-                    <FlexItem key={"pager-" + idx + "-delete-button"}>
-                      <SecondaryButton
-                        name="remove"
-                        onClickHandler={() => onRemovePagerHandler(idx)}
-                      >
-                        Delete
-                      </SecondaryButton>
-                    </FlexItem>
+                    {isFieldWritable(props.attrLevelRights.pager) && (
+                      <FlexItem key={"pager-" + idx + "-delete-button"}>
+                        <SecondaryButton
+                          name="remove"
+                          onClickHandler={() => onRemovePagerHandler(idx)}
+                        >
+                          Delete
+                        </SecondaryButton>
+                      </FlexItem>
+                    )}
                   </Flex>
                 ))}
             </Flex>
-            <SecondaryButton
-              classname="pf-u-mt-sm"
-              name="add"
-              onClickHandler={onAddPagerFieldHandler}
-            >
-              Add
-            </SecondaryButton>
+            {isFieldWritable(props.attrLevelRights.pager) && (
+              <SecondaryButton
+                classname="pf-u-mt-sm"
+                name="add"
+                onClickHandler={onAddPagerFieldHandler}
+              >
+                Add
+              </SecondaryButton>
+            )}
           </FormGroup>
         </Form>
       </FlexItem>
@@ -334,26 +362,33 @@ const UsersContactSettings = (props: PropsToUsersContactSettings) => {
                         onChange={(value, event) =>
                           onHandleMobilePhoneChange(value, event, idx)
                         }
+                        isDisabled={
+                          !isFieldWritable(props.attrLevelRights.mobile)
+                        }
                       />
                     </FlexItem>
-                    <FlexItem key={"mobile-" + idx + "-delete-button"}>
-                      <SecondaryButton
-                        name="remove"
-                        onClickHandler={() => onRemoveMobilePhoneHandler(idx)}
-                      >
-                        Delete
-                      </SecondaryButton>
-                    </FlexItem>
+                    {isFieldWritable(props.attrLevelRights.mobile) && (
+                      <FlexItem key={"mobile-" + idx + "-delete-button"}>
+                        <SecondaryButton
+                          name="remove"
+                          onClickHandler={() => onRemoveMobilePhoneHandler(idx)}
+                        >
+                          Delete
+                        </SecondaryButton>
+                      </FlexItem>
+                    )}
                   </Flex>
                 ))}
             </Flex>
-            <SecondaryButton
-              classname="pf-u-mt-sm"
-              name="add"
-              onClickHandler={onAddMobilePhoneFieldHandler}
-            >
-              Add
-            </SecondaryButton>
+            {isFieldWritable(props.attrLevelRights.mobile) && (
+              <SecondaryButton
+                classname="pf-u-mt-sm"
+                name="add"
+                onClickHandler={onAddMobilePhoneFieldHandler}
+              >
+                Add
+              </SecondaryButton>
+            )}
           </FormGroup>
           <FormGroup label="Fax number" fieldId="fax-number">
             <Flex
@@ -380,28 +415,43 @@ const UsersContactSettings = (props: PropsToUsersContactSettings) => {
                         onChange={(value, event) =>
                           onHandleFaxChange(value, event, idx)
                         }
+                        isDisabled={
+                          !isFieldWritable(
+                            props.attrLevelRights.facsimiletelephonenumber
+                          )
+                        }
                       />
                     </FlexItem>
-                    <FlexItem
-                      key={"facsimiletelephonenumber-" + idx + "-delete-button"}
-                    >
-                      <SecondaryButton
-                        name="remove"
-                        onClickHandler={() => onRemoveFaxHandler(idx)}
+                    {isFieldWritable(
+                      props.attrLevelRights.facsimiletelephonenumber
+                    ) && (
+                      <FlexItem
+                        key={
+                          "facsimiletelephonenumber-" + idx + "-delete-button"
+                        }
                       >
-                        Delete
-                      </SecondaryButton>
-                    </FlexItem>
+                        <SecondaryButton
+                          name="remove"
+                          onClickHandler={() => onRemoveFaxHandler(idx)}
+                        >
+                          Delete
+                        </SecondaryButton>
+                      </FlexItem>
+                    )}
                   </Flex>
                 ))}
             </Flex>
-            <SecondaryButton
-              classname="pf-u-mt-sm"
-              name="add"
-              onClickHandler={onAddFaxFieldHandler}
-            >
-              Add
-            </SecondaryButton>
+            {isFieldWritable(
+              props.attrLevelRights.facsimiletelephonenumber
+            ) && (
+              <SecondaryButton
+                classname="pf-u-mt-sm"
+                name="add"
+                onClickHandler={onAddFaxFieldHandler}
+              >
+                Add
+              </SecondaryButton>
+            )}
           </FormGroup>
         </Form>
       </FlexItem>

--- a/src/components/UsersSections/UsersEmployeeInfo.tsx
+++ b/src/components/UsersSections/UsersEmployeeInfo.tsx
@@ -15,10 +15,14 @@ import {
 import SecondaryButton from "../layouts/SecondaryButton";
 // Data types
 import { User } from "src/utils/datatypes/globalDataTypes";
+// Utils
+import { isFieldReadable, isFieldWritable } from "src/utils/utils";
+import FieldWrapper from "src/utils/FieldWrapper";
 
 interface PropsToEmployeeData {
   uidsData: any;
   userData: any;
+  attrLevelRights: any;
 }
 
 const UsersEmployeeInfo = (props: PropsToEmployeeData) => {
@@ -124,35 +128,45 @@ const UsersEmployeeInfo = (props: PropsToEmployeeData) => {
     <Flex direction={{ default: "column", md: "row" }}>
       <FlexItem flex={{ default: "flex_1" }}>
         <Form className="pf-u-mb-lg">
-          <FormGroup label="Org. unit" fieldId="org-unit">
-            <TextInput
-              id="org-unit"
-              name="ou"
-              value={orgUnit}
-              type="text"
-              aria-label="organization unit"
-              onChange={onChangeOrgUnit}
-            />
-          </FormGroup>
-          <FormGroup label="Manager" fieldId="manager">
-            <Select
-              id="manager"
-              name="manager"
-              variant={SelectVariant.single}
-              placeholderText=" "
-              aria-label="Select manager"
-              onToggle={managerOnToggle}
-              onSelect={managerOnSelect}
-              selections={managerSelected}
-              isOpen={isManagerOpen}
-              aria-labelledby="manager"
-              style={{ height: "186px", overflowY: "scroll" }}
-            >
-              {managerOptions.map((option, index) => (
-                <SelectOption key={index} value={option} />
-              ))}
-            </Select>
-          </FormGroup>
+          <FieldWrapper
+            isWritable={isFieldWritable(props.attrLevelRights.ou)}
+            isReadable={isFieldReadable(props.attrLevelRights.ou)}
+          >
+            <FormGroup label="Org. unit" fieldId="org-unit">
+              <TextInput
+                id="org-unit"
+                name="ou"
+                value={orgUnit}
+                type="text"
+                aria-label="organization unit"
+                onChange={onChangeOrgUnit}
+              />
+            </FormGroup>
+          </FieldWrapper>
+          <FieldWrapper
+            isWritable={isFieldWritable(props.attrLevelRights.manager)}
+            isReadable={isFieldReadable(props.attrLevelRights.manager)}
+          >
+            <FormGroup label="Manager" fieldId="manager">
+              <Select
+                id="manager"
+                name="manager"
+                variant={SelectVariant.single}
+                placeholderText=" "
+                aria-label="Select manager"
+                onToggle={managerOnToggle}
+                onSelect={managerOnSelect}
+                selections={managerSelected}
+                isOpen={isManagerOpen}
+                aria-labelledby="manager"
+                style={{ height: "186px", overflowY: "scroll" }}
+              >
+                {managerOptions.map((option, index) => (
+                  <SelectOption key={index} value={option} />
+                ))}
+              </Select>
+            </FormGroup>
+          </FieldWrapper>
           <FormGroup label="Department number" fieldId="department-number">
             <Flex direction={{ default: "column" }} name="departmentnumber">
               {departmentNumberList.map((departmentNumber, idx) => (
@@ -174,65 +188,93 @@ const UsersEmployeeInfo = (props: PropsToEmployeeData) => {
                       onChange={(value, event) =>
                         onHandleDepartmentNumberChange(value, event, idx)
                       }
+                      isDisabled={
+                        !isFieldWritable(props.attrLevelRights.departmentnumber)
+                      }
                     />
                   </FlexItem>
                   <FlexItem
                     key={departmentNumber + "-" + idx + "-delete-button"}
                   >
-                    <SecondaryButton
-                      name="remove"
-                      onClickHandler={() =>
-                        onRemoveDepartmentNumberHandler(idx)
-                      }
-                    >
-                      Delete
-                    </SecondaryButton>
+                    {isFieldWritable(
+                      props.attrLevelRights.departmentnumber
+                    ) && (
+                      <SecondaryButton
+                        name="remove"
+                        onClickHandler={() =>
+                          onRemoveDepartmentNumberHandler(idx)
+                        }
+                      >
+                        Delete
+                      </SecondaryButton>
+                    )}
                   </FlexItem>
                 </Flex>
               ))}
             </Flex>
-            <SecondaryButton
-              classname="pf-u-mt-sm"
-              name="add"
-              onClickHandler={onAddDepartmentNumberHandler}
-            >
-              Add
-            </SecondaryButton>
+            {isFieldWritable(props.attrLevelRights.departmentnumber) && (
+              <SecondaryButton
+                classname="pf-u-mt-sm"
+                name="add"
+                onClickHandler={onAddDepartmentNumberHandler}
+              >
+                Add
+              </SecondaryButton>
+            )}
           </FormGroup>
         </Form>
       </FlexItem>
       <FlexItem flex={{ default: "flex_1" }}>
         <Form className="pf-u-mb-lg">
-          <FormGroup label="Employee number" fieldId="employee-number">
-            <TextInput
-              id="employee-number"
-              name="employeenumber"
-              value={employeeNumber}
-              type="text"
-              aria-label="employee number"
-              onChange={onChangeEmployeeNumber}
-            />
-          </FormGroup>
-          <FormGroup label="Employee type" fieldId="employee-type">
-            <TextInput
-              id="employee-type"
-              name="employeetype"
-              value={employeeType}
-              type="text"
-              aria-label="employee type"
-              onChange={onChangeEmployeeType}
-            />
-          </FormGroup>
-          <FormGroup label="Preferred language" fieldId="preferred-language">
-            <TextInput
-              id="preferred-language"
-              name="preferredlanguage"
-              value={preferredLanguage}
-              type="text"
-              aria-label="preferred language"
-              onChange={onChangePreferredLanguage}
-            />
-          </FormGroup>
+          <FieldWrapper
+            isWritable={isFieldWritable(props.attrLevelRights.employeenumber)}
+            isReadable={isFieldReadable(props.attrLevelRights.employeenumber)}
+          >
+            <FormGroup label="Employee number" fieldId="employee-number">
+              <TextInput
+                id="employee-number"
+                name="employeenumber"
+                value={employeeNumber}
+                type="text"
+                aria-label="employee number"
+                onChange={onChangeEmployeeNumber}
+              />
+            </FormGroup>
+          </FieldWrapper>
+          <FieldWrapper
+            isWritable={isFieldWritable(props.attrLevelRights.employeetype)}
+            isReadable={isFieldReadable(props.attrLevelRights.employeetype)}
+          >
+            <FormGroup label="Employee type" fieldId="employee-type">
+              <TextInput
+                id="employee-type"
+                name="employeetype"
+                value={employeeType}
+                type="text"
+                aria-label="employee type"
+                onChange={onChangeEmployeeType}
+              />
+            </FormGroup>
+          </FieldWrapper>
+          <FieldWrapper
+            isWritable={isFieldWritable(
+              props.attrLevelRights.preferredlanguage
+            )}
+            isReadable={isFieldReadable(
+              props.attrLevelRights.preferredlanguage
+            )}
+          >
+            <FormGroup label="Preferred language" fieldId="preferred-language">
+              <TextInput
+                id="preferred-language"
+                name="preferredlanguage"
+                value={preferredLanguage}
+                type="text"
+                aria-label="preferred language"
+                onChange={onChangePreferredLanguage}
+              />
+            </FormGroup>
+          </FieldWrapper>
         </Form>
       </FlexItem>
     </Flex>

--- a/src/components/UsersSections/UsersIdentity.tsx
+++ b/src/components/UsersSections/UsersIdentity.tsx
@@ -10,9 +10,13 @@ import {
 } from "@patternfly/react-core";
 // Data types
 import { User } from "src/utils/datatypes/globalDataTypes";
+// Utils
+import { isFieldReadable, isFieldWritable } from "src/utils/utils";
+import FieldWrapper from "src/utils/FieldWrapper";
 
 interface PropsToUsersIdentity {
   userData: any;
+  attrLevelRights: any;
 }
 
 const UsersIdentity = (props: PropsToUsersIdentity) => {
@@ -68,76 +72,104 @@ const UsersIdentity = (props: PropsToUsersIdentity) => {
     <Flex direction={{ default: "column", lg: "row" }}>
       <FlexItem flex={{ default: "flex_1" }}>
         <Form className="pf-u-mb-lg">
-          <FormGroup label="First name" fieldId="first-name" isRequired>
-            <TextInput
-              id="first-name"
-              name="givenname"
-              value={firstName}
-              type="text"
-              onChange={firstNameInputHandler}
-              aria-label="first name"
-              isRequired
-            />
-          </FormGroup>
-          <FormGroup label="Last name" fieldId="last-name" isRequired>
-            <TextInput
-              id="last-name"
-              name="sn"
-              value={lastName}
-              type="text"
-              onChange={lastNameInputHandler}
-              aria-label="last name"
-              isRequired
-            />
-          </FormGroup>
-          <FormGroup label="Full name" fieldId="full-name" isRequired>
-            <TextInput
-              id="full-name"
-              name="cn"
-              value={fullName}
-              type="text"
-              onChange={fullNameInputHandler}
-              aria-label="full name"
-              isRequired
-            />
-          </FormGroup>
+          <FieldWrapper
+            isWritable={isFieldWritable(props.attrLevelRights.givenname)}
+            isReadable={isFieldReadable(props.attrLevelRights.givenname)}
+          >
+            <FormGroup label="First name" fieldId="first-name" isRequired>
+              <TextInput
+                id="first-name"
+                name="givenname"
+                value={firstName}
+                type="text"
+                onChange={firstNameInputHandler}
+                aria-label="first name"
+                isRequired
+              />
+            </FormGroup>
+          </FieldWrapper>
+          <FieldWrapper
+            isWritable={isFieldWritable(props.attrLevelRights.sn)}
+            isReadable={isFieldReadable(props.attrLevelRights.sn)}
+          >
+            <FormGroup label="Last name" fieldId="last-name" isRequired>
+              <TextInput
+                id="last-name"
+                name="sn"
+                value={lastName}
+                type="text"
+                onChange={lastNameInputHandler}
+                aria-label="last name"
+                isRequired
+              />
+            </FormGroup>
+          </FieldWrapper>
+          <FieldWrapper
+            isWritable={isFieldWritable(props.attrLevelRights.cn)}
+            isReadable={isFieldReadable(props.attrLevelRights.cn)}
+          >
+            <FormGroup label="Full name" fieldId="full-name" isRequired>
+              <TextInput
+                id="full-name"
+                name="cn"
+                value={fullName}
+                type="text"
+                onChange={fullNameInputHandler}
+                aria-label="full name"
+                isRequired
+              />
+            </FormGroup>
+          </FieldWrapper>
         </Form>
       </FlexItem>
       <FlexItem flex={{ default: "flex_1" }}>
         <Form className="pf-u-mb-lg">
-          <FormGroup label="Job title" fieldId="job-title">
-            <TextInput
-              id="job-title"
-              name="title"
-              value={jobTitle}
-              type="text"
-              onChange={jobTitleInputHandler}
-              aria-label="job title"
-              isDisabled
-            />
-          </FormGroup>
-          <FormGroup label="GECOS" fieldId="gecos">
-            <TextInput
-              id="gecos"
-              name="gecos"
-              value={gecos}
-              type="text"
-              onChange={gecosInputHandler}
-              aria-label="gecos"
-              isDisabled
-            />
-          </FormGroup>
-          <FormGroup label="Class" fieldId="class-field">
-            <TextInput
-              id="class-field"
-              name="userclass"
-              value={classField && classField[0]} // TODO: Better represent the classes array
-              type="text"
-              onChange={classFieldInputHandler}
-              aria-label="class field"
-              isRequired
-            />
-          </FormGroup>
+          <FieldWrapper
+            isWritable={isFieldWritable(props.attrLevelRights.title)}
+            isReadable={isFieldReadable(props.attrLevelRights.title)}
+          >
+            <FormGroup label="Job title" fieldId="job-title">
+              <TextInput
+                id="job-title"
+                name="title"
+                value={jobTitle}
+                type="text"
+                onChange={jobTitleInputHandler}
+                aria-label="job title"
+              />
+            </FormGroup>
+          </FieldWrapper>
+          <FieldWrapper
+            isWritable={isFieldWritable(props.attrLevelRights.gecos)}
+            isReadable={isFieldReadable(props.attrLevelRights.gecos)}
+          >
+            <FormGroup label="GECOS" fieldId="gecos">
+              <TextInput
+                id="gecos"
+                name="gecos"
+                value={gecos}
+                type="text"
+                onChange={gecosInputHandler}
+                aria-label="gecos"
+              />
+            </FormGroup>
+          </FieldWrapper>
+          <FieldWrapper
+            isWritable={isFieldWritable(props.attrLevelRights.userclass)}
+            isReadable={isFieldReadable(props.attrLevelRights.userclass)}
+          >
+            <FormGroup label="Class" fieldId="class-field">
+              <TextInput
+                id="class-field"
+                name="userclass"
+                value={classField && classField[0]} // TODO: Better represent the classes array
+                type="text"
+                onChange={classFieldInputHandler}
+                aria-label="class field"
+                isRequired
+              />
+            </FormGroup>
+          </FieldWrapper>
         </Form>
       </FlexItem>
     </Flex>

--- a/src/components/UsersSections/UsersIdentity.tsx
+++ b/src/components/UsersSections/UsersIdentity.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React, { useEffect, useState } from "react";
 // PatternFly
 import {
   Flex,
@@ -11,17 +12,37 @@ import {
 import { User } from "src/utils/datatypes/globalDataTypes";
 
 interface PropsToUsersIdentity {
-  user: User;
+  userData: any;
 }
 
 const UsersIdentity = (props: PropsToUsersIdentity) => {
   // TODO: This state variables should update the user data via the IPA API (`user_mod`)
-  const [firstName] = useState(props.user.givenname);
-  const [lastName, setLastName] = useState(props.user.sn);
-  const [fullName, setFullName] = useState(firstName + " " + lastName);
-  const [jobTitle] = useState(props.user.title);
-  const [gecos, setGecos] = useState(fullName);
-  const [classField, setClassField] = useState("");
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [fullName, setFullName] = useState("");
+  const [jobTitle, setJobTitle] = useState("");
+  const [gecos, setGecos] = useState("");
+  const [classField, setClassField] = useState<string[]>([]);
+
+  // Updates data on 'userData' changes
+  useEffect(() => {
+    if (props.userData !== undefined) {
+      const userData = props.userData as User;
+      setFirstName(userData.givenname);
+      setLastName(userData.sn);
+      setFullName(userData.displayname);
+      setJobTitle(userData.title);
+      setGecos(userData.gecos);
+      if (userData.userclass !== undefined) {
+        setClassField(userData.userclass);
+      }
+    }
+  }, [props.userData]);
+
+  // Field input handlers
+  const firstNameInputHandler = (value: string) => {
+    setFirstName(value);
+  };
 
   const lastNameInputHandler = (value: string) => {
     setLastName(value);
@@ -31,12 +52,16 @@ const UsersIdentity = (props: PropsToUsersIdentity) => {
     setFullName(value);
   };
 
+  const jobTitleInputHandler = (value: string) => {
+    setJobTitle(value);
+  };
+
   const gecosInputHandler = (value: string) => {
     setGecos(value);
   };
 
   const classFieldInputHandler = (value: string) => {
-    setClassField(value);
+    setClassField([value]);
   };
 
   return (
@@ -49,6 +74,7 @@ const UsersIdentity = (props: PropsToUsersIdentity) => {
               name="givenname"
               value={firstName}
               type="text"
+              onChange={firstNameInputHandler}
               aria-label="first name"
               isRequired
             />
@@ -85,6 +111,7 @@ const UsersIdentity = (props: PropsToUsersIdentity) => {
               name="title"
               value={jobTitle}
               type="text"
+              onChange={jobTitleInputHandler}
               aria-label="job title"
               isDisabled
             />
@@ -104,7 +131,7 @@ const UsersIdentity = (props: PropsToUsersIdentity) => {
             <TextInput
               id="class-field"
               name="userclass"
-              value={classField}
+              value={classField && classField[0]} // TODO: Better represent the classes array
               type="text"
               onChange={classFieldInputHandler}
               aria-label="class field"

--- a/src/components/UsersSections/UsersKerberosTicket.tsx
+++ b/src/components/UsersSections/UsersKerberosTicket.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React, { useEffect, useState } from "react";
 // PatternFly
 import {
   Flex,
@@ -8,10 +9,22 @@ import {
   TextInput,
 } from "@patternfly/react-core";
 
-const UsersKerberosTicket = () => {
-  // TODO: This state variables should update the user data via the IPA API (`krbtpolicy_mod`)
-  const [maxRenew] = useState("");
-  const [maxLife] = useState("");
+interface PropsToKerberosTicket {
+  krbtpolicyData: any;
+}
+
+const UsersKerberosTicket = (props: PropsToKerberosTicket) => {
+  // TODO: Specify field access (read/write) based on 'attributelevelrights'
+  const [maxRenew, setMaxRenew] = useState("");
+  const [maxLife, setMaxLife] = useState("");
+
+  // Updates data on 'krbtpolicyData' changes
+  useEffect(() => {
+    if (props.krbtpolicyData !== undefined) {
+      setMaxRenew(props.krbtpolicyData.krbmaxrenewableage[0]);
+      setMaxLife(props.krbtpolicyData.krbmaxticketlife[0]);
+    }
+  }, [props.krbtpolicyData]);
 
   return (
     <Flex direction={{ default: "column", md: "row" }}>

--- a/src/components/UsersSections/UsersKerberosTicket.tsx
+++ b/src/components/UsersSections/UsersKerberosTicket.tsx
@@ -8,9 +8,13 @@ import {
   FormGroup,
   TextInput,
 } from "@patternfly/react-core";
+// Utils
+import { isFieldReadable, isFieldWritable } from "src/utils/utils";
+import FieldWrapper from "src/utils/FieldWrapper";
 
 interface PropsToKerberosTicket {
   krbtpolicyData: any;
+  attrLevelRights: any;
 }
 
 const UsersKerberosTicket = (props: PropsToKerberosTicket) => {
@@ -30,30 +34,42 @@ const UsersKerberosTicket = (props: PropsToKerberosTicket) => {
     <Flex direction={{ default: "column", md: "row" }}>
       <FlexItem flex={{ default: "flex_1" }}>
         <Form className="pf-u-mb-lg">
-          <FormGroup label="Max renew (seconds)" fieldId="max-renew">
-            <TextInput
-              id="max-renew"
-              name="krbmaxrenewableage"
-              value={maxRenew}
-              type="text"
-              aria-label="max renew in seconds"
-              isDisabled
-            />
-          </FormGroup>
+          <FieldWrapper
+            isWritable={isFieldWritable(
+              props.attrLevelRights.krbmaxrenewableage
+            )}
+            isReadable={isFieldReadable(
+              props.attrLevelRights.krbmaxrenewableage
+            )}
+          >
+            <FormGroup label="Max renew (seconds)" fieldId="max-renew">
+              <TextInput
+                id="max-renew"
+                name="krbmaxrenewableage"
+                value={maxRenew}
+                type="text"
+                aria-label="max renew in seconds"
+              />
+            </FormGroup>
+          </FieldWrapper>
         </Form>
       </FlexItem>
       <FlexItem flex={{ default: "flex_1" }}>
         <Form className="pf-u-mb-lg">
-          <FormGroup label="Max life (seconds)" fieldId="max-life">
-            <TextInput
-              id="max-life"
-              name="krbmaxticketlife"
-              value={maxLife}
-              type="text"
-              aria-label="max life in seconds"
-              isDisabled
-            />
-          </FormGroup>
+          <FieldWrapper
+            isWritable={isFieldWritable(props.attrLevelRights.krbmaxticketlife)}
+            isReadable={isFieldReadable(props.attrLevelRights.krbmaxticketlife)}
+          >
+            <FormGroup label="Max life (seconds)" fieldId="max-life">
+              <TextInput
+                id="max-life"
+                name="krbmaxticketlife"
+                value={maxLife}
+                type="text"
+                aria-label="max life in seconds"
+              />
+            </FormGroup>
+          </FieldWrapper>
         </Form>
       </FlexItem>
     </Flex>

--- a/src/components/UsersSections/UsersMailingAddress.tsx
+++ b/src/components/UsersSections/UsersMailingAddress.tsx
@@ -10,9 +10,13 @@ import {
 } from "@patternfly/react-core";
 // Data types
 import { User } from "src/utils/datatypes/globalDataTypes";
+// Util
+import { isFieldReadable, isFieldWritable } from "src/utils/utils";
+import FieldWrapper from "src/utils/FieldWrapper";
 
 interface PropsToMailingAddress {
   userData: any;
+  attrLevelRights: any;
 }
 
 const UsersMailingAddress = (props: PropsToMailingAddress) => {
@@ -62,50 +66,76 @@ const UsersMailingAddress = (props: PropsToMailingAddress) => {
     <Flex direction={{ default: "column", md: "row" }}>
       <FlexItem flex={{ default: "flex_1" }}>
         <Form className="pf-u-mb-lg">
-          <FormGroup label="Street address" fieldId="street-address">
-            <TextInput
-              id="street-address"
-              name="street"
-              value={streetAddress}
-              type="text"
-              aria-label="street address"
-              onChange={onChangeStreetAddressHandler}
-            />
-          </FormGroup>
-          <FormGroup label="City" fieldId="city">
-            <TextInput
-              id="city"
-              name="l"
-              value={city}
-              type="text"
-              aria-label="city"
-              onChange={onChangeCityHandler}
-            />
-          </FormGroup>
+          <FieldWrapper
+            isWritable={isFieldWritable(props.attrLevelRights.street)}
+            isReadable={isFieldReadable(props.attrLevelRights.street)}
+          >
+            <FormGroup label="Street address" fieldId="street-address">
+              <TextInput
+                id="street-address"
+                name="street"
+                value={streetAddress}
+                type="text"
+                aria-label="street address"
+                onChange={onChangeStreetAddressHandler}
+                isDisabled={isFieldWritable(props.attrLevelRights.street)}
+              />
+            </FormGroup>
+          </FieldWrapper>
+
+          <FieldWrapper
+            isWritable={isFieldWritable(props.attrLevelRights.l)}
+            isReadable={isFieldReadable(props.attrLevelRights.l)}
+          >
+            <FormGroup label="City" fieldId="city">
+              <TextInput
+                id="city"
+                name="l"
+                value={city}
+                type="text"
+                aria-label="city"
+                onChange={onChangeCityHandler}
+                isDisabled={isFieldWritable(props.attrLevelRights.l)}
+              />
+            </FormGroup>
+          </FieldWrapper>
         </Form>
       </FlexItem>
       <FlexItem flex={{ default: "flex_1" }}>
         <Form className="pf-u-mb-lg">
-          <FormGroup label="State/province" fieldId="state-province">
-            <TextInput
-              id="state-province"
-              name="st"
-              value={stateProvince}
-              type="text"
-              aria-label="state province"
-              onChange={onChangeStateProvinceHandler}
-            />
-          </FormGroup>
-          <FormGroup label="ZIP" fieldId="zip">
-            <TextInput
-              id="zip"
-              name="postalcode"
-              value={zip}
-              type="text"
-              aria-label="zip"
-              onChange={onChangeZipHandler}
-            />
-          </FormGroup>
+          <FieldWrapper
+            isWritable={isFieldWritable(props.attrLevelRights.st)}
+            isReadable={isFieldReadable(props.attrLevelRights.st)}
+          >
+            <FormGroup label="State/province" fieldId="state-province">
+              <TextInput
+                id="state-province"
+                name="st"
+                value={stateProvince}
+                type="text"
+                aria-label="state province"
+                onChange={onChangeStateProvinceHandler}
+                isDisabled={isFieldWritable(props.attrLevelRights.st)}
+              />
+            </FormGroup>
+          </FieldWrapper>
+
+          <FieldWrapper
+            isWritable={isFieldWritable(props.attrLevelRights.postalcode)}
+            isReadable={isFieldReadable(props.attrLevelRights.postalcode)}
+          >
+            <FormGroup label="ZIP" fieldId="zip">
+              <TextInput
+                id="zip"
+                name="postalcode"
+                value={zip}
+                type="text"
+                aria-label="zip"
+                onChange={onChangeZipHandler}
+                isDisabled={isFieldWritable(props.attrLevelRights.postalcode)}
+              />
+            </FormGroup>
+          </FieldWrapper>
         </Form>
       </FlexItem>
     </Flex>

--- a/src/components/UsersSections/UsersMailingAddress.tsx
+++ b/src/components/UsersSections/UsersMailingAddress.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React, { useEffect, useState } from "react";
 // PatternFly
 import {
   Flex,
@@ -7,13 +8,39 @@ import {
   FormGroup,
   TextInput,
 } from "@patternfly/react-core";
+// Data types
+import { User } from "src/utils/datatypes/globalDataTypes";
 
-const UsersMailingAddress = () => {
+interface PropsToMailingAddress {
+  userData: any;
+}
+
+const UsersMailingAddress = (props: PropsToMailingAddress) => {
   // TODO: This state variables should update the user data via the IPA API (`user_mod`)
   const [streetAddress, setStreetAddress] = useState("");
   const [city, setCity] = useState("");
   const [stateProvince, setStateProvince] = useState("");
   const [zip, setZip] = useState("");
+
+  // Updates data on 'userData' changes
+  useEffect(() => {
+    if (props.userData !== undefined) {
+      const userData = props.userData as User;
+
+      if (userData.street !== undefined) {
+        setStreetAddress(userData.street);
+      }
+      if (userData.l !== undefined) {
+        setCity(userData.l);
+      }
+      if (userData.st !== undefined) {
+        setStateProvince(userData.st);
+      }
+      if (userData.postalcode !== undefined) {
+        setZip(userData.postalcode);
+      }
+    }
+  }, [props.userData]);
 
   const onChangeStreetAddressHandler = (value: string) => {
     setStreetAddress(value);

--- a/src/components/UsersSections/UsersPasswordPolicy.tsx
+++ b/src/components/UsersSections/UsersPasswordPolicy.tsx
@@ -8,9 +8,13 @@ import {
   FormGroup,
   TextInput,
 } from "@patternfly/react-core";
+// Utils
+import { isFieldReadable, isFieldWritable } from "src/utils/utils";
+import FieldWrapper from "src/utils/FieldWrapper";
 
 interface PropsToPasswordPolicy {
   pwpolicyData: any;
+  attrLevelRights: any;
 }
 
 const UsersPasswordPolicy = (props: PropsToPasswordPolicy) => {
@@ -44,109 +48,168 @@ const UsersPasswordPolicy = (props: PropsToPasswordPolicy) => {
     <Flex direction={{ default: "column", md: "row" }}>
       <FlexItem flex={{ default: "flex_1" }}>
         <Form className="pf-u-mb-lg">
-          <FormGroup label="Max lifetime (days)" fieldId="max-lifetime-days">
-            <TextInput
-              id="max-lifetime-days"
-              name="krbmaxpwdlife"
-              value={maxLifetimeDays}
-              type="text"
-              aria-label="max lifetime in days"
-              isDisabled
-            />
-          </FormGroup>
-          <FormGroup label="Min lifetime (hours)" fieldId="mini-lifetime-hours">
-            <TextInput
-              id="min-lifetime-hours"
-              name="krbminpwdlife"
-              value={minLifetimeHours}
-              type="text"
-              aria-label="min lifetime in hours"
-              isDisabled
-            />
-          </FormGroup>
-          <FormGroup
-            label="History size (number of passwords)"
-            fieldId="history-size"
+          <FieldWrapper
+            isWritable={isFieldWritable(props.attrLevelRights.krbmaxpwdlife)}
+            isReadable={isFieldReadable(props.attrLevelRights.krbmaxpwdlife)}
           >
-            <TextInput
-              id="history-size"
-              name="krbpwdhistorylength"
-              value={historySize}
-              type="text"
-              aria-label="history size"
-              isDisabled
-            />
-          </FormGroup>
-          <FormGroup label="Character classes" fieldId="character-classes">
-            <TextInput
-              id="character-classes"
-              name="krbpwdmindiffchars"
-              value={characterClasses}
-              type="text"
-              aria-label="character classes"
-              isDisabled
-            />
-          </FormGroup>
-          <FormGroup label="Min length" fieldId="min-length">
-            <TextInput
-              id="min-length"
-              name="krbpwdminlength"
-              value={minLength}
-              type="text"
-              aria-label="min length"
-              isDisabled
-            />
-          </FormGroup>
+            <FormGroup label="Max lifetime (days)" fieldId="max-lifetime-days">
+              <TextInput
+                id="max-lifetime-days"
+                name="krbmaxpwdlife"
+                value={maxLifetimeDays}
+                type="text"
+                aria-label="max lifetime in days"
+              />
+            </FormGroup>
+          </FieldWrapper>
+          <FieldWrapper
+            isWritable={isFieldWritable(props.attrLevelRights.krbminpwdlife)}
+            isReadable={isFieldReadable(props.attrLevelRights.krbminpwdlife)}
+          >
+            <FormGroup
+              label="Min lifetime (hours)"
+              fieldId="mini-lifetime-hours"
+            >
+              <TextInput
+                id="min-lifetime-hours"
+                name="krbminpwdlife"
+                value={minLifetimeHours}
+                type="text"
+                aria-label="min lifetime in hours"
+              />
+            </FormGroup>
+          </FieldWrapper>
+          <FieldWrapper
+            isWritable={isFieldWritable(
+              props.attrLevelRights.krbpwdhistorylength
+            )}
+            isReadable={isFieldReadable(
+              props.attrLevelRights.krbpwdhistorylength
+            )}
+          >
+            <FormGroup
+              label="History size (number of passwords)"
+              fieldId="history-size"
+            >
+              <TextInput
+                id="history-size"
+                name="krbpwdhistorylength"
+                value={historySize}
+                type="text"
+                aria-label="history size"
+              />
+            </FormGroup>
+          </FieldWrapper>
+          <FieldWrapper
+            isWritable={isFieldWritable(
+              props.attrLevelRights.krbpwdmindiffchars
+            )}
+            isReadable={isFieldReadable(
+              props.attrLevelRights.krbpwdmindiffchars
+            )}
+          >
+            <FormGroup label="Character classes" fieldId="character-classes">
+              <TextInput
+                id="character-classes"
+                name="krbpwdmindiffchars"
+                value={characterClasses}
+                type="text"
+                aria-label="character classes"
+              />
+            </FormGroup>
+          </FieldWrapper>
+          <FieldWrapper
+            isWritable={isFieldWritable(props.attrLevelRights.krbpwdminlength)}
+            isReadable={isFieldReadable(props.attrLevelRights.krbpwdminlength)}
+          >
+            <FormGroup label="Min length" fieldId="min-length">
+              <TextInput
+                id="min-length"
+                name="krbpwdminlength"
+                value={minLength}
+                type="text"
+                aria-label="min length"
+              />
+            </FormGroup>
+          </FieldWrapper>
         </Form>
       </FlexItem>
       <FlexItem flex={{ default: "flex_1" }}>
         <Form className="pf-u-mb-lg">
-          <FormGroup label="Max failures" fieldId="max-failures">
-            <TextInput
-              id="max-failures"
-              name="krbpwdminlength"
-              value={maxFailures}
-              type="text"
-              aria-label="max failures"
-              isDisabled
-            />
-          </FormGroup>
-          <FormGroup
-            label="Future reset interval (seconds)"
-            fieldId="future-reset-interval"
+          <FieldWrapper
+            isWritable={isFieldWritable(props.attrLevelRights.krbpwdmaxfailure)}
+            isReadable={isFieldReadable(props.attrLevelRights.krbpwdmaxfailure)}
           >
-            <TextInput
-              id="future-reset-interval"
-              name="krbpwdfailurecountinterval"
-              value={futureResetInterval}
-              type="text"
-              aria-label="future reset interval in seconds"
-              isDisabled
-            />
-          </FormGroup>
-          <FormGroup
-            label="Lockout duration (seconds)"
-            fieldId="lockout-duration"
+            <FormGroup label="Max failures" fieldId="max-failures">
+              <TextInput
+                id="max-failures"
+                name="krbpwdmaxfailure"
+                value={maxFailures}
+                type="text"
+                aria-label="max failures"
+              />
+            </FormGroup>
+          </FieldWrapper>
+          <FieldWrapper
+            isWritable={isFieldWritable(
+              props.attrLevelRights.krbpwdfailurecountinterval
+            )}
+            isReadable={isFieldReadable(
+              props.attrLevelRights.krbpwdfailurecountinterval
+            )}
           >
-            <TextInput
-              id="lockout-duration"
-              name="krbpwdlockoutduration"
-              value={lockoutDuration}
-              type="text"
-              aria-label="lockout duration in seconds"
-              isDisabled
-            />
-          </FormGroup>
-          <FormGroup label="Grace login limit" fieldId="grace-login-limit">
-            <TextInput
-              id="grace-login-limit"
-              name="passwordgracelimit"
-              value={graceLoginLimit}
-              type="text"
-              aria-label="grace login limit"
-              isDisabled
-            />
-          </FormGroup>
+            <FormGroup
+              label="Future reset interval (seconds)"
+              fieldId="future-reset-interval"
+            >
+              <TextInput
+                id="future-reset-interval"
+                name="krbpwdfailurecountinterval"
+                value={futureResetInterval}
+                type="text"
+                aria-label="future reset interval in seconds"
+              />
+            </FormGroup>
+          </FieldWrapper>
+          <FieldWrapper
+            isWritable={isFieldWritable(
+              props.attrLevelRights.krbpwdlockoutduration
+            )}
+            isReadable={isFieldReadable(
+              props.attrLevelRights.krbpwdlockoutduration
+            )}
+          >
+            <FormGroup
+              label="Lockout duration (seconds)"
+              fieldId="lockout-duration"
+            >
+              <TextInput
+                id="lockout-duration"
+                name="krbpwdlockoutduration"
+                value={lockoutDuration}
+                type="text"
+                aria-label="lockout duration in seconds"
+              />
+            </FormGroup>
+          </FieldWrapper>
+          <FieldWrapper
+            isWritable={isFieldWritable(
+              props.attrLevelRights.passwordgracelimit
+            )}
+            isReadable={isFieldReadable(
+              props.attrLevelRights.passwordgracelimit
+            )}
+          >
+            <FormGroup label="Grace login limit" fieldId="grace-login-limit">
+              <TextInput
+                id="grace-login-limit"
+                name="passwordgracelimit"
+                value={graceLoginLimit}
+                type="text"
+                aria-label="grace login limit"
+              />
+            </FormGroup>
+          </FieldWrapper>
         </Form>
       </FlexItem>
     </Flex>

--- a/src/components/UsersSections/UsersPasswordPolicy.tsx
+++ b/src/components/UsersSections/UsersPasswordPolicy.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React, { useEffect, useState } from "react";
 // PatternFly
 import {
   Flex,
@@ -8,17 +9,36 @@ import {
   TextInput,
 } from "@patternfly/react-core";
 
-const UsersPasswordPolicy = () => {
-  // TODO: This state variables should update the user data via the IPA API (`pwpolicy_mod`)
-  const [maxLifetimeDays] = useState("");
-  const [minLifetimeHours] = useState("");
-  const [historySize] = useState("");
-  const [characterClasses] = useState("");
-  const [minLength] = useState("");
-  const [maxFailures] = useState("");
-  const [futureResetInterval] = useState("");
-  const [lockoutDuration] = useState("");
-  const [graceLoginLimit] = useState("");
+interface PropsToPasswordPolicy {
+  pwpolicyData: any;
+}
+
+const UsersPasswordPolicy = (props: PropsToPasswordPolicy) => {
+  // TODO: Specify field access (read/write) based on 'attributelevelrights'
+  const [maxLifetimeDays, setMaxLifetimeDays] = useState("");
+  const [minLifetimeHours, setMinLifetimeHours] = useState("");
+  const [historySize, setHistorySize] = useState("");
+  const [characterClasses, setCharacterClasses] = useState("");
+  const [minLength, setMinLength] = useState("");
+  const [maxFailures, setMaxFailures] = useState("");
+  const [futureResetInterval, setFutureResetInterval] = useState("");
+  const [lockoutDuration, setLockoutDuration] = useState("");
+  const [graceLoginLimit, setGraceLoginLimit] = useState("");
+
+  // Updates data on 'pwpolicyData' changes
+  useEffect(() => {
+    if (props.pwpolicyData !== undefined) {
+      setMaxLifetimeDays(props.pwpolicyData.krbmaxpwdlife[0]);
+      setMinLifetimeHours(props.pwpolicyData.krbminpwdlife[0]);
+      setHistorySize(props.pwpolicyData.krbpwdhistorylength[0]);
+      setCharacterClasses(props.pwpolicyData.krbpwdmindiffchars[0]);
+      setMinLength(props.pwpolicyData.krbpwdminlength[0]);
+      setMaxFailures(props.pwpolicyData.krbpwdmaxfailure[0]);
+      setFutureResetInterval(props.pwpolicyData.krbpwdfailurecountinterval[0]);
+      setLockoutDuration(props.pwpolicyData.krbpwdlockoutduration[0]);
+      setGraceLoginLimit(props.pwpolicyData.passwordgracelimit[0]);
+    }
+  }, [props.pwpolicyData]);
 
   return (
     <Flex direction={{ default: "column", md: "row" }}>

--- a/src/components/layouts/Calendar/CalendarLayout.tsx
+++ b/src/components/layouts/Calendar/CalendarLayout.tsx
@@ -27,6 +27,7 @@ interface PropsToCalendar {
   textInputAriaLabel?: string;
   textInputValue: string | number;
   children: JSX.Element[];
+  isDisable?: boolean;
 }
 
 const CalendarLayout = (props: PropsToCalendar) => {
@@ -46,6 +47,7 @@ const CalendarLayout = (props: PropsToCalendar) => {
           name={props.name}
           aria-label={props.textInputAriaLabel}
           value={props.textInputValue}
+          isDisabled={props.isDisable}
         />
         {props.children}
       </InputGroup>

--- a/src/components/modals/CertificateMappingDataModal.tsx
+++ b/src/components/modals/CertificateMappingDataModal.tsx
@@ -13,12 +13,8 @@ import {
 // Layouts
 import SecondaryButton from "../layouts/SecondaryButton";
 import PopoverWithIconLayout from "../layouts/PopoverWithIconLayout";
-
-// Generic data to pass to the Textbox adder
-interface ElementData {
-  id: string | number;
-  element: string;
-}
+// Data types
+import { Certificate } from "src/utils/datatypes/globalDataTypes";
 
 interface PropsToCertificateMappingData {
   // Modal options
@@ -36,8 +32,8 @@ interface PropsToCertificateMappingData {
   onChangeIssuer: (value: string) => void;
   onChangeSubject: (value: string) => void;
   // Generated texboxes, textareas, and data
-  certificateMappingDataList: ElementData[];
-  certificateList: ElementData[];
+  certificateMappingDataList: Certificate[];
+  certificateList: Certificate[];
   onAddCertificateMappingDataHandler: () => void;
   onHandleCertificateMappingDataChange: (
     value: string,
@@ -98,16 +94,16 @@ const CertificateMappingDataModal = (props: PropsToCertificateMappingData) => {
               {props.certificateMappingDataList.map((certMap, idx) => (
                 <Flex
                   direction={{ default: "row" }}
-                  key={certMap.id + "-" + idx + "-div"}
+                  key={certMap.serialNumber + "-" + idx + "-div"}
                   name="value"
                 >
                   <FlexItem
-                    key={certMap.id + "-textbox"}
+                    key={certMap.serialNumber + "-textbox"}
                     flex={{ default: "flex_1" }}
                   >
                     <TextInput
                       id="cert-map-data"
-                      value={certMap.element}
+                      value={certMap.certificate}
                       type="text"
                       name={"ipacertmapdata-" + idx}
                       aria-label="certificate mapping data textbox"
@@ -120,7 +116,7 @@ const CertificateMappingDataModal = (props: PropsToCertificateMappingData) => {
                       }
                     />
                   </FlexItem>
-                  <FlexItem key={certMap.id + "-delete-button"}>
+                  <FlexItem key={certMap.serialNumber + "-delete-button"}>
                     <SecondaryButton
                       name="remove"
                       onClickHandler={() =>
@@ -155,17 +151,17 @@ const CertificateMappingDataModal = (props: PropsToCertificateMappingData) => {
               {props.certificateList.map((certificate, idx) => (
                 <Flex
                   direction={{ default: "row" }}
-                  key={certificate.id + "-" + idx + "-div"}
+                  key={certificate.serialNumber + "-" + idx + "-div"}
                   alignItems={{ default: "alignItemsFlexEnd" }}
                   name="value"
                 >
                   <FlexItem
-                    key={certificate.id + "-textbox"}
+                    key={certificate.serialNumber + "-textbox"}
                     flex={{ default: "flex_1" }}
                   >
                     <TextArea
                       id="cert-map-data"
-                      value={certificate.element}
+                      value={certificate.certificate}
                       type="text"
                       name={"certificate-" + idx}
                       aria-label="certificate textarea"
@@ -176,7 +172,7 @@ const CertificateMappingDataModal = (props: PropsToCertificateMappingData) => {
                       style={{ height: "135px" }}
                     />
                   </FlexItem>
-                  <FlexItem key={certificate.id + "-delete-button"}>
+                  <FlexItem key={certificate.serialNumber + "-delete-button"}>
                     <SecondaryButton
                       name="remove"
                       onClickHandler={() =>

--- a/src/utils/FieldWrapper.tsx
+++ b/src/utils/FieldWrapper.tsx
@@ -1,0 +1,71 @@
+import React = require("react");
+
+interface PropsToFieldWrapper {
+  isWritable: boolean;
+  isReadable: boolean;
+  children: JSX.Element;
+}
+
+/*
+    Description: Wrapper to assign write and read permissions to <FormGroup>
+      elements.
+
+    Eliminates the need to manipulate the component to check if it has
+      read (if it should be rendered) and write (`isDisabled` prop) permissions.
+      The wrapper is just applicable on those <FormGroup> elements that have simple
+      elements (TextInputs, selectors, etc). Due to the limitations of the wrapper,
+      the complex elements attributes should be managed manually.
+
+    Usage: Wrap the FormGroup with the wrapper providing the `isWritable`
+      and `isReadable` props (from `attrbutelevelrights`).
+
+      E.g.:
+        <FieldWrapper
+              isWritable={isFieldWritable(attrLevelRights.gidnumber)}
+              isReadable={isFieldReadable(attrLevelRights.gidnumber)}
+            >
+              <FormGroup label="GID" fieldId="gid">
+                <TextInput
+                  id="gid"
+                  name="gidnumber"
+                  value={gid}
+                  type="text"
+                  onChange={gidInputHandler}
+                  aria-label="gid"
+                  // No need to add `isDisabled` here
+                />
+              </FormGroup>
+            </FieldWrapper>
+
+ */
+
+const FieldWrapper = (props: PropsToFieldWrapper) => {
+  // Clone the childen's children and apply the `isDisabled` prop
+  const updatedSubChildren = React.Children.map(props.children, (child) => {
+    const subChildren = child.props.children;
+    const subChildrensArray: JSX.Element[] = subChildren;
+    const newSubChildrensArray: JSX.Element[] = [];
+
+    React.Children.map(subChildrensArray, (subChild) => {
+      newSubChildrensArray.push(
+        React.cloneElement(subChild, {
+          isDisabled: !props.isWritable,
+        }) as React.ReactElement
+      );
+    });
+
+    return newSubChildrensArray;
+  });
+
+  // Clone the received component and apply the new sub-children
+  const updatedChildren = React.cloneElement(
+    props.children,
+    {},
+    updatedSubChildren
+  );
+
+  // Render component
+  return <>{props.isReadable ? updatedChildren : <></>}</>;
+};
+
+export default FieldWrapper;

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -139,15 +139,23 @@ export interface ErrorData {
   error: string;
 }
 
-// Identity Provider server
-export interface IDPServer {
+// Certificates
+export interface Certificate {
+  certificate: string;
+  issuer: string;
+  ownerUser: string[];
+  serialNumber: number;
+  serialNumberHex: string;
+  sha1Fingerprint: string;
+  sha256Fingerprint: string;
+  subject: string;
+  validNotAfter: string;
+  validNotBefore: string;
+}
+
+// RADIUS server
+export interface RadiusServer {
   cn: string;
   dn: string;
-  ipaidpauthendpoint: string;
-  ipaidpclientid: string[];
-  ipaidpdevauthendpoint: string[];
-  ipaidpscope: string;
-  ipaidpsub: string;
-  ipaidptokenendpoint: string;
-  ipaidpuserinfoendpoint: string[];
+  ipatokenradiusserver: string;
 }

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -92,3 +92,42 @@ export const parseStringToUTCFormat = (date: string) => {
 
   return dateFormat;
 };
+
+// Returns a boolean value if file is writable
+// Writable:
+// - attribute level rights for acl param contains 'w'
+// - with 'w_if_no_aci' flag and no attribute level rights and user has rights to modify objectclass
+export const isFieldWritable = (
+  aci: string,
+  objectClass?: string,
+  flag?: string
+) => {
+  if (aci !== undefined) {
+    return aci.includes("w");
+  } else {
+    // Writable if no aci defined, but `objectclass` defined, flag received and it has permissions.
+    if (
+      objectClass !== undefined &&
+      flag === "w_if_no_aci" &&
+      isFieldWritable(objectClass)
+    ) {
+      return true;
+    }
+  }
+
+  // Not writable if aci is not defined in `attributelevelrights` and no flag provided
+  return false;
+};
+
+// Returns a boolean value if file is readable
+export const isFieldReadable = (aci: string, flag?: string) => {
+  if (aci !== undefined) {
+    // Hide if empty aci
+    if (aci === "") return false;
+    return aci.includes("r");
+  }
+  // Readable if flag received
+  if (flag !== undefined && flag === "r_if_no_aci") return true;
+  // Not readable if aci is not defined in `attributelevelrights` and no flag provided
+  return false;
+};

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -70,3 +70,25 @@ export const apiErrorToJsXError = (
 
   return errorJsx;
 };
+
+// Parse string to UTC date format
+// '20230809120244Z' --> 'Sat Aug 09 2023 14:02:44 GMT+0200 (Central European Summer Time)'
+export const parseStringToUTCFormat = (date: string) => {
+  const year = date.substring(0, 4);
+  const month = date.substring(4, 6);
+  const day = date.substring(6, 8);
+  const hour = date.substring(8, 10);
+  const minutes = date.substring(10, 12);
+  const seconds = date.substring(12, 14);
+
+  const dateFormat = new Date(
+    +year,
+    +month - 1, // number between 0 and 11 (January to December).
+    +day,
+    +hour,
+    +minutes,
+    +seconds
+  ); // UTC
+
+  return dateFormat;
+};


### PR DESCRIPTION
![image](https://github.com/freeipa/freeipa-webui/assets/8112750/d7476256-db45-4dcf-9066-2ad7f2a2dc3d)

### Description
The action buttons in the 'Active users' > 'Settings' page ('Refresh', 'Revert', and 'Save') are used to manage the content of the fields on that page.

The 'Refresh' button updates the content of the fields with the data retrieved from the IPA server, discarding any change made on any field (if any).

Signed-off-by: Carla Martinez <carlmart@redhat.com>