### PR TITLE
[Active users][Settings][Account settings] Add functionality for text inputs with buttons

### DIFF
--- a/src/components/Form/IpaTextInputFromList.tsx
+++ b/src/components/Form/IpaTextInputFromList.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+// Patternfly
+import { Flex, FlexItem, TextInput } from "@patternfly/react-core";
+// Layouts
+import SecondaryButton from "../layouts/SecondaryButton";
+// Data types
+import { Metadata } from "src/utils/datatypes/globalDataTypes";
+// Hooks
+import useAlerts from "src/hooks/useAlerts";
+// ipaObject utils
+import { getParamProperties } from "src/utils/ipaObjectUtils";
+
+interface PropsToTextInputFromList {
+  name: string;
+  elementsList: string[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ipaObject: Record<string, any>;
+  metadata: Metadata;
+  onOpenModal: () => void;
+  onRemove: (idx: number) => void;
+}
+
+const IpaTextInputFromList = (props: PropsToTextInputFromList) => {
+  // Get 'readOnly' to determine if the field has permissions to be edited
+  const { readOnly, required } = getParamProperties({
+    name: props.name,
+    ipaObject: props.ipaObject,
+    objectName: "user",
+    metadata: props.metadata,
+  });
+
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
+  return (
+    <>
+      <alerts.ManagedAlerts />
+      <Flex direction={{ default: "column" }} name={props.name}>
+        {props.elementsList !== undefined &&
+          props.elementsList.map((element, idx) => (
+            <Flex direction={{ default: "row" }} key={idx} name="value">
+              <FlexItem
+                key={idx}
+                flex={{ default: "flex_1" }}
+                className="pf-u-ml-lg"
+              >
+                <TextInput
+                  key={idx}
+                  name={props.name}
+                  value={element}
+                  type="text"
+                  aria-label={props.name}
+                  isRequired={required}
+                  readOnlyVariant={"plain"} // This is always read-only
+                />
+              </FlexItem>
+              <FlexItem
+                key={element + "-delete-button"}
+                order={{ default: "-1" }}
+              >
+                <SecondaryButton
+                  name="remove"
+                  onClickHandler={() => props.onRemove(idx)}
+                  isDisabled={readOnly}
+                >
+                  Delete
+                </SecondaryButton>
+              </FlexItem>
+            </Flex>
+          ))}
+      </Flex>
+      <SecondaryButton
+        classname="pf-u-mt-md"
+        name="add"
+        onClickHandler={props.onOpenModal}
+        isDisabled={readOnly}
+      >
+        Add
+      </SecondaryButton>
+    </>
+  );
+};
+
+export default IpaTextInputFromList;

--- a/src/components/Form/PrincipalAliasMultiTextBox.tsx
+++ b/src/components/Form/PrincipalAliasMultiTextBox.tsx
@@ -1,0 +1,219 @@
+import React from "react";
+// PatternFly
+import { Button } from "@patternfly/react-core";
+// Form
+import IpaTextInputFromList from "./IpaTextInputFromList";
+// Modals
+import AddTextInputFromListModal from "../modals/AddTextInputFromListModal";
+import DeletionConfirmationModal from "../modals/DeletionConfirmationModal";
+// RTK
+import {
+  ErrorResult,
+  useAddPrincipalAliasMutation,
+  useRemovePrincipalAliasMutation,
+} from "src/services/rpc";
+// Layouts
+import SecondaryButton from "../layouts/SecondaryButton";
+// Hooks
+import useAlerts from "src/hooks/useAlerts";
+// Data types
+import { Metadata } from "src/utils/datatypes/globalDataTypes";
+// Utils
+import { getRealmFromKrbPolicy } from "src/utils/utils";
+
+interface PrincipalAliasMultiTextBoxProps {
+  ipaObject: Record<string, unknown>;
+  metadata: Metadata;
+  onRefresh: () => void;
+}
+
+const PrincipalAliasMultiTextBox = (props: PrincipalAliasMultiTextBoxProps) => {
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
+  // RTK hooks
+  const [addPrincipalAlias] = useAddPrincipalAliasMutation();
+  const [removePrincipalAlias] = useRemovePrincipalAliasMutation();
+
+  // 'krbprincipalname' value from ipaObject
+  const krbprincipalname = props.ipaObject["krbprincipalname"] as string[];
+
+  // TextInput Modal data
+  const [isTextInputModalOpen, setIsTextInputModalOpen] = React.useState(false);
+  const [newAliasValue, setNewAliasValue] = React.useState("");
+
+  const onOpenTextInputModal = () => {
+    setIsTextInputModalOpen(true);
+  };
+
+  const onCloseTextInputModal = () => {
+    setIsTextInputModalOpen(false);
+  };
+
+  // Current realm
+  const currentRealm = getRealmFromKrbPolicy(props.metadata);
+
+  // Get realm from 'newAliasValue' (if any)
+  const getRealmNewAliasValue = () => {
+    const realm = newAliasValue.split("@")[1];
+    return realm;
+  };
+
+  const newAliasValueRealm = getRealmNewAliasValue();
+
+  // Validation for textInput: realm matches with the current realm (if specified)
+  const areRealmsMatching =
+    newAliasValue !== "" &&
+    newAliasValue.includes("@") &&
+    currentRealm !== "" &&
+    newAliasValueRealm !== undefined &&
+    newAliasValueRealm === currentRealm;
+
+  // Deletion confirmation Modal data
+  const [isDeleteConfModalOpen, setIsDeleteConfModalOpen] =
+    React.useState(false);
+  const [aliasIdxToDelete, setAliasIdxToDelete] = React.useState<number>(999); // Asumption: There will never be 999 alias
+  const [messageDeletionConf, setMessageDeletionConf] = React.useState("");
+
+  const onRemoveAlias = (idx: number) => {
+    // Get the specific index of the element to remove
+    setAliasIdxToDelete(idx);
+    // Set message to show on the deletion confirmation modal
+    const aliasToDelete = krbprincipalname[idx];
+    setMessageDeletionConf(
+      "Do you want to remove kerberos alias " + aliasToDelete + "?"
+    );
+    // Open deletion confirmation modal
+    onOpenDeletionConfModal();
+  };
+
+  const onOpenDeletionConfModal = () => {
+    setIsDeleteConfModalOpen(true);
+  };
+
+  const onCloseDeletionConfModal = () => {
+    setIsDeleteConfModalOpen(false);
+  };
+
+  const deletionConfModalActions = [
+    <Button
+      key="del-principal-alias"
+      variant="danger"
+      onClick={() => onRemovePrincipalAlias(aliasIdxToDelete)}
+    >
+      Delete
+    </Button>,
+    <Button key="cancel" variant="link" onClick={onCloseDeletionConfModal}>
+      Cancel
+    </Button>,
+  ];
+
+  // Add 'principal alias'
+  const onAddPrincipalAlias = () => {
+    const payload = [props.ipaObject.uid, [newAliasValue]];
+
+    addPrincipalAlias(payload).then((response) => {
+      if ("data" in response) {
+        if (response.data.result) {
+          // Close modal
+          setIsTextInputModalOpen(false);
+          // Set alert: success
+          alerts.addAlert(
+            "add-alias-success",
+            "Added new aliases to user '" + props.ipaObject.uid + "'",
+            "success"
+          );
+        } else if (response.data.error) {
+          // Set alert: error
+          const errorMessage = response.data.error as ErrorResult;
+          alerts.addAlert("add-alias-error", errorMessage.message, "danger");
+        }
+        // Refresh data to show new changes in the UI
+        props.onRefresh();
+      }
+    });
+  };
+
+  // Remove handler
+  const onRemovePrincipalAlias = (idx: number) => {
+    const aliasList = [...krbprincipalname];
+    const elementToRemove = aliasList[idx];
+
+    // Set payload
+    const payload = [props.ipaObject.uid, [elementToRemove]];
+
+    removePrincipalAlias(payload).then((response) => {
+      if ("data" in response) {
+        if (response.data.result) {
+          // Close modal
+          setIsDeleteConfModalOpen(false);
+          // Show toast notification: success
+          alerts.addAlert(
+            "remove-alias-success",
+            "Removed aliases from user '" + props.ipaObject.uid + "'",
+            "success"
+          );
+        } else if (response.data.error) {
+          // Show toast notification: error
+          const errorMessage = response.data.error as ErrorResult;
+          alerts.addAlert("remove-alias-error", errorMessage.message, "danger");
+        }
+        // Refresh data to show new changes in the UI
+        props.onRefresh();
+      }
+    });
+  };
+
+  const textInputModalActions = [
+    <SecondaryButton
+      key="add-principal-alias"
+      onClickHandler={onAddPrincipalAlias}
+      // isDisabled={newAliasValue === "" ? true : false}
+      isDisabled={
+        (newAliasValue !== "" && !newAliasValue.includes("@")) ||
+        areRealmsMatching
+          ? false
+          : true
+      }
+    >
+      Add
+    </SecondaryButton>,
+    <Button key="cancel" variant="link" onClick={onCloseTextInputModal}>
+      Cancel
+    </Button>,
+  ];
+
+  return (
+    <>
+      <alerts.ManagedAlerts />
+      <IpaTextInputFromList
+        name="krbprincipalname"
+        elementsList={krbprincipalname}
+        ipaObject={props.ipaObject}
+        metadata={props.metadata}
+        onOpenModal={onOpenTextInputModal}
+        onRemove={onRemoveAlias}
+      />
+      <AddTextInputFromListModal
+        newValue={newAliasValue}
+        setNewValue={setNewAliasValue}
+        title={"Add kerberos principal alias"}
+        isOpen={isTextInputModalOpen}
+        onClose={onCloseTextInputModal}
+        actions={textInputModalActions}
+        textInputTitle={"New kerberos principal alias"}
+        textInputName="krbprincalname"
+        textInputValidator={areRealmsMatching}
+      />
+      <DeletionConfirmationModal
+        title={"Remove kerberos alias"}
+        isOpen={isDeleteConfModalOpen}
+        onClose={onCloseDeletionConfModal}
+        actions={deletionConfModalActions}
+        messageText={messageDeletionConf}
+      />
+    </>
+  );
+};
+
+export default PrincipalAliasMultiTextBox;

--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -38,7 +38,7 @@ import UsersMailingAddress from "src/components/UsersSections/UsersMailingAddres
 import UsersEmployeeInfo from "src/components/UsersSections/UsersEmployeeInfo";
 import UsersAttributesSMB from "src/components/UsersSections/UsersAttributesSMB";
 // RPC
-import { useSaveUserMutation } from "src/services/rpc";
+import { ErrorResult, useSaveUserMutation } from "src/services/rpc";
 // Hooks
 import useAlerts from "src/hooks/useAlerts";
 
@@ -121,13 +121,10 @@ const UserSettings = (props: PropsToUserSettings) => {
           alerts.addAlert("save-success", "User modified", "success");
         } else if (response.data.error) {
           // Show toast notification: error
-          alerts.addAlert(
-            "save-error",
-            response.data.error || "Error when modifying user",
-            "danger"
-          );
+          const errorMessage = response.data.error as ErrorResult;
+          alerts.addAlert("save-error", errorMessage.message, "danger");
         }
-        // TODO: Reset values. Disable 'revert' and 'save' buttons
+        // Reset values. Disable 'revert' and 'save' buttons
         props.onResetValues();
       }
     });

--- a/src/components/UsersSections/UsersAccountSettings.tsx
+++ b/src/components/UsersSections/UsersAccountSettings.tsx
@@ -33,6 +33,7 @@ import { asRecord } from "src/utils/userUtils";
 import IpaTextInput from "src/components/Form/IpaTextInput";
 import IpaSelect from "../Form/IpaSelect";
 import IpaCheckboxes from "../Form/IpaCheckboxes";
+import PrincipalAliasMultiTextBox from "../Form/PrincipalAliasMultiTextBox";
 
 interface PropsToUsersAccountSettings {
   user: Partial<User>;
@@ -66,44 +67,6 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
 
   // Dropdown 'External IdP configuration'
   const idpConfOptions = props.idpConf.map((item) => item.cn.toString());
-
-  const [principalAliasList, setPrincipalAliasList] = useState<ElementData[]>([
-    {
-      id: 0,
-      element: props.user.uid + "@IPAEXAMPLE.TEST",
-    },
-  ]);
-
-  // Principal alias
-  // - 'Add principal alias' handler
-  const onAddPrincipalAliasFieldHandler = () => {
-    const principalAliasListCopy = [...principalAliasList];
-    principalAliasListCopy.push({
-      id: Date.now.toString(),
-      element: "",
-    });
-    setPrincipalAliasList(principalAliasListCopy);
-  };
-
-  // - 'Change principal alias' handler
-  const onHandlePrincipalAliasChange = (
-    value: string,
-    event: React.FormEvent<HTMLInputElement>,
-    idx: number
-  ) => {
-    const principalAliasListCopy = [...principalAliasList];
-    principalAliasListCopy[idx]["element"] = (
-      event.target as HTMLInputElement
-    ).value;
-    setPrincipalAliasList(principalAliasListCopy);
-  };
-
-  // - 'Remove principal alias' handler
-  const onRemovePrincipalAliasHandler = (idx: number) => {
-    const principalAliasListCopy = [...principalAliasList];
-    principalAliasListCopy.splice(idx, 1);
-    setPrincipalAliasList(principalAliasListCopy);
-  };
 
   // SSH public keys
   // -Text area
@@ -500,49 +463,15 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
                 metadata={props.metadata}
               />
             </FormGroup>
-            <FormGroup label="Principal alias" fieldId="principal-alias">
-              <Flex direction={{ default: "column" }} name="krbprincipalname">
-                {principalAliasList.map((principalAlias, idx) => (
-                  <Flex
-                    direction={{ default: "row" }}
-                    key={principalAlias.id + "-" + idx + "-div"}
-                    name="value"
-                  >
-                    <FlexItem
-                      key={principalAlias.id + "-textbox"}
-                      flex={{ default: "flex_1" }}
-                    >
-                      <TextInput
-                        id="principal-alias"
-                        value={principalAlias.element}
-                        type="text"
-                        name={"krbprincipalname-" + idx}
-                        aria-label="principal alias"
-                        onChange={(value, event) =>
-                          onHandlePrincipalAliasChange(value, event, idx)
-                        }
-                      />
-                    </FlexItem>
-                    <FlexItem key={principalAlias.id + "-delete-button"}>
-                      <SecondaryButton
-                        name="remove"
-                        onClickHandler={() =>
-                          onRemovePrincipalAliasHandler(idx)
-                        }
-                      >
-                        Delete
-                      </SecondaryButton>
-                    </FlexItem>
-                  </Flex>
-                ))}
-              </Flex>
-              <SecondaryButton
-                classname="pf-u-mt-md"
-                name="add"
-                onClickHandler={onAddPrincipalAliasFieldHandler}
-              >
-                Add
-              </SecondaryButton>
+            <FormGroup
+              label="Kerberos principal alias"
+              fieldId="kerberos-principal-alias"
+            >
+              <PrincipalAliasMultiTextBox
+                ipaObject={ipaObject}
+                metadata={props.metadata}
+                onRefresh={props.onRefresh}
+              />
             </FormGroup>
             <FormGroup
               label="Kerberos principal expiration (UTC)"

--- a/src/components/modals/AddTextInputFromListModal.tsx
+++ b/src/components/modals/AddTextInputFromListModal.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+// PatternFly
+import {
+  Form,
+  FormGroup,
+  Modal,
+  TextInput,
+  ValidatedOptions,
+} from "@patternfly/react-core";
+
+interface PropsToAddModal {
+  newValue: string;
+  setNewValue: (newValue: string) => void;
+  variant?: "small" | "medium" | "large" | "default";
+  title: string;
+  isOpen: boolean;
+  onClose: () => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  actions: any[];
+  textInputTitle: string;
+  textInputName: string;
+  textInputValidator?: boolean;
+}
+
+const AddTextInputFromListModal = (props: PropsToAddModal) => {
+  // Reset text input value when the modal is closed
+  React.useEffect(() => {
+    if (!props.isOpen) {
+      props.setNewValue("");
+    }
+  }, [props.isOpen]);
+
+  return (
+    <Modal
+      variant={props.variant || "small"}
+      title={props.title}
+      isOpen={props.isOpen}
+      onClose={props.onClose}
+      actions={props.actions}
+    >
+      <Form>
+        <FormGroup
+          label={props.textInputTitle}
+          type="string"
+          fieldId="selection"
+        >
+          <TextInput
+            name={props.textInputName}
+            value={props.newValue}
+            onChange={props.setNewValue}
+            type="text"
+            aria-label={props.textInputName}
+            isRequired={true}
+            validated={
+              (props.newValue !== "" && !props.newValue.includes("@")) ||
+              props.textInputValidator
+                ? ValidatedOptions.default
+                : ValidatedOptions.error
+            }
+          />
+        </FormGroup>
+      </Form>
+    </Modal>
+  );
+};
+
+export default AddTextInputFromListModal;

--- a/src/components/modals/DeletionConfirmationModal.tsx
+++ b/src/components/modals/DeletionConfirmationModal.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+// PatternFly
+import { Modal } from "@patternfly/react-core";
+// Components
+import TextLayout from "../layouts/TextLayout";
+
+interface PropsToDeletionConfModal {
+  variant?: "default" | "small" | "medium" | "large";
+  title: string;
+  isOpen?: boolean;
+  onClose: () => void;
+  actions: JSX.Element[];
+  messageText: string;
+}
+
+const DeletionConfirmationModal = (props: PropsToDeletionConfModal) => {
+  return (
+    <Modal
+      variant={props.variant || "small"}
+      title={props.title}
+      isOpen={props.isOpen}
+      onClose={props.onClose}
+      actions={props.actions}
+    >
+      <TextLayout>{props.messageText}</TextLayout>
+    </Modal>
+  );
+};
+
+export default DeletionConfirmationModal;

--- a/src/hooks/useUserSettingsData.tsx
+++ b/src/hooks/useUserSettingsData.tsx
@@ -19,6 +19,7 @@ type UserSettingsData = {
   isLoading: boolean;
   isFetching: boolean;
   modified: boolean;
+  setModified: (value: boolean) => void;
   resetValues: () => void;
   metadata: Metadata;
   originalUser: Partial<User>;
@@ -73,6 +74,7 @@ const useUserSettingsData = (userId: string): UserSettingsData => {
       isIdpLoading,
     isFetching: userFullDataQuery.isFetching,
     modified,
+    setModified,
     metadata,
     user,
     setUser,

--- a/src/services/rpc.ts
+++ b/src/services/rpc.ts
@@ -55,10 +55,20 @@ export interface BatchResponse {
   };
 }
 
+export interface ErrorResult {
+  code: number;
+  message: string;
+  data: {
+    attr: string;
+    value: string;
+  };
+  name: string;
+}
+
 // 'FindRPCResponse' type
 //   - Has 'result' > 'result' structure
 export interface FindRPCResponse {
-  error: string;
+  error: string | ErrorResult;
   id: string;
   principal: string;
   version: string;
@@ -328,6 +338,26 @@ export const api = createApi({
         response.result.result as unknown as IDPServer[],
       providesTags: ["IdpServerData"],
     }),
+    removePrincipalAlias: build.mutation<FindRPCResponse, any[]>({
+      query: (payload) => {
+        const params = [payload, { version: API_VERSION_BACKUP }];
+
+        return getCommand({
+          method: "user_remove_principal",
+          params: params,
+        });
+      },
+    }),
+    addPrincipalAlias: build.mutation<FindRPCResponse, any[]>({
+      query: (payload) => {
+        const params = [payload, { version: API_VERSION_BACKUP }];
+
+        return getCommand({
+          method: "user_add_principal",
+          params: params,
+        });
+      },
+    }),
   }),
 });
 
@@ -342,4 +372,6 @@ export const {
   useSaveUserMutation,
   useGetRadiusProxyQuery,
   useGetIdpServerQuery,
+  useRemovePrincipalAliasMutation,
+  useAddPrincipalAliasMutation,
 } = api;

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -2,7 +2,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import React from "react";
 // Data type
-import { Host, Service, User } from "./datatypes/globalDataTypes";
+import { Host, Metadata, Service, User } from "./datatypes/globalDataTypes";
 // Errors
 import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
 import { SerializedError } from "@reduxjs/toolkit";
@@ -69,4 +69,18 @@ export const apiErrorToJsXError = (
   }
 
   return errorJsx;
+};
+
+// Get the current realm of the user
+export const getRealmFromKrbPolicy = (metadata: Metadata) => {
+  let realm = "";
+  if (metadata.objects !== undefined) {
+    const krbPolicy = metadata.objects.krbtpolicy.container_dn as string;
+    if (krbPolicy !== undefined) {
+      // Get realm from krbtpolicy
+      //  - Format: "cn=REALM, cn=kerberos"
+      realm = krbPolicy.split(",")[0].split("=")[1];
+    }
+  }
+  return realm;
 };


### PR DESCRIPTION
The functionality to take data directly from the metadata has been implemented for the Text inputs with buttons (list of text inputs retrieved from the API call). This has been applied to the following field: 'Principal alias' (`krbprincipalname`).