### PR TITLE
Upgrade fedora version in vagrant file

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 
 Vagrant.configure("2") do |config|
   config.vm.hostname = "server.ipa.demo"
-  config.vm.box = "fedora/36-cloud-base"
+  config.vm.box = "fedora/38-cloud-base"
 
   config.vm.synced_folder ".", "/vagrant", disabled: true
   config.vm.synced_folder ".", "/usr/src/freeipa-webui"


### PR DESCRIPTION
The Fedora version available in the Vagrant file should be upgraded to a newer version (e.g.: 38) to prevent possible errors related to product discontinuation.