### PR TITLE
[RFE] Allow modifying 'Password Expiration' field

### DIFF
--- a/src/components/UsersSections/UsersAccountSettings.tsx
+++ b/src/components/UsersSections/UsersAccountSettings.tsx
@@ -359,7 +359,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
               label="Password expiration"
               fieldId="password-expiration"
             >
-              <IpaTextInput
+              <IpaCalendar
                 name={"krbpasswordexpiration"}
                 ipaObject={ipaObject}
                 onChange={recordOnChange}


### PR DESCRIPTION
The 'Password expiration' field contains a date-time and should be properly displayed (ideally using a component that manages the Metadata data).

Also, an admin user (or any user with full permissions) should be able to modify this field.

Instead of using a regular textbox as described in the issue, the proposed solution uses the `IpaCalendar` component, which retrieves field data from the Metadata.



Fixes: https://github.com/freeipa/freeipa-webui/issues/72
Signed-off-by: Carla Martinez <carlmart@redhat.com>