### PR TITLE
Adapt the 'Certificates' field and modal 

### DIFF
--- a/src/components/Form/IpaCertificates.tsx
+++ b/src/components/Form/IpaCertificates.tsx
@@ -1,0 +1,462 @@
+import React from "react";
+// PatternFly
+import {
+  Button,
+  CardBody,
+  CardTitle,
+  DropdownItem,
+  DropdownSeparator,
+} from "@patternfly/react-core";
+// Data types
+import { Certificate, Metadata } from "src/utils/datatypes/globalDataTypes";
+// ipaObject utils
+import { getParamProperties } from "src/utils/ipaObjectUtils";
+// Modals
+import ModalWithTextAreaLayout from "../layouts/ModalWithTextAreaLayout";
+import DeletionConfirmationModal from "../modals/DeletionConfirmationModal";
+// Components
+import SecondaryButton from "../layouts/SecondaryButton";
+// RTK
+import {
+  ErrorResult,
+  useAddCertificateMutation,
+  useRemoveCertificateMutation,
+} from "src/services/rpc";
+// Components
+import ExpandableCardLayout from "../layouts/ExpandableCardLayout";
+// Hooks
+import useAlerts from "src/hooks/useAlerts";
+
+interface PropsToIpaCertificates {
+  ipaObject: Record<string, unknown>;
+  onChange: (ipaObject: Record<string, unknown>) => void;
+  metadata: Metadata;
+  certificates: Record<string, unknown>;
+  onRefresh: () => void;
+}
+
+interface CertificateParam {
+  __base64__: string;
+}
+
+interface CertificateData {
+  certificate: CertificateParam;
+  certInfo: Certificate;
+}
+
+interface DN {
+  c: string;
+  cn: string;
+  o: string;
+}
+
+export interface DictWithName {
+  key: string | React.ReactNode;
+  name: string;
+  value: string | React.ReactNode;
+}
+
+const IpaCertificates = (props: PropsToIpaCertificates) => {
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
+  // RTK hooks
+  const [addCertificate] = useAddCertificateMutation();
+  const [removeCertificate] = useRemoveCertificateMutation();
+
+  const { readOnly, value } = getParamProperties({
+    name: "usercertificate",
+    ipaObject: props.ipaObject,
+    metadata: props.metadata,
+    objectName: "user",
+  });
+
+  // Get different values from DN
+  const parseDn = (dn: string) => {
+    const result = {} as DN;
+    if (dn === undefined) return result;
+
+    // TODO: Use proper LDAP DN parser
+    const rdns = dn.split(",");
+    for (let i = 0; i < rdns.length; i++) {
+      const rdn = rdns[i];
+      if (!rdn) continue;
+
+      const parts = rdn.split("=");
+      const name = parts[0].toLowerCase();
+      const value = parts[1];
+
+      const old_value = result[name];
+      if (!old_value) {
+        result[name] = value;
+      } else if (typeof old_value == "string") {
+        result[name] = [old_value, value];
+      } else {
+        result[name].push(value);
+      }
+    }
+
+    return result as DN;
+  };
+
+  // Get further details of a certificate (via the `cert_find` results)
+  const getCertificateInfo = (certificate: CertificateParam) => {
+    const certificatesInfoList = props.certificates as unknown as Certificate[];
+    if (certificatesInfoList !== undefined) {
+      return certificatesInfoList.find(
+        (cert) => cert.certificate === certificate.__base64__
+      ) as Certificate;
+    }
+    return {} as Certificate;
+  };
+
+  // Get data from 'value'
+  const getCertificatesList = () => {
+    const valueAsArray = value as CertificateParam[];
+    const certsList: CertificateData[] = [];
+
+    if (valueAsArray !== undefined) {
+      valueAsArray.map((cert) => {
+        const certsInfo: Certificate | undefined = getCertificateInfo(cert);
+        const certEntry = {
+          certificate: cert,
+          certInfo: certsInfo,
+        };
+        certsList.push(certEntry);
+      });
+    }
+    return certsList;
+  };
+
+  // Update certificates list when 'value' changes
+  //  - This prevents the list to be empty when exiting the page and coming back
+  React.useEffect(() => {
+    setCertificatesList(getCertificatesList());
+  }, [value]);
+
+  // States
+  const [textAreaValue, setTextAreaValue] = React.useState("");
+  const [isModalOpen, setIsModalOpen] = React.useState(false);
+  const [certificatesList, setCertificatesList] = React.useState<
+    CertificateData[]
+  >(getCertificatesList() || []);
+
+  const onChangeTextAreaValue = (value: string) => {
+    setTextAreaValue(value);
+  };
+
+  // On delete certificate
+  const onDeleteCertificate = (idx: number) => {
+    const certificateToRemove = certificatesList[idx].certInfo.certificate;
+
+    const payload = [
+      props.ipaObject.uid,
+      removeCertificateDelimiters(certificateToRemove),
+    ];
+
+    removeCertificate(payload).then((response) => {
+      if ("data" in response) {
+        if (response.data.result) {
+          // Close modal
+          setIsDeleteConfModalOpen(false);
+          // Set alert: success
+          alerts.addAlert(
+            "remove-certificate-success",
+            "Removed certificates from user '" + props.ipaObject.uid + "'",
+            "success"
+          );
+        } else if (response.data.error) {
+          // Set alert: error
+          const errorMessage = response.data.error as ErrorResult;
+          alerts.addAlert(
+            "remove-certificate-error",
+            errorMessage.message,
+            "danger"
+          );
+        }
+        // Refresh data to show new changes in the UI
+        props.onRefresh();
+      }
+    });
+  };
+
+  // Function to get the dropdown items (based on 'idx')
+  const getDropdownItems = (idx: number) => {
+    return [
+      <DropdownItem key="view" component="button">
+        View
+      </DropdownItem>,
+      <DropdownItem key="get" component="button">
+        Get
+      </DropdownItem>,
+      <DropdownItem key="download" component="button">
+        Download
+      </DropdownItem>,
+      <DropdownItem key="revoke" component="button" isDisabled>
+        Revoke
+      </DropdownItem>,
+      <DropdownItem key="remove-hold" component="button" isDisabled>
+        Remove hold
+      </DropdownItem>,
+      <DropdownSeparator key="separator" />,
+      <DropdownItem
+        key="delete"
+        component="button"
+        onClick={() => onRemoveCert(idx)}
+      >
+        Delete
+      </DropdownItem>,
+    ];
+  };
+
+  // Get card title
+  const getCardTitle = (cert: CertificateData) => {
+    let title = parseDn(cert.certInfo.issuer).cn;
+    if (cert.certInfo.san_rfc822name !== undefined) {
+      title = cert.certInfo.san_rfc822name[0];
+    }
+
+    return (
+      <CardTitle
+        id={"card-" + parseDn(cert.certInfo.issuer).cn}
+        className="pf-u-font-weight-normal pf-u-font-family-redhatVF-sans-serif"
+      >
+        {title}
+      </CardTitle>
+    );
+  };
+
+  // Get header toggle button props
+  const getHeaderToggleButtonProps = (cert: CertificateData, idx: number) => {
+    return {
+      id: "toggle-button-" + idx,
+      "aria-label": "Details",
+      "aria-labelledby":
+        "toggle-button card-" + parseDn(cert.certInfo.issuer).cn,
+    };
+  };
+
+  const buildTableBody = (elements: DictWithName[]) => {
+    return (
+      <div className="pf-u-display-table">
+        {elements.map((element) => {
+          return (
+            <>
+              <div className="pf-u-display-table-row">
+                <div className="pf-u-display-table-cell">
+                  <p className="pf-u-mb-xs pf-u-mr-xs pf-u-font-weight-bold">
+                    {element.key + ": "}
+                  </p>
+                </div>
+                <div className="pf-u-display-table-cell">
+                  <p
+                    className="pf-u-mb-xs"
+                    id={element.name}
+                    data-name={element.name}
+                  >
+                    {element.value}
+                  </p>
+                </div>
+              </div>
+            </>
+          );
+        })}
+      </div>
+    );
+  };
+
+  // Get card body
+  const getCardBody = (cert: CertificateData) => {
+    const tableElements: DictWithName[] = [
+      {
+        key: "Serial number",
+        name: "cert-serial-num",
+        value: cert.certInfo.serial_number,
+      },
+      {
+        key: "Issued by",
+        name: "cert-issued-by",
+        value: parseDn(cert.certInfo.issuer).cn,
+      },
+      {
+        key: "Valid from",
+        name: "cert-valid-from",
+        value: cert.certInfo.valid_not_before,
+      },
+      {
+        key: "Valid to",
+        name: "cert-valid-to",
+        value: cert.certInfo.valid_not_after,
+      },
+    ];
+    return <CardBody>{buildTableBody(tableElements)}</CardBody>;
+  };
+
+  // MODAL
+  // On open modal
+  const onOpenModal = () => {
+    // Assign value to text area state
+    setTextAreaValue("");
+    // Open modal
+    setIsModalOpen(true);
+  };
+
+  // On click 'Cancel' button (within modal)
+  const onClickCancel = () => {
+    // Closes the modal
+    setIsModalOpen(false);
+  };
+
+  // Remove certificate delimiters
+  // - This is needed to process the certificate in the API call
+  const removeCertificateDelimiters = (certificate: string) => {
+    return certificate
+      .replace(/-----BEGIN CERTIFICATE-----/g, "")
+      .replace(/-----END CERTIFICATE-----/g, "")
+      .replace(/\n/g, "");
+  };
+
+  // On adding a certificate
+  const onAddCertificate = () => {
+    const payload = [
+      props.ipaObject.uid,
+      removeCertificateDelimiters(textAreaValue),
+    ];
+
+    addCertificate(payload).then((response) => {
+      if ("data" in response) {
+        if (response.data.result) {
+          // Close modal
+          setIsModalOpen(false);
+          // Set alert: success
+          alerts.addAlert(
+            "add-certificate-success",
+            "Added certificate to user '" + props.ipaObject.uid + "'",
+            "success"
+          );
+        } else if (response.data.error) {
+          // Set alert: error
+          const errorMessage = response.data.error as ErrorResult;
+          alerts.addAlert(
+            "add-certificate-error",
+            errorMessage.message,
+            "danger"
+          );
+        }
+        // Refresh data to show new changes in the UI
+        props.onRefresh();
+      }
+    });
+  };
+
+  // Delete confirmation modal
+  const [isDeleteConfModalOpen, setIsDeleteConfModalOpen] =
+    React.useState(false);
+  const [idxToDelete, setIdxToDelete] = React.useState<number>(999); // Asumption: There will never be 999 alias
+  const [messageDeletionConf, setMessageDeletionConf] = React.useState("");
+
+  const onOpenDeletionConfModal = () => {
+    setIsDeleteConfModalOpen(true);
+  };
+
+  const onCloseDeletionConfModal = () => {
+    setIsDeleteConfModalOpen(false);
+  };
+
+  const onRemoveCert = (idx: number) => {
+    // Get the specific index of the element to remove
+    setIdxToDelete(idx);
+    // Set message to show on the deletion confirmation modal
+    const aliasToDelete = certificatesList[idx].certInfo.serial_number;
+    setMessageDeletionConf(
+      "Are you sure you want to delete the certificate with serial number " +
+        aliasToDelete +
+        "?"
+    );
+    // Open deletion confirmation modal
+    onOpenDeletionConfModal();
+  };
+
+  const deletionConfModalActions = [
+    <Button
+      key="del-certificate-conf"
+      variant="danger"
+      onClick={() => onDeleteCertificate(idxToDelete)}
+    >
+      Delete
+    </Button>,
+    <Button key="cancel" variant="link" onClick={onCloseDeletionConfModal}>
+      Cancel
+    </Button>,
+  ];
+
+  // Render component
+  return (
+    <>
+      {certificatesList.length > 0
+        ? certificatesList.map((cert, idx) => {
+            return (
+              <>
+                {cert.certInfo !== undefined &&
+                  Object.keys(cert.certInfo).length !== 0 && (
+                    <div key={"certificate-" + idx}>
+                      <ExpandableCardLayout
+                        id={"card-" + idx}
+                        isCompact={true}
+                        headerToggleButtonProps={getHeaderToggleButtonProps(
+                          cert,
+                          idx
+                        )}
+                        dropdownItems={getDropdownItems(idx)}
+                        cardTitle={getCardTitle(cert)}
+                        cardBody={getCardBody(cert)}
+                      />
+                    </div>
+                  )}
+              </>
+            );
+          })
+        : null}
+      <SecondaryButton onClickHandler={onOpenModal} isDisabled={readOnly}>
+        Add
+      </SecondaryButton>
+      <ModalWithTextAreaLayout
+        value={textAreaValue}
+        onChange={onChangeTextAreaValue}
+        isOpen={isModalOpen}
+        onClose={onClickCancel}
+        actions={[
+          <SecondaryButton
+            key="add-certificate"
+            onClickHandler={onAddCertificate}
+            isDisabled={textAreaValue === ""}
+          >
+            Add
+          </SecondaryButton>,
+          <Button key="cancel" variant="link" onClick={onClickCancel}>
+            Cancel
+          </Button>,
+        ]}
+        title="New certificate"
+        subtitle="Certificate in base64 or PEM format"
+        isRequired={true}
+        ariaLabel="new certificate modal text area"
+        cssStyle={{ height: "422px" }}
+        name={"usercertificate"}
+        objectName="user"
+        ipaObject={props.ipaObject}
+        metadata={props.metadata}
+        variant="medium"
+      />
+      <DeletionConfirmationModal
+        title={"Remove certificate"}
+        isOpen={isDeleteConfModalOpen}
+        onClose={onCloseDeletionConfModal}
+        actions={deletionConfModalActions}
+        messageText={messageDeletionConf}
+      />
+    </>
+  );
+};
+
+export default IpaCertificates;

--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -260,6 +260,7 @@ const UserSettings = (props: PropsToUserSettings) => {
                 onRefresh={props.onRefresh}
                 radiusProxyConf={props.radiusProxyData || []}
                 idpConf={props.idpData || []}
+                certData={props.certData}
               />
               <TitleLayout
                 key={2}

--- a/src/components/UsersSections/UsersAccountSettings.tsx
+++ b/src/components/UsersSections/UsersAccountSettings.tsx
@@ -19,7 +19,6 @@ import {
 // Layouts
 import SecondaryButton from "src/components/layouts/SecondaryButton";
 import PopoverWithIconLayout from "src/components/layouts/PopoverWithIconLayout";
-import ModalWithTextAreaLayout from "src/components/layouts/ModalWithTextAreaLayout";
 // Modals
 import CertificateMappingDataModal from "src/components/modals/CertificateMappingDataModal";
 // Utils
@@ -31,6 +30,7 @@ import IpaCheckboxes from "../Form/IpaCheckboxes";
 import PrincipalAliasMultiTextBox from "../Form/PrincipalAliasMultiTextBox";
 import IpaCalendar from "../Form/IpaCalendar";
 import IpaSshPublicKeys from "../Form/IpaSshPublicKeys";
+import IpaCertificates from "../Form/IpaCertificates";
 
 interface PropsToUsersAccountSettings {
   user: Partial<User>;
@@ -39,6 +39,7 @@ interface PropsToUsersAccountSettings {
   onRefresh: () => void;
   radiusProxyConf: RadiusServer[];
   idpConf: IDPServer[];
+  certData: Record<string, unknown>;
 }
 
 // Generic data to pass to the Textbox adder
@@ -64,45 +65,6 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
 
   // Dropdown 'External IdP configuration'
   const idpConfOptions = props.idpConf.map((item) => item.cn.toString());
-
-  // Certificates
-  // -Text area
-  const [textAreaCertificatesValue, setTextAreaCertificatesValue] =
-    useState("");
-  const [isTextAreaCertificatesOpen, setIsTextAreaCertificatesOpen] =
-    useState(false);
-
-  const onChangeTextAreaCertificatesValue = (value: string) => {
-    setTextAreaCertificatesValue(value);
-  };
-
-  const onClickAddTextAreaCertificates = () => {
-    // Store data here
-    // Closes the modal
-    setIsTextAreaCertificatesOpen(false);
-  };
-
-  const onClickCancelTextAreaCertificates = () => {
-    // Closes the modal
-    setIsTextAreaCertificatesOpen(false);
-  };
-
-  const openCertificatesModal = () => {
-    setIsTextAreaCertificatesOpen(true);
-  };
-
-  const certificatesOptions = [
-    <SecondaryButton key="add" onClickHandler={onClickAddTextAreaCertificates}>
-      Add
-    </SecondaryButton>,
-    <Button
-      key="cancel"
-      variant="link"
-      onClick={onClickCancelTextAreaCertificates}
-    >
-      Cancel
-    </Button>,
-  ];
 
   // Certificate mapping data
   // - Radio buttons
@@ -399,9 +361,13 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
               />
             </FormGroup>
             <FormGroup label="Certificates" fieldId="certificates">
-              <SecondaryButton onClickHandler={openCertificatesModal}>
-                Add
-              </SecondaryButton>
+              <IpaCertificates
+                ipaObject={ipaObject}
+                onChange={recordOnChange}
+                metadata={props.metadata}
+                certificates={props.certData}
+                onRefresh={props.onRefresh}
+              />
             </FormGroup>
             <FormGroup
               label="Certificate mapping data"
@@ -514,21 +480,6 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
           </Form>
         </FlexItem>
       </Flex>
-      <ModalWithTextAreaLayout
-        value={textAreaCertificatesValue}
-        onChange={onChangeTextAreaCertificatesValue}
-        isOpen={isTextAreaCertificatesOpen}
-        onClose={onClickCancelTextAreaCertificates}
-        actions={certificatesOptions}
-        title="New certificate"
-        subtitle="Certificate in base64 or PEM format:"
-        ariaLabel="new certificate modal text area"
-        cssStyle={{ height: "422px" }}
-        name="usercertificate"
-        objectName="user"
-        ipaObject={ipaObject}
-        metadata={props.metadata}
-      />
       <CertificateMappingDataModal
         // Modal options
         isOpen={isCertificatesMappingDataModalOpen}

--- a/src/components/layouts/ExpandableCardLayout.tsx
+++ b/src/components/layouts/ExpandableCardLayout.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+// PatternFly
+import {
+  Card,
+  CardHeader,
+  CardExpandableContent,
+  Dropdown,
+  KebabToggle,
+} from "@patternfly/react-core";
+
+interface PropsToCardLayout {
+  className?: string;
+  id: string;
+  isCompact?: boolean;
+  dropdownItems?: React.ReactNode[];
+  headerToggleButtonProps?: Record<string, unknown>;
+  cardActions?: React.ReactNode;
+  cardTitle?: React.ReactNode;
+  cardBody: React.ReactNode;
+}
+
+const ExpandableCardLayout = (props: PropsToCardLayout) => {
+  const [isExpanded, setIsExpanded] = React.useState<boolean>(false);
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const onExpand = (_event: React.MouseEvent) => {
+    setIsExpanded(!isExpanded);
+  };
+
+  // KEBAB MENU
+  const [isOpen, setIsOpen] = React.useState<boolean>(false);
+
+  const onSelect = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const getDropdownItems = () => {
+    if (props.dropdownItems !== undefined && props.dropdownItems.length > 0) {
+      return (
+        <Dropdown
+          onSelect={onSelect}
+          toggle={<KebabToggle onToggle={setIsOpen} />}
+          isOpen={isOpen}
+          isPlain
+          dropdownItems={props.dropdownItems}
+          position={"right"}
+          className="pf-u-ml-auto"
+        />
+      );
+    }
+  };
+
+  return (
+    <Card
+      className={"pf-u-mb-sm " + props.className}
+      isCompact={props.isCompact}
+      isExpanded={isExpanded}
+    >
+      <CardHeader
+        onExpand={onExpand}
+        toggleButtonProps={props.headerToggleButtonProps}
+      >
+        {props.cardActions !== undefined && <>{props.cardActions}</>}
+        {props.cardTitle !== undefined && <>{props.cardTitle}</>}
+        {props.dropdownItems !== undefined && getDropdownItems()}
+      </CardHeader>
+      <CardExpandableContent>{props.cardBody}</CardExpandableContent>
+    </Card>
+  );
+};
+
+export default ExpandableCardLayout;

--- a/src/components/layouts/ModalWithTextAreaLayout.tsx
+++ b/src/components/layouts/ModalWithTextAreaLayout.tsx
@@ -12,6 +12,7 @@ interface PropsToPKModal {
   actions: JSX.Element[];
   title: string;
   subtitle?: string;
+  isRequired?: boolean | false;
   ariaLabel?: string;
   resizeOrientation?: "horizontal" | "vertical";
   cssStyle?: React.CSSProperties;
@@ -19,19 +20,25 @@ interface PropsToPKModal {
   objectName: string;
   ipaObject: Record<string, unknown>;
   metadata: Metadata;
+  variant?: "default" | "small" | "medium" | "large";
 }
 
 const ModalWithTextAreaLayout = (props: PropsToPKModal) => {
   return (
     <Modal
-      variant="small"
+      variant={props.variant || "small"}
       title={props.title}
       isOpen={props.isOpen}
       onClose={props.onClose}
       actions={props.actions}
     >
       <Form>
-        <FormGroup label={props.subtitle} type="string" fieldId="selection">
+        <FormGroup
+          label={props.subtitle}
+          type="string"
+          fieldId="selection"
+          isRequired={props.isRequired}
+        >
           <TextArea
             value={props.value}
             name={props.name}

--- a/src/services/rpc.ts
+++ b/src/services/rpc.ts
@@ -280,7 +280,7 @@ export const api = createApi({
 
         const certFindCommand: Command = {
           method: "cert_find",
-          params: [[], { user: userId[0], sizelimit: 0, all: true }],
+          params: [[], { user: [userId[0]], sizelimit: 0, all: true }],
         };
 
         const batchPayload: Command[] = [
@@ -361,6 +361,32 @@ export const api = createApi({
         });
       },
     }),
+    addCertificate: build.mutation<FindRPCResponse, any[]>({
+      query: (payload) => {
+        const params = [
+          [payload[0]],
+          { usercertificate: payload[1], version: API_VERSION_BACKUP },
+        ];
+
+        return getCommand({
+          method: "user_add_cert",
+          params: params,
+        });
+      },
+    }),
+    removeCertificate: build.mutation<FindRPCResponse, any[]>({
+      query: (payload) => {
+        const params = [
+          [payload[0]],
+          { usercertificate: payload[1], version: API_VERSION_BACKUP },
+        ];
+
+        return getCommand({
+          method: "user_remove_cert",
+          params: params,
+        });
+      },
+    }),
   }),
 });
 
@@ -377,4 +403,6 @@ export const {
   useGetIdpServerQuery,
   useRemovePrincipalAliasMutation,
   useAddPrincipalAliasMutation,
+  useAddCertificateMutation,
+  useRemoveCertificateMutation,
 } = api;

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -204,3 +204,17 @@ export interface RadiusServer {
   cn: string;
   dn: string;
 }
+
+export interface Certificate {
+  serial_number: string;
+  certificate: string;
+  subject: string;
+  issuer: string;
+  serial_number_hex: string;
+  valid_not_before: string;
+  valid_not_after: string;
+  sha1_fingerprint: string;
+  sha256_fingerprint: string;
+  san_rfc822name: string[];
+  owner_user: string[];
+}


### PR DESCRIPTION
The 'Certificates' field must be implemented to manage the different certificates associated with a given user.

The proposed solution displays the certificates using [expandable Card](http://v4-archive.patternfly.org/v4/components/card#expandable-cards)[1] components. This way, the information remains hidden by default and provides a cleaner look. For that, a reusable `ExpandableCardLayout` component has been implemented to manage the inner logic of each certificate.


This solution addresses the following:
- Synchronization with the Metadata values
and parameters.
- Addition of a new certificate.
- Deletion of an existing certificate.
- Notification of the operations mentioned above via alerts.

The rest of the dropdown options (accessible by the kebab) will be implemented in a different PR.

[1] - http://v4-archive.patternfly.org/v4/components/card#expandable-cards
Signed-off-by: Carla Martinez <carlmart@redhat.com>