### PR TITLE
[Active users][Settings][Account settings] Adapt fields and sync data

### DIFF
--- a/src/components/Form/IpaCalendar.tsx
+++ b/src/components/Form/IpaCalendar.tsx
@@ -1,0 +1,164 @@
+import React from "react";
+// PatternFly
+import { CalendarMonth, DropdownItem } from "@patternfly/react-core";
+// Layouts
+import DataTimePickerLayout from "src/components/layouts/Calendar/DataTimePickerLayout";
+// Components
+import CalendarButton from "src/components/layouts/Calendar/CalendarButton";
+// Data types
+import { User } from "src/utils/datatypes/globalDataTypes";
+// Utils
+import {
+  getFullDate,
+  getFullTime,
+  getLDAPGeneralizedTime,
+  parseFullDateStringToUTCFormat,
+} from "src/utils/utils";
+// ipaObject Utils
+import {
+  IPAParamDefinition,
+  getParamProperties,
+  updateIpaObject,
+} from "src/utils/ipaObjectUtils";
+import CalendarLayout from "src/components/layouts/Calendar/CalendarLayout";
+
+const IpaCalendar = (props: IPAParamDefinition) => {
+  // Date and time picker (Calendar)
+  const [isCalendarOpen, setIsCalendarOpen] = React.useState(false);
+  const [isTimeOpen, setIsTimeOpen] = React.useState(false);
+  const [valueDate, setValueDate] = React.useState("YYYY-MM-DD");
+  const [valueTime, setValueTime] = React.useState("HH:MM");
+  const times = Array.from(new Array(10), (_, i) => i + 10);
+  const defaultTime = "10:00";
+
+  const { readOnly } = getParamProperties(props);
+
+  // Initialize parameters got from the 'User' object
+  React.useEffect(() => {
+    if (props.ipaObject !== undefined) {
+      // Parse ipaObject into 'User' type to access the 'datetime' parameter
+      const user = props.ipaObject as unknown as User;
+      if (user[props.name] && user[props.name][0].__datetime__) {
+        // Parse to UTC format
+        const paramUtcDate = parseFullDateStringToUTCFormat(
+          user[props.name][0].__datetime__
+        );
+
+        // Get date
+        const fullDate = getFullDate(paramUtcDate);
+        setValueDate(fullDate);
+
+        // Get time
+        const fullTime = getFullTime(paramUtcDate);
+        setValueTime(fullTime);
+      }
+    }
+  }, [props.ipaObject]);
+
+  // 'onToggle' calendar function
+  const onToggleCalendar = () => {
+    setIsCalendarOpen(!isCalendarOpen);
+    setIsTimeOpen(false);
+  };
+
+  // 'onToggle' time function
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
+  const onToggleTime = (_ev: any) => {
+    setIsTimeOpen(!isTimeOpen);
+    setIsCalendarOpen(false);
+  };
+
+  // On selecting a date from the calendar
+  const onSelectCalendar = (newValueDate: Date) => {
+    const newValue = getFullDate(newValueDate);
+    setValueDate(newValue);
+
+    setIsCalendarOpen(!isCalendarOpen);
+    // setting default time when it is not picked
+    let valTime = valueTime;
+    if (valueTime === "HH:MM") {
+      setValueTime(defaultTime);
+      valTime = defaultTime;
+    }
+
+    // Convert to LDAP format
+    const newFullDate = new Date(newValue + " " + valTime);
+    const LDAPDate = getLDAPGeneralizedTime(newFullDate);
+
+    // Update 'ipaObject' with the new date
+    if (props.ipaObject !== undefined && props.onChange !== undefined) {
+      updateIpaObject(props.ipaObject, props.onChange, LDAPDate, props.name);
+    }
+  };
+
+  // On selecting a time from the dropdown
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const onSelectTime = (ev: any) => {
+    const newTime = ev.target.value as string;
+
+    setValueTime(newTime);
+    setIsTimeOpen(!isTimeOpen);
+
+    const newFullDate = new Date(valueDate + " " + newTime);
+    const LDAPDate = getLDAPGeneralizedTime(newFullDate);
+
+    // Update 'ipaObject' with the new date
+    // - Parse to ISO format (to return to the "user_mod" API call)
+    if (props.ipaObject !== undefined && props.onChange !== undefined) {
+      updateIpaObject(props.ipaObject, props.onChange, LDAPDate, props.name);
+    }
+  };
+
+  const timeOptions = times.map((time) => (
+    <DropdownItem key={time} component="button" value={`${time}:00`}>
+      {`${time}:00`}
+    </DropdownItem>
+  ));
+
+  const calendar = (
+    <CalendarMonth
+      date={new Date(valueDate)}
+      onChange={onSelectCalendar}
+      disabled={readOnly}
+    />
+  );
+
+  const time = (
+    <DataTimePickerLayout
+      dropdownOnSelect={onSelectTime}
+      toggleAriaLabel="Toggle the time picker menu"
+      toggleIndicator={null}
+      toggleOnToggle={onToggleTime}
+      toggleStyle={{ padding: "6px 16px" }}
+      dropdownIsOpen={isTimeOpen}
+      dropdownItems={timeOptions}
+    />
+  );
+
+  const calendarButton = (
+    <CalendarButton
+      ariaLabel="Toggle the calendar"
+      onClick={onToggleCalendar}
+    />
+  );
+
+  return (
+    <CalendarLayout
+      name={props.name}
+      position="bottom"
+      bodyContent={calendar}
+      showClose={false}
+      isVisible={isCalendarOpen}
+      hasNoPadding={true}
+      hasAutoWidth={true}
+      textInputId="date-time"
+      textInputAriaLabel="date and time picker"
+      textInputValue={valueDate + " " + valueTime}
+    >
+      {readOnly ? <></> : calendarButton}
+      {readOnly ? <></> : time}
+    </CalendarLayout>
+  );
+};
+
+export default IpaCalendar;

--- a/src/components/Form/IpaCheckbox.tsx
+++ b/src/components/Form/IpaCheckbox.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+// PatternFly
+import { Checkbox } from "@patternfly/react-core";
+// Utils
+import {
+  IPAParamDefinitionCheckbox,
+  getParamPropertiesCheckBox,
+} from "src/utils/ipaObjectUtils";
+
+const IpaCheckbox = (props: IPAParamDefinitionCheckbox) => {
+  const { required, readOnly, onChange, className } =
+    getParamPropertiesCheckBox(props);
+  const [isChecked, setIsChecked] = React.useState(false);
+
+  React.useEffect(() => {
+    if (props.ipaObject !== undefined && props.value !== undefined) {
+      const checkboxesStateList = props.ipaObject[props.name] as string[];
+      if (checkboxesStateList !== undefined) {
+        const index = checkboxesStateList.indexOf(props.value);
+
+        if (index > -1) {
+          setIsChecked(true);
+        } else {
+          setIsChecked(false);
+        }
+      }
+    }
+  }, [props.ipaObject]);
+
+  return (
+    <Checkbox
+      id={props.id || ""}
+      name={props.name}
+      label={props.value}
+      onChange={onChange}
+      isRequired={required}
+      readOnly={readOnly}
+      isChecked={isChecked}
+      aria-label={props.name}
+      className={className}
+      isDisabled={readOnly}
+    />
+  );
+};
+
+export default IpaCheckbox;

--- a/src/components/Form/IpaSelect.tsx
+++ b/src/components/Form/IpaSelect.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+// PatternFly
+import { Select, SelectOption, SelectVariant } from "@patternfly/react-core";
+// Utils
+import {
+  IPAParamDefinitionSelect,
+  getParamPropertiesSelect,
+} from "src/utils/ipaObjectUtils";
+
+const IpaSelect = (props: IPAParamDefinitionSelect) => {
+  const { required, readOnly, value } = getParamPropertiesSelect(props);
+
+  return (
+    <Select
+      id={props.id}
+      name={props.name}
+      variant={props.variant || SelectVariant.single}
+      aria-label={props.name}
+      onToggle={props.onToggle}
+      onSelect={props.onSelect}
+      selections={value?.toString()}
+      isOpen={props.isOpen}
+      aria-labelledby={props.ariaLabelledBy || props.id}
+      readOnly={readOnly}
+      isDisabled={readOnly}
+      required={required}
+    >
+      {props.elementsOptions.map((option, index) => (
+        <SelectOption key={index} value={option} />
+      ))}
+    </Select>
+  );
+};
+
+export default IpaSelect;

--- a/src/components/Form/IpaTextInput.tsx
+++ b/src/components/Form/IpaTextInput.tsx
@@ -12,7 +12,6 @@ const IpaTextInput = (props: IPAParamDefinition) => {
 
   return (
     <TextInput
-      id={props.name}
       name={props.name}
       value={convertToString(value)}
       onChange={onChange}

--- a/src/components/Form/IpaTextInputFromList.tsx
+++ b/src/components/Form/IpaTextInputFromList.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+// Patternfly
+import { Flex, FlexItem } from "@patternfly/react-core";
+// Layouts
+import SecondaryButton from "../layouts/SecondaryButton";
+// Data types
+import { Metadata } from "src/utils/datatypes/globalDataTypes";
+// Fields
+import IpaTextInputWithId from "./IpaTextInputWithId";
+// Hooks
+import useAlerts from "src/hooks/useAlerts";
+// ipaObject utils
+import { getParamProperties } from "src/utils/ipaObjectUtils";
+
+interface PropsToTextInputFromList {
+  name: string;
+  elementsList: string[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ipaObject: Record<string, any>;
+  metadata: Metadata;
+  onOpenModal: () => void;
+  onRemove: (idx: number) => void;
+}
+
+const IpaTextInputFromList = (props: PropsToTextInputFromList) => {
+  const [elementsList, setElementsList] = React.useState(props.elementsList);
+
+  // Get 'readOnly' to determine if the field has permissions to be edited
+  const { readOnly } = getParamProperties({
+    name: props.name,
+    ipaObject: props.ipaObject,
+    objectName: "user",
+    metadata: props.metadata,
+  });
+
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
+  React.useEffect(() => {
+    setElementsList(props.elementsList);
+  }, [props.elementsList]);
+
+  return (
+    <>
+      <alerts.ManagedAlerts />
+      <Flex direction={{ default: "column" }} name={props.name}>
+        {elementsList !== undefined &&
+          elementsList.map((element, idx) => (
+            <Flex direction={{ default: "row" }} key={idx} name="value">
+              <FlexItem
+                key={idx}
+                flex={{ default: "flex_1" }}
+                className="pf-u-ml-lg"
+              >
+                <IpaTextInputWithId
+                  id={props.name + "-" + idx}
+                  value={element}
+                  name={props.name}
+                  ipaObject={props.ipaObject}
+                  objectName="user"
+                  metadata={props.metadata}
+                  idx={idx}
+                  readOnly={true} // This field is always read-only
+                />
+              </FlexItem>
+              <FlexItem
+                key={element + "-delete-button"}
+                order={{ default: "-1" }}
+              >
+                <SecondaryButton
+                  name="remove"
+                  onClickHandler={() => props.onRemove(idx)}
+                  isDisabled={readOnly}
+                >
+                  Delete
+                </SecondaryButton>
+              </FlexItem>
+            </Flex>
+          ))}
+      </Flex>
+      <SecondaryButton
+        classname="pf-u-mt-md"
+        name="add"
+        onClickHandler={props.onOpenModal}
+        isDisabled={readOnly}
+      >
+        Add
+      </SecondaryButton>
+    </>
+  );
+};
+
+export default IpaTextInputFromList;

--- a/src/components/Form/IpaTextInputWithId.tsx
+++ b/src/components/Form/IpaTextInputWithId.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+// PatternFly
+import { TextInput } from "@patternfly/react-core";
+// Utils
+import {
+  IPAParamDefinitionWithIndex,
+  convertToString,
+  getParamPropertiesWithIndex,
+} from "src/utils/ipaObjectUtils";
+
+const IpaTextInputWithId = (props: IPAParamDefinitionWithIndex) => {
+  const { required, readOnly, value, idx } = getParamPropertiesWithIndex(props);
+
+  const [paramValue, setParamValue] = React.useState("");
+
+  React.useEffect(() => {
+    if (props.value !== undefined) {
+      setParamValue(props.value);
+    } else {
+      setParamValue(convertToString(value));
+    }
+  }, [props.value, value]);
+
+  return (
+    <TextInput
+      key={idx}
+      id={props.id || props.name}
+      name={props.name}
+      value={paramValue}
+      type="text"
+      aria-label={props.name}
+      isRequired={required}
+      readOnlyVariant={readOnly ? "plain" : undefined}
+    />
+  );
+};
+
+export default IpaTextInputWithId;

--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -33,7 +33,7 @@ import UsersMailingAddress from "src/components/UsersSections/UsersMailingAddres
 import UsersEmployeeInfo from "src/components/UsersSections/UsersEmployeeInfo";
 import UsersAttributesSMB from "src/components/UsersSections/UsersAttributesSMB";
 // RPC
-import { useSaveUserMutation } from "src/services/rpc";
+import { ErrorResult, useSaveUserMutation } from "src/services/rpc";
 // Hooks
 import useAlerts from "src/hooks/useAlerts";
 
@@ -114,13 +114,10 @@ const UserSettings = (props: PropsToUserSettings) => {
           alerts.addAlert("save-success", "User modified", "success");
         } else if (response.data.error) {
           // Show toast notification: error
-          alerts.addAlert(
-            "save-error",
-            response.data.error || "Error when modifying user",
-            "danger"
-          );
+          const errorMessage = response.data.error as ErrorResult;
+          alerts.addAlert("save-error", errorMessage.message, "danger");
         }
-        // TODO: Reset values. Disable 'revert' and 'save' buttons
+        // Reset values. Disable 'revert' and 'save' buttons
         props.onResetValues();
       }
     });
@@ -249,7 +246,12 @@ const UserSettings = (props: PropsToUserSettings) => {
                 id="account-settings"
                 text="Account settings"
               />
-              <UsersAccountSettings user={props.user} />
+              <UsersAccountSettings
+                user={props.user}
+                onUserChange={props.onUserChange}
+                metadata={props.metadata}
+                onRefresh={props.onRefresh}
+              />
               <TitleLayout
                 key={2}
                 headingLevel="h2"

--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -16,7 +16,12 @@ import {
 // Icons
 import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
 // Data types
-import { Metadata, User } from "src/utils/datatypes/globalDataTypes";
+import {
+  IDPServer,
+  Metadata,
+  RadiusServer,
+  User,
+} from "src/utils/datatypes/globalDataTypes";
 // Layouts
 import ToolbarLayout from "src/components/layouts/ToolbarLayout";
 import TitleLayout from "src/components/layouts/TitleLayout";
@@ -53,6 +58,8 @@ export interface PropsToUserSettings {
   isDataLoading?: boolean;
   modifiedValues: () => Partial<User>;
   onResetValues: () => void;
+  radiusProxyData?: RadiusServer[];
+  idpData?: IDPServer[];
   from: "active-users" | "stage-users" | "preserved-users";
 }
 
@@ -251,6 +258,8 @@ const UserSettings = (props: PropsToUserSettings) => {
                 onUserChange={props.onUserChange}
                 metadata={props.metadata}
                 onRefresh={props.onRefresh}
+                radiusProxyConf={props.radiusProxyData || []}
+                idpConf={props.idpData || []}
               />
               <TitleLayout
                 key={2}

--- a/src/components/UsersSections/UsersAccountSettings.tsx
+++ b/src/components/UsersSections/UsersAccountSettings.tsx
@@ -7,7 +7,6 @@ import {
   Form,
   FormGroup,
   TextInput,
-  Checkbox,
   Select,
   SelectVariant,
   SelectOption,
@@ -39,6 +38,8 @@ import {
 // Hooks
 import useAlerts from "src/hooks/useAlerts";
 import DeletionConfirmationModal from "../modals/DeletionConfirmationModal";
+// Form
+import IpaCheckbox from "../Form/IpaCheckbox";
 
 interface PropsToUsersAccountSettings {
   user: Partial<User>;
@@ -478,14 +479,6 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
     setIdpIdentifier(value);
   };
 
-  // Checkboxes
-  const [passwordCheckbox] = useState(false);
-  const [radiusCheckbox] = useState(false);
-  const [tpaCheckbox] = useState(false);
-  const [pkinitCheckbox] = useState(false);
-  const [hardenedPassCheckbox] = useState(false);
-  const [extIdentityProvCheckbox] = useState(false);
-
   // Date and time picker (Calendar)
   const [isCalendarOpen, setIsCalendarOpen] = React.useState(false);
   const [isTimeOpen, setIsTimeOpen] = React.useState(false);
@@ -783,58 +776,70 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
                 <PopoverWithIconLayout message={userAuthTypesMessage} />
               }
             >
-              <Checkbox
+              <IpaCheckbox
+                id="password"
                 label="Password"
-                isChecked={passwordCheckbox}
-                aria-label="password from user authentication types"
-                id="passwordCheckbox"
                 name="ipauserauthtype"
                 value="password"
+                ipaObject={ipaObject}
+                onChange={recordOnChange}
+                objectName="user"
+                metadata={props.metadata}
                 className="pf-u-mt-xs pf-u-mb-sm"
               />
-              <Checkbox
+              <IpaCheckbox
+                id="radius"
                 label="RADIUS"
-                isChecked={radiusCheckbox}
-                aria-label="radius from user authentication types"
-                id="radiusCheckbox"
                 name="ipauserauthtype"
                 value="radius"
+                ipaObject={ipaObject}
+                onChange={recordOnChange}
+                objectName="user"
+                metadata={props.metadata}
                 className="pf-u-mt-xs pf-u-mb-sm"
               />
-              <Checkbox
+              <IpaCheckbox
+                id="otp"
                 label="Two-factor authentication (password + OTP)"
-                isChecked={tpaCheckbox}
-                aria-label="two factor authentication from user authentication types"
-                id="tpaCheckbox"
                 name="ipauserauthtype"
                 value="otp"
+                ipaObject={ipaObject}
+                onChange={recordOnChange}
+                objectName="user"
+                metadata={props.metadata}
                 className="pf-u-mt-xs pf-u-mb-sm"
               />
-              <Checkbox
+              <IpaCheckbox
+                id="pkinit"
                 label="PKINIT"
-                isChecked={pkinitCheckbox}
-                aria-label="pkinit from user authentication types"
-                id="pkinitCheckbox"
                 name="ipauserauthtype"
                 value="pkinit"
+                ipaObject={ipaObject}
+                onChange={recordOnChange}
+                objectName="user"
+                metadata={props.metadata}
                 className="pf-u-mt-xs pf-u-mb-sm"
               />
-              <Checkbox
+              <IpaCheckbox
+                id="hardened"
                 label="Hardened password (by SPAKE or FAST)"
-                isChecked={hardenedPassCheckbox}
-                aria-label="hardened password from user authentication types"
-                id="hardenedPassCheckbox"
                 name="ipauserauthtype"
                 value="hardened"
+                ipaObject={ipaObject}
+                onChange={recordOnChange}
+                objectName="user"
+                metadata={props.metadata}
                 className="pf-u-mt-xs pf-u-mb-sm"
               />
-              <Checkbox
+              <IpaCheckbox
+                id="idp"
                 label="External Identity Provider"
-                isChecked={extIdentityProvCheckbox}
-                aria-label="external identity provider from user authentication types"
-                id="extIdentityProvCheckbox"
                 name="ipauserauthtype"
                 value="idp"
+                ipaObject={ipaObject}
+                onChange={recordOnChange}
+                objectName="user"
+                metadata={props.metadata}
               />
             </FormGroup>
             <FormGroup

--- a/src/components/UsersSections/UsersAccountSettings.tsx
+++ b/src/components/UsersSections/UsersAccountSettings.tsx
@@ -6,9 +6,6 @@ import {
   FlexItem,
   Form,
   FormGroup,
-  TextInput,
-  DropdownItem,
-  CalendarMonth,
   Button,
 } from "@patternfly/react-core";
 // Data types
@@ -253,37 +250,6 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
     setIdpConfOptions(idpList);
   }, [props.idpConf]);
 
-  // TODO: This state variables should update the user data via the IPA API (`user_mod`)
-  const [userLogin] = useState(props.user.uid);
-  const [password] = useState("");
-  const [passwordExpiration] = useState("");
-  const [uid, setUid] = useState(props.user.uidnumber);
-  const [gid, setGid] = useState("");
-  const [homeDirectory, setHomeDirectory] = useState("/home/" + userLogin);
-  const [loginShell, setLoginShell] = useState("/bin/sh");
-  const [radiusUsername, setRadiusUsername] = useState("");
-  const [idpIdentifier, setIdpIdentifier] = useState("");
-
-  // UID
-  const uidInputHandler = (value: string) => {
-    setUid(value);
-  };
-
-  // GID
-  const gidInputHandler = (value: string) => {
-    setGid(value);
-  };
-
-  // Home directory
-  const homeDirectoryInputHandler = (value: string) => {
-    setHomeDirectory(value);
-  };
-
-  // Login shell
-  const loginShellInputHandler = (value: string) => {
-    setLoginShell(value);
-  };
-
   // SSH public keys
   // -Text area
   const [textAreaSshPublicKeysValue, setTextAreaSshPublicKeysValue] =
@@ -525,16 +491,6 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
     </Button>,
   ];
 
-  // RADIUS username
-  const radiusUsernameInputHandler = (value: string) => {
-    setRadiusUsername(value);
-  };
-
-  // Track changes on External IdP user identifier textbox field
-  const idpIdentifierInputHandler = (value: string) => {
-    setIdpIdentifier(value);
-  };
-
   // Messages for the popover
   const certificateMappingDataMessage = () => (
     <div>
@@ -568,56 +524,51 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
         <FlexItem flex={{ default: "flex_1" }}>
           <Form className="pf-u-mb-lg">
             <FormGroup label="User login" fieldId="user-login">
-              <TextInput
-                id="user-login"
-                name="uid"
-                value={userLogin}
-                type="text"
-                aria-label="user login"
-                isDisabled
+              <IpaTextInput
+                name={"uid"}
+                ipaObject={ipaObject}
+                onChange={recordOnChange}
+                objectName="user"
+                metadata={props.metadata}
               />
             </FormGroup>
             <FormGroup label="Password" fieldId="password">
-              <TextInput
-                id="password"
-                name="has_password"
-                value={password}
-                type="password"
-                aria-label="password"
-                isDisabled
+              <IpaTextInput
+                name={"has_password"}
+                ipaObject={ipaObject}
+                onChange={recordOnChange}
+                objectName="user"
+                metadata={props.metadata}
               />
             </FormGroup>
             <FormGroup
               label="Password expiration"
               fieldId="password-expiration"
             >
-              <TextInput
-                id="password-expiration"
-                name="krbpasswordexpiration"
-                value={passwordExpiration}
-                type="text"
-                aria-label="password expiration"
-                isDisabled
+              <IpaTextInput
+                name={"krbpasswordexpiration"}
+                ipaObject={ipaObject}
+                onChange={recordOnChange}
+                objectName="user"
+                metadata={props.metadata}
               />
             </FormGroup>
             <FormGroup label="UID" fieldId="uid">
-              <TextInput
-                id="uid"
-                name="uidnumber"
-                value={uid}
-                type="text"
-                onChange={uidInputHandler}
-                aria-label="uid"
+              <IpaTextInput
+                name={"uidnumber"}
+                ipaObject={ipaObject}
+                onChange={recordOnChange}
+                objectName="user"
+                metadata={props.metadata}
               />
             </FormGroup>
             <FormGroup label="GID" fieldId="gid">
-              <TextInput
-                id="gid"
-                name="gidnumber"
-                value={gid}
-                type="text"
-                onChange={gidInputHandler}
-                aria-label="gid"
+              <IpaTextInput
+                name={"gidnumber"}
+                ipaObject={ipaObject}
+                onChange={recordOnChange}
+                objectName="user"
+                metadata={props.metadata}
               />
             </FormGroup>
             <FormGroup
@@ -663,13 +614,12 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
               />
             </FormGroup>
             <FormGroup label="Login shell" fieldId="login-shell">
-              <TextInput
-                id="login-shell"
-                name="loginshell"
-                value={loginShell}
-                type="text"
-                onChange={loginShellInputHandler}
-                aria-label="login shell"
+              <IpaTextInput
+                name={"loginshell"}
+                ipaObject={ipaObject}
+                onChange={recordOnChange}
+                objectName="user"
+                metadata={props.metadata}
               />
             </FormGroup>
           </Form>
@@ -677,13 +627,12 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
         <FlexItem flex={{ default: "flex_1" }}>
           <Form className="pf-u-mb-lg">
             <FormGroup label="Home directory" fieldId="home-directory">
-              <TextInput
-                id="home-directory"
-                name="homedirectory"
-                value={homeDirectory}
-                type="text"
-                onChange={homeDirectoryInputHandler}
-                aria-label="home directory"
+              <IpaTextInput
+                name={"homedirectory"}
+                ipaObject={ipaObject}
+                onChange={recordOnChange}
+                objectName="user"
+                metadata={props.metadata}
               />
             </FormGroup>
             <FormGroup label="SSH public keys" fieldId="ssh-public-keys">
@@ -805,13 +754,12 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
               label="Radius proxy username"
               fieldId="radius-proxy-username"
             >
-              <TextInput
-                id="radius-proxy-username"
-                name="ipatokenradiususername"
-                value={radiusUsername}
-                type="text"
-                onChange={radiusUsernameInputHandler}
-                aria-label="radius proxy username"
+              <IpaTextInput
+                name={"ipatokenradiususername"}
+                ipaObject={ipaObject}
+                onChange={recordOnChange}
+                objectName="user"
+                metadata={props.metadata}
               />
             </FormGroup>
             <FormGroup
@@ -835,13 +783,12 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
               label="External IdP user identifier"
               fieldId="external-idp-user-identifier"
             >
-              <TextInput
-                id="external-idp-user-identifier"
-                name="ipaidpsub"
-                value={idpIdentifier}
-                type="text"
-                onChange={idpIdentifierInputHandler}
-                aria-label="idp user identifier"
+              <IpaTextInput
+                name={"ipaidpsub"}
+                ipaObject={ipaObject}
+                onChange={recordOnChange}
+                objectName="user"
+                metadata={props.metadata}
               />
             </FormGroup>
           </Form>

--- a/src/components/layouts/Calendar/DataTimePickerLayout.tsx
+++ b/src/components/layouts/Calendar/DataTimePickerLayout.tsx
@@ -14,6 +14,7 @@ interface PropsToDataTimePicker {
   toggleIndicator?: React.ElementType | null;
   toggleOnToggle?: (value: boolean, event: any) => void;
   toggleStyle?: React.CSSProperties | undefined;
+  // isDisabled: boolean;
 }
 
 const DataTimePickerLayout = (props: PropsToDataTimePicker) => {
@@ -26,6 +27,7 @@ const DataTimePickerLayout = (props: PropsToDataTimePicker) => {
           toggleIndicator={props.toggleIndicator}
           onToggle={props.toggleOnToggle}
           style={props.toggleStyle}
+          // isDisabled={props.isDisabled}
         >
           <OutlinedClockIcon />
         </DropdownToggle>

--- a/src/components/modals/AddTextInputFromListModal.tsx
+++ b/src/components/modals/AddTextInputFromListModal.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+// PatternFly
+import { Form, FormGroup, Modal, TextInput } from "@patternfly/react-core";
+
+interface PropsToAddModal {
+  newValue: string;
+  setNewValue: (newValue: string) => void;
+  variant?: "small" | "medium" | "large" | "default";
+  title: string;
+  isOpen: boolean;
+  onClose: () => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  actions: any[];
+  textInputTitle: string;
+  textInputName: string;
+}
+
+const AddTextInputFromListModal = (props: PropsToAddModal) => {
+  // Reset text input value when the modal is closed
+  React.useEffect(() => {
+    if (!props.isOpen) {
+      props.setNewValue("");
+    }
+  }, [props.isOpen]);
+
+  return (
+    <Modal
+      variant={props.variant || "small"}
+      title={props.title}
+      isOpen={props.isOpen}
+      onClose={props.onClose}
+      actions={props.actions}
+    >
+      <Form>
+        <FormGroup
+          label={props.textInputTitle}
+          type="string"
+          fieldId="selection"
+        >
+          <TextInput
+            name={props.textInputName}
+            value={props.newValue}
+            onChange={props.setNewValue}
+            type="text"
+            aria-label={props.textInputName}
+            isRequired={true}
+          />
+        </FormGroup>
+      </Form>
+    </Modal>
+  );
+};
+
+export default AddTextInputFromListModal;

--- a/src/components/modals/DeletionConfirmationModal.tsx
+++ b/src/components/modals/DeletionConfirmationModal.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+// PatternFly
+import { Modal } from "@patternfly/react-core";
+import TextLayout from "../layouts/TextLayout";
+
+interface PropsToDeletionConfModal {
+  variant?: "default" | "small" | "medium" | "large";
+  title: string;
+  isOpen?: boolean;
+  onClose: () => void;
+  actions: JSX.Element[];
+  messageText: string;
+}
+
+const DeletionConfirmationModal = (props: PropsToDeletionConfModal) => {
+  return (
+    <Modal
+      variant={props.variant || "small"}
+      title={props.title}
+      isOpen={props.isOpen}
+      onClose={props.onClose}
+      actions={props.actions}
+    >
+      <TextLayout>{props.messageText}</TextLayout>
+    </Modal>
+  );
+};
+
+export default DeletionConfirmationModal;

--- a/src/hooks/useUserSettingsData.tsx
+++ b/src/hooks/useUserSettingsData.tsx
@@ -12,6 +12,7 @@ type UserSettingsData = {
   isLoading: boolean;
   isFetching: boolean;
   modified: boolean;
+  setModified: (value: boolean) => void;
   resetValues: () => void;
   metadata: Metadata;
   originalUser: Partial<User>;
@@ -48,6 +49,7 @@ const useUserSettingsData = (userId: string): UserSettingsData => {
     isLoading: metadataLoading || isFullDataLoading,
     isFetching: userFullDataQuery.isFetching,
     modified,
+    setModified,
     metadata,
     user,
     setUser,
@@ -84,9 +86,17 @@ const useUserSettingsData = (userId: string): UserSettingsData => {
     }
     let modified = false;
     for (const [key, value] of Object.entries(user)) {
-      if (userFullData.user[key] !== value) {
-        modified = true;
-        break;
+      if (Array.isArray(value)) {
+        // 'JSON.stringify' when comparing arrays (to prevent data type false positives)
+        if (JSON.stringify(userFullData.user[key]) !== JSON.stringify(value)) {
+          modified = true;
+          break;
+        }
+      } else {
+        if (userFullData.user[key] !== value) {
+          modified = true;
+          break;
+        }
       }
     }
     setModified(modified);

--- a/src/pages/ActiveUsers/ActiveUsersTabs.tsx
+++ b/src/pages/ActiveUsers/ActiveUsersTabs.tsx
@@ -99,6 +99,8 @@ const ActiveUsersTabs = () => {
               isModified={userSettingsData.modified}
               onResetValues={userSettingsData.resetValues}
               modifiedValues={userSettingsData.modifiedValues}
+              radiusProxyData={userSettingsData.radiusServer}
+              idpData={userSettingsData.idpServer}
               from="active-users"
             />
           </Tab>

--- a/src/services/rpc.ts
+++ b/src/services/rpc.ts
@@ -8,7 +8,12 @@ import {
 } from "@reduxjs/toolkit/query/react";
 // Utils
 import { API_VERSION_BACKUP } from "src/utils/utils";
-import { Metadata, User } from "src/utils/datatypes/globalDataTypes";
+import {
+  IDPServer,
+  Metadata,
+  RadiusServer,
+  User,
+} from "src/utils/datatypes/globalDataTypes";
 import { apiToUser } from "src/utils/userUtils";
 
 export type UserFullData = {
@@ -148,7 +153,12 @@ export const getBatchCommand = (commandData: Command[], apiVersion: string) => {
 export const api = createApi({
   reducerPath: "api",
   baseQuery: fetchBaseQuery({ baseUrl: "/" }), // TODO: Global settings!
-  tagTypes: ["ObjectMetadata", "FullUserData"],
+  tagTypes: [
+    "ObjectMetadata",
+    "FullUserData",
+    "RadiusServerData",
+    "IdpServerData",
+  ],
   endpoints: (build) => ({
     simpleCommand: build.query<FindRPCResponse, Command | void>({
       query: (payloadData: Command) => getCommand(payloadData),
@@ -326,6 +336,28 @@ export const api = createApi({
         });
       },
     }),
+    getRadiusProxy: build.query<RadiusServer[], void>({
+      query: () => {
+        return getCommand({
+          method: "radiusproxy_find",
+          params: [[null], { version: API_VERSION_BACKUP }],
+        });
+      },
+      transformResponse: (response: FindRPCResponse): RadiusServer[] =>
+        response.result.result as unknown as RadiusServer[],
+      providesTags: ["RadiusServerData"],
+    }),
+    getIdpServer: build.query<IDPServer[], void>({
+      query: () => {
+        return getCommand({
+          method: "idp_find",
+          params: [[null], { version: API_VERSION_BACKUP }],
+        });
+      },
+      transformResponse: (response: FindRPCResponse): IDPServer[] =>
+        response.result.result as unknown as IDPServer[],
+      providesTags: ["IdpServerData"],
+    }),
   }),
 });
 
@@ -340,4 +372,6 @@ export const {
   useSaveUserMutation,
   useRemovePrincipalAliasMutation,
   useAddPrincipalAliasMutation,
+  useGetRadiusProxyQuery,
+  useGetIdpServerQuery,
 } = api;

--- a/src/services/rpc.ts
+++ b/src/services/rpc.ts
@@ -50,10 +50,20 @@ export interface BatchResponse {
   };
 }
 
+export interface ErrorResult {
+  code: number;
+  message: string;
+  data: {
+    attr: string;
+    value: string;
+  };
+  name: string;
+}
+
 // 'FindRPCResponse' type
 //   - Has 'result' > 'result' structure
 export interface FindRPCResponse {
-  error: string;
+  error: string | ErrorResult;
   id: string;
   principal: string;
   version: string;
@@ -296,6 +306,26 @@ export const api = createApi({
       },
       invalidatesTags: ["FullUserData"],
     }),
+    removePrincipalAlias: build.mutation<FindRPCResponse, any[]>({
+      query: (payload) => {
+        const params = [payload, { version: API_VERSION_BACKUP }];
+
+        return getCommand({
+          method: "user_remove_principal",
+          params: params,
+        });
+      },
+    }),
+    addPrincipalAlias: build.mutation<FindRPCResponse, any[]>({
+      query: (payload) => {
+        const params = [payload, { version: API_VERSION_BACKUP }];
+
+        return getCommand({
+          method: "user_add_principal",
+          params: params,
+        });
+      },
+    }),
   }),
 });
 
@@ -308,4 +338,6 @@ export const {
   useGetObjectMetadataQuery,
   useGetUsersFullDataQuery,
   useSaveUserMutation,
+  useRemovePrincipalAliasMutation,
+  useAddPrincipalAliasMutation,
 } = api;

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -198,3 +198,9 @@ export interface ParamMetadata {
   sortorder: number;
   type: string;
 }
+
+export interface RadiusServer {
+  ipatokenradiusserver: string;
+  cn: string;
+  dn: string;
+}

--- a/src/utils/ipaObjectUtils.ts
+++ b/src/utils/ipaObjectUtils.ts
@@ -1,5 +1,7 @@
 import { Metadata, ParamMetadata } from "src/utils/datatypes/globalDataTypes";
 import { isSimpleValue } from "./userUtils";
+// PatternFly
+import { SelectOptionObject } from "@patternfly/react-core";
 
 export type BasicType = string | number | boolean | null | undefined | [];
 
@@ -51,6 +53,31 @@ export interface IPAParamDefinitionCheckbox {
   className?: string; //
 }
 
+export interface IPAParamDefinitionSelect {
+  id?: string;
+  value?: string;
+  name: string;
+  ipaObject?: Record<string, unknown>;
+  objectName: string;
+  metadata: Metadata;
+  propertyName?: string;
+  alwaysWritable?: boolean;
+  readOnly?: boolean;
+  required?: boolean;
+  //---
+  variant?: "single" | "checkbox" | "typeahead" | "typeaheadmulti";
+  elementsOptions: string[];
+  onToggle: (isOpen: boolean) => void;
+  onSelect?: (
+    event: React.MouseEvent | React.ChangeEvent,
+    value: string | SelectOptionObject,
+    isPlaceholder?: boolean
+  ) => void;
+  selections?: string | SelectOptionObject | (string | SelectOptionObject)[];
+  isOpen: boolean;
+  ariaLabelledBy?: string;
+}
+
 export interface ParamProperties {
   writable: boolean;
   required: boolean;
@@ -79,6 +106,14 @@ export interface ParamPropertiesCheckbox {
   paramMetadata: ParamMetadata;
   label: string; //
   className: string; //
+}
+
+export interface ParamPropertiesSelect {
+  writable: boolean;
+  required: boolean;
+  readOnly: boolean;
+  value: BasicType;
+  paramMetadata: ParamMetadata;
 }
 
 function getParamMetadata(
@@ -225,7 +260,6 @@ export function getParamProperties(
   };
 }
 
-// TEST
 export function getParamPropertiesWithIndex(
   parDef: IPAParamDefinitionWithIndex
 ): ParamPropertiesWithIndex {
@@ -357,6 +391,43 @@ export function getParamPropertiesCheckBox(
     paramMetadata,
     label,
     className,
+  };
+}
+
+export function getParamPropertiesSelect(
+  parDef: IPAParamDefinitionSelect
+): ParamPropertiesSelect {
+  const propName = parDef.propertyName || parDef.name;
+  const paramMetadata = getParamMetadata(
+    parDef.metadata,
+    parDef.objectName,
+    propName
+  );
+  if (!paramMetadata) {
+    return {
+      writable: false,
+      required: false,
+      readOnly: true,
+      value: "",
+      paramMetadata: {} as ParamMetadata,
+    };
+  }
+  const writable = isWritable(
+    paramMetadata,
+    parDef.ipaObject,
+    parDef.alwaysWritable
+  );
+  const required = isRequired(parDef, paramMetadata, writable);
+  const readOnly = parDef.readOnly === undefined ? !writable : parDef.readOnly;
+  const value = getValue(parDef.ipaObject, propName)?.toString();
+
+  return {
+    writable,
+    required,
+    readOnly,
+    value,
+    // onChange,
+    paramMetadata,
   };
 }
 

--- a/src/utils/ipaObjectUtils.ts
+++ b/src/utils/ipaObjectUtils.ts
@@ -459,3 +459,18 @@ export function convertApiObj(
   }
   return obj;
 }
+
+// Updates 'ipaObject'
+export const updateIpaObject = (
+  ipaObject: Record<string, unknown>,
+  setIpaObject: (ipaObject: Record<string, unknown>) => void,
+  newValue: string | string[],
+  paramName: string
+) => {
+  if (!isSimpleValue(paramName)) {
+    const paramToModify = newValue as string[];
+    setIpaObject({ ...ipaObject, [paramName]: paramToModify });
+  } else {
+    setIpaObject({ ...ipaObject, [paramName]: newValue });
+  }
+};

--- a/src/utils/userUtils.tsx
+++ b/src/utils/userUtils.tsx
@@ -71,3 +71,9 @@ const dateValues = new Set(["krbpasswordexpiration", "krbprincipalexpiration"]);
 export function apiToUser(apiRecord: Record<string, unknown>) {
   return convertApiObj(apiRecord, simpleValues, dateValues) as Partial<User>;
 }
+
+// Determines whether a given property name is a simple value or is it multivalue (Array)
+//  - Returns: boolean
+export const isSimpleValue = (propertyName) => {
+  return simpleValues.has(propertyName);
+};

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -70,3 +70,108 @@ export const apiErrorToJsXError = (
 
   return errorJsx;
 };
+
+// Parse full string date to UTC date format
+// '20230809120244Z' --> 'Sat Aug 09 2023 14:02:44 GMT+0200 (Central European Summer Time)'
+export const parseFullDateStringToUTCFormat = (date: string) => {
+  const year = date.substring(0, 4);
+  const month = date.substring(4, 6);
+  const day = date.substring(6, 8);
+  const hour = date.substring(8, 10);
+  const minutes = date.substring(10, 12);
+  const seconds = date.substring(12, 14);
+
+  const dateFormat = new Date(
+    +year,
+    +month - 1, // number between 0 and 11 (January to December).
+    +day,
+    +hour,
+    +minutes,
+    +seconds
+  ); // UTC
+
+  return dateFormat;
+};
+
+// Get the full day of a specific Date object
+// - As the getDate() function returns a
+//   number between 0 and 31, we need to add
+//   a '0' in front of the number if it is
+//   less than 10.
+// - E.g.: 3 --> 03
+export const getFullDay = (day: Date) => {
+  return (day.getDate() < 10 ? "0" : "") + day.getDate();
+};
+
+// Get the full month of a specific Date object
+// - As the getMonth() function returns a
+//   number between 0 and 31, we need to add
+//   a '0' in front of the number if it is
+//   less than 10.
+// - E.g.: 3 --> 03
+export const getFullMonth = (month: Date) => {
+  return (month.getMonth() + 1 < 10 ? "0" : "") + (month.getMonth() + 1);
+};
+
+// Get the full minutes of a specific Date object
+// - As the getMinutes() function returns a
+//   number between 0 and 59, we need to add
+//   a '0' in front of the number if it is
+//   less than 10.
+// - E.g.: 9 --> 09
+export const getFullMinutes = (minutes: Date) => {
+  return (minutes.getMinutes() < 10 ? "0" : "") + minutes.getMinutes();
+};
+
+// Get the full seconds of a specific Date object
+// - As the getSeconds() function returns a
+//   number between 0 and 59, we need to add
+//   a '0' in front of the number if it is
+//   less than 10.
+// - E.g.: 9 --> 09
+export const getFullSeconds = (minutes: Date) => {
+  return (minutes.getSeconds() < 10 ? "0" : "") + minutes.getSeconds();
+};
+
+// Given a date, obtain the date in the format 'YYYY-MM-DD'
+export const getFullDate = (date: Date) => {
+  const year = date.getFullYear();
+  const month = getFullMonth(date);
+  const day = getFullDay(date);
+
+  return year + "-" + month + "-" + day;
+};
+
+// Given a date, obtain the time in the format 'HH:MM'
+export const getFullTime = (date: Date) => {
+  const hours = date.getHours();
+  const minutes = getFullMinutes(date);
+
+  return hours + ":" + minutes;
+};
+
+// Given a date, obtain the time in LDAP generalized time format
+export const getLDAPGeneralizedTime = (date: Date) => {
+  const year = date.getFullYear();
+  const month = getFullMonth(date);
+  const day = getFullDay(date);
+  const hours = date.getHours();
+  const minutes = getFullMinutes(date);
+  const seconds = getFullSeconds(date);
+
+  return (
+    year +
+    "" +
+    month +
+    "" +
+    day +
+    "" +
+    hours +
+    "" +
+    minutes +
+    "" +
+    seconds +
+    "" +
+    "Z"
+  );
+};


### PR DESCRIPTION
The 'Account settings' section has different types of UI components. Only the 'Text input' ones (given by the `IpaTextInput` component) were adapted to retrieve the data from the metadata and update this value. This has been adapted and now more elements are capable to do that. Those are: 

- Text inputs accompanied with 'Add' and 'Delete' buttons
  - Field(s): 'Principal alias' (`krbprincipalname`)
- Dropdown selectors
  - Field(s): 'Radius proxy configuration' (`ipatokenradiusconfiglink`) and 'External IdP configuration' (`ipaidpconfiglink`)
- Data-time selectors
  - Field(s): 'Kerberos principal expiration (UTC) (`krbprincipalexpiration`)
- Group of checkboxes
  - Field(s): 'User authentication types' (`ipauserauthtype`)

Also, the following fields have been adapted to use the `IpaTextInput` component:
- 'User login' (`uid`)
- 'Password' (`has_password`)
- 'Password expiration' (`krbpasswordexpiration`)
- 'UID' (`uidnumber`)
- 'GID' (`gidnumber`)
- 'Login shell' (`loginshell`)
- 'Home directory' (`homedirectory`)
- 'Radius proxy username' (`ipatokenradiususername`)
- 'External IdP user identifier' (`ipaidpsub`)

Signed-off-by: Carla Martinez <carlmart@redhat.com>