### PR TITLE
[Bug] Fix search input for active users

### DIFF
--- a/src/components/tables/UsersTable.tsx
+++ b/src/components/tables/UsersTable.tsx
@@ -79,14 +79,15 @@ const UsersTable = (props: PropsToTable) => {
 
     let input: RegExp;
     try {
-      input = new RegExp(props.searchValue, "i");
+      // Find matches that begin with the pattern
+      input = new RegExp("^" + props.searchValue, "i");
     } catch (err) {
       input = new RegExp(
         props.searchValue.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
         "i"
       );
     }
-    return user.uid.search(input) >= 0;
+    return user.uid[0].search(input) >= 0;
   };
 
   const filteredShownUsers =


### PR DESCRIPTION
The search input was not working on the 'Active users' main page. The new changes require that the code should be adapted to make the component work again.

This is because the `user.id` is making reference to an array entry (instead of a plain string value), so this needed to be adapted as `user.id[0]`.



Signed-off-by: Carla Martinez <carlmart@redhat.com>