### PR TITLE
Whitelist helper-define-polyfill-provider>semver

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -35,6 +35,7 @@
     "GHSA-c2qf-rxjj-qqgw|@babel/helper-compilation-targets>semver",
     "GHSA-c2qf-rxjj-qqgw|@babel/preset-env>semver",
     "GHSA-c2qf-rxjj-qqgw|babel-loader>make-dir>semver",
-    "GHSA-c2qf-rxjj-qqgw|@babel/preset-env>babel-plugin-polyfill-corejs2>semver"
+    "GHSA-c2qf-rxjj-qqgw|@babel/preset-env>babel-plugin-polyfill-corejs2>semver",
+    "GHSA-c2qf-rxjj-qqgw|@babel/preset-env>babel-plugin-polyfill-corejs2>@babel/helper-define-polyfill-provider>semver"
   ]
 }


### PR DESCRIPTION
A new audit warning needs to be added to the audit-ci whitelist:
```
GHSA-c2qf-rxjj-qqgw|@babel/preset-env>babel-plugin-polyfill-corejs2>@babel/helper-define-polyfill-provider>semver
```