### PR TITLE
Issue 89 - Adapt the ‘Stage/Preserved users’ main pages

### DIFF
--- a/src/components/BulkSelectorUsersPrep.tsx
+++ b/src/components/BulkSelectorUsersPrep.tsx
@@ -204,6 +204,9 @@ const BulkSelectorPrep = (props: PropsToBulkSelectorPrep) => {
     isSelecting = true,
     selectableUsersList: User[]
   ) => {
+    if (selectableUsersList.length === 0) {
+      return;
+    }
     props.usersData.changeSelectedUserNames(
       isSelecting ? selectableUsersList.map((r) => r.uid) : []
     );

--- a/src/components/Form/PrincipalAliasMultiTextBox.tsx
+++ b/src/components/Form/PrincipalAliasMultiTextBox.tsx
@@ -11,6 +11,8 @@ import {
   ErrorResult,
   useAddPrincipalAliasMutation,
   useRemovePrincipalAliasMutation,
+  useAddStagePrincipalAliasMutation,
+  useRemoveStagePrincipalAliasMutation,
 } from "src/services/rpc";
 // Layouts
 import SecondaryButton from "../layouts/SecondaryButton";
@@ -25,6 +27,7 @@ interface PrincipalAliasMultiTextBoxProps {
   ipaObject: Record<string, unknown>;
   metadata: Metadata;
   onRefresh: () => void;
+  from: "active-users" | "stage-users" | "preserved-users";
 }
 
 const PrincipalAliasMultiTextBox = (props: PrincipalAliasMultiTextBoxProps) => {
@@ -32,9 +35,14 @@ const PrincipalAliasMultiTextBox = (props: PrincipalAliasMultiTextBoxProps) => {
   const alerts = useAlerts();
 
   // RTK hooks
-  const [addPrincipalAlias] = useAddPrincipalAliasMutation();
-  const [removePrincipalAlias] = useRemovePrincipalAliasMutation();
-
+  let [addPrincipalAlias] = useAddPrincipalAliasMutation();
+  if (props.from === "stage-users") {
+    [addPrincipalAlias] = useAddStagePrincipalAliasMutation();
+  }
+  let [removePrincipalAlias] = useRemovePrincipalAliasMutation();
+  if (props.from === "stage-users") {
+    [removePrincipalAlias] = useRemoveStagePrincipalAliasMutation();
+  }
   // 'krbprincipalname' value from ipaObject
   const krbprincipalname = props.ipaObject["krbprincipalname"] as string[];
 

--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -38,7 +38,11 @@ import UsersMailingAddress from "src/components/UsersSections/UsersMailingAddres
 import UsersEmployeeInfo from "src/components/UsersSections/UsersEmployeeInfo";
 import UsersAttributesSMB from "src/components/UsersSections/UsersAttributesSMB";
 // RPC
-import { ErrorResult, useSaveUserMutation } from "src/services/rpc";
+import {
+  ErrorResult,
+  useSaveUserMutation,
+  useSaveStageUserMutation,
+} from "src/services/rpc";
 // Hooks
 import useAlerts from "src/hooks/useAlerts";
 
@@ -67,8 +71,11 @@ const UserSettings = (props: PropsToUserSettings) => {
   // Alerts to show in the UI
   const alerts = useAlerts();
 
-  // RTK hook: save user
-  const [saveUser] = useSaveUserMutation();
+  // RTK hook: save user (acive/preserved and stage)
+  let [saveUser] = useSaveUserMutation();
+  if (props.from === "stage-users") {
+    [saveUser] = useSaveStageUserMutation();
+  }
 
   // Kebab
   const [isKebabOpen, setIsKebabOpen] = useState(false);
@@ -260,6 +267,7 @@ const UserSettings = (props: PropsToUserSettings) => {
                 onRefresh={props.onRefresh}
                 radiusProxyConf={props.radiusProxyData || []}
                 idpConf={props.idpData || []}
+                from={props.from}
               />
               <TitleLayout
                 key={2}

--- a/src/components/UsersSections/UsersAccountSettings.tsx
+++ b/src/components/UsersSections/UsersAccountSettings.tsx
@@ -39,6 +39,7 @@ interface PropsToUsersAccountSettings {
   onRefresh: () => void;
   radiusProxyConf: RadiusServer[];
   idpConf: IDPServer[];
+  from: "active-users" | "stage-users" | "preserved-users";
 }
 
 // Generic data to pass to the Textbox adder
@@ -355,6 +356,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
                 ipaObject={ipaObject}
                 metadata={props.metadata}
                 onRefresh={props.onRefresh}
+                from={props.from}
               />
             </FormGroup>
             <FormGroup

--- a/src/components/modals/ActivateStageUsers.tsx
+++ b/src/components/modals/ActivateStageUsers.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from "react";
 // PatternFly
 import {
-  TextContent,
-  Text,
-  TextVariants,
-  Radio,
   Button,
+  Checkbox,
+  Text,
+  TextContent,
+  TextVariants,
 } from "@patternfly/react-core";
 // Layouts
 import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
@@ -13,9 +13,7 @@ import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
 import UsersDisplayTable from "src/components/tables/UsersDisplayTable";
 // Redux
 import { useAppDispatch } from "src/store/hooks";
-import { removeUser as removeActiveUser } from "src/store/Identity/activeUsers-slice";
 import { removeUser as removeStageUser } from "src/store/Identity/stageUsers-slice";
-import { removeUser as removePreservedUser } from "src/store/Identity/preservedUsers-slice";
 // RPC
 import {
   Command,
@@ -31,22 +29,15 @@ import { ErrorData } from "src/utils/datatypes/globalDataTypes";
 // Hooks
 import useAlerts from "src/hooks/useAlerts";
 
-interface ButtonsData {
-  updateIsDeleteButtonDisabled?: (value: boolean) => void;
-  updateIsDeletion: (value: boolean) => void;
-}
-
 interface SelectedUsersData {
   selectedUsers: string[];
   updateSelectedUsers: (newSelectedUsers: string[]) => void;
 }
 
-export interface PropsToDeleteUsers {
+export interface PropsToActivateUsers {
   show: boolean;
-  from: "active-users" | "stage-users" | "preserved-users";
   handleModalToggle: () => void;
   selectedUsersData: SelectedUsersData;
-  buttonsData: ButtonsData;
   //  NOTE: 'onRefresh' is handled as { (User) => void | undefined } as a temporal solution
   //    until the C.L. is adapted in 'stage-' and 'preserved users' (otherwise
   //    the operation will fail for those components)
@@ -61,31 +52,17 @@ export interface PropsToDeleteUsers {
   onCloseDeleteModal?: () => void;
 }
 
-const DeleteUsers = (props: PropsToDeleteUsers) => {
+const ActivateStageUsers = (props: PropsToActivateUsers) => {
   // Set dispatch (Redux)
   const dispatch = useAppDispatch();
 
   // Alerts
   const alerts = useAlerts();
 
-  // Define 'executeUserDelCommand' to add user data to IPA server
-  const [executeUserDelCommand] = useBatchMutCommandMutation();
+  // Define 'executeUserStageCommand' to activate user data to IPA server
+  const [executeUserActivateCommand] = useBatchMutCommandMutation();
 
-  // Radio buttons states
-  const [isDeleteChecked, setIsDeleteChecked] = useState(true);
-
-  // Only one radio button must be checked
-  const manageRadioButtons = () => {
-    setIsDeleteChecked(!isDeleteChecked);
-  };
-
-  // Generate page name (based on 'from' text)
-  // E.g.: 'active-users' --> 'Active users'
-  const getUserPageName = () => {
-    const capitalizedName =
-      props.from.charAt(0).toUpperCase() + props.from.slice(1);
-    return capitalizedName.replace("-", " ");
-  };
+  const [noMembersChecked, setNoMembers] = useState<boolean>(false);
 
   // List of fields
   const fields = [
@@ -94,64 +71,39 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
       pfComponent: (
         <TextContent>
           <Text component={TextVariants.p}>
-            Are you sure you want to remove the selected entries from{" "}
-            {getUserPageName()}?
+            Are you sure you want to activate the selected stage users?
           </Text>
         </TextContent>
       ),
     },
     {
-      id: "deleted-users-table",
+      id: "activate-users-table",
       pfComponent: (
         <UsersDisplayTable
           usersToDisplay={props.selectedUsersData.selectedUsers}
-          from={props.from}
+          from={"stage-users"}
         />
       ),
     },
     {
-      id: "radio-buttons",
+      id: "no-members",
       pfComponent: (
-        <>
-          <TextContent>
-            <Text component={TextVariants.p}>Remove mode</Text>
-          </TextContent>
-          <Radio
-            id="radio-delete"
-            label="Delete"
-            name="radio-delete"
-            isChecked={isDeleteChecked}
-            onChange={manageRadioButtons}
-          />
-          <Radio
-            id="radio-preserve"
-            label="Preserve"
-            name="radio-preserve"
-            isChecked={!isDeleteChecked}
-            onChange={manageRadioButtons}
-          />
-        </>
+        <Checkbox
+          label="Suppress processing of membership attributes"
+          isChecked={noMembersChecked}
+          onChange={() => {
+            setNoMembers(!noMembersChecked);
+          }}
+          id="no-members-checkbox"
+          name="no-members"
+        />
       ),
     },
   ];
 
   // Close modal
   const closeModal = () => {
-    setIsDeleteChecked(true);
     props.handleModalToggle();
-  };
-
-  // Redux: Delete user
-  const deleteUsersFromRedux = () => {
-    props.selectedUsersData.selectedUsers.map((user) => {
-      if (props.from === "active-users") {
-        dispatch(removeActiveUser(user[0]));
-      } else if (props.from === "stage-users") {
-        dispatch(removeStageUser(user[0]));
-      } else if (props.from === "preserved-users") {
-        dispatch(removePreservedUser(user[0]));
-      }
-    });
   };
 
   // Handle API error data
@@ -193,28 +145,21 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
     setIsModalErrorOpen(true);
   };
 
-  // Delete user
-  const deleteUsers = (uidsToDelete: string[]) => {
+  // Stage user
+  const activateUsers = () => {
     // Prepare users params
-    const uidsToDeletePayload: Command[] = [];
-    let deletionParams = {};
-    if (props.from !== "stage-users") {
-      deletionParams = { preserve: !isDeleteChecked };
-    }
-    uidsToDelete.map((uid) => {
-      let method = "user_del";
-      if (props.from === "stage-users") {
-        method = "stageuser_del";
-      }
+    const uidsToActivatePayload: Command[] = [];
+
+    props.selectedUsersData.selectedUsers.map((uid) => {
       const payloadItem = {
-        method: method,
-        params: [[uid], deletionParams],
+        method: "stageuser_activate",
+        params: [uid, { no_members: noMembersChecked }],
       } as Command;
-      uidsToDeletePayload.push(payloadItem);
+      uidsToActivatePayload.push(payloadItem);
     });
 
-    // [API call] Delete elements
-    executeUserDelCommand(uidsToDeletePayload).then((response) => {
+    // [API call] activate elements
+    executeUserActivateCommand(uidsToActivatePayload).then((response) => {
       if ("data" in response) {
         const data = response.data as BatchRPCResponse;
         const result = data.result;
@@ -237,19 +182,12 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
             handleAPIError(error);
           } else {
             // Update data from Redux
-            deleteUsersFromRedux();
+            props.selectedUsersData.selectedUsers.map((user) => {
+              dispatch(removeStageUser(user[0]));
+            });
 
             // Reset selected values
             props.selectedUsersData.updateSelectedUsers([]);
-
-            // Disable 'Delete' button
-            if (
-              props.from === "active-users" &&
-              props.buttonsData.updateIsDeleteButtonDisabled !== undefined
-            ) {
-              props.buttonsData.updateIsDeleteButtonDisabled(true);
-            }
-            props.buttonsData.updateIsDeletion(true);
 
             // Refresh data
             if (props.onRefresh !== undefined) {
@@ -257,19 +195,11 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
             }
 
             // Show alert: success
-            if (isDeleteChecked) {
-              alerts.addAlert(
-                "remove-users-success",
-                "Users removed",
-                "success"
-              );
-            } else {
-              alerts.addAlert(
-                "preserve-users-success",
-                "Users preserved",
-                "success"
-              );
-            }
+            alerts.addAlert(
+              "activate-users-success",
+              "Users activated",
+              "success"
+            );
 
             closeModal();
           }
@@ -281,84 +211,40 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
     });
   };
 
-  // Set the Modal and Action buttons for 'Delete' option
-  const modalActionsDelete: JSX.Element[] = [
+  // Set the Modal and Action buttons for 'Stage' option
+  const modalStageActions: JSX.Element[] = [
     <Button
-      key="delete-users"
-      variant="danger"
-      onClick={() => {
-        deleteUsers(props.selectedUsersData.selectedUsers);
-      }}
-      form="active-users-remove-users-modal"
-    >
-      Delete
-    </Button>,
-    <Button key="cancel-new-user" variant="link" onClick={closeModal}>
-      Cancel
-    </Button>,
-  ];
-
-  let title = "Remove Active Users";
-  if (props.from === "stage-users") {
-    title = "Remove Stage Users";
-    // Drop last field (radio buttons with option to perserve)
-    fields.splice(-1);
-  } else if (props.from === "preserved-users") {
-    title = "Remove Preserved Users";
-    // Drop last field (radio buttons with option to perserve)
-    fields.splice(-1);
-  }
-
-  const modalDelete: JSX.Element = (
-    <ModalWithFormLayout
-      variantType="medium"
-      modalPosition="top"
-      offPosition="76px"
-      title={title}
-      formId="active-users-remove-users-modal"
-      fields={fields}
-      show={props.show}
-      onClose={closeModal}
-      actions={modalActionsDelete}
-    />
-  );
-
-  // Set the Modal and Action buttons for 'Preserve' option
-  const modalActionsPreserve: JSX.Element[] = [
-    <Button
-      key="preserve-users"
+      key="stage-users"
       variant="primary"
-      onClick={() => {
-        deleteUsers(props.selectedUsersData.selectedUsers);
-      }}
-      form="active-users-remove-users-modal"
+      onClick={activateUsers}
+      form="stage-users-modal"
     >
-      Preserve
+      Stage
     </Button>,
-    <Button key="cancel-new-user" variant="link" onClick={closeModal}>
+    <Button key="cancel-stage-user" variant="link" onClick={closeModal}>
       Cancel
     </Button>,
   ];
 
-  const modalPreserve: JSX.Element = (
+  const modalActivate: JSX.Element = (
     <ModalWithFormLayout
       variantType="medium"
       modalPosition="top"
       offPosition="76px"
-      title={title}
-      formId="active-users-remove-users-modal"
+      title="Activate Stage User"
+      formId="preserved-users-stage-modal"
       fields={fields}
       show={props.show}
       onClose={closeModal}
-      actions={modalActionsPreserve}
+      actions={modalStageActions}
     />
   );
 
-  // Render 'DeleteUsers'
+  // Render 'ActivateStageUsers'
   return (
     <>
       <alerts.ManagedAlerts />
-      {isDeleteChecked ? modalDelete : modalPreserve}
+      {modalActivate}
       {isModalErrorOpen && (
         <ErrorModal
           title={errorTitle}
@@ -372,4 +258,4 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
   );
 };
 
-export default DeleteUsers;
+export default ActivateStageUsers;

--- a/src/components/modals/PrincipalAliasDeleteModal.tsx
+++ b/src/components/modals/PrincipalAliasDeleteModal.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 // PatternFly
-import { TextInput } from "@patternfly/react-core";
 // Layouts
 import ModalWithFormLayout from "../layouts/ModalWithFormLayout";
 import TextLayout from "../layouts/TextLayout";

--- a/src/components/modals/RestorePreservedUsers.tsx
+++ b/src/components/modals/RestorePreservedUsers.tsx
@@ -1,11 +1,10 @@
 import React, { useState } from "react";
 // PatternFly
 import {
-  TextContent,
-  Text,
-  TextVariants,
-  Radio,
   Button,
+  Text,
+  TextContent,
+  TextVariants,
 } from "@patternfly/react-core";
 // Layouts
 import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
@@ -13,8 +12,6 @@ import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
 import UsersDisplayTable from "src/components/tables/UsersDisplayTable";
 // Redux
 import { useAppDispatch } from "src/store/hooks";
-import { removeUser as removeActiveUser } from "src/store/Identity/activeUsers-slice";
-import { removeUser as removeStageUser } from "src/store/Identity/stageUsers-slice";
 import { removeUser as removePreservedUser } from "src/store/Identity/preservedUsers-slice";
 // RPC
 import {
@@ -31,22 +28,15 @@ import { ErrorData } from "src/utils/datatypes/globalDataTypes";
 // Hooks
 import useAlerts from "src/hooks/useAlerts";
 
-interface ButtonsData {
-  updateIsDeleteButtonDisabled?: (value: boolean) => void;
-  updateIsDeletion: (value: boolean) => void;
-}
-
 interface SelectedUsersData {
   selectedUsers: string[];
   updateSelectedUsers: (newSelectedUsers: string[]) => void;
 }
 
-export interface PropsToDeleteUsers {
+export interface PropsToPreservedUsers {
   show: boolean;
-  from: "active-users" | "stage-users" | "preserved-users";
   handleModalToggle: () => void;
   selectedUsersData: SelectedUsersData;
-  buttonsData: ButtonsData;
   //  NOTE: 'onRefresh' is handled as { (User) => void | undefined } as a temporal solution
   //    until the C.L. is adapted in 'stage-' and 'preserved users' (otherwise
   //    the operation will fail for those components)
@@ -61,7 +51,7 @@ export interface PropsToDeleteUsers {
   onCloseDeleteModal?: () => void;
 }
 
-const DeleteUsers = (props: PropsToDeleteUsers) => {
+const RestorePreservedUsers = (props: PropsToPreservedUsers) => {
   // Set dispatch (Redux)
   const dispatch = useAppDispatch();
 
@@ -69,23 +59,7 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
   const alerts = useAlerts();
 
   // Define 'executeUserDelCommand' to add user data to IPA server
-  const [executeUserDelCommand] = useBatchMutCommandMutation();
-
-  // Radio buttons states
-  const [isDeleteChecked, setIsDeleteChecked] = useState(true);
-
-  // Only one radio button must be checked
-  const manageRadioButtons = () => {
-    setIsDeleteChecked(!isDeleteChecked);
-  };
-
-  // Generate page name (based on 'from' text)
-  // E.g.: 'active-users' --> 'Active users'
-  const getUserPageName = () => {
-    const capitalizedName =
-      props.from.charAt(0).toUpperCase() + props.from.slice(1);
-    return capitalizedName.replace("-", " ");
-  };
+  const [executeUserStageCommand] = useBatchMutCommandMutation();
 
   // List of fields
   const fields = [
@@ -94,64 +68,25 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
       pfComponent: (
         <TextContent>
           <Text component={TextVariants.p}>
-            Are you sure you want to remove the selected entries from{" "}
-            {getUserPageName()}?
+            Are you sure you want to restore the preserved entries?
           </Text>
         </TextContent>
       ),
     },
     {
-      id: "deleted-users-table",
+      id: "restore-users-table",
       pfComponent: (
         <UsersDisplayTable
           usersToDisplay={props.selectedUsersData.selectedUsers}
-          from={props.from}
+          from={"preserved-users"}
         />
-      ),
-    },
-    {
-      id: "radio-buttons",
-      pfComponent: (
-        <>
-          <TextContent>
-            <Text component={TextVariants.p}>Remove mode</Text>
-          </TextContent>
-          <Radio
-            id="radio-delete"
-            label="Delete"
-            name="radio-delete"
-            isChecked={isDeleteChecked}
-            onChange={manageRadioButtons}
-          />
-          <Radio
-            id="radio-preserve"
-            label="Preserve"
-            name="radio-preserve"
-            isChecked={!isDeleteChecked}
-            onChange={manageRadioButtons}
-          />
-        </>
       ),
     },
   ];
 
   // Close modal
   const closeModal = () => {
-    setIsDeleteChecked(true);
     props.handleModalToggle();
-  };
-
-  // Redux: Delete user
-  const deleteUsersFromRedux = () => {
-    props.selectedUsersData.selectedUsers.map((user) => {
-      if (props.from === "active-users") {
-        dispatch(removeActiveUser(user[0]));
-      } else if (props.from === "stage-users") {
-        dispatch(removeStageUser(user[0]));
-      } else if (props.from === "preserved-users") {
-        dispatch(removePreservedUser(user[0]));
-      }
-    });
   };
 
   // Handle API error data
@@ -193,28 +128,21 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
     setIsModalErrorOpen(true);
   };
 
-  // Delete user
-  const deleteUsers = (uidsToDelete: string[]) => {
-    // Prepare users params
-    const uidsToDeletePayload: Command[] = [];
-    let deletionParams = {};
-    if (props.from !== "stage-users") {
-      deletionParams = { preserve: !isDeleteChecked };
-    }
-    uidsToDelete.map((uid) => {
-      let method = "user_del";
-      if (props.from === "stage-users") {
-        method = "stageuser_del";
-      }
+  // Stage user
+  const restoreUsers = () => {
+    // Prepare user params
+    const uidsToRestorePayload: Command[] = [];
+
+    props.selectedUsersData.selectedUsers.map((uid) => {
       const payloadItem = {
-        method: method,
-        params: [[uid], deletionParams],
+        method: "user_undel",
+        params: [uid, {}],
       } as Command;
-      uidsToDeletePayload.push(payloadItem);
+      uidsToRestorePayload.push(payloadItem);
     });
 
-    // [API call] Delete elements
-    executeUserDelCommand(uidsToDeletePayload).then((response) => {
+    // [API call] Restore elements
+    executeUserStageCommand(uidsToRestorePayload).then((response) => {
       if ("data" in response) {
         const data = response.data as BatchRPCResponse;
         const result = data.result;
@@ -237,19 +165,12 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
             handleAPIError(error);
           } else {
             // Update data from Redux
-            deleteUsersFromRedux();
+            props.selectedUsersData.selectedUsers.map((user) => {
+              dispatch(removePreservedUser(user[0]));
+            });
 
             // Reset selected values
             props.selectedUsersData.updateSelectedUsers([]);
-
-            // Disable 'Delete' button
-            if (
-              props.from === "active-users" &&
-              props.buttonsData.updateIsDeleteButtonDisabled !== undefined
-            ) {
-              props.buttonsData.updateIsDeleteButtonDisabled(true);
-            }
-            props.buttonsData.updateIsDeletion(true);
 
             // Refresh data
             if (props.onRefresh !== undefined) {
@@ -257,19 +178,11 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
             }
 
             // Show alert: success
-            if (isDeleteChecked) {
-              alerts.addAlert(
-                "remove-users-success",
-                "Users removed",
-                "success"
-              );
-            } else {
-              alerts.addAlert(
-                "preserve-users-success",
-                "Users preserved",
-                "success"
-              );
-            }
+            alerts.addAlert(
+              "restore-users-success",
+              "Users restored",
+              "success"
+            );
 
             closeModal();
           }
@@ -281,84 +194,40 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
     });
   };
 
-  // Set the Modal and Action buttons for 'Delete' option
-  const modalActionsDelete: JSX.Element[] = [
+  // Set the Modal and Action buttons for 'Restore' option
+  const modalRestoreActions: JSX.Element[] = [
     <Button
-      key="delete-users"
-      variant="danger"
-      onClick={() => {
-        deleteUsers(props.selectedUsersData.selectedUsers);
-      }}
-      form="active-users-remove-users-modal"
-    >
-      Delete
-    </Button>,
-    <Button key="cancel-new-user" variant="link" onClick={closeModal}>
-      Cancel
-    </Button>,
-  ];
-
-  let title = "Remove Active Users";
-  if (props.from === "stage-users") {
-    title = "Remove Stage Users";
-    // Drop last field (radio buttons with option to perserve)
-    fields.splice(-1);
-  } else if (props.from === "preserved-users") {
-    title = "Remove Preserved Users";
-    // Drop last field (radio buttons with option to perserve)
-    fields.splice(-1);
-  }
-
-  const modalDelete: JSX.Element = (
-    <ModalWithFormLayout
-      variantType="medium"
-      modalPosition="top"
-      offPosition="76px"
-      title={title}
-      formId="active-users-remove-users-modal"
-      fields={fields}
-      show={props.show}
-      onClose={closeModal}
-      actions={modalActionsDelete}
-    />
-  );
-
-  // Set the Modal and Action buttons for 'Preserve' option
-  const modalActionsPreserve: JSX.Element[] = [
-    <Button
-      key="preserve-users"
+      key="restore-users"
       variant="primary"
-      onClick={() => {
-        deleteUsers(props.selectedUsersData.selectedUsers);
-      }}
-      form="active-users-remove-users-modal"
+      onClick={restoreUsers}
+      form="restore-users-modal"
     >
-      Preserve
+      Restore
     </Button>,
-    <Button key="cancel-new-user" variant="link" onClick={closeModal}>
+    <Button key="cancel-restore-user" variant="link" onClick={closeModal}>
       Cancel
     </Button>,
   ];
 
-  const modalPreserve: JSX.Element = (
+  const modalRestore: JSX.Element = (
     <ModalWithFormLayout
       variantType="medium"
       modalPosition="top"
       offPosition="76px"
-      title={title}
-      formId="active-users-remove-users-modal"
+      title="Restore Preserved User"
+      formId="restore-users-stage-modal"
       fields={fields}
       show={props.show}
       onClose={closeModal}
-      actions={modalActionsPreserve}
+      actions={modalRestoreActions}
     />
   );
 
-  // Render 'DeleteUsers'
+  // Render 'StageUsers'
   return (
     <>
       <alerts.ManagedAlerts />
-      {isDeleteChecked ? modalDelete : modalPreserve}
+      {modalRestore}
       {isModalErrorOpen && (
         <ErrorModal
           title={errorTitle}
@@ -372,4 +241,4 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
   );
 };
 
-export default DeleteUsers;
+export default RestorePreservedUsers;

--- a/src/components/tables/UsersDisplayTable.tsx
+++ b/src/components/tables/UsersDisplayTable.tsx
@@ -8,12 +8,12 @@ import { User } from "src/utils/datatypes/globalDataTypes";
 // Redux
 import { useAppSelector } from "src/store/hooks";
 
-export interface PropsToDeletedUsersTable {
-  usersToDelete: string[];
+export interface PropsToDisplayUsersTable {
+  usersToDisplay: string[];
   from: "active-users" | "stage-users" | "preserved-users";
 }
 
-const DeletedUsersTable = (props: PropsToDeletedUsersTable) => {
+const UsersDisplayTable = (props: PropsToDisplayUsersTable) => {
   // Retrieve all users list from Store
   // - Active users
   const activeUsersList = useAppSelector(
@@ -32,31 +32,31 @@ const DeletedUsersTable = (props: PropsToDeletedUsersTable) => {
   const preservedUsersListCopy = [...preservedUsersList];
 
   // Given userIds, retrieve full user info to display into table
-  const usersToDelete: User[] = [];
+  const usersToDisplay: User[] = [];
   switch (props.from) {
     case "active-users":
       activeUsersListCopy.map((user) => {
-        props.usersToDelete.map((selected) => {
+        props.usersToDisplay.map((selected) => {
           if (user.uid[0] === selected[0]) {
-            usersToDelete.push(user);
+            usersToDisplay.push(user);
           }
         });
       });
       break;
     case "stage-users":
       stageUsersListCopy.map((user) => {
-        props.usersToDelete.map((selected) => {
+        props.usersToDisplay.map((selected) => {
           if (user.uid === selected) {
-            usersToDelete.push(user);
+            usersToDisplay.push(user);
           }
         });
       });
       break;
     case "preserved-users":
       preservedUsersListCopy.map((user) => {
-        props.usersToDelete.map((selected) => {
+        props.usersToDisplay.map((selected) => {
           if (user.uid === selected) {
-            usersToDelete.push(user);
+            usersToDisplay.push(user);
           }
         });
       });
@@ -83,7 +83,7 @@ const DeletedUsersTable = (props: PropsToDeletedUsersTable) => {
     </Tr>
   );
 
-  const body = usersToDelete.map((user) => (
+  const body = usersToDisplay.map((user) => (
     <Tr key={user.uid} id={user.uid}>
       <Td dataLabel={columnNames.userLogin}>{user.uid}</Td>
       <Td dataLabel={columnNames.firstName}>{user.givenname}</Td>
@@ -93,7 +93,7 @@ const DeletedUsersTable = (props: PropsToDeletedUsersTable) => {
     </Tr>
   ));
 
-  // Render 'DeletedUsersTable'
+  // Render 'UsersDisplayTable'
   return (
     <TableLayout
       ariaLabel={"Remove users table"}
@@ -107,4 +107,4 @@ const DeletedUsersTable = (props: PropsToDeletedUsersTable) => {
   );
 };
 
-export default DeletedUsersTable;
+export default UsersDisplayTable;

--- a/src/hooks/useUserSettingsData.tsx
+++ b/src/hooks/useUserSettingsData.tsx
@@ -5,7 +5,8 @@ import {
   useGetIdpServerQuery,
   useGetObjectMetadataQuery,
   useGetRadiusProxyQuery,
-  useGetUsersFullDataQuery,
+  useGetUsersFullQuery,
+  useGetStageUsersFullQuery,
 } from "src/services/rpc";
 // Data types
 import {
@@ -34,14 +35,28 @@ type UserSettingsData = {
   idpServers: IDPServer[];
 };
 
-const useUserSettingsData = (userId: string): UserSettingsData => {
+const useUserSettings = (userId: string): UserSettingsData => {
+  return useSettingsData(userId, "active");
+};
+
+const useStageUserSettings = (userId: string): UserSettingsData => {
+  return useSettingsData(userId, "stage");
+};
+
+const useSettingsData = (
+  userId: string,
+  userType: string
+): UserSettingsData => {
   // [API call] Metadata
   const metadataQuery = useGetObjectMetadataQuery();
   const metadata = metadataQuery.data || {};
   const metadataLoading = metadataQuery.isLoading;
 
   // [API call] User
-  const userFullDataQuery = useGetUsersFullDataQuery(userId);
+  let userFullDataQuery = useGetUsersFullQuery(userId);
+  if (userType === "stage") {
+    userFullDataQuery = useGetStageUsersFullQuery(userId);
+  }
   const userFullData = userFullDataQuery.data;
   const isFullDataLoading = userFullDataQuery.isLoading;
 
@@ -138,4 +153,4 @@ const useUserSettingsData = (userId: string): UserSettingsData => {
   return settings;
 };
 
-export default useUserSettingsData;
+export { useUserSettings, useStageUserSettings };

--- a/src/pages/ActiveUsers/ActiveUsers.tsx
+++ b/src/pages/ActiveUsers/ActiveUsers.tsx
@@ -48,7 +48,7 @@ import { API_VERSION_BACKUP, isUserSelectable } from "src/utils/utils";
 // RPC client
 import {
   Command,
-  useGettingUserQuery,
+  useGettingActiveUserQuery,
   useSimpleMutCommandMutation,
   UsersPayload,
 } from "src/services/rpc";
@@ -93,7 +93,7 @@ const ActiveUsers = () => {
   const [isDisabledDueError, setIsDisabledDueError] = useState<boolean>(false);
 
   // Derived states - what we get from API
-  const userDataResponse = useGettingUserQuery({
+  const userDataResponse = useGettingActiveUserQuery({
     searchValue,
     sizeLimit: 0,
     apiVersion: apiVersion || API_VERSION_BACKUP,
@@ -658,7 +658,7 @@ const ActiveUsers = () => {
           <TitleLayout
             id="active users title"
             headingLevel="h1"
-            text="Active users"
+            text="Active Users"
           />
         </PageSection>
         <PageSection

--- a/src/pages/ActiveUsers/ActiveUsersTabs.tsx
+++ b/src/pages/ActiveUsers/ActiveUsersTabs.tsx
@@ -24,7 +24,7 @@ import UserMemberOf from "./UserMemberOf";
 import BreadcrumbLayout from "src/components/layouts/BreadcrumbLayout";
 import DataSpinner from "src/components/layouts/DataSpinner";
 // Hooks
-import useUserSettingsData from "src/hooks/useUserSettingsData";
+import { useUserSettings } from "src/hooks/useUserSettingsData";
 
 const ActiveUsersTabs = () => {
   // Get location (React Router DOM) and get state data
@@ -33,7 +33,7 @@ const ActiveUsersTabs = () => {
   const uid = userData.uid;
 
   // Data loaded from DB
-  const userSettingsData = useUserSettingsData(uid);
+  const userSettingsData = useUserSettings(uid);
 
   // Tab
   const [activeTabKey, setActiveTabKey] = useState(0);

--- a/src/pages/PreservedUsers/PreservedUsers.tsx
+++ b/src/pages/PreservedUsers/PreservedUsers.tsx
@@ -1,11 +1,11 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 // PatternFly
 import {
   Page,
+  PaginationVariant,
   PageSection,
   PageSectionVariants,
   TextVariants,
-  PaginationVariant,
 } from "@patternfly/react-core";
 // PatternFly table
 import {
@@ -18,7 +18,7 @@ import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/o
 import { User } from "src/utils/datatypes/globalDataTypes";
 import { ToolbarItem } from "src/components/layouts/ToolbarLayout";
 // Redux
-import { useAppSelector } from "src/store/hooks";
+import { useAppDispatch, useAppSelector } from "src/store/hooks";
 // Layouts
 import TitleLayout from "src/components/layouts/TitleLayout";
 import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
@@ -32,14 +32,121 @@ import PaginationPrep from "src/components/PaginationPrep";
 import BulkSelectorUsersPrep from "src/components/BulkSelectorUsersPrep";
 // Modals
 import DeleteUsers from "src/components/modals/DeleteUsers";
+import StagePreservedUsers from "src/components/modals/StagePreservedUsers";
+import RestorePreservedUsers from "src/components/modals/RestorePreservedUsers";
+// Hooks
+import { updateUsersList } from "src/store/Identity/preservedUsers-slice";
 // Utils
-import { isUserSelectable } from "src/utils/utils";
+import { API_VERSION_BACKUP, isUserSelectable } from "src/utils/utils";
+import { useGettingPreservedUserQuery, UsersPayload } from "src/services/rpc";
+import useApiError from "src/hooks/useApiError";
+import GlobalErrors from "src/components/errors/GlobalErrors";
+import ModalErrors from "src/components/errors/ModalErrors";
 
 const PreservedUsers = () => {
-  // Initialize preserved users list (Redux)
-  const preservedUsersList = useAppSelector(
-    (state) => state.preservedUsers.usersList
-  );
+  // Initialize stage users list (Redux)
+  const dispatch = useAppDispatch();
+
+  // Retrieve API version from environment data
+  const apiVersion = useAppSelector(
+    (state) => state.global.environment.api_version
+  ) as string;
+
+  // Preservered users list
+  const [preservedUsersList, setPreservedUsersList] = useState<User[]>([]);
+
+  // Handle API calls errors
+  const globalErrors = useApiError([]);
+  const modalErrors = useApiError([]);
+
+  // Main states - what user can define / what we could use in page URL
+  const [searchValue, setSearchValue] = React.useState("");
+  const [page, setPage] = useState<number>(1);
+  const [perPage, setPerPage] = useState<number>(15);
+  const [selectedUserIds, setSelectedUserIds] = useState<string[]>([]);
+
+  // Users displayed on the first page
+  const [shownUsersList, setShownUsersList] = useState<User[]>([]);
+
+  // Derived states - what we get from API
+  const userDataResponse = useGettingPreservedUserQuery({
+    searchValue,
+    sizeLimit: 0,
+    apiVersion: apiVersion || API_VERSION_BACKUP,
+  } as UsersPayload);
+
+  const {
+    data: batchResponse,
+    isLoading: isBatchLoading,
+    error: batchError,
+  } = userDataResponse;
+
+  // Page indexes
+  const firstUserIdx = (page - 1) * perPage;
+  const lastUserIdx = page * perPage;
+
+  // Handle data when the API call is finished
+  useEffect(() => {
+    if (userDataResponse.isFetching) {
+      setShowTableRows(false);
+      // Reset selected users on refresh
+      setSelectedUserNames([]);
+      setSelectedUserIds([]);
+      setSelectedUsers([]);
+      globalErrors.clear();
+      return;
+    }
+
+    // API response: Success
+    if (
+      userDataResponse.isSuccess &&
+      userDataResponse.data &&
+      batchResponse !== undefined
+    ) {
+      const usersListResult = batchResponse.result.results;
+      const usersListSize = batchResponse.result.count;
+      const usersList: User[] = [];
+
+      for (let i = 0; i < usersListSize; i++) {
+        usersList.push(usersListResult[i].result);
+      }
+
+      // Update 'Active users' slice data
+      dispatch(updateUsersList(usersList));
+      // Update the list of users
+      setPreservedUsersList(usersList);
+      // Update the shown users list
+      setShownUsersList(usersList.slice(firstUserIdx, lastUserIdx));
+      // Show table elements
+      setShowTableRows(true);
+    }
+
+    // API response: Error
+    if (
+      !userDataResponse.isLoading &&
+      userDataResponse.isError &&
+      userDataResponse.error !== undefined
+    ) {
+      globalErrors.addError(
+        batchError,
+        "Error when loading data",
+        "error-batch-users"
+      );
+    }
+  }, [userDataResponse]);
+
+  // Refresh button handling
+  const refreshUsersData = () => {
+    // Hide table
+    setShowTableRows(false);
+
+    // Reset selected users on refresh
+    setSelectedUserNames([]);
+    setSelectedUserIds([]);
+    setSelectedUsers([]);
+
+    userDataResponse.refetch();
+  };
 
   // Selected users state
   const [selectedUsers, setSelectedUsers] = useState<string[]>([]);
@@ -63,9 +170,6 @@ const PreservedUsers = () => {
     setIsDeletion(value);
   };
 
-  // - Selected user ids state
-  const [selectedUserIds, setSelectedUserIds] = useState<string[]>([]);
-
   const updateSelectedUserIds = (newSelectedUserIds: string[]) => {
     setSelectedUserIds(newSelectedUserIds);
   };
@@ -79,50 +183,33 @@ const PreservedUsers = () => {
   };
 
   // Pagination
-  const [page, setPage] = useState<number>(1);
-
   const updatePage = (newPage: number) => {
     setPage(newPage);
   };
-
-  const [perPage, setPerPage] = useState<number>(15);
 
   const updatePerPage = (newSetPerPage: number) => {
     setPerPage(newSetPerPage);
   };
 
   // Users displayed on the first page
-  const [shownUsersList, setShownUsersList] = useState(
-    preservedUsersList.slice(0, perPage)
-  );
-
   const updateShownUsersList = (newShownUsersList: User[]) => {
     setShownUsersList(newShownUsersList);
   };
 
   // Filter (Input search)
-  const [searchValue, setSearchValue] = React.useState("");
-
   const updateSearchValue = (value: string) => {
     setSearchValue(value);
   };
 
   // Show table rows
-  const [showTableRows, setShowTableRows] = useState(false);
+  const [showTableRows, setShowTableRows] = useState(!isBatchLoading);
 
-  const updateShowTableRows = (value: boolean) => {
-    setShowTableRows(value);
-  };
-
-  // Modals functionality
-  const [showDeleteModal, setShowDeleteModal] = useState(false);
-
-  const onDeleteHandler = () => {
-    setShowDeleteModal(true);
-  };
-  const onDeleteModalToggle = () => {
-    setShowDeleteModal(!showDeleteModal);
-  };
+  // Show table rows only when data is fully retrieved
+  useEffect(() => {
+    if (showTableRows !== !isBatchLoading) {
+      setShowTableRows(!isBatchLoading);
+    }
+  }, [isBatchLoading]);
 
   // Table-related shared functionality
   // - Selectable checkboxes on table
@@ -144,17 +231,28 @@ const PreservedUsers = () => {
         : otherSelectedUserNames;
     });
 
-  // Refresh displayed elements every time elements list changes (from Redux or somewhere else)
-  React.useEffect(() => {
-    updatePage(1);
-    if (showTableRows) updateShowTableRows(false);
-    setTimeout(() => {
-      updateShownUsersList(preservedUsersList.slice(0, perPage));
-      updateShowTableRows(true);
-      // Reset 'selectedPerPage'
-      updateSelectedPerPage(0);
-    }, 2000);
-  }, [preservedUsersList]);
+  // Modals functionality
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [showRestoreModal, setShowRestoreModal] = useState(false);
+  const [showStageModal, setShowStageModal] = useState(false);
+  const onDeleteHandler = () => {
+    setShowDeleteModal(true);
+  };
+  const onDeleteModalToggle = () => {
+    setShowDeleteModal(!showDeleteModal);
+  };
+  const onRestoreHandler = () => {
+    setShowRestoreModal(true);
+  };
+  const onRestoreModalToggle = () => {
+    setShowRestoreModal(!showRestoreModal);
+  };
+  const onStageHandler = () => {
+    setShowStageModal(true);
+  };
+  const onStageModalToggle = () => {
+    setShowStageModal(!showStageModal);
+  };
 
   // Data wrappers
   // - 'PaginationPrep'
@@ -257,13 +355,20 @@ const PreservedUsers = () => {
     },
     {
       key: 3,
-      element: <SecondaryButton>Refresh</SecondaryButton>,
+      element: (
+        <SecondaryButton
+          onClickHandler={refreshUsersData}
+          isDisabled={!showTableRows}
+        >
+          Refresh
+        </SecondaryButton>
+      ),
     },
     {
       key: 4,
       element: (
         <SecondaryButton
-          isDisabled={isDeleteButtonDisabled}
+          isDisabled={isDeleteButtonDisabled || !showTableRows}
           onClickHandler={onDeleteHandler}
         >
           Delete
@@ -272,11 +377,25 @@ const PreservedUsers = () => {
     },
     {
       key: 5,
-      element: <SecondaryButton>Restore</SecondaryButton>,
+      element: (
+        <SecondaryButton
+          isDisabled={!showTableRows || selectedUsers.length === 0}
+          onClickHandler={onRestoreHandler}
+        >
+          Restore
+        </SecondaryButton>
+      ),
     },
     {
       key: 6,
-      element: <SecondaryButton>Stage</SecondaryButton>,
+      element: (
+        <SecondaryButton
+          isDisabled={!showTableRows || selectedUsers.length === 0}
+          onClickHandler={onStageHandler}
+        >
+          Stage
+        </SecondaryButton>
+      ),
     },
     {
       key: 7,
@@ -317,7 +436,7 @@ const PreservedUsers = () => {
         <TitleLayout
           id="preserved users title"
           headingLevel="h1"
-          text="Preserved users"
+          text="Preserved Users"
         />
       </PageSection>
       <PageSection
@@ -333,16 +452,20 @@ const PreservedUsers = () => {
         <div style={{ height: `calc(100vh - 352.2px)` }}>
           <OuterScrollContainer>
             <InnerScrollContainer>
-              <UsersTable
-                elementsList={preservedUsersList}
-                shownElementsList={shownUsersList}
-                from="preserved-users"
-                showTableRows={showTableRows}
-                usersData={usersTableData}
-                buttonsData={usersTableButtonsData}
-                paginationData={selectedPerPageData}
-                searchValue={searchValue}
-              />
+              {batchError !== undefined && batchError ? (
+                <GlobalErrors errors={globalErrors.getAll()} />
+              ) : (
+                <UsersTable
+                  elementsList={preservedUsersList}
+                  shownElementsList={shownUsersList}
+                  from="preserved-users"
+                  showTableRows={showTableRows}
+                  usersData={usersTableData}
+                  buttonsData={usersTableButtonsData}
+                  paginationData={selectedPerPageData}
+                  searchValue={searchValue}
+                />
+              )}
             </InnerScrollContainer>
           </OuterScrollContainer>
         </div>
@@ -355,12 +478,26 @@ const PreservedUsers = () => {
           className="pf-u-pb-0 pf-u-pr-md"
         />
       </PageSection>
+      <ModalErrors errors={modalErrors.getAll()} />
       <DeleteUsers
         show={showDeleteModal}
         from="preserved-users"
         handleModalToggle={onDeleteModalToggle}
         selectedUsersData={selectedUsersData}
         buttonsData={deleteUsersButtonsData}
+        onRefresh={refreshUsersData}
+      />
+      <RestorePreservedUsers
+        show={showRestoreModal}
+        handleModalToggle={onRestoreModalToggle}
+        selectedUsersData={selectedUsersData}
+        onRefresh={refreshUsersData}
+      />
+      <StagePreservedUsers
+        show={showStageModal}
+        handleModalToggle={onStageModalToggle}
+        selectedUsersData={selectedUsersData}
+        onRefresh={refreshUsersData}
       />
     </Page>
   );

--- a/src/pages/PreservedUsers/PreservedUsersTabs.tsx
+++ b/src/pages/PreservedUsers/PreservedUsersTabs.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 // PatternFly
 import {
   Title,
@@ -23,7 +23,7 @@ import UserSettings from "src/components/UserSettings";
 import BreadcrumbLayout from "src/components/layouts/BreadcrumbLayout";
 import DataSpinner from "src/components/layouts/DataSpinner";
 // Hooks
-import useUserSettingsData from "src/hooks/useUserSettingsData";
+import { useUserSettings } from "src/hooks/useUserSettingsData";
 
 const PreservedUsersTabs = () => {
   // Get location (React Router DOM) and get state data
@@ -32,7 +32,7 @@ const PreservedUsersTabs = () => {
   const uid = userData.uid;
 
   // Data loaded from DB
-  const userSettingsData = useUserSettingsData(uid);
+  const userSettingsData = useUserSettings(uid);
 
   // Tab
   const [activeTabKey, setActiveTabKey] = useState(0);
@@ -98,6 +98,8 @@ const PreservedUsersTabs = () => {
               isModified={userSettingsData.modified}
               onResetValues={userSettingsData.resetValues}
               modifiedValues={userSettingsData.modifiedValues}
+              radiusProxyData={userSettingsData.radiusServers}
+              idpData={userSettingsData.idpServers}
               from="preserved-users"
             />
           </Tab>

--- a/src/pages/StageUsers/StageUsersTabs.tsx
+++ b/src/pages/StageUsers/StageUsersTabs.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 // PatternFly
 import {
   Title,
@@ -23,7 +23,7 @@ import UserSettings from "src/components/UserSettings";
 import BreadcrumbLayout from "src/components/layouts/BreadcrumbLayout";
 import DataSpinner from "src/components/layouts/DataSpinner";
 // Hooks
-import useUserSettingsData from "src/hooks/useUserSettingsData";
+import { useStageUserSettings } from "src/hooks/useUserSettingsData";
 
 const StageUsersTabs = () => {
   // Get location (React Router DOM) and get state data
@@ -32,7 +32,7 @@ const StageUsersTabs = () => {
   const uid = userData.uid;
 
   // Data loaded from DB
-  const userSettingsData = useUserSettingsData(uid);
+  const userSettingsData = useStageUserSettings(uid);
 
   // Tab
   const [activeTabKey, setActiveTabKey] = useState(0);
@@ -98,6 +98,8 @@ const StageUsersTabs = () => {
               isModified={userSettingsData.modified}
               onResetValues={userSettingsData.resetValues}
               modifiedValues={userSettingsData.modifiedValues}
+              radiusProxyData={userSettingsData.radiusServers}
+              idpData={userSettingsData.idpServers}
               from="stage-users"
             />
           </Tab>

--- a/src/services/rpc.ts
+++ b/src/services/rpc.ts
@@ -116,6 +116,7 @@ export interface UsersPayload {
   searchValue: string;
   sizeLimit: number;
   apiVersion: string;
+  userType?: string;
 }
 
 // Body data to perform the calls
@@ -180,7 +181,7 @@ export const api = createApi({
     }),
     gettingUser: build.query<BatchRPCResponse, UsersPayload>({
       async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
-        const { searchValue, sizeLimit, apiVersion } = payloadData;
+        const { searchValue, sizeLimit, apiVersion, userType } = payloadData;
 
         // 1ST CALL - GETTING ALL UIDS
         if (apiVersion === undefined) {
@@ -192,17 +193,26 @@ export const api = createApi({
             } as FetchBaseQueryError,
           };
         }
+
+        // Prepare search parameters
+        const params = {
+          pkey_only: true,
+          sizelimit: sizeLimit,
+          version: apiVersion,
+        };
+        let method = "user_find";
+        let show_method = "user_show";
+        if (userType === "stage") {
+          method = "stageuser_find";
+          show_method = "stageuser_show";
+        } else if (userType === "preserved") {
+          params["preserved"] = true;
+        }
+
         // Prepare payload
         const payloadDataUids: Command = {
-          method: "user_find",
-          params: [
-            [searchValue],
-            {
-              pkey_only: true,
-              sizelimit: sizeLimit,
-              version: apiVersion,
-            },
-          ],
+          method: method,
+          params: [[searchValue], params],
         };
 
         // Make call using 'fetchWithBQ'
@@ -226,7 +236,7 @@ export const api = createApi({
         // Prepare payload
         const options = { no_members: true };
         const payloadUserDataBatch: Command[] = uids.map((uid) => ({
-          method: "user_show",
+          method: show_method,
           params: [[uid], options],
         }));
 
@@ -261,26 +271,42 @@ export const api = createApi({
         response.result,
       providesTags: ["ObjectMetadata"],
     }),
-    getUsersFullData: build.query<UserFullData, string>({
-      query: (userId: string, apiVersion?: string) => {
+    getGenericUsersFullData: build.query<UserFullData, object>({
+      query: (query_args) => {
+        // Prepare search parameters
+        const user_params = {
+          all: true,
+          rights: true,
+        };
+        let method = "user_show";
+        if (query_args["user_type"] === "stage") {
+          // Preserved users work with user_show, but not stage users
+          method = "stageuser_show";
+        }
         const userShowCommand: Command = {
-          method: "user_show",
-          params: [userId, { all: true, rights: true }],
+          method: method,
+          params: [query_args["userId"], user_params],
         };
 
         const pwpolicyShowCommand: Command = {
           method: "pwpolicy_show",
-          params: [[], { user: userId[0], all: true, rights: true }],
+          params: [
+            [],
+            { user: query_args["userId"][0], all: true, rights: true },
+          ],
         };
 
         const krbtpolicyShowCommand: Command = {
           method: "krbtpolicy_show",
-          params: [userId, { all: true, rights: true }],
+          params: [query_args["userId"], { all: true, rights: true }],
         };
 
         const certFindCommand: Command = {
           method: "cert_find",
-          params: [[], { user: userId[0], sizelimit: 0, all: true }],
+          params: [
+            [],
+            { user: query_args["userId"][0], sizelimit: 0, all: true },
+          ],
         };
 
         const batchPayload: Command[] = [
@@ -290,7 +316,10 @@ export const api = createApi({
           certFindCommand,
         ];
 
-        return getBatchCommand(batchPayload, apiVersion || API_VERSION_BACKUP);
+        return getBatchCommand(
+          batchPayload,
+          query_args["version"] || API_VERSION_BACKUP
+        );
       },
       transformResponse: (response: BatchResponse): UserFullData => {
         const results = response.result.results;
@@ -304,16 +333,36 @@ export const api = createApi({
       providesTags: ["FullUser"],
     }),
     saveUser: build.mutation<FindRPCResponse, Partial<User>>({
+      query: (save_args) => {
+        const params = {
+          version: API_VERSION_BACKUP,
+          ...save_args["user"],
+        };
+
+        delete params["uid"];
+
+        let method = "user_mod";
+        if (save_args["user_type"] === "stage") {
+          method = "stageuser_mod";
+        }
+
+        return getCommand({
+          method: method,
+          params: [[params.user.uid], params],
+        });
+      },
+      invalidatesTags: ["FullUser"],
+    }),
+    saveStageUser: build.mutation<FindRPCResponse, Partial<User>>({
       query: (user) => {
         const params = {
           version: API_VERSION_BACKUP,
           ...user,
         };
-
         delete params["uid"];
 
         return getCommand({
-          method: "user_mod",
+          method: "stageuser_mod",
           params: [[user.uid], params],
         });
       },
@@ -361,8 +410,63 @@ export const api = createApi({
         });
       },
     }),
+    removeStagePrincipalAlias: build.mutation<FindRPCResponse, any[]>({
+      query: (payload) => {
+        const params = [payload, { version: API_VERSION_BACKUP }];
+
+        return getCommand({
+          method: "stageuser_remove_principal",
+          params: params,
+        });
+      },
+    }),
+    addStagePrincipalAlias: build.mutation<FindRPCResponse, any[]>({
+      query: (payload) => {
+        const params = [payload, { version: API_VERSION_BACKUP }];
+
+        return getCommand({
+          method: "stageuser_add_principal",
+          params: params,
+        });
+      },
+    }),
   }),
 });
+
+// Wrappers for active, preserved, and stage users
+export const useGettingActiveUserQuery = (payloadData) => {
+  payloadData["userType"] = "user";
+  return useGettingUserQuery(payloadData);
+};
+
+export const useGettingStageUserQuery = (payloadData) => {
+  payloadData["userType"] = "stage";
+  return useGettingUserQuery(payloadData);
+};
+
+export const useGettingPreservedUserQuery = (payloadData) => {
+  payloadData["userType"] = "preserved";
+  return useGettingUserQuery(payloadData);
+};
+
+export const useGetUsersFullQuery = (userId: string) => {
+  // Active and preserved users
+  const query_args = {
+    userId: userId,
+    user_type: "active",
+    version: API_VERSION_BACKUP,
+  };
+  return useGetGenericUsersFullDataQuery(query_args);
+};
+
+export const useGetStageUsersFullQuery = (userId: string) => {
+  const query_args = {
+    userId: userId,
+    user_type: "stage",
+    version: API_VERSION_BACKUP,
+  };
+  return useGetGenericUsersFullDataQuery(query_args);
+};
 
 export const {
   useSimpleCommandQuery,
@@ -371,10 +475,13 @@ export const {
   useBatchMutCommandMutation,
   useGettingUserQuery,
   useGetObjectMetadataQuery,
-  useGetUsersFullDataQuery,
+  useGetGenericUsersFullDataQuery,
   useSaveUserMutation,
+  useSaveStageUserMutation,
   useGetRadiusProxyQuery,
   useGetIdpServerQuery,
   useRemovePrincipalAliasMutation,
   useAddPrincipalAliasMutation,
+  useRemoveStagePrincipalAliasMutation,
+  useAddStagePrincipalAliasMutation,
 } = api;

--- a/src/store/Identity/preservedUsers-slice.ts
+++ b/src/store/Identity/preservedUsers-slice.ts
@@ -237,7 +237,7 @@ const preservedUsersSlice = createSlice({
   },
 });
 
-export const { addUser, removeUser, changeStatus } =
+export const { updateUsersList, addUser, removeUser, changeStatus } =
   preservedUsersSlice.actions;
 export const selectUsers = (state: RootState) =>
   state.preservedUsers.usersList as User[];

--- a/src/store/Identity/services-slice.ts
+++ b/src/store/Identity/services-slice.ts
@@ -1,5 +1,5 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import type { RootState } from "src/store/store";
+// import type { RootState } from "src/store/store";
 // User data (JSON file)
 import servicesJson from "./services.json";
 // Data types

--- a/src/store/Identity/stageUsers-slice.ts
+++ b/src/store/Identity/stageUsers-slice.ts
@@ -237,7 +237,8 @@ const stageUsersSlice = createSlice({
   },
 });
 
-export const { addUser, removeUser, changeStatus } = stageUsersSlice.actions;
+export const { updateUsersList, addUser, removeUser, changeStatus } =
+  stageUsersSlice.actions;
 export const selectUsers = (state: RootState) =>
   state.stageUsers.usersList as User[];
 export default stageUsersSlice.reducer;


### PR DESCRIPTION
Migrated Staged/Perserved users to the C.L.

Added generic "display" table, this name is up for debate, but it can be reused for various modals when doing bulk updates.

All features are fully functional

relates: https://github.com/freeipa/freeipa-webui/issues/89

signed-off: Mark Reynolds <mreynolds@redhat.com>