### PR TITLE
Whitelist 'babel/preset-env>babel-plugin-polyfill-corejs2'

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -34,6 +34,7 @@
     "GHSA-c2qf-rxjj-qqgw|@babel/core>semver",
     "GHSA-c2qf-rxjj-qqgw|@babel/helper-compilation-targets>semver",
     "GHSA-c2qf-rxjj-qqgw|@babel/preset-env>semver",
-    "GHSA-c2qf-rxjj-qqgw|babel-loader>make-dir>semver"
+    "GHSA-c2qf-rxjj-qqgw|babel-loader>make-dir>semver",
+    "GHSA-c2qf-rxjj-qqgw|@babel/preset-env>babel-plugin-polyfill-corejs2>semver"
   ]
 }


### PR DESCRIPTION
This new vulnerability warning has been whitelisted:
```
GHSA-c2qf-rxjj-qqgw|@babel/preset-env>babel-plugin-polyfill-corejs2>semver
```