### PR TITLE
Add vulnerable advisory paths into whitelist

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -30,6 +30,10 @@
     "GHSA-c2qf-rxjj-qqgw|eslint-plugin-react>semver",
     "GHSA-c2qf-rxjj-qqgw|make-dir>semver>",
     "GHSA-c2qf-rxjj-qqgw|find-cache-dir>make-dir>semver>",
-    "GHSA-j8xg-fqg3-53r7|optionator>word-wrap"
+    "GHSA-j8xg-fqg3-53r7|optionator>word-wrap",
+    "GHSA-c2qf-rxjj-qqgw|@babel/core>semver",
+    "GHSA-c2qf-rxjj-qqgw|@babel/helper-compilation-targets>semver",
+    "GHSA-c2qf-rxjj-qqgw|@babel/preset-env>semver",
+    "GHSA-c2qf-rxjj-qqgw|babel-loader>make-dir>semver"
   ]
 }


### PR DESCRIPTION
As per [this semver vulnerability](https://github.com/advisories/GHSA-c2qf-rxjj-qqgw)[1], the following vulnerable advisory paths have been whitelisted:
- GHSA-c2qf-rxjj-qqgw|@babel/core>semver
- GHSA-c2qf-rxjj-qqgw|@babel/helper-compilation-targets>semver
- GHSA-c2qf-rxjj-qqgw|@babel/preset-env>semver
- GHSA-c2qf-rxjj-qqgw|babel-loader>make-dir>semver

This can be checked by running the following command:
```
npx audit-ci --config audit-ci.json
```
[1]- https://github.com/advisories/GHSA-c2qf-rxjj-qqgw
Signed-off-by: Carla Martinez <carlmart@redhat.com>