### PR TITLE
Add 'word-wrap' advisory warning to allowlist

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -29,6 +29,7 @@
     "GHSA-c2qf-rxjj-qqgw|core-js-compat>semver",
     "GHSA-c2qf-rxjj-qqgw|eslint-plugin-react>semver",
     "GHSA-c2qf-rxjj-qqgw|make-dir>semver>",
-    "GHSA-c2qf-rxjj-qqgw|find-cache-dir>make-dir>semver>"
+    "GHSA-c2qf-rxjj-qqgw|find-cache-dir>make-dir>semver>",
+    "GHSA-j8xg-fqg3-53r7|optionator>word-wrap"
   ]
 }


### PR DESCRIPTION
The risk is tolerable as the issue word-wrap is indirect dependency of eslint - thus in dev environment.

Also the word-wrap author doesn't seem very responsive in accepting a fix: 
  https://github.com/jonschlinkert/word-wrap/pull/33

https://github.com/advisories/GHSA-j8xg-fqg3-53r7