### PR TITLE
fix: host and service list pages to display data

### DIFF
--- a/src/pages/Hosts/Hosts.tsx
+++ b/src/pages/Hosts/Hosts.tsx
@@ -94,6 +94,18 @@ const Hosts = () => {
     setShownHostsList(newShownHostsList);
   };
 
+  // Refresh displayed elements every time elements list changes (from Redux or somewhere else)
+  React.useEffect(() => {
+    updatePage(1);
+    if (showTableRows) updateShowTableRows(false);
+    setTimeout(() => {
+      updateShownHostsList(hostsList.slice(0, perPage));
+      updateShowTableRows(true);
+      // Reset 'selectedPerPage'
+      updateSelectedPerPage(0);
+    }, 1000);
+  }, [hostsList]);
+
   // Filter (Input search)
   const [searchValue, setSearchValue] = React.useState("");
 

--- a/src/pages/Services/Services.tsx
+++ b/src/pages/Services/Services.tsx
@@ -108,6 +108,18 @@ const Services = () => {
     setShowTableRows(value);
   };
 
+  // Refresh displayed elements every time elements list changes (from Redux or somewhere else)
+  React.useEffect(() => {
+    updatePage(1);
+    if (showTableRows) updateShowTableRows(false);
+    setTimeout(() => {
+      updateShownServicesList(servicesList.slice(0, perPage));
+      updateShowTableRows(true);
+      // Reset 'selectedPerPage'
+      updateSelectedPerPage(0);
+    }, 1000);
+  }, [servicesList]);
+
   // Dropdown kebab
   const [kebabIsOpen, setKebabIsOpen] = useState(false);
 


### PR DESCRIPTION
This is similar fix to d4b3bc4583f37f38e4fee93c7b6f13924bfb06a4 but for Hosts and Services pages.

Before the pages were not loading and now they are.