### PR TITLE
chore: skip audit of devDependencies

### DIFF
--- a/.github/workflows/gating.yml
+++ b/.github/workflows/gating.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: "16"
 
       - name: Audit dependencies
-        run: npx audit-ci --config audit-ci.json
+        run: npx audit-ci --config audit-ci.json --skip-dev
 
       - name: Cache dependencies
         id: cache-deps


### PR DESCRIPTION
Audit is failing a lot recently, usually with issue in some dependency of dependency of devDependencies. The usuall "fix" is to add it to allow list.

To avoid this, this change is skipping testing of devDependencies so that audit will fail only on runtime deps.