### PR TITLE
Fix: Use private_network config only in Github Actions

### DIFF
--- a/.github/workflows/gating.yml
+++ b/.github/workflows/gating.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main, devel]
 
+env:
+  GITHUB_CI: true
+
 jobs:
   audit-and-build:
     name: Audit and build

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,11 +10,13 @@ Vagrant.configure("2") do |config|
 
   # Needed by Cypress - optional if you edit your /etc/hosts
   config.vm.network "forwarded_port", guest: 443, host: 443
-  config.vm.network "private_network",
-            :ip => "192.168.56.10",
-            :virtualbox__dhcp_enabled => false,
-            :virtualbox__network_address => '192.168.56.0/21',
-            :virtualbox__forward_mode => 'route'
+  if ENV['GITHUB_CI']
+    config.vm.network "private_network",
+              :ip => "192.168.56.10",
+              :virtualbox__dhcp_enabled => false,
+              :virtualbox__network_address => '192.168.56.0/21',
+              :virtualbox__forward_mode => 'route'
+  end
 
   config.vm.provider "libvirt" do |v,override|
     v.memory = 4096


### PR DESCRIPTION
Set config.vm.network to "private_network" with static IP only in Github Actions environment to avoid provisioning issues elsewhere.