### PR TITLE
'Certificates' > dropdown options

### DIFF
--- a/src/components/Form/IpaCertificates.tsx
+++ b/src/components/Form/IpaCertificates.tsx
@@ -172,7 +172,11 @@ const IpaCertificates = (props: PropsToIpaCertificates) => {
       >
         Get
       </DropdownItem>,
-      <DropdownItem key="download" component="button">
+      <DropdownItem
+        key="download"
+        component="button"
+        onClick={() => onDownloadCertificate(idx)}
+      >
         Download
       </DropdownItem>,
       <DropdownItem key="revoke" component="button" isDisabled>
@@ -416,6 +420,19 @@ const IpaCertificates = (props: PropsToIpaCertificates) => {
     setTextareaModalOption("get");
     // Show modal
     setIsModalOpen(true);
+  };
+
+  const onDownloadCertificate = (idx: number) => {
+    const certificate =
+      "-----BEGIN CERTIFICATE-----" +
+      certificatesList[idx].certificate.__base64__ +
+      "\n-----END CERTIFICATE-----";
+    const blob = new Blob([certificate], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.download = "cert.pem";
+    link.href = url;
+    link.click();
   };
 
   // Render component

--- a/src/components/UsersSections/UsersAccountSettings.tsx
+++ b/src/components/UsersSections/UsersAccountSettings.tsx
@@ -15,6 +15,7 @@ import {
   Metadata,
   User,
   RadiusServer,
+  Certificate,
 } from "src/utils/datatypes/globalDataTypes";
 // Layouts
 import SecondaryButton from "src/components/layouts/SecondaryButton";

--- a/src/components/UsersSections/UsersAccountSettings.tsx
+++ b/src/components/UsersSections/UsersAccountSettings.tsx
@@ -15,7 +15,6 @@ import {
   Metadata,
   User,
   RadiusServer,
-  Certificate,
 } from "src/utils/datatypes/globalDataTypes";
 // Layouts
 import SecondaryButton from "src/components/layouts/SecondaryButton";

--- a/src/components/layouts/InformationModalLayout.tsx
+++ b/src/components/layouts/InformationModalLayout.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+// PatternFly
+import { Modal } from "@patternfly/react-core";
+
+interface PropsToModalLayout {
+  isOpen: boolean;
+  onClose: () => void;
+  actions: JSX.Element[];
+  title: string;
+  variant?: "default" | "small" | "medium" | "large";
+  content: React.ReactNode;
+}
+
+const InformationModalLayout = (props: PropsToModalLayout) => {
+  return (
+    <Modal
+      variant={props.variant || "small"}
+      title={props.title}
+      isOpen={props.isOpen}
+      onClose={props.onClose}
+      actions={props.actions}
+    >
+      {props.content}
+    </Modal>
+  );
+};
+
+export default InformationModalLayout;

--- a/src/components/layouts/ModalWithTextAreaLayout.tsx
+++ b/src/components/layouts/ModalWithTextAreaLayout.tsx
@@ -21,6 +21,7 @@ interface PropsToPKModal {
   ipaObject: Record<string, unknown>;
   metadata: Metadata;
   variant?: "default" | "small" | "medium" | "large";
+  isTextareaDisabled?: boolean;
 }
 
 const ModalWithTextAreaLayout = (props: PropsToPKModal) => {
@@ -46,6 +47,7 @@ const ModalWithTextAreaLayout = (props: PropsToPKModal) => {
             aria-label={props.ariaLabel}
             resizeOrientation={props.resizeOrientation || "vertical"}
             style={props.cssStyle}
+            isDisabled={props.isTextareaDisabled || false}
           />
         </FormGroup>
       </Form>

--- a/src/components/modals/CertificatesInformationModal.tsx
+++ b/src/components/modals/CertificatesInformationModal.tsx
@@ -1,0 +1,143 @@
+import React from "react";
+// PatternFly
+import { Button, Flex, FlexItem } from "@patternfly/react-core";
+// Components
+import TitleLayout from "../layouts/TitleLayout";
+import TextLayout from "../layouts/TextLayout";
+// Modals
+import InformationModalLayout from "../layouts/InformationModalLayout";
+// Data types
+import { CertificateData } from "../Form/IpaCertificates";
+// Utils
+import { parseDn } from "src/utils/utils";
+
+interface PropsToCertificatesInfoModal {
+  isOpen: boolean;
+  onClose: () => void;
+  idxSelected: number;
+  certificatesList: CertificateData[];
+  uid: string;
+}
+
+const CertificatesInformationModal = (props: PropsToCertificatesInfoModal) => {
+  const infoModalActions = [
+    <Button key="close" variant="primary" onClick={props.onClose}>
+      Close
+    </Button>,
+  ];
+
+  const parseKeyValue = (key: string, value: string) => {
+    return (
+      <Flex>
+        <FlexItem>
+          <TextLayout>{key}:</TextLayout>
+        </FlexItem>
+        <FlexItem>
+          <TextLayout className="pf-u-ml-md">{value}</TextLayout>
+        </FlexItem>
+      </Flex>
+    );
+  };
+
+  const infoModalContent = (
+    <>
+      <TitleLayout
+        id={"info-modal-issued-to"}
+        headingLevel="h2"
+        text={"Issued to"}
+      />
+      {parseKeyValue(
+        "Common name",
+        parseDn(props.certificatesList[props.idxSelected].certInfo.subject)
+          .cn || ""
+      )}
+      {parseKeyValue(
+        "Organization",
+        parseDn(props.certificatesList[props.idxSelected].certInfo.subject).o ||
+          ""
+      )}
+      {parseKeyValue(
+        "Organization unit",
+        parseDn(props.certificatesList[props.idxSelected].certInfo.issuer).ou ||
+          ""
+      )}
+      {parseKeyValue(
+        "Serial number",
+        props.certificatesList[props.idxSelected].certInfo.serial_number || ""
+      )}
+      {parseKeyValue(
+        "Serial number (hex)",
+        props.certificatesList[props.idxSelected].certInfo.serial_number_hex ||
+          ""
+      )}
+      <TitleLayout
+        id={"info-modal-issued-by"}
+        headingLevel="h2"
+        text={"Issued by"}
+        className="pf-u-mt-sm"
+      />
+      {parseKeyValue(
+        "Common name",
+        parseDn(props.certificatesList[props.idxSelected].certInfo.issuer).cn ||
+          ""
+      )}
+      {parseKeyValue(
+        "Organization",
+        parseDn(props.certificatesList[props.idxSelected].certInfo.issuer).o ||
+          ""
+      )}
+      {parseKeyValue(
+        "Organization unit",
+        parseDn(props.certificatesList[props.idxSelected].certInfo.issuer).ou ||
+          ""
+      )}
+      <TitleLayout
+        id={"info-modal-validity"}
+        headingLevel="h2"
+        text={"Validity"}
+        className="pf-u-mt-sm"
+      />
+      {parseKeyValue(
+        "Issued on",
+        props.certificatesList[props.idxSelected].certInfo.valid_not_before ||
+          ""
+      )}
+      {parseKeyValue(
+        "Expires on",
+        props.certificatesList[props.idxSelected].certInfo.valid_not_after || ""
+      )}
+      <TitleLayout
+        id={"info-modal-fingerprints"}
+        headingLevel="h2"
+        text={"Fingerprints"}
+        className="pf-u-mt-sm"
+      />
+      {parseKeyValue(
+        "Expires on",
+        props.certificatesList[props.idxSelected].certInfo.sha1_fingerprint ||
+          ""
+      )}
+      {parseKeyValue(
+        "Expires on",
+        props.certificatesList[props.idxSelected].certInfo.sha256_fingerprint ||
+          ""
+      )}
+    </>
+  );
+
+  return (
+    <InformationModalLayout
+      title={
+        "Certificate for " +
+        parseDn(props.certificatesList[props.idxSelected].certInfo.subject).cn
+      }
+      variant="medium"
+      actions={infoModalActions}
+      isOpen={props.isOpen}
+      onClose={props.onClose}
+      content={infoModalContent}
+    />
+  );
+};
+
+export default CertificatesInformationModal;

--- a/src/components/modals/RemoveHoldCertificate.tsx
+++ b/src/components/modals/RemoveHoldCertificate.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+// PatternFly
+import { Button } from "@patternfly/react-core";
+// Modals
+import InformationModalLayout from "../layouts/InformationModalLayout";
+// Components
+import TextLayout from "../layouts/TextLayout";
+// Hooks
+import useAlerts from "src/hooks/useAlerts";
+// Data types
+import { CertificateData } from "../Form/IpaCertificates";
+// Utils
+import { parseDn } from "src/utils/utils";
+// RPC
+import {
+  ErrorResult,
+  useRemoveHoldCertificateMutation,
+} from "src/services/rpc";
+
+interface PropsToRemoveHoldCertificate {
+  certificate: CertificateData;
+  isOpen: boolean;
+  onClose: () => void;
+  onRefresh: () => void;
+}
+
+const RemoveHoldCertificate = (props: PropsToRemoveHoldCertificate) => {
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
+  // Prepare "cert_remove_hold" API call
+  const [certRemoveHold] = useRemoveHoldCertificateMutation();
+
+  const onRemoveHold = () => {
+    // Prepare payload
+    const serialNumber = props.certificate.certInfo.serial_number;
+    const cacn = props.certificate.certInfo.cacn;
+    const payload = [serialNumber, cacn];
+
+    // Perform the API call
+    certRemoveHold(payload).then((response) => {
+      if ("data" in response) {
+        if (response.data.result) {
+          // Close modal
+          props.onClose();
+          // Set alert: success
+          alerts.addAlert(
+            "remove-hold-certificate-success",
+            "Certificate hold removed",
+            "success"
+          );
+        } else if (response.data.error) {
+          // Set alert: error
+          const errorMessage = response.data.error as ErrorResult;
+          alerts.addAlert(
+            "remove-hold-certificate-error",
+            errorMessage.message,
+            "danger"
+          );
+        }
+        // Refresh data to show new changes in the UI
+        props.onRefresh();
+      }
+    });
+  };
+
+  const infoModalActions = [
+    <Button key="remove-hold" variant="danger" onClick={onRemoveHold}>
+      Remove hold
+    </Button>,
+    <Button key="close" variant="link" onClick={props.onClose}>
+      Close
+    </Button>,
+  ];
+
+  const contentMessage = (
+    <TextLayout>Do you want to remove the certificate hold?</TextLayout>
+  );
+
+  return (
+    <>
+      <alerts.ManagedAlerts />
+      <InformationModalLayout
+        title={
+          "Certificate for " + parseDn(props.certificate.certInfo.issuer).cn
+        }
+        variant="medium"
+        actions={infoModalActions}
+        isOpen={props.isOpen}
+        onClose={props.onClose}
+        content={contentMessage}
+      />
+    </>
+  );
+};
+
+export default RemoveHoldCertificate;

--- a/src/components/modals/RevokeCertificate.tsx
+++ b/src/components/modals/RevokeCertificate.tsx
@@ -1,0 +1,214 @@
+import React from "react";
+// PatternFly
+import { Button, Select, SelectOption } from "@patternfly/react-core";
+// Modals
+import ModalWithFormLayout, { Field } from "../layouts/ModalWithFormLayout";
+// Data types
+import { CertificateData } from "../Form/IpaCertificates";
+// Components
+import SecondaryButton from "../layouts/SecondaryButton";
+// Utils
+import { parseDn } from "src/utils/utils";
+// RPC
+import {
+  ErrorResult,
+  useGetCertificateAuthorityQuery,
+  useRevokeCertificateMutation,
+} from "src/services/rpc";
+// Hooks
+import useAlerts from "src/hooks/useAlerts";
+
+interface PropsToRevokeCertificate {
+  certificate: CertificateData;
+  isOpen: boolean;
+  onClose: () => void;
+  onRefresh: () => void;
+}
+
+const RevokeCertificate = (props: PropsToRevokeCertificate) => {
+  const REVOCATION_REASONS = {
+    0: "Unspecified",
+    1: "Key Compromise",
+    2: "CA Compromise",
+    3: "Affiliation Changed",
+    4: "Superseded",
+    5: "Cessation of Operation",
+    6: "Certificate Hold",
+    8: "Remove from CRL",
+    9: "Privilege Withdrawn",
+    10: "AA Compromise",
+  };
+
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
+  // Obtain CAs from the IPA server
+  const certificateAuthorityQuery = useGetCertificateAuthorityQuery();
+  const certificateAuthorities = certificateAuthorityQuery.data || [];
+  const isCALoading = certificateAuthorityQuery.isLoading;
+
+  // Prepare "cert_revoke" API call
+  const [certRevoke] = useRevokeCertificateMutation();
+
+  // SELECT: 'Revocation reason'
+  const [isRevReasonOpen, setIsRevReasonOpen] = React.useState(false);
+  const [revReasonSelected, setRevReasonSelected] =
+    React.useState<string>("Unspecified");
+
+  const onToggleRevReason = (isOpen: boolean) => {
+    setIsRevReasonOpen(isOpen);
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const onSelectRevReason = (selection: any) => {
+    setRevReasonSelected(selection.target.textContent);
+    setIsRevReasonOpen(false);
+  };
+
+  // SELECT: 'CA'
+  const [isCAOpen, setIsCAOpen] = React.useState(false);
+  const [CASelected, setCASelected] = React.useState<string>("ipa"); // Assumtion: 'ipa' is the default CA
+  const [CAOptions, setCAOptions] = React.useState<string[]>([]);
+
+  // Update CAs list when updated
+  // - Assumption: There is only one CA by default ('ipa')
+  React.useEffect(() => {
+    if (!isCALoading) {
+      const caArray: string[] = [];
+      certificateAuthorities.map((ca) => {
+        caArray.push(ca.cn[0]);
+      });
+      setCAOptions(caArray);
+    }
+  }, [certificateAuthorities]);
+
+  const onCAToggle = (isOpen: boolean) => {
+    setIsCAOpen(isOpen);
+  };
+
+  const onCASelect = (event: React.MouseEvent | React.ChangeEvent) => {
+    const target = event.target as HTMLInputElement;
+    setCASelected(target.value);
+    setIsCAOpen(false);
+  };
+
+  // MODAL
+  const onCancel = () => {
+    // Reset fields
+    setRevReasonSelected("Unspecified");
+    setCASelected("ipa");
+    // Close modal
+    props.onClose();
+  };
+
+  const onRevokeCert = () => {
+    // Prepare payload
+    const serialNumber = props.certificate.certInfo.serial_number;
+    const reasonKey = Object.keys(REVOCATION_REASONS).find(
+      (key) => REVOCATION_REASONS[key] === revReasonSelected
+    );
+    const reason = reasonKey || "0";
+    const payload = [serialNumber, reason, CASelected];
+
+    // Call API
+    certRevoke(payload).then((response) => {
+      if ("data" in response) {
+        if (response.data.result) {
+          // Close modal
+          props.onClose();
+          alerts.addAlert(
+            "revoke-certificate-success",
+            "Certificate revoked",
+            "success"
+          );
+        } else if (response.data.error) {
+          // Set alert: error
+          const errorMessage = response.data.error as ErrorResult;
+          alerts.addAlert(
+            "revoke-certificate-error",
+            errorMessage.message,
+            "danger"
+          );
+        }
+        // Refresh data to show new changes in the UI
+        props.onRefresh();
+      }
+    });
+  };
+
+  const modalActions = [
+    <SecondaryButton key="revoke" onClickHandler={onRevokeCert}>
+      Revoke
+    </SecondaryButton>,
+    <Button key="cancel" variant="link" onClick={onCancel}>
+      Cancel
+    </Button>,
+  ];
+
+  const fields: Field[] = [
+    {
+      id: "revocation-reason",
+      name: "Revocation reason",
+      pfComponent: (
+        <Select
+          id="revocation-reasons"
+          variant="single"
+          aria-label="Select a revocation reason"
+          aria-labelledby="revocation-reasons"
+          selections={revReasonSelected}
+          isOpen={isRevReasonOpen}
+          onToggle={onToggleRevReason}
+          onSelect={onSelectRevReason}
+        >
+          {Object.entries(REVOCATION_REASONS).map((value) => (
+            <SelectOption key={value[0]} value={value[1]} />
+          ))}
+        </Select>
+      ),
+    },
+    {
+      id: "revocation-ca",
+      name: "CA",
+      pfComponent: (
+        <Select
+          id="revocation-certificate-authority"
+          variant="single"
+          placeholderText=" "
+          aria-label="Select a certificate authority for the revocation"
+          aria-labelledby="revocation certificate authority"
+          selections={CASelected}
+          isOpen={isCAOpen}
+          onToggle={onCAToggle}
+          onSelect={onCASelect}
+        >
+          {CAOptions.map((option, index) => (
+            <SelectOption key={index} value={option} />
+          ))}
+        </Select>
+      ),
+    },
+  ];
+
+  return (
+    <>
+      <alerts.ManagedAlerts />
+      <ModalWithFormLayout
+        variantType="small"
+        modalPosition="top"
+        title={
+          "Certificate for " + parseDn(props.certificate.certInfo.issuer).cn
+        }
+        description={
+          "Do you want to revoke this certificate? Select a reason from the pull-down list."
+        }
+        formId={"revoke-certificate"}
+        fields={fields}
+        show={props.isOpen}
+        onClose={props.onClose}
+        actions={modalActions}
+      />
+    </>
+  );
+};
+
+export default RevokeCertificate;

--- a/src/services/rpc.ts
+++ b/src/services/rpc.ts
@@ -422,6 +422,22 @@ export const api = createApi({
         });
       },
     }),
+    removeHoldCertificate: build.mutation<FindRPCResponse, any[]>({
+      query: (payload) => {
+        const params = [
+          [payload[0]],
+          {
+            cacn: payload[1],
+            version: API_VERSION_BACKUP,
+          },
+        ];
+
+        return getCommand({
+          method: "cert_remove_hold",
+          params: params,
+        });
+      },
+    }),
   }),
 });
 
@@ -442,4 +458,5 @@ export const {
   useRemoveCertificateMutation,
   useGetCertificateAuthorityQuery,
   useRevokeCertificateMutation,
+  useRemoveHoldCertificateMutation,
 } = api;

--- a/src/services/rpc.ts
+++ b/src/services/rpc.ts
@@ -13,6 +13,7 @@ import {
   User,
   IDPServer,
   RadiusServer,
+  CertificateAuthority,
 } from "src/utils/datatypes/globalDataTypes";
 import { apiToUser } from "src/utils/userUtils";
 
@@ -393,6 +394,34 @@ export const api = createApi({
         });
       },
     }),
+    getCertificateAuthority: build.query<CertificateAuthority[], void>({
+      query: () => {
+        return getCommand({
+          method: "ca_find",
+          params: [[null], { version: API_VERSION_BACKUP }],
+        });
+      },
+      transformResponse: (response: FindRPCResponse): CertificateAuthority[] =>
+        response.result.result as unknown as CertificateAuthority[],
+      providesTags: ["CertificateAuthority"],
+    }),
+    revokeCertificate: build.mutation<FindRPCResponse, any[]>({
+      query: (payload) => {
+        const params = [
+          [payload[0]],
+          {
+            revocation_reason: payload[1],
+            cacn: payload[2],
+            version: API_VERSION_BACKUP,
+          },
+        ];
+
+        return getCommand({
+          method: "cert_revoke",
+          params: params,
+        });
+      },
+    }),
   }),
 });
 
@@ -411,4 +440,6 @@ export const {
   useAddPrincipalAliasMutation,
   useAddCertificateMutation,
   useRemoveCertificateMutation,
+  useGetCertificateAuthorityQuery,
+  useRevokeCertificateMutation,
 } = api;

--- a/src/services/rpc.ts
+++ b/src/services/rpc.ts
@@ -159,7 +159,13 @@ export const getBatchCommand = (commandData: Command[], apiVersion: string) => {
 export const api = createApi({
   reducerPath: "api",
   baseQuery: fetchBaseQuery({ baseUrl: "/" }), // TODO: Global settings!
-  tagTypes: ["ObjectMetadata", "FullUser", "RadiusServer", "IdpServer"],
+  tagTypes: [
+    "ObjectMetadata",
+    "FullUser",
+    "RadiusServer",
+    "IdpServer",
+    "CertificateAuthority",
+  ],
   endpoints: (build) => ({
     simpleCommand: build.query<FindRPCResponse, Command | void>({
       query: (payloadData: Command) => getCommand(payloadData),

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -206,6 +206,8 @@ export interface RadiusServer {
 }
 
 export interface Certificate {
+  cacn: string;
+  certificate_chain: string[];
   serial_number: string;
   certificate: string;
   subject: string;
@@ -217,6 +219,9 @@ export interface Certificate {
   sha256_fingerprint: string;
   san_rfc822name: string[];
   owner_user: string[];
+  revocation_reason: number;
+  revoked: boolean;
+  status: string;
 }
 
 export interface DN {
@@ -224,4 +229,14 @@ export interface DN {
   cn: string;
   o: string;
   ou?: string;
+}
+
+export interface CertificateAuthority {
+  cn: string;
+  description: string;
+  dn: string;
+  ipacaid: string;
+  ipacaissuerdn: string;
+  ipacarandomserialnumberversion: string;
+  ipacasubjectdn: string;
 }

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -218,3 +218,10 @@ export interface Certificate {
   san_rfc822name: string[];
   owner_user: string[];
 }
+
+export interface DN {
+  c: string;
+  cn: string;
+  o: string;
+  ou?: string;
+}

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -2,7 +2,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import React from "react";
 // Data type
-import { Host, Metadata, Service, User } from "./datatypes/globalDataTypes";
+import { DN, Host, Metadata, Service, User } from "./datatypes/globalDataTypes";
 // Errors
 import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
 import { SerializedError } from "@reduxjs/toolkit";
@@ -228,4 +228,32 @@ const formatDate = (date, format, local) => {
 
 export const toGeneralizedTime = (date: Date) => {
   return formatDate(date, templates.generalized, false);
+};
+
+// Get different values from DN
+export const parseDn = (dn: string) => {
+  const result = {} as DN;
+  if (dn === undefined) return result;
+
+  // TODO: Use proper LDAP DN parser
+  const rdns = dn.split(",");
+  for (let i = 0; i < rdns.length; i++) {
+    const rdn = rdns[i];
+    if (!rdn) continue;
+
+    const parts = rdn.split("=");
+    const name = parts[0].toLowerCase();
+    const value = parts[1];
+
+    const old_value = result[name];
+    if (!old_value) {
+      result[name] = value;
+    } else if (typeof old_value == "string") {
+      result[name] = [old_value, value];
+    } else {
+      result[name].push(value);
+    }
+  }
+
+  return result as DN;
 };


### PR DESCRIPTION
The dropdown options of the 'Certificates' field  (under 'Active users' > 'Settings') allow to perform some operations in a given certificate. These options are:
- View
  - Shows the certificate's full information.
- Get
  - Displays the given certificate (in base64 or PEM format)
- Download
  - Allows to download the certificate.
- Revoke
  - Revokes those certificates according to the following conditions: should be issued by IPA CA, shouldn't be expired, and shouldn't have been revoked.
- Remove hold
  - Option 6 on revocation reasons refers to the 'Certificate hold' one. 
  - When selecting this option, the 'Remove hold' option should be enabled in the UI to allow users to enable again the given certificate.