### PR TITLE
text input behavior based on IPA object metadata

### DIFF
--- a/src/components/Form/IpaTextInput.tsx
+++ b/src/components/Form/IpaTextInput.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+// PatternFly
+import { TextInput } from "@patternfly/react-core";
+import {
+  IPAParamDefinition,
+  getParamProperties,
+  convertToString,
+} from "src/utils/ipaObjectUtils";
+
+const IpaTextInput = (props: IPAParamDefinition) => {
+  const { required, readOnly, value, onChange } = getParamProperties(props);
+
+  return (
+    <TextInput
+      id={props.name}
+      name={props.name}
+      value={convertToString(value)}
+      onChange={onChange}
+      type="text"
+      aria-label={props.name}
+      isRequired={required}
+      readOnlyVariant={readOnly ? "plain" : undefined}
+    />
+  );
+};
+
+export default IpaTextInput;

--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -16,7 +16,7 @@ import {
 // Icons
 import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
 // Data types
-import { User } from "src/utils/datatypes/globalDataTypes";
+import { Metadata, User } from "src/utils/datatypes/globalDataTypes";
 // Layouts
 import ToolbarLayout from "src/components/layouts/ToolbarLayout";
 import TitleLayout from "src/components/layouts/TitleLayout";
@@ -35,6 +35,8 @@ import UsersAttributesSMB from "src/components/UsersSections/UsersAttributesSMB"
 
 export interface PropsToUserSettings {
   user: User;
+  onUserChange: (user: User) => void;
+  metadata: Metadata;
   from: "active-users" | "stage-users" | "preserved-users";
 }
 
@@ -166,7 +168,11 @@ const UserSettings = (props: PropsToUserSettings) => {
                 id="identity-settings"
                 text="Identity settings"
               />
-              <UsersIdentity user={props.user} />
+              <UsersIdentity
+                user={props.user}
+                onUserChange={props.onUserChange}
+                metadata={props.metadata}
+              />
               <TitleLayout
                 key={1}
                 headingLevel="h2"

--- a/src/components/UsersSections/UsersIdentity.tsx
+++ b/src/components/UsersSections/UsersIdentity.tsx
@@ -1,115 +1,95 @@
-import React, { useState } from "react";
+import React from "react";
 // PatternFly
-import {
-  Flex,
-  FlexItem,
-  Form,
-  FormGroup,
-  TextInput,
-} from "@patternfly/react-core";
+import { Flex, FlexItem, Form, FormGroup } from "@patternfly/react-core";
 // Data types
-import { User } from "src/utils/datatypes/globalDataTypes";
+import { Metadata, User } from "src/utils/datatypes/globalDataTypes";
+import IpaTextInput from "../Form/IpaTextInput";
 
 interface PropsToUsersIdentity {
   user: User;
+  onUserChange: (user: User) => void;
+  metadata: Metadata;
+}
+
+function usersTextInput(
+  property: string,
+  onChange: (user: User) => void,
+  user: User,
+  metadata: Metadata
+) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ipaObject = user as Record<string, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function recordOnChange(ipaObject: Record<string, any>) {
+    onChange(ipaObject as User);
+  }
+  return (
+    <IpaTextInput
+      name={property}
+      ipaObject={ipaObject}
+      onChange={recordOnChange}
+      objectName="user"
+      metadata={metadata}
+    />
+  );
 }
 
 const UsersIdentity = (props: PropsToUsersIdentity) => {
-  // TODO: This state variables should update the user data via the IPA API (`user_mod`)
-  const [firstName] = useState(props.user.givenname);
-  const [lastName, setLastName] = useState(props.user.sn);
-  const [fullName, setFullName] = useState(firstName + " " + lastName);
-  const [jobTitle] = useState(props.user.title);
-  const [gecos, setGecos] = useState(fullName);
-  const [classField, setClassField] = useState("");
-
-  const lastNameInputHandler = (value: string) => {
-    setLastName(value);
-  };
-
-  const fullNameInputHandler = (value: string) => {
-    setFullName(value);
-  };
-
-  const gecosInputHandler = (value: string) => {
-    setGecos(value);
-  };
-
-  const classFieldInputHandler = (value: string) => {
-    setClassField(value);
-  };
-
   return (
     <Flex direction={{ default: "column", lg: "row" }}>
       <FlexItem flex={{ default: "flex_1" }}>
         <Form className="pf-u-mb-lg">
           <FormGroup label="First name" fieldId="first-name" isRequired>
-            <TextInput
-              id="first-name"
-              name="givenname"
-              value={firstName}
-              type="text"
-              aria-label="first name"
-              isRequired
-            />
+            {usersTextInput(
+              "givenname",
+              props.onUserChange,
+              props.user,
+              props.metadata
+            )}
           </FormGroup>
           <FormGroup label="Last name" fieldId="last-name" isRequired>
-            <TextInput
-              id="last-name"
-              name="sn"
-              value={lastName}
-              type="text"
-              onChange={lastNameInputHandler}
-              aria-label="last name"
-              isRequired
-            />
+            {usersTextInput(
+              "sn",
+              props.onUserChange,
+              props.user,
+              props.metadata
+            )}
           </FormGroup>
           <FormGroup label="Full name" fieldId="full-name" isRequired>
-            <TextInput
-              id="full-name"
-              name="cn"
-              value={fullName}
-              type="text"
-              onChange={fullNameInputHandler}
-              aria-label="full name"
-              isRequired
-            />
+            {usersTextInput(
+              "cn",
+              props.onUserChange,
+              props.user,
+              props.metadata
+            )}
           </FormGroup>
         </Form>
       </FlexItem>
       <FlexItem flex={{ default: "flex_1" }}>
         <Form className="pf-u-mb-lg">
           <FormGroup label="Job title" fieldId="job-title">
-            <TextInput
-              id="job-title"
-              name="title"
-              value={jobTitle}
-              type="text"
-              aria-label="job title"
-              isDisabled
-            />
+            {usersTextInput(
+              "title",
+              props.onUserChange,
+              props.user,
+              props.metadata
+            )}
           </FormGroup>
           <FormGroup label="GECOS" fieldId="gecos">
-            <TextInput
-              id="gecos"
-              name="gecos"
-              value={gecos}
-              type="text"
-              onChange={gecosInputHandler}
-              aria-label="gecos"
-              isDisabled
-            />
+            {usersTextInput(
+              "gecos",
+              props.onUserChange,
+              props.user,
+              props.metadata
+            )}
           </FormGroup>
           <FormGroup label="Class" fieldId="class-field">
-            <TextInput
-              id="class-field"
-              name="userclass"
-              value={classField}
-              type="text"
-              onChange={classFieldInputHandler}
-              aria-label="class field"
-              isRequired
-            />
+            {usersTextInput(
+              "userclass",
+              props.onUserChange,
+              props.user,
+              props.metadata
+            )}
           </FormGroup>
         </Form>
       </FlexItem>

--- a/src/components/layouts/DataSpinner.tsx
+++ b/src/components/layouts/DataSpinner.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+import { Spinner } from "@patternfly/react-core";
+
+export function DataSpinner() {
+  return (
+    <Spinner
+      isSVG
+      style={{ alignSelf: "center", marginTop: "15%" }}
+      aria-label="Loading Data..."
+    />
+  );
+}
+
+export default DataSpinner;

--- a/src/pages/ActiveUsers/ActiveUsersTabs.tsx
+++ b/src/pages/ActiveUsers/ActiveUsersTabs.tsx
@@ -22,11 +22,20 @@ import UserSettings from "../../components/UserSettings";
 import UserMemberOf from "./UserMemberOf";
 // Layouts
 import BreadcrumbLayout from "src/components/layouts/BreadcrumbLayout";
+import DataSpinner from "src/components/layouts/DataSpinner";
+// RPC client
+import { useGetObjectMetadataQuery } from "src/services/rpc";
 
 const ActiveUsersTabs = () => {
   // Get location (React Router DOM) and get state data
   const location = useLocation();
   const userData: User = location.state as User;
+
+  const [user, setUser] = useState<User>(userData);
+
+  const metadataQuery = useGetObjectMetadataQuery();
+  const metadata = metadataQuery.data || {};
+  const metadataLoading = metadataQuery.isLoading;
 
   // Tab
   const [activeTabKey, setActiveTabKey] = useState(0);
@@ -46,6 +55,10 @@ const ActiveUsersTabs = () => {
       url: URL_PREFIX + "/active-users",
     },
   ];
+
+  if (metadataLoading) {
+    return <DataSpinner />;
+  }
 
   return (
     <Page>
@@ -75,7 +88,12 @@ const ActiveUsersTabs = () => {
             title={<TabTitleText>Settings</TabTitleText>}
           >
             <PageSection className="pf-u-pb-0"></PageSection>
-            <UserSettings user={userData} from="active-users" />
+            <UserSettings
+              user={user}
+              metadata={metadata}
+              onUserChange={setUser}
+              from="active-users"
+            />
           </Tab>
           <Tab
             eventKey={1}

--- a/src/pages/PreservedUsers/PreservedUsersTabs.tsx
+++ b/src/pages/PreservedUsers/PreservedUsersTabs.tsx
@@ -21,11 +21,20 @@ import { User } from "src/utils/datatypes/globalDataTypes";
 import UserSettings from "src/components/UserSettings";
 // Layouts
 import BreadcrumbLayout from "src/components/layouts/BreadcrumbLayout";
+import DataSpinner from "src/components/layouts/DataSpinner";
+// RPC client
+import { useGetObjectMetadataQuery } from "src/services/rpc";
 
 const PreservedUsersTabs = () => {
   // Get location (React Router DOM) and get state data
   const location = useLocation();
   const userData: User = location.state as User;
+
+  const [user, setUser] = useState<User>(userData);
+
+  const metadataQuery = useGetObjectMetadataQuery();
+  const metadata = metadataQuery.data || {};
+  const metadataLoading = metadataQuery.isLoading;
 
   // Tab
   const [activeTabKey, setActiveTabKey] = useState(0);
@@ -45,6 +54,10 @@ const PreservedUsersTabs = () => {
       url: URL_PREFIX + "/preserved-users",
     },
   ];
+
+  if (metadataLoading) {
+    return <DataSpinner />;
+  }
 
   return (
     <Page>
@@ -74,7 +87,12 @@ const PreservedUsersTabs = () => {
             title={<TabTitleText>Settings</TabTitleText>}
           >
             <PageSection className="pf-u-pb-0"></PageSection>
-            <UserSettings user={userData} from="preserved-users" />
+            <UserSettings
+              user={user}
+              metadata={metadata}
+              onUserChange={setUser}
+              from="preserved-users"
+            />
           </Tab>
         </Tabs>
       </PageSection>

--- a/src/pages/StageUsers/StageUsersTabs.tsx
+++ b/src/pages/StageUsers/StageUsersTabs.tsx
@@ -21,11 +21,20 @@ import { User } from "src/utils/datatypes/globalDataTypes";
 import UserSettings from "src/components/UserSettings";
 // Layouts
 import BreadcrumbLayout from "src/components/layouts/BreadcrumbLayout";
+import DataSpinner from "src/components/layouts/DataSpinner";
+// RPC client
+import { useGetObjectMetadataQuery } from "src/services/rpc";
 
 const StageUsersTabs = () => {
   // Get location (React Router DOM) and get state data
   const location = useLocation();
   const userData: User = location.state as User;
+
+  const [user, setUser] = useState<User>(userData);
+
+  const metadataQuery = useGetObjectMetadataQuery();
+  const metadata = metadataQuery.data || {};
+  const metadataLoading = metadataQuery.isLoading;
 
   // Tab
   const [activeTabKey, setActiveTabKey] = useState(0);
@@ -45,6 +54,10 @@ const StageUsersTabs = () => {
       url: URL_PREFIX + "/stage-users",
     },
   ];
+
+  if (metadataLoading) {
+    return <DataSpinner />;
+  }
 
   return (
     <Page>
@@ -74,7 +87,12 @@ const StageUsersTabs = () => {
             title={<TabTitleText>Settings</TabTitleText>}
           >
             <PageSection className="pf-u-pb-0"></PageSection>
-            <UserSettings user={userData} from="stage-users" />
+            <UserSettings
+              user={user}
+              metadata={metadata}
+              onUserChange={setUser}
+              from="stage-users"
+            />
           </Tab>
         </Tabs>
       </PageSection>

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -151,3 +151,50 @@ export interface IDPServer {
   ipaidptokenendpoint: string;
   ipaidpuserinfoendpoint: string[];
 }
+
+export interface Metadata {
+  commands?: Record<string, unknown>;
+  methods?: Record<string, unknown>;
+  objects?: ObjectsMetadata;
+}
+
+export interface ObjectsMetadata {
+  [key: string]: ObjectMetadata;
+}
+
+export interface ObjectMetadata {
+  name: string;
+  aciattrs?: string[];
+  attribute_members?: { [key: string]: string[] };
+  bindable?: boolean;
+  can_have_permissions?: boolean;
+  takes_params: ParamMetadata[];
+  [key: string]: unknown; // TODO add missing properties
+}
+
+export interface ParamMetadata {
+  alwaysask: boolean;
+  attribute: boolean;
+  autofill: boolean;
+  class: string;
+  cli_metavar: string;
+  cli_name: string;
+  confirm: boolean;
+  deprecated_cli_aliases: string[];
+  deprecated: boolean;
+  doc: string;
+  flags: string[];
+  label: string;
+  maxlength: number;
+  multivalue: boolean;
+  name: string;
+  no_convert: boolean;
+  noextrawhitespace: boolean;
+  pattern_errmsg: string;
+  pattern: string;
+  primary_key: boolean;
+  query: boolean;
+  required: boolean;
+  sortorder: number;
+  type: string;
+}

--- a/src/utils/ipaObjectUtils.ts
+++ b/src/utils/ipaObjectUtils.ts
@@ -1,0 +1,168 @@
+import { Metadata, ParamMetadata } from "src/utils/datatypes/globalDataTypes";
+
+export type BasicType = string | number | boolean | null | undefined | [];
+
+export type IPAObject = Record<string, unknown>;
+
+export interface IPAParamDefinition {
+  name: string;
+  ipaObject?: Record<string, unknown>;
+  onChange?: (ipaObject: IPAObject) => void;
+  objectName: string;
+  metadata: Metadata;
+  propertyName?: string;
+  alwaysWritable?: boolean;
+  readOnly?: boolean;
+  required?: boolean;
+}
+
+export interface ParamProperties {
+  writable: boolean;
+  required: boolean;
+  readOnly: boolean;
+  value: BasicType;
+  onChange: (value: BasicType) => void;
+  paramMetadata: ParamMetadata;
+}
+
+function getParamMetadata(
+  metadata: Metadata,
+  objectName: string,
+  paramName: string
+): ParamMetadata | null {
+  const objects = metadata.objects || {};
+  const object = objects[objectName] || null;
+  if (!object) {
+    window.console.error(`Object ${objectName} not found in metadata`);
+    return null;
+  }
+
+  const takesParams = object["takes_params"] || [];
+  const param = takesParams.find((param) => param.name === paramName);
+  if (!param) {
+    window.console.error(
+      `Param ${paramName} not found in object ${objectName}`
+    );
+    return null;
+  }
+  return param;
+}
+
+function isFieldWritable(acis: Record<string, string>, attr: string): boolean {
+  const aci = acis[attr];
+  if (typeof aci === "string") {
+    return aci.includes("w");
+  }
+  return false;
+}
+
+function isWritable(
+  paramMetadata: ParamMetadata,
+  ipaObject?: IPAObject,
+  alwaysWritable?: boolean
+): boolean {
+  if (alwaysWritable) {
+    return true;
+  }
+  if (paramMetadata.primary_key) {
+    return false;
+  }
+  if (paramMetadata.flags && paramMetadata.flags.includes("no_update")) {
+    return false;
+  }
+
+  if (!ipaObject) {
+    return true; // assume writable
+  }
+
+  const aci: Record<string, string> = ipaObject[
+    "attributelevelrights"
+  ] as Record<string, string>;
+  if (aci) {
+    const paramWritable = isFieldWritable(aci, paramMetadata.name);
+    const allWritable = isFieldWritable(aci, "*");
+
+    // assume old w_if_no_aci behavior by default. I.e. if object class is
+    // writable than field is also writable (if param ACIs are not defined)
+    const paramACIsDefined = aci[paramMetadata.name] !== undefined;
+    const ocWritable = isFieldWritable(aci, "objectclass");
+
+    return paramWritable || (!paramACIsDefined && ocWritable) || allWritable;
+  }
+
+  return true; // we don't know, assume writable
+}
+
+function isRequired(
+  parDef: IPAParamDefinition,
+  param: ParamMetadata,
+  writable: boolean
+): boolean {
+  if (parDef.readOnly) return false;
+  if (!writable) return false;
+  if (parDef.required !== undefined) return parDef.required;
+  return (param && param.required) || false;
+}
+
+function getValue(
+  ipaObject: Record<string, unknown> | undefined,
+  name: string
+): BasicType {
+  if (!ipaObject) {
+    return "";
+  }
+  return ipaObject[name] as BasicType;
+}
+
+export function getParamProperties(
+  parDef: IPAParamDefinition
+): ParamProperties {
+  const propName = parDef.propertyName || parDef.name;
+  const paramMetadata = getParamMetadata(
+    parDef.metadata,
+    parDef.objectName,
+    propName
+  );
+  if (!paramMetadata) {
+    return {
+      writable: false,
+      required: false,
+      readOnly: true,
+      value: "",
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      onChange: () => {},
+      paramMetadata: {} as ParamMetadata,
+    };
+  }
+  const writable = isWritable(
+    paramMetadata,
+    parDef.ipaObject,
+    parDef.alwaysWritable
+  );
+  const required = isRequired(parDef, paramMetadata, writable);
+  const readOnly = parDef.readOnly === undefined ? !writable : parDef.readOnly;
+  const value = getValue(parDef.ipaObject, propName);
+  const onChange = (value: BasicType) => {
+    if (parDef.onChange) {
+      parDef.onChange({ ...parDef.ipaObject, [propName]: value });
+    }
+  };
+  return {
+    writable,
+    required,
+    readOnly,
+    value,
+    onChange,
+    paramMetadata,
+  };
+}
+
+export function convertToString(value: BasicType): string {
+  if (value === null || value === undefined) {
+    return "";
+  } else if (typeof value === "number" || typeof value === "boolean") {
+    return value.toString();
+  } else {
+    return String(value);
+  }
+}


### PR DESCRIPTION
This commit adds loading of metadata and creates an example how a common field logic can be defined in single place (ipaObjectUtils and IpaTextInput) and used for multiple fields - thus limit the amount of code in various sections + make it possible to change behavior/appearance of all fields of the same type on single place.

Next steps would be to implement new "Ipa" components for different style of inputs - checkboxes, multi-valued text boxes, ... and use it.