### PR TITLE
Add alerts on action buttons success

### DIFF
--- a/src/components/modals/AddUser.tsx
+++ b/src/components/modals/AddUser.tsx
@@ -34,6 +34,8 @@ import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
 import { SerializedError } from "@reduxjs/toolkit";
 // Modals
 import ErrorModal from "./ErrorModal";
+// Hooks
+import useAlerts from "src/hooks/useAlerts";
 
 interface GroupId {
   cn: string;
@@ -69,6 +71,9 @@ export interface PropsToAddUser {
 const AddUser = (props: PropsToAddUser) => {
   // Set dispatch (Redux)
   const dispatch = useAppDispatch();
+
+  // Alerts to show in the UI
+  const alerts = useAlerts();
 
   // Retrieve API version from environment data
   const apiVersion = useAppSelector(
@@ -608,6 +613,9 @@ const AddUser = (props: PropsToAddUser) => {
           if (props.onRefresh !== undefined) {
             props.onRefresh(updatedUsersList);
           }
+
+          // Set alert: success
+          alerts.addAlert("add-user-success", "New user added", "success");
         } else if (error) {
           // Set status flag: error
           isAdditionSuccess = false;
@@ -762,6 +770,7 @@ const AddUser = (props: PropsToAddUser) => {
   // Render 'AddUser'
   return (
     <>
+      <alerts.ManagedAlerts />
       <ModalWithFormLayout
         variantType="small"
         modalPosition="top"

--- a/src/components/modals/DeleteUsers.tsx
+++ b/src/components/modals/DeleteUsers.tsx
@@ -26,7 +26,10 @@ import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
 import { SerializedError } from "@reduxjs/toolkit";
 // Modals
 import ErrorModal from "./ErrorModal";
+// Data types
 import { ErrorData } from "src/utils/datatypes/globalDataTypes";
+// Hooks
+import useAlerts from "src/hooks/useAlerts";
 
 interface ButtonsData {
   updateIsDeleteButtonDisabled?: (value: boolean) => void;
@@ -61,6 +64,9 @@ export interface PropsToDeleteUsers {
 const DeleteUsers = (props: PropsToDeleteUsers) => {
   // Set dispatch (Redux)
   const dispatch = useAppDispatch();
+
+  // Alerts
+  const alerts = useAlerts();
 
   // Define 'executeUserDelCommand' to add user data to IPA server
   const [executeUserDelCommand] = useBatchMutCommandMutation();
@@ -244,6 +250,21 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
               props.onRefresh();
             }
 
+            // Show alert: success
+            if (isDeleteChecked) {
+              alerts.addAlert(
+                "remove-users-success",
+                "Users removed",
+                "success"
+              );
+            } else {
+              alerts.addAlert(
+                "preserve-users-success",
+                "Users preserved",
+                "success"
+              );
+            }
+
             closeModal();
           }
         } else if (error) {
@@ -353,6 +374,7 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
   // Render 'DeleteUsers'
   return (
     <>
+      <alerts.ManagedAlerts />
       {isDeleteChecked ? modalDelete : modalPreserve}
       {isModalErrorOpen && (
         <ErrorModal

--- a/src/components/modals/DisableEnableUsers.tsx
+++ b/src/components/modals/DisableEnableUsers.tsx
@@ -22,7 +22,10 @@ import {
 import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
 import { SerializedError } from "@reduxjs/toolkit";
 import ErrorModal from "./ErrorModal";
+// Data types
 import { ErrorData } from "src/utils/datatypes/globalDataTypes";
+// Hooks
+import useAlerts from "src/hooks/useAlerts";
 
 interface ButtonsData {
   updateIsEnableButtonDisabled: (value: boolean) => void;
@@ -51,6 +54,9 @@ export interface PropsToDisableEnableUsers {
 const DisableEnableUsers = (props: PropsToDisableEnableUsers) => {
   // Set dispatch (Redux)
   const dispatch = useAppDispatch();
+
+  // Alerts to show in the UI
+  const alerts = useAlerts();
 
   // Define 'executeEnableDisableCommand' to add user data to IPA server
   const [executeEnableDisableCommand] = useBatchMutCommandMutation();
@@ -216,10 +222,22 @@ const DisableEnableUsers = (props: PropsToDisableEnableUsers) => {
               // Enable
               props.buttonsData.updateIsEnableButtonDisabled(true);
               props.buttonsData.updateIsDisableButtonDisabled(false);
+              // Set alert: success
+              alerts.addAlert(
+                "enable-user-success",
+                "Users enabled",
+                "success"
+              );
             } else if (props.optionSelected) {
               // Disable
               props.buttonsData.updateIsEnableButtonDisabled(false);
               props.buttonsData.updateIsDisableButtonDisabled(true);
+              // Set alert: success
+              alerts.addAlert(
+                "disable-user-success",
+                "Users disabled",
+                "success"
+              );
             }
 
             // Reset selected users
@@ -316,6 +334,7 @@ const DisableEnableUsers = (props: PropsToDisableEnableUsers) => {
   // Render 'DisableEnableUsers'
   return (
     <>
+      <alerts.ManagedAlerts />
       {!props.optionSelected ? modalEnable : modalDisable}
       {isModalErrorOpen && (
         <ErrorModal


### PR DESCRIPTION
Currently, there is no indication of success when any of these operations are done on the 'Active users' page:
- Adding a new user
- Removing users
- Enabling / Disabling users

Ideally, an [Alert](http://v4-archive.patternfly.org/v4/components/alert)[1] (Toast notification) should be shown to determine that the operation has been successful.


[1] - http://v4-archive.patternfly.org/v4/components/alert
Signed-off-by: Carla Martinez <carlmart@redhat.com>