### PR TITLE
[Identity settings] - Enhance the components structure and data retrieval

### DIFF
--- a/src/components/UsersSections/UsersIdentity.tsx
+++ b/src/components/UsersSections/UsersIdentity.tsx
@@ -3,93 +3,114 @@ import React from "react";
 import { Flex, FlexItem, Form, FormGroup } from "@patternfly/react-core";
 // Data types
 import { Metadata, User } from "src/utils/datatypes/globalDataTypes";
+// Utils
+import { asRecord } from "src/utils/userUtils";
+// Fields
 import IpaTextInput from "../Form/IpaTextInput";
 
 interface PropsToUsersIdentity {
   user: User;
-  onUserChange: (user: User) => void;
+  onUserChange: (element: User) => void;
   metadata: Metadata;
 }
 
-function usersTextInput(
-  property: string,
-  onChange: (user: User) => void,
-  user: User,
-  metadata: Metadata
-) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const ipaObject = user as Record<string, any>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  function recordOnChange(ipaObject: Record<string, any>) {
-    onChange(ipaObject as User);
-  }
-  return (
+const UsersIdentity = (props: PropsToUsersIdentity) => {
+  // Get 'ipaObject' and 'recordOnChange' to use in 'IpaTextInput'
+  const { ipaObject, recordOnChange } = asRecord(
+    props.user,
+    props.onUserChange
+  );
+
+  const firstNameTextInput = (
     <IpaTextInput
-      name={property}
+      name={"givenname"}
       ipaObject={ipaObject}
       onChange={recordOnChange}
       objectName="user"
-      metadata={metadata}
+      metadata={props.metadata}
     />
   );
-}
 
-const UsersIdentity = (props: PropsToUsersIdentity) => {
+  // - Last name
+  const lastNameTextInput = (
+    <IpaTextInput
+      name={"sn"}
+      ipaObject={ipaObject}
+      onChange={recordOnChange}
+      objectName="user"
+      metadata={props.metadata}
+    />
+  );
+
+  // - Full name
+  const fullNameTextInput = (
+    <IpaTextInput
+      name={"cn"}
+      ipaObject={ipaObject}
+      onChange={recordOnChange}
+      objectName="user"
+      metadata={props.metadata}
+    />
+  );
+
+  // - Job title
+  const jobTitleTextInput = (
+    <IpaTextInput
+      name={"title"}
+      ipaObject={ipaObject}
+      onChange={recordOnChange}
+      objectName="user"
+      metadata={props.metadata}
+    />
+  );
+
+  // - GECOS
+  const gecosTextInput = (
+    <IpaTextInput
+      name={"gecos"}
+      ipaObject={ipaObject}
+      onChange={recordOnChange}
+      objectName="user"
+      metadata={props.metadata}
+    />
+  );
+
+  // - User class
+  const userClassTextInput = (
+    <IpaTextInput
+      name={"userclass"}
+      ipaObject={ipaObject}
+      onChange={recordOnChange}
+      objectName="user"
+      metadata={props.metadata}
+    />
+  );
+
   return (
     <Flex direction={{ default: "column", lg: "row" }}>
       <FlexItem flex={{ default: "flex_1" }}>
         <Form className="pf-u-mb-lg">
           <FormGroup label="First name" fieldId="first-name" isRequired>
-            {usersTextInput(
-              "givenname",
-              props.onUserChange,
-              props.user,
-              props.metadata
-            )}
+            {firstNameTextInput}
           </FormGroup>
           <FormGroup label="Last name" fieldId="last-name" isRequired>
-            {usersTextInput(
-              "sn",
-              props.onUserChange,
-              props.user,
-              props.metadata
-            )}
+            {lastNameTextInput}
           </FormGroup>
           <FormGroup label="Full name" fieldId="full-name" isRequired>
-            {usersTextInput(
-              "cn",
-              props.onUserChange,
-              props.user,
-              props.metadata
-            )}
+            {fullNameTextInput}
           </FormGroup>
         </Form>
       </FlexItem>
       <FlexItem flex={{ default: "flex_1" }}>
         <Form className="pf-u-mb-lg">
           <FormGroup label="Job title" fieldId="job-title">
-            {usersTextInput(
-              "title",
-              props.onUserChange,
-              props.user,
-              props.metadata
-            )}
+            {jobTitleTextInput}
           </FormGroup>
           <FormGroup label="GECOS" fieldId="gecos">
-            {usersTextInput(
-              "gecos",
-              props.onUserChange,
-              props.user,
-              props.metadata
-            )}
+            {gecosTextInput}
           </FormGroup>
           <FormGroup label="Class" fieldId="class-field">
-            {usersTextInput(
-              "userclass",
-              props.onUserChange,
-              props.user,
-              props.metadata
-            )}
+            {userClassTextInput}
           </FormGroup>
         </Form>
       </FlexItem>

--- a/src/utils/userUtils.tsx
+++ b/src/utils/userUtils.tsx
@@ -1,0 +1,20 @@
+// Data types
+import { User } from "src/utils/datatypes/globalDataTypes";
+
+// Parse the 'textInputField' data into expected data type
+// - TODO: Adapt it to work with many types of data
+export const asRecord = (
+  // property: string,
+  element: User,
+  onElementChange: (element: User) => void
+  // metadata: Metadata
+) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ipaObject = element as Record<string, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function recordOnChange(ipaObject: Record<string, any>) {
+    onElementChange(ipaObject as User);
+  }
+
+  return { ipaObject, recordOnChange };
+};


### PR DESCRIPTION
### Description
The `IpaTextInput` component is used to render the Text input fields, providing a structure to manage its properties. But, in order to be used, its code structure needs to be replicated. E.g.: the `ipaObject` should be defined when using the `IpaTextInput` component.

To prevent that, the code and some parts of the structure of the components have been adapted in a more React-friendly way. This has been implemented in the 'Identity settings' section only.

The code has been refactored as follows:
- Before, a custom hook `useTextInputField` was used to prevent duplicating the same code in many components. This has been now replaced by the `usersUtils` file. The motivation behind this is that custom hooks should provide functionality and not render other components and doing so can be considered an anti-pattern.
- The parsing of the given user and its setter function is done in the `userUtils` file. This is called from `usersIdentity` using a `useEffect`.
- The `IpaTextInput` component is being used directly in the `UsersIdentity` component, without using a wrapper. This is more readable and amends what is mentioned in the first point.
  - AFAIK, it is not good to render a component from a custom hook or utility function.

In the future, this can be adapted to work with multiple field types and data types (apart from `User`).

Signed-off-by: Carla Martinez <carlmart@redhat.com>