### PR TITLE
Improve active users refresh experience

### DIFF
--- a/src/components/layouts/SecondaryButton.tsx
+++ b/src/components/layouts/SecondaryButton.tsx
@@ -16,6 +16,10 @@ interface PropsToSecondaryButton {
   ouijaSafe?: boolean;
   innerRef?: React.Ref<any>;
   form?: string;
+  isLoading?: boolean;
+  spinnerAriaValueText?: string;
+  spinnerAriaLabelledBy?: string;
+  spinnerAriaLabel?: string;
 }
 
 const SecondaryButton = (props: PropsToSecondaryButton) => {
@@ -33,6 +37,10 @@ const SecondaryButton = (props: PropsToSecondaryButton) => {
       onClick={props.onClickHandler}
       innerRef={props.innerRef}
       form={props.form}
+      isLoading={props.isLoading}
+      spinnerAriaValueText={props.spinnerAriaValueText}
+      spinnerAriaLabelledBy={props.spinnerAriaLabelledBy}
+      spinnerAriaLabel={props.spinnerAriaLabel}
     >
       {props.children}
     </Button>

--- a/src/pages/ActiveUsers/ActiveUsers.tsx
+++ b/src/pages/ActiveUsers/ActiveUsers.tsx
@@ -488,10 +488,17 @@ const ActiveUsers = () => {
     dispatch(updateUsersList(newUsersList));
   };
 
+  const [refreshing, setRefreshing] = useState(false);
+
   // Refresh data
   const refreshUsersData = (listToRefresh: User[]) => {
-    // Hide table elements
-    setShowTableRows(false);
+    // Hide table and start spinning the refresh button
+    setRefreshing(true);
+
+    // Reset selected users on refresh
+    setSelectedUserNames([]);
+    setSelectedUserIds([]);
+    setSelectedUsers([]);
 
     // Getting uids
     const userFindPayload: Command = {
@@ -566,14 +573,12 @@ const ActiveUsers = () => {
                 if (listToRefresh.length > 0) {
                   storedData = true;
                 }
-
-                // Show table elements
-                setShowTableRows(true);
               } else if (usersListError !== undefined) {
                 // TODO: Handle error
                 handleAPIError(usersListError);
               }
             }
+            setRefreshing(false);
           });
         } else if (uidsError !== undefined) {
           // TODO: Handle error
@@ -712,8 +717,12 @@ const ActiveUsers = () => {
       element: (
         <SecondaryButton
           onClickHandler={() => refreshUsersData(activeUsersList)}
+          isLoading={refreshing}
+          isDisabled={refreshing}
+          spinnerAriaValueText="Refreshing"
+          spinnerAriaLabel="Refresh active users table"
         >
-          Refresh
+          {refreshing ? "Refreshing" : "Refresh"}
         </SecondaryButton>
       ),
     },
@@ -721,7 +730,7 @@ const ActiveUsers = () => {
       key: 4,
       element: (
         <SecondaryButton
-          isDisabled={isDeleteButtonDisabled}
+          isDisabled={isDeleteButtonDisabled || refreshing}
           onClickHandler={onDeleteHandler}
         >
           Delete
@@ -731,7 +740,10 @@ const ActiveUsers = () => {
     {
       key: 5,
       element: (
-        <SecondaryButton onClickHandler={onAddClickHandler}>
+        <SecondaryButton
+          onClickHandler={onAddClickHandler}
+          isDisabled={refreshing}
+        >
           Add
         </SecondaryButton>
       ),
@@ -740,7 +752,7 @@ const ActiveUsers = () => {
       key: 6,
       element: (
         <SecondaryButton
-          isDisabled={isDisableButtonDisabled}
+          isDisabled={isDisableButtonDisabled || refreshing}
           onClickHandler={() => onEnableDisableHandler(true)}
         >
           Disable
@@ -751,7 +763,7 @@ const ActiveUsers = () => {
       key: 7,
       element: (
         <SecondaryButton
-          isDisabled={isEnableButtonDisabled}
+          isDisabled={isEnableButtonDisabled || refreshing}
           onClickHandler={() => onEnableDisableHandler(false)}
         >
           Enable
@@ -767,7 +779,7 @@ const ActiveUsers = () => {
           idKebab="main-dropdown-kebab"
           isKebabOpen={kebabIsOpen}
           isPlain={true}
-          dropdownItems={dropdownItems}
+          dropdownItems={!refreshing ? dropdownItems : []}
         />
       ),
     },
@@ -830,6 +842,8 @@ const ActiveUsers = () => {
               <InnerScrollContainer>
                 {batchError !== undefined && batchError ? (
                   <>{errorGlobalMessage}</>
+                ) : refreshing ? (
+                  ""
                 ) : (
                   <UsersTable
                     elementsList={activeUsersList}


### PR DESCRIPTION
When refreshing the Active Users table disable all the buttons and set the refresh button as "loading/spinning".  Also "remove" the table instead of showing an empty table.

Also fixed issues when users are selected and then you refresh the table. Previously the selected users would incorrectly remain after a refresh. Now the "selected users" dropdown is also reset.