### PR TITLE
Adapt field permissions in 'Identity settings' 

### DIFF
--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -34,9 +34,17 @@ import UsersEmployeeInfo from "src/components/UsersSections/UsersEmployeeInfo";
 import UsersAttributesSMB from "src/components/UsersSections/UsersAttributesSMB";
 
 export interface PropsToUserSettings {
-  user: User;
+  user: User; // TODO: Replace with `userData` in all subsections
   onUserChange: (user: User) => void;
   metadata: Metadata;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  userData: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  pwPolicyData: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  krbPolicyData: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  certData: any;
   from: "active-users" | "stage-users" | "preserved-users";
 }
 
@@ -169,7 +177,7 @@ const UserSettings = (props: PropsToUserSettings) => {
                 text="Identity settings"
               />
               <UsersIdentity
-                user={props.user}
+                user={props.userData}
                 onUserChange={props.onUserChange}
                 metadata={props.metadata}
               />

--- a/src/hooks/useUserSettingsData.tsx
+++ b/src/hooks/useUserSettingsData.tsx
@@ -1,0 +1,44 @@
+// RPC
+import {
+  Command,
+  useGetObjectMetadataQuery,
+  useGetUsersFullDataQuery,
+} from "src/services/rpc";
+
+import { Metadata } from "src/utils/datatypes/globalDataTypes";
+
+type UserSettingsData = {
+  isLoading: boolean;
+  metadata: Metadata;
+  userData?: Record<string, unknown>;
+  pwPolicyData?: Record<string, unknown>;
+  krbtPolicyData?: Record<string, unknown>;
+  certData?: Record<string, unknown>;
+};
+
+const useUserSettingsData = (userId: string): UserSettingsData => {
+  // [API call] Metadata
+  const metadataQuery = useGetObjectMetadataQuery();
+  const metadata = metadataQuery.data || {};
+  const metadataLoading = metadataQuery.isLoading;
+
+  const userFullDataQuery = useGetUsersFullDataQuery(userId);
+  const userFullData = userFullDataQuery.data;
+  const isFullDataLoading = userFullDataQuery.isLoading;
+
+  const settingsData = {
+    isLoading: metadataLoading || isFullDataLoading,
+    metadata,
+  } as UserSettingsData;
+
+  if (userFullData) {
+    settingsData.userData = userFullData.user;
+    settingsData.pwPolicyData = userFullData.pwPolicy;
+    settingsData.krbtPolicyData = userFullData.krbtPolicy;
+    settingsData.certData = userFullData.cert;
+  }
+
+  return settingsData;
+};
+
+export default useUserSettingsData;

--- a/src/pages/ActiveUsers/ActiveUsersTabs.tsx
+++ b/src/pages/ActiveUsers/ActiveUsersTabs.tsx
@@ -23,8 +23,8 @@ import UserMemberOf from "./UserMemberOf";
 // Layouts
 import BreadcrumbLayout from "src/components/layouts/BreadcrumbLayout";
 import DataSpinner from "src/components/layouts/DataSpinner";
-// RPC client
-import { useGetObjectMetadataQuery } from "src/services/rpc";
+// Hooks
+import useUserSettingsData from "src/hooks/useUserSettingsData";
 
 const ActiveUsersTabs = () => {
   // Get location (React Router DOM) and get state data
@@ -33,9 +33,8 @@ const ActiveUsersTabs = () => {
 
   const [user, setUser] = useState<User>(userData);
 
-  const metadataQuery = useGetObjectMetadataQuery();
-  const metadata = metadataQuery.data || {};
-  const metadataLoading = metadataQuery.isLoading;
+  // Make API calls needed for user Settings' data
+  const userSettingsData = useUserSettingsData(userData.uid);
 
   // Tab
   const [activeTabKey, setActiveTabKey] = useState(0);
@@ -56,7 +55,7 @@ const ActiveUsersTabs = () => {
     },
   ];
 
-  if (metadataLoading) {
+  if (userSettingsData.isLoading) {
     return <DataSpinner />;
   }
 
@@ -90,7 +89,11 @@ const ActiveUsersTabs = () => {
             <PageSection className="pf-u-pb-0"></PageSection>
             <UserSettings
               user={user}
-              metadata={metadata}
+              metadata={userSettingsData.metadata}
+              userData={userSettingsData.userData}
+              pwPolicyData={userSettingsData.pwPolicyData}
+              krbPolicyData={userSettingsData.krbtPolicyData}
+              certData={userSettingsData.certData}
               onUserChange={setUser}
               from="active-users"
             />

--- a/src/pages/PreservedUsers/PreservedUsersTabs.tsx
+++ b/src/pages/PreservedUsers/PreservedUsersTabs.tsx
@@ -22,8 +22,8 @@ import UserSettings from "src/components/UserSettings";
 // Layouts
 import BreadcrumbLayout from "src/components/layouts/BreadcrumbLayout";
 import DataSpinner from "src/components/layouts/DataSpinner";
-// RPC client
-import { useGetObjectMetadataQuery } from "src/services/rpc";
+// Hooks
+import useUserSettingsData from "src/hooks/useUserSettingsData";
 
 const PreservedUsersTabs = () => {
   // Get location (React Router DOM) and get state data
@@ -32,9 +32,8 @@ const PreservedUsersTabs = () => {
 
   const [user, setUser] = useState<User>(userData);
 
-  const metadataQuery = useGetObjectMetadataQuery();
-  const metadata = metadataQuery.data || {};
-  const metadataLoading = metadataQuery.isLoading;
+  // Make API calls needed for user Settings' data
+  const userSettingsData = useUserSettingsData(userData.uid);
 
   // Tab
   const [activeTabKey, setActiveTabKey] = useState(0);
@@ -55,7 +54,7 @@ const PreservedUsersTabs = () => {
     },
   ];
 
-  if (metadataLoading) {
+  if (userSettingsData.isLoading) {
     return <DataSpinner />;
   }
 
@@ -89,7 +88,11 @@ const PreservedUsersTabs = () => {
             <PageSection className="pf-u-pb-0"></PageSection>
             <UserSettings
               user={user}
-              metadata={metadata}
+              metadata={userSettingsData.metadata}
+              userData={userSettingsData.userData}
+              pwPolicyData={userSettingsData.pwPolicyData}
+              krbPolicyData={userSettingsData.krbtPolicyData}
+              certData={userSettingsData.certData}
               onUserChange={setUser}
               from="preserved-users"
             />

--- a/src/pages/StageUsers/StageUsersTabs.tsx
+++ b/src/pages/StageUsers/StageUsersTabs.tsx
@@ -22,8 +22,8 @@ import UserSettings from "src/components/UserSettings";
 // Layouts
 import BreadcrumbLayout from "src/components/layouts/BreadcrumbLayout";
 import DataSpinner from "src/components/layouts/DataSpinner";
-// RPC client
-import { useGetObjectMetadataQuery } from "src/services/rpc";
+// Hooks
+import useUserSettingsData from "src/hooks/useUserSettingsData";
 
 const StageUsersTabs = () => {
   // Get location (React Router DOM) and get state data
@@ -32,9 +32,8 @@ const StageUsersTabs = () => {
 
   const [user, setUser] = useState<User>(userData);
 
-  const metadataQuery = useGetObjectMetadataQuery();
-  const metadata = metadataQuery.data || {};
-  const metadataLoading = metadataQuery.isLoading;
+  // Make API calls needed for user Settings' data
+  const userSettingsData = useUserSettingsData(userData.uid);
 
   // Tab
   const [activeTabKey, setActiveTabKey] = useState(0);
@@ -55,7 +54,7 @@ const StageUsersTabs = () => {
     },
   ];
 
-  if (metadataLoading) {
+  if (userSettingsData.isLoading) {
     return <DataSpinner />;
   }
 
@@ -89,7 +88,11 @@ const StageUsersTabs = () => {
             <PageSection className="pf-u-pb-0"></PageSection>
             <UserSettings
               user={user}
-              metadata={metadata}
+              metadata={userSettingsData.metadata}
+              userData={userSettingsData.userData}
+              pwPolicyData={userSettingsData.pwPolicyData}
+              krbPolicyData={userSettingsData.krbtPolicyData}
+              certData={userSettingsData.certData}
               onUserChange={setUser}
               from="stage-users"
             />


### PR DESCRIPTION
### Description
Field permissions have been provided to the fields of the 'Identity settings' section.

This has been implemented by defining a new endpoint in the `rpc.ts` file. The data has been retrieved from a custom hook
that is used in the `ActiveUsersTabs`, `StageUsersTabs`, and `PreservedUsersTabs` components.

Finally, the `user` data in the `UserSettings` components has been replaced by the new `userData` from the API call.

Signed-off-by: Carla Martinez <carlmart@redhat.com>