### PR TITLE
[Active users][Settings][Account settings] Add functionality for Selectors

### DIFF
--- a/src/components/Form/IpaSelect.tsx
+++ b/src/components/Form/IpaSelect.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+// PatternFly
+import {
+  Select,
+  SelectOption,
+  SelectOptionObject,
+  SelectVariant,
+} from "@patternfly/react-core";
+// Utils
+import {
+  IPAParamDefinition,
+  getParamProperties,
+} from "src/utils/ipaObjectUtils";
+import { updateIpaObject } from "src/utils/ipaObjectUtils";
+import { NO_SELECTION_OPTION } from "src/utils/constUtils";
+
+interface IPAParamDefinitionSelect extends IPAParamDefinition {
+  id?: string;
+  setIpaObject?: (ipaObject: Record<string, unknown>) => void;
+  variant?: "single" | "checkbox" | "typeahead" | "typeaheadmulti";
+  options: string[];
+  ariaLabelledBy?: string;
+}
+
+const IpaSelect = (props: IPAParamDefinitionSelect) => {
+  // Obtains the metadata of the parameter
+  const { required, readOnly, value } = getParamProperties(props);
+
+  // Handle selected value
+  let valueSelected = NO_SELECTION_OPTION;
+  if (value !== undefined && value && value !== "") {
+    valueSelected = value.toString();
+  }
+
+  const ipaObject = props.ipaObject || {};
+
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  const onSelect = (
+    _event: React.MouseEvent | React.ChangeEvent,
+    selection: string | SelectOptionObject
+  ) => {
+    let valueToUpdate = "";
+
+    if (selection !== NO_SELECTION_OPTION) {
+      valueToUpdate = selection as string;
+    }
+
+    if (ipaObject && props.setIpaObject !== undefined) {
+      updateIpaObject(ipaObject, props.setIpaObject, valueToUpdate, props.name);
+    }
+
+    setIsOpen(false);
+  };
+
+  // Provide empty option at the beginning of the list
+  const optionsToSelect: string[] = [...(props.options || [])];
+  optionsToSelect.unshift(NO_SELECTION_OPTION);
+
+  return (
+    <Select
+      id={props.id}
+      name={props.name}
+      variant={props.variant || SelectVariant.single}
+      aria-label={props.name}
+      onToggle={setIsOpen}
+      onSelect={onSelect}
+      selections={valueSelected}
+      isOpen={isOpen}
+      aria-labelledby={props.ariaLabelledBy || props.id}
+      readOnly={readOnly}
+      isDisabled={readOnly}
+      required={required}
+    >
+      {optionsToSelect.map((option, index) => {
+        return <SelectOption key={index} value={option} />;
+      })}
+    </Select>
+  );
+};
+
+export default IpaSelect;

--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -16,7 +16,12 @@ import {
 // Icons
 import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
 // Data types
-import { Metadata, User } from "src/utils/datatypes/globalDataTypes";
+import {
+  Metadata,
+  User,
+  IDPServer,
+  RadiusServer,
+} from "src/utils/datatypes/globalDataTypes";
 // Layouts
 import ToolbarLayout from "src/components/layouts/ToolbarLayout";
 import TitleLayout from "src/components/layouts/TitleLayout";
@@ -53,6 +58,8 @@ export interface PropsToUserSettings {
   isDataLoading?: boolean;
   modifiedValues: () => Partial<User>;
   onResetValues: () => void;
+  radiusProxyData?: RadiusServer[];
+  idpData?: IDPServer[];
   from: "active-users" | "stage-users" | "preserved-users";
 }
 
@@ -254,6 +261,8 @@ const UserSettings = (props: PropsToUserSettings) => {
                 onUserChange={props.onUserChange}
                 metadata={props.metadata}
                 onRefresh={props.onRefresh}
+                radiusProxyConf={props.radiusProxyData || []}
+                idpConf={props.idpData || []}
               />
               <TitleLayout
                 key={2}

--- a/src/components/UsersSections/UsersAccountSettings.tsx
+++ b/src/components/UsersSections/UsersAccountSettings.tsx
@@ -8,15 +8,17 @@ import {
   FormGroup,
   TextInput,
   Checkbox,
-  Select,
-  SelectVariant,
-  SelectOption,
   DropdownItem,
   CalendarMonth,
   Button,
 } from "@patternfly/react-core";
 // Data types
-import { IDPServer, Metadata, User } from "src/utils/datatypes/globalDataTypes";
+import {
+  IDPServer,
+  Metadata,
+  User,
+  RadiusServer,
+} from "src/utils/datatypes/globalDataTypes";
 // Layouts
 import SecondaryButton from "src/components/layouts/SecondaryButton";
 import DataTimePickerLayout from "src/components/layouts/Calendar/DataTimePickerLayout";
@@ -30,12 +32,15 @@ import CertificateMappingDataModal from "src/components/modals/CertificateMappin
 import { asRecord } from "src/utils/userUtils";
 // Form
 import IpaTextInput from "src/components/Form/IpaTextInput";
+import IpaSelect from "../Form/IpaSelect";
 
 interface PropsToUsersAccountSettings {
   user: Partial<User>;
   onUserChange: (element: Partial<User>) => void;
   metadata: Metadata;
   onRefresh: () => void;
+  radiusProxyConf: RadiusServer[];
+  idpConf: IDPServer[];
 }
 
 // Generic data to pass to the Textbox adder
@@ -53,6 +58,14 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
     props.user,
     props.onUserChange
   );
+
+  // Dropdown 'Radius proxy configuration'
+  const radiusProxyList = props.radiusProxyConf.map((item) =>
+    item.cn.toString()
+  );
+
+  // Dropdown 'External IdP configuration'
+  const idpConfOptions = props.idpConf.map((item) => item.cn.toString());
 
   const [principalAliasList, setPrincipalAliasList] = useState<ElementData[]>([
     {
@@ -415,38 +428,6 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
     />
   );
 
-  // Dropdown 'Radius proxy configuration'
-  const [isRadiusConfOpen, setIsRadiusConfOpen] = useState(false);
-  const [radiusConfSelected, setRadiusConfSelected] = useState("");
-  const radiusConfOptions = [
-    { value: "Option 1", disabled: false },
-    { value: "Option 2", disabled: false },
-    { value: "Option 3", disabled: false },
-  ];
-  const radiusConfOnToggle = (isOpen: boolean) => {
-    setIsRadiusConfOpen(isOpen);
-  };
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const radiusConfOnSelect = (selection: any) => {
-    setRadiusConfSelected(selection.target.textContent);
-    setIsRadiusConfOpen(false);
-  };
-
-  // Dropdown 'External IdP configuration'
-  const [isIdpConfOpen, setIsIdpConfOpen] = useState(false);
-  const [idpConfSelected, setIdpConfSelected] = useState("");
-  const [idpConfOptions] = useState<IDPServer[]>([]);
-
-  const idpConfOnToggle = (isOpen: boolean) => {
-    setIsIdpConfOpen(isOpen);
-  };
-
-  const idpConfOnSelect = (selection: any) => {
-    setIdpConfSelected(selection.target.textContent);
-    setIsIdpConfOpen(false);
-  };
-
   // Messages for the popover
   const certificateMappingDataMessage = () => (
     <div>
@@ -703,26 +684,15 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
               label="Radius proxy configuration"
               fieldId="radius-proxy-configuration"
             >
-              <Select
+              <IpaSelect
                 id="radius-proxy-configuration"
                 name="ipatokenradiusconfiglink"
-                variant={SelectVariant.single}
-                placeholderText=" "
-                aria-label="Select Input with descriptions"
-                onToggle={radiusConfOnToggle}
-                onSelect={radiusConfOnSelect}
-                selections={radiusConfSelected}
-                isOpen={isRadiusConfOpen}
-                aria-labelledby="radius-proxy-conf"
-              >
-                {radiusConfOptions.map((option, index) => (
-                  <SelectOption
-                    isDisabled={option.disabled}
-                    key={index}
-                    value={option.value}
-                  />
-                ))}
-              </Select>
+                options={radiusProxyList}
+                ipaObject={ipaObject}
+                setIpaObject={recordOnChange}
+                objectName="user"
+                metadata={props.metadata}
+              />
             </FormGroup>
             <FormGroup
               label="Radius proxy username"
@@ -740,22 +710,15 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
               label="External IdP configuration"
               fieldId="external-idp-configuration"
             >
-              <Select
+              <IpaSelect
                 id="external-idp-configuration"
                 name="ipaidpconfiglink"
-                variant={SelectVariant.single}
-                placeholderText=" "
-                aria-label="Select Input with descriptions"
-                onToggle={idpConfOnToggle}
-                onSelect={idpConfOnSelect}
-                selections={idpConfSelected}
-                isOpen={isIdpConfOpen}
-                aria-labelledby="external-idp-conf"
-              >
-                {idpConfOptions.map((option, index) => (
-                  <SelectOption key={index} value={option.cn} />
-                ))}
-              </Select>
+                options={idpConfOptions}
+                ipaObject={ipaObject}
+                setIpaObject={recordOnChange}
+                objectName="user"
+                metadata={props.metadata}
+              />
             </FormGroup>
             <FormGroup
               label="External IdP user identifier"

--- a/src/pages/ActiveUsers/ActiveUsersTabs.tsx
+++ b/src/pages/ActiveUsers/ActiveUsersTabs.tsx
@@ -99,6 +99,8 @@ const ActiveUsersTabs = () => {
               isModified={userSettingsData.modified}
               onResetValues={userSettingsData.resetValues}
               modifiedValues={userSettingsData.modifiedValues}
+              radiusProxyData={userSettingsData.radiusServers}
+              idpData={userSettingsData.idpServers}
               from="active-users"
             />
           </Tab>

--- a/src/services/rpc.ts
+++ b/src/services/rpc.ts
@@ -8,7 +8,12 @@ import {
 } from "@reduxjs/toolkit/query/react";
 // Utils
 import { API_VERSION_BACKUP } from "src/utils/utils";
-import { Metadata, User } from "src/utils/datatypes/globalDataTypes";
+import {
+  Metadata,
+  User,
+  IDPServer,
+  RadiusServer,
+} from "src/utils/datatypes/globalDataTypes";
 import { apiToUser } from "src/utils/userUtils";
 
 export type UserFullData = {
@@ -138,7 +143,12 @@ export const getBatchCommand = (commandData: Command[], apiVersion: string) => {
 export const api = createApi({
   reducerPath: "api",
   baseQuery: fetchBaseQuery({ baseUrl: "/" }), // TODO: Global settings!
-  tagTypes: ["ObjectMetadata", "FullUserData"],
+  tagTypes: [
+    "ObjectMetadata",
+    "FullUserData",
+    "RadiusServerData",
+    "IdpServerData",
+  ],
   endpoints: (build) => ({
     simpleCommand: build.query<FindRPCResponse, Command | void>({
       query: (payloadData: Command) => getCommand(payloadData),
@@ -296,6 +306,28 @@ export const api = createApi({
       },
       invalidatesTags: ["FullUserData"],
     }),
+    getRadiusProxy: build.query<RadiusServer[], void>({
+      query: () => {
+        return getCommand({
+          method: "radiusproxy_find",
+          params: [[null], { version: API_VERSION_BACKUP }],
+        });
+      },
+      transformResponse: (response: FindRPCResponse): RadiusServer[] =>
+        response.result.result as unknown as RadiusServer[],
+      providesTags: ["RadiusServerData"],
+    }),
+    getIdpServer: build.query<IDPServer[], void>({
+      query: () => {
+        return getCommand({
+          method: "idp_find",
+          params: [[null], { version: API_VERSION_BACKUP }],
+        });
+      },
+      transformResponse: (response: FindRPCResponse): IDPServer[] =>
+        response.result.result as unknown as IDPServer[],
+      providesTags: ["IdpServerData"],
+    }),
   }),
 });
 
@@ -308,4 +340,6 @@ export const {
   useGetObjectMetadataQuery,
   useGetUsersFullDataQuery,
   useSaveUserMutation,
+  useGetRadiusProxyQuery,
+  useGetIdpServerQuery,
 } = api;

--- a/src/utils/constUtils.ts
+++ b/src/utils/constUtils.ts
@@ -1,0 +1,4 @@
+/* This file contains constants ready to use in any component */
+
+// Selectors
+export const NO_SELECTION_OPTION = "No selection";

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -198,3 +198,9 @@ export interface ParamMetadata {
   sortorder: number;
   type: string;
 }
+
+export interface RadiusServer {
+  ipatokenradiusserver: string;
+  cn: string;
+  dn: string;
+}

--- a/src/utils/ipaObjectUtils.ts
+++ b/src/utils/ipaObjectUtils.ts
@@ -25,7 +25,7 @@ export interface ParamProperties {
   paramMetadata: ParamMetadata;
 }
 
-function getParamMetadata(
+export function getParamMetadata(
   metadata: Metadata,
   objectName: string,
   paramName: string
@@ -56,7 +56,7 @@ function isFieldWritable(acis: Record<string, string>, attr: string): boolean {
   return false;
 }
 
-function isWritable(
+export function isWritable(
   paramMetadata: ParamMetadata,
   ipaObject?: IPAObject,
   alwaysWritable?: boolean
@@ -93,7 +93,7 @@ function isWritable(
   return true; // we don't know, assume writable
 }
 
-function isRequired(
+export function isRequired(
   parDef: IPAParamDefinition,
   param: ParamMetadata,
   writable: boolean
@@ -104,7 +104,7 @@ function isRequired(
   return (param && param.required) || false;
 }
 
-function getValue(
+export function getValue(
   ipaObject: Record<string, unknown> | undefined,
   name: string
 ): BasicType {
@@ -185,3 +185,12 @@ export function convertApiObj(
   }
   return obj;
 }
+
+export const updateIpaObject = (
+  ipaObject: Record<string, unknown>,
+  setIpaObject: (ipaObject: Record<string, unknown>) => void,
+  newValue: unknown,
+  paramName: string
+) => {
+  setIpaObject({ ...ipaObject, [paramName]: newValue });
+};

--- a/src/utils/userUtils.tsx
+++ b/src/utils/userUtils.tsx
@@ -71,3 +71,9 @@ const dateValues = new Set(["krbpasswordexpiration", "krbprincipalexpiration"]);
 export function apiToUser(apiRecord: Record<string, unknown>) {
   return convertApiObj(apiRecord, simpleValues, dateValues) as Partial<User>;
 }
+
+// Determines whether a given property name is a simple value or is it multivalue (Array)
+//  - Returns: boolean
+export const isSimpleValue = (propertyName) => {
+  return simpleValues.has(propertyName);
+};


### PR DESCRIPTION
The [Select](http://v4-archive.patternfly.org/v4/components/select)[1] components has been adapted to take data from the metadata. This has been applied for the fields 'Radius proxy configuration' and 'External IdP configuration'.

[1]- [http://v4-archive.patternfly.org/v4/components/select](http://v4-archive.patternfly.org/v4/components/select)