### PR TITLE
[Active users][Settings][Account settings] Add functionality for Text inputs

### DIFF
--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -249,7 +249,12 @@ const UserSettings = (props: PropsToUserSettings) => {
                 id="account-settings"
                 text="Account settings"
               />
-              <UsersAccountSettings user={props.user} />
+              <UsersAccountSettings
+                user={props.user}
+                onUserChange={props.onUserChange}
+                metadata={props.metadata}
+                onRefresh={props.onRefresh}
+              />
               <TitleLayout
                 key={2}
                 headingLevel="h2"

--- a/src/hooks/useUserSettingsData.tsx
+++ b/src/hooks/useUserSettingsData.tsx
@@ -84,9 +84,17 @@ const useUserSettingsData = (userId: string): UserSettingsData => {
     }
     let modified = false;
     for (const [key, value] of Object.entries(user)) {
-      if (userFullData.user[key] !== value) {
-        modified = true;
-        break;
+      if (Array.isArray(value)) {
+        // Using 'JSON.stringify' when comparing arrays (to prevent data type false positives)
+        if (JSON.stringify(userFullData.user[key]) !== JSON.stringify(value)) {
+          modified = true;
+          break;
+        }
+      } else {
+        if (userFullData.user[key] !== value) {
+          modified = true;
+          break;
+        }
       }
     }
     setModified(modified);


### PR DESCRIPTION
The following fields have been adapted to use the `IpaTextInput` component:
- 'User login' (`uid`)
- 'Password' (`has_password`)
- 'Password expiration' (`krbpasswordexpiration`)
- 'UID' (`uidnumber`)
- 'GID' (`gidnumber`)
- 'Login shell' (`loginshell`)
- 'Home directory' (`homedirectory`)
- 'Radius proxy username' (`ipatokenradiususername`)
- 'External IdP user identifier' (`ipaidpsub`)