### PR TITLE
Adapt 'SSH public keys' field and modal

### DIFF
--- a/src/components/Form/IpaSshPublicKeys.tsx
+++ b/src/components/Form/IpaSshPublicKeys.tsx
@@ -1,0 +1,201 @@
+import React from "react";
+// PatternFly
+import { Button, Flex, FlexItem } from "@patternfly/react-core";
+// Components
+import SecondaryButton from "../layouts/SecondaryButton";
+import TextLayout from "../layouts/TextLayout";
+// Modals
+import ModalWithTextAreaLayout from "../layouts/ModalWithTextAreaLayout";
+// Data types
+import { Metadata } from "src/utils/datatypes/globalDataTypes";
+// ipaObject utils
+import { getParamProperties, updateIpaObject } from "src/utils/ipaObjectUtils";
+
+interface PropsToSshPublicKeysModal {
+  ipaObject: Record<string, unknown>;
+  onChange: (ipaObject: Record<string, unknown>) => void;
+  metadata: Metadata;
+}
+
+const IpaSshPublicKeys = (props: PropsToSshPublicKeysModal) => {
+  const { readOnly, value } = getParamProperties({
+    name: "ipasshpubkey",
+    ipaObject: props.ipaObject,
+    metadata: props.metadata,
+    objectName: "user",
+  });
+
+  // States
+  const [textAreaSshPublicKeysValue, setTextAreaSshPublicKeysValue] =
+    React.useState("");
+  const [isTextAreaSshPublicKeysOpen, setIsTextAreaSshPublicKeysOpen] =
+    React.useState(false);
+  const [sshPublicKeysList, setSshPublicKeysList] = React.useState<string[]>(
+    (value as string[]) || []
+  );
+  const [idxSelected, setIdxSelected] = React.useState<number | null>(null);
+  const [originalIpaObject] = React.useState(props.ipaObject);
+  const [isSetButtonDisabled, setIsSetButtonDisabled] = React.useState(true);
+
+  const onChangeTextAreaSshPublicKeysValue = (value: string) => {
+    // Update text area state
+    setTextAreaSshPublicKeysValue(value);
+    // Enable 'Set' button
+    if (value !== "") {
+      setIsSetButtonDisabled(false);
+    } else {
+      setIsSetButtonDisabled(true);
+    }
+  };
+
+  // On click 'Set' button (within modal)
+  const onClickSetTextAreaSshPublicKeys = () => {
+    // Store new entry
+    const newSshPublicKeysList = [...sshPublicKeysList];
+    // Takes 'idxSelected' as reference to determine whether the entry is new or not
+    if (idxSelected !== null) {
+      // Existing entries
+      newSshPublicKeysList[idxSelected] = textAreaSshPublicKeysValue;
+    } else {
+      // New entries
+      newSshPublicKeysList.push(textAreaSshPublicKeysValue);
+    }
+
+    setSshPublicKeysList(newSshPublicKeysList);
+    // No element index selected
+    setIdxSelected(null);
+    // Closes the modal
+    setIsTextAreaSshPublicKeysOpen(false);
+    // Update ipaObject
+    updateIpaObject(
+      props.ipaObject,
+      props.onChange,
+      newSshPublicKeysList,
+      "ipasshpubkey"
+    );
+    // Disable 'Set' button
+    setIsSetButtonDisabled(true);
+  };
+
+  // on click 'Cancel' button (within modal)
+  const onClickCancelTextAreaSshPublicKeys = () => {
+    // No element index selected
+    setIdxSelected(null);
+    // Closes the modal
+    setIsTextAreaSshPublicKeysOpen(false);
+  };
+
+  const openSshPublicKeysModal = () => {
+    // Assign value to text area state
+    setTextAreaSshPublicKeysValue("");
+    // Open modal
+    setIsTextAreaSshPublicKeysOpen(true);
+  };
+
+  // Update entry on the ssh public key list (from 'Show/Set' button)
+  const onShowSetSshKey = (idx: number, sshKey: string) => {
+    // Store idx
+    setIdxSelected(idx);
+    // Assign value to text area state
+    setTextAreaSshPublicKeysValue(sshKey);
+    // Open modal
+    setIsTextAreaSshPublicKeysOpen(true);
+  };
+
+  // Delete entry on the ssh public key list
+  const onDeleteSshKey = (idx: number) => {
+    const newSshPublicKeysList = [...sshPublicKeysList];
+    newSshPublicKeysList.splice(idx, 1);
+    setSshPublicKeysList(newSshPublicKeysList);
+    // Update ipaObject when deleting the last changes (to disable 'Revert' and 'Save' button)
+    if (
+      JSON.stringify(newSshPublicKeysList) ===
+      JSON.stringify(originalIpaObject["ipasshpubkey"])
+    ) {
+      updateIpaObject(
+        props.ipaObject,
+        props.onChange,
+        newSshPublicKeysList,
+        "ipasshpubkey"
+      );
+    }
+    // TODO: When 'ipaObject[<name>]' is undefined, the 'Revert' button is not disabled
+  };
+
+  // Render component
+  return (
+    <>
+      {sshPublicKeysList !== undefined
+        ? sshPublicKeysList.map((publicKey, idx) => {
+            return (
+              <>
+                <Flex direction={{ default: "row" }}>
+                  {publicKey !== "" && (
+                    <>
+                      <FlexItem>
+                        <TextLayout>New: key set</TextLayout>
+                      </FlexItem>
+                      <FlexItem>
+                        <SecondaryButton
+                          onClickHandler={() => onShowSetSshKey(idx, publicKey)}
+                          isDisabled={readOnly}
+                        >
+                          Show/Set key
+                        </SecondaryButton>
+                      </FlexItem>
+                      <FlexItem className="pf-u-mb-md">
+                        <SecondaryButton
+                          onClickHandler={() => onDeleteSshKey(idx)}
+                          isDisabled={readOnly}
+                        >
+                          Undo
+                        </SecondaryButton>
+                      </FlexItem>
+                    </>
+                  )}
+                </Flex>
+              </>
+            );
+          })
+        : null}
+      <ModalWithTextAreaLayout
+        value={textAreaSshPublicKeysValue}
+        onChange={onChangeTextAreaSshPublicKeysValue}
+        isOpen={isTextAreaSshPublicKeysOpen}
+        onClose={onClickCancelTextAreaSshPublicKeys}
+        actions={[
+          <SecondaryButton
+            key="set"
+            onClickHandler={onClickSetTextAreaSshPublicKeys}
+            isDisabled={isSetButtonDisabled}
+          >
+            Set
+          </SecondaryButton>,
+          <Button
+            key="cancel"
+            variant="link"
+            onClick={onClickCancelTextAreaSshPublicKeys}
+          >
+            Cancel
+          </Button>,
+        ]}
+        title="Set SSH key"
+        subtitle="SSH public key:"
+        ariaLabel="new ssh public key modal text area"
+        cssStyle={{ height: "422px" }}
+        name={"ipasshpubkey"}
+        objectName="user"
+        ipaObject={props.ipaObject}
+        metadata={props.metadata}
+      />
+      <SecondaryButton
+        onClickHandler={openSshPublicKeysModal}
+        isDisabled={readOnly}
+      >
+        Add
+      </SecondaryButton>
+    </>
+  );
+};
+
+export default IpaSshPublicKeys;

--- a/src/components/UsersSections/UsersAccountSettings.tsx
+++ b/src/components/UsersSections/UsersAccountSettings.tsx
@@ -30,6 +30,7 @@ import IpaSelect from "../Form/IpaSelect";
 import IpaCheckboxes from "../Form/IpaCheckboxes";
 import PrincipalAliasMultiTextBox from "../Form/PrincipalAliasMultiTextBox";
 import IpaCalendar from "../Form/IpaCalendar";
+import IpaSshPublicKeys from "../Form/IpaSshPublicKeys";
 
 interface PropsToUsersAccountSettings {
   user: Partial<User>;
@@ -63,45 +64,6 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
 
   // Dropdown 'External IdP configuration'
   const idpConfOptions = props.idpConf.map((item) => item.cn.toString());
-
-  // SSH public keys
-  // -Text area
-  const [textAreaSshPublicKeysValue, setTextAreaSshPublicKeysValue] =
-    useState("");
-  const [isTextAreaSshPublicKeysOpen, setIsTextAreaSshPublicKeysOpen] =
-    useState(false);
-
-  const onChangeTextAreaSshPublicKeysValue = (value: string) => {
-    setTextAreaSshPublicKeysValue(value);
-  };
-
-  const onClickSetTextAreaSshPublicKeys = () => {
-    // Store data here
-    // Closes the modal
-    setIsTextAreaSshPublicKeysOpen(false);
-  };
-
-  const onClickCancelTextAreaSshPublicKeys = () => {
-    // Closes the modal
-    setIsTextAreaSshPublicKeysOpen(false);
-  };
-
-  const openSshPublicKeysModal = () => {
-    setIsTextAreaSshPublicKeysOpen(true);
-  };
-
-  const sshPublicKeysOptions = [
-    <SecondaryButton key="set" onClickHandler={onClickSetTextAreaSshPublicKeys}>
-      Set
-    </SecondaryButton>,
-    <Button
-      key="cancel"
-      variant="link"
-      onClick={onClickCancelTextAreaSshPublicKeys}
-    >
-      Cancel
-    </Button>,
-  ];
 
   // Certificates
   // -Text area
@@ -430,9 +392,11 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
               />
             </FormGroup>
             <FormGroup label="SSH public keys" fieldId="ssh-public-keys">
-              <SecondaryButton onClickHandler={openSshPublicKeysModal}>
-                Add
-              </SecondaryButton>
+              <IpaSshPublicKeys
+                ipaObject={ipaObject}
+                onChange={recordOnChange}
+                metadata={props.metadata}
+              />
             </FormGroup>
             <FormGroup label="Certificates" fieldId="certificates">
               <SecondaryButton onClickHandler={openCertificatesModal}>
@@ -551,17 +515,6 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
         </FlexItem>
       </Flex>
       <ModalWithTextAreaLayout
-        value={textAreaSshPublicKeysValue}
-        onChange={onChangeTextAreaSshPublicKeysValue}
-        isOpen={isTextAreaSshPublicKeysOpen}
-        onClose={onClickCancelTextAreaSshPublicKeys}
-        actions={sshPublicKeysOptions}
-        title="Set SSH key"
-        subtitle="SSH public key:"
-        cssName="ipasshpubkey"
-        ariaLabel="new ssh public key modal text area"
-      />
-      <ModalWithTextAreaLayout
         value={textAreaCertificatesValue}
         onChange={onChangeTextAreaCertificatesValue}
         isOpen={isTextAreaCertificatesOpen}
@@ -569,8 +522,12 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
         actions={certificatesOptions}
         title="New certificate"
         subtitle="Certificate in base64 or PEM format:"
-        cssName="usercertificate"
         ariaLabel="new certificate modal text area"
+        cssStyle={{ height: "422px" }}
+        name="usercertificate"
+        objectName="user"
+        ipaObject={ipaObject}
+        metadata={props.metadata}
       />
       <CertificateMappingDataModal
         // Modal options

--- a/src/components/layouts/ModalWithTextAreaLayout.tsx
+++ b/src/components/layouts/ModalWithTextAreaLayout.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 // PatternFly
 import { Form, FormGroup, Modal, TextArea } from "@patternfly/react-core";
+// Data types
+import { Metadata } from "src/utils/datatypes/globalDataTypes";
 
 interface PropsToPKModal {
   value: string;
@@ -10,8 +12,13 @@ interface PropsToPKModal {
   actions: JSX.Element[];
   title: string;
   subtitle?: string;
-  cssName: string;
   ariaLabel?: string;
+  resizeOrientation?: "horizontal" | "vertical";
+  cssStyle?: React.CSSProperties;
+  name: string;
+  objectName: string;
+  ipaObject: Record<string, unknown>;
+  metadata: Metadata;
 }
 
 const ModalWithTextAreaLayout = (props: PropsToPKModal) => {
@@ -27,11 +34,11 @@ const ModalWithTextAreaLayout = (props: PropsToPKModal) => {
         <FormGroup label={props.subtitle} type="string" fieldId="selection">
           <TextArea
             value={props.value}
-            name={props.cssName}
+            name={props.name}
             onChange={props.onChange}
             aria-label={props.ariaLabel}
-            resizeOrientation="vertical"
-            style={{ height: "422px" }}
+            resizeOrientation={props.resizeOrientation || "vertical"}
+            style={props.cssStyle}
           />
         </FormGroup>
       </Form>


### PR DESCRIPTION
The 'SSh public keys' field and its modal need to be adapted to sync its data with the IPA Metadata.

The main logic and variables are handled by the `IpaSshPublicKeys` component that renders the modal content by calling the `ModalWithTextAreaLayout` component. The `IpaSshPublicKeys` variable is consumed by the parent component (`UsersAccountSettings`) as follows:
```ts
<FormGroup label="SSH public keys" fieldId="ssh-public-keys">
  <IpaSshPublicKeys
    ipaObject={ipaObject}
    onChange={recordOnChange}
    metadata={props.metadata}
  />
</FormGroup>
```


Signed-off-by: Carla Martinez <carlmart@redhat.com>