### PR TITLE
[Active users][Settings][Identity settings] 'Revert' and 'Save' button

### DIFF
--- a/src/pages/ActiveUsers/ActiveUsersTabs.tsx
+++ b/src/pages/ActiveUsers/ActiveUsersTabs.tsx
@@ -87,6 +87,7 @@ const ActiveUsersTabs = () => {
           >
             <PageSection className="pf-u-pb-0"></PageSection>
             <UserSettings
+              originalUser={userSettingsData.originalUser}
               user={userSettingsData.user}
               metadata={userSettingsData.metadata}
               pwPolicyData={userSettingsData.pwPolicyData}
@@ -95,6 +96,9 @@ const ActiveUsersTabs = () => {
               onUserChange={userSettingsData.setUser}
               isDataLoading={userSettingsData.isFetching}
               onRefresh={userSettingsData.refetch}
+              isModified={userSettingsData.modified}
+              onResetValues={userSettingsData.resetValues}
+              modifiedValues={userSettingsData.modifiedValues}
               from="active-users"
             />
           </Tab>

--- a/src/pages/PreservedUsers/PreservedUsersTabs.tsx
+++ b/src/pages/PreservedUsers/PreservedUsersTabs.tsx
@@ -86,12 +86,18 @@ const PreservedUsersTabs = () => {
           >
             <PageSection className="pf-u-pb-0"></PageSection>
             <UserSettings
+              originalUser={userSettingsData.originalUser}
               user={userSettingsData.user}
               metadata={userSettingsData.metadata}
               pwPolicyData={userSettingsData.pwPolicyData}
               krbPolicyData={userSettingsData.krbtPolicyData}
               certData={userSettingsData.certData}
               onUserChange={userSettingsData.setUser}
+              isDataLoading={userSettingsData.isFetching}
+              onRefresh={userSettingsData.refetch}
+              isModified={userSettingsData.modified}
+              onResetValues={userSettingsData.resetValues}
+              modifiedValues={userSettingsData.modifiedValues}
               from="preserved-users"
             />
           </Tab>

--- a/src/pages/StageUsers/StageUsersTabs.tsx
+++ b/src/pages/StageUsers/StageUsersTabs.tsx
@@ -86,12 +86,18 @@ const StageUsersTabs = () => {
           >
             <PageSection className="pf-u-pb-0"></PageSection>
             <UserSettings
+              originalUser={userSettingsData.originalUser}
               user={userSettingsData.user}
               metadata={userSettingsData.metadata}
               pwPolicyData={userSettingsData.pwPolicyData}
               krbPolicyData={userSettingsData.krbtPolicyData}
               certData={userSettingsData.certData}
               onUserChange={userSettingsData.setUser}
+              isDataLoading={userSettingsData.isFetching}
+              onRefresh={userSettingsData.refetch}
+              isModified={userSettingsData.modified}
+              onResetValues={userSettingsData.resetValues}
+              modifiedValues={userSettingsData.modifiedValues}
               from="stage-users"
             />
           </Tab>

--- a/src/utils/ipaObjectUtils.ts
+++ b/src/utils/ipaObjectUtils.ts
@@ -166,3 +166,22 @@ export function convertToString(value: BasicType): string {
     return String(value);
   }
 }
+
+export function convertApiObj(
+  apiRecord: Record<string, unknown>,
+  simpleValues: Set<string>,
+  dateValues: Set<string>
+) {
+  const obj = {};
+  for (const [key, value] of Object.entries(apiRecord)) {
+    if (simpleValues.has(key)) {
+      obj[key] = convertToString(value as BasicType);
+    } else if (dateValues.has(key)) {
+      // TODO convert to Datetime object
+      obj[key] = value;
+    } else {
+      obj[key] = value;
+    }
+  }
+  return obj;
+}

--- a/src/utils/userUtils.tsx
+++ b/src/utils/userUtils.tsx
@@ -1,5 +1,6 @@
 // Data types
 import { User } from "src/utils/datatypes/globalDataTypes";
+import { convertApiObj } from "src/utils/ipaObjectUtils";
 
 // Parse the 'textInputField' data into expected data type
 // - TODO: Adapt it to work with many types of data
@@ -18,3 +19,55 @@ export const asRecord = (
 
   return { ipaObject, recordOnChange };
 };
+
+const simpleValues = new Set([
+  "title",
+  "givenname",
+  "sn",
+  "cn",
+  "displayname",
+  "initials",
+  "gecos",
+  "userclass",
+  "uid",
+  "uidnumber",
+  "gidnumber",
+  "loginshell",
+  "homedirectory",
+  "ipatokenradiusconfiglink",
+  "ipatokenradiususername",
+  "ipaidpconfiglink",
+  "ipaidpsub",
+  "krbmaxpwdlife",
+  "krbminpwdlife",
+  "krbpwdhistorylength",
+  "krbpwdmindiffchars",
+  "krbpwdminlength",
+  "krbpwdmaxfailure",
+  "krbpwdfailurecountinterval",
+  "krbpwdlockoutduration",
+  "passwordgracelimit",
+  "krbmaxrenewableage",
+  "krbmaxticketlife",
+  "street",
+  "l",
+  "st",
+  "postalcode",
+  "ou",
+  "manager",
+  "employeenumber",
+  "employeetype",
+  "preferredlanguage",
+  "ipantlogonscript",
+  "ipantprofilepath",
+  "ipanthomedirectory",
+  "ipanthomedirectorydrive",
+  "ipauniqueid",
+  "ipantsecurityidentifier",
+  "dn",
+]);
+const dateValues = new Set(["krbpasswordexpiration", "krbprincipalexpiration"]);
+
+export function apiToUser(apiRecord: Record<string, unknown>) {
+  return convertApiObj(apiRecord, simpleValues, dateValues) as Partial<User>;
+}


### PR DESCRIPTION
### Description
The 'Revert' button will undo the changes made in the fields (as long as those have not been saved). On the other hand, the 'Save' button will store any updated data provided in the form. Those are managed by the `useUserSettingsData` hook and some parameters are being used in this case:

- `modified: boolean`: Determine if a specific field from the form has been modified.
- `resetValues: () => void`: Used after the save button actions are applied. This restores some values needed.
- `originalUser: Partial<User>`: Backup of the original data. Needed to compare potential modifications between two users.
- `modifiedValues: () => Partial<User>`: Get the specific modified fields. This will be needed to modify the user (via `user_mod`).

A [toast notification](https://www.patternfly.org/v4/components/alert/) is shown when any of the aforementioned operations are done.

Signed-off-by: Carla Martinez <carlmart@redhat.com>