### PR TITLE
Redirect to 'Active users' on root URL

### DIFF
--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -95,7 +95,7 @@ export const AppRoutes = (): React.ReactElement => (
       </Route>
     </Route>
     <Route
-      path=""
+      path={URL_PREFIX + "/"}
       element={<Navigate to={URL_PREFIX + "/active-users"} replace />}
     />
     <Route path="*" element={<NotFound />} />


### PR DESCRIPTION
When navigating to `<IPA-BASE-URL>/ipa/modern_ui/`, an empty page is being shown. This should redirect directly to the 'Active users' page.

This has been solve by settings a redirection when the aforementioned page is rendered:
```ts
<Routes
  (...)
  <Route
    path={URL_PREFIX + "/"}    // <---
    element={<Navigate to={URL_PREFIX + "/active-users"} replace />}
  />
 <Route path="*" element={<NotFound />} />
</Routes>
``` 


Signed-off-by: Carla Martinez <carlmart@redhat.com>