### PR TITLE
Add 'semver' advisory warning into allowlist

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,5 +1,34 @@
 {
   "moderate": true,
   "advisories": [],
-  "allowlist": []
+  "allowlist": [
+    "GHSA-c2qf-rxjj-qqgw|@babel/helper-compilation-targets>@babel/core>semver>",
+    "GHSA-c2qf-rxjj-qqgw|@babel/preset-env>@babel/plugin-proposal-object-rest-spread>@babel/helper-compilation-targets>@babel/core>semver",
+    "GHSA-c2qf-rxjj-qqgw|@babel/plugin-transform-function-name>@babel/helper-compilation-targets>@babel/core>semver>",
+    "GHSA-c2qf-rxjj-qqgw|@babel/plugin-proposal-class-properties>@babel/helper-create-class-features-plugin>@babel/core>semver>",
+    "GHSA-c2qf-rxjj-qqgw|@babel/plugin-proposal-class-static-block>@babel/helper-create-class-features-plugin>@babel/core>semver>",
+    "GHSA-c2qf-rxjj-qqgw|@babel/plugin-proposal-private-methods>@babel/helper-create-class-features-plugin>@babel/core>semver",
+    "GHSA-c2qf-rxjj-qqgw|@babel/plugin-proposal-private-property-in-object>@babel/helper-create-class-features-plugin>@babel/core>semver>",
+    "GHSA-c2qf-rxjj-qqgw|@babel/plugin-transform-typescript>@babel/helper-create-class-features-plugin>@babel/core>semver",
+    "GHSA-c2qf-rxjj-qqgw|@babel/plugin-proposal-unicode-property-regex>@babel/helper-create-regexp-features-plugin>@babel/core>semver>",
+    "GHSA-c2qf-rxjj-qqgw|@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>@babel/core>semver>",
+    "GHSA-c2qf-rxjj-qqgw|@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>@babel/core>semver",
+    "GHSA-c2qf-rxjj-qqgw|@babel/plugin-transform-named-capturing-groups-regex>@babel/helper-create-regexp-features-plugin>@babel/core>semver>",
+    "GHSA-c2qf-rxjj-qqgw|@babel/plugin-transform-unicode-regex>@babel/helper-create-regexp-features-plugin>@babel/core>semver",
+    "GHSA-c2qf-rxjj-qqgw|@babel/plugin-transform-unicode-regex>@babel/helper-create-regexp-features-plugin>@babel/core>semver>",
+    "GHSA-c2qf-rxjj-qqgw|@babel/plugin-proposal-async-generator-functions>@babel/helper-remap-async-to-generator>@babel/core>semver>",
+    "GHSA-c2qf-rxjj-qqgw|@babel/plugin-transform-async-to-generator>@babel/helper-remap-async-to-generator>@babel/core>semver>",
+    "GHSA-c2qf-rxjj-qqgw|@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression>@babel/core>semver>",
+    "GHSA-c2qf-rxjj-qqgw|@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining>@babel/core>semver>",
+    "GHSA-c2qf-rxjj-qqgw|@babel/core>semver>",
+    "GHSA-c2qf-rxjj-qqgw|babel-loader>@babel/core>semver",
+    "GHSA-c2qf-rxjj-qqgw|semver>",
+    "GHSA-c2qf-rxjj-qqgw|babel-plugin-polyfill-corejs3>@babel/helper-define-polyfill-provider>semver",
+    "GHSA-c2qf-rxjj-qqgw|babel-plugin-polyfill-regenerator>@babel/helper-define-polyfill-provider>semver",
+    "GHSA-c2qf-rxjj-qqgw|babel-plugin-polyfill-corejs2>semver>",
+    "GHSA-c2qf-rxjj-qqgw|core-js-compat>semver",
+    "GHSA-c2qf-rxjj-qqgw|eslint-plugin-react>semver",
+    "GHSA-c2qf-rxjj-qqgw|make-dir>semver>",
+    "GHSA-c2qf-rxjj-qqgw|find-cache-dir>make-dir>semver>"
+  ]
 }


### PR DESCRIPTION
The audit-ci tool detected a [vulnerability](https://github.com/advisories/GHSA-c2qf-rxjj-qqgw)[1] of a WebUI dependency. The semver library is a direct dependency of the babel-loader library. Due to this error, the gating tests are not passing.

This has been fixed by adding the babel-loader warnings to the audit-ci whitelist ([allowlisting](https://github.com/IBM/audit-ci#allowlisting)[2]).

[1]- https://github.com/advisories/GHSA-c2qf-rxjj-qqgw
[2]- https://github.com/IBM/audit-ci#allowlisting
Related: https://github.com/babel/babel-loader/issues/992
Signed-off-by: Carla Martinez <carlmart@redhat.com>