### PR TITLE
Issue 106 - User searching using UID does not work in idm Web UI

### DIFF
--- a/src/components/tables/UsersTable.tsx
+++ b/src/components/tables/UsersTable.tsx
@@ -87,7 +87,17 @@ const UsersTable = (props: PropsToTable) => {
         "i"
       );
     }
-    return user.uid[0].search(input) >= 0;
+
+    for (const attr of Object.keys(columnNames)) {
+      if (
+        attr !== "nsaccountlock" &&
+        user[attr] !== undefined &&
+        user[attr][0].search(input) >= 0
+      ) {
+        return true;
+      }
+    }
+    return false;
   };
 
   const filteredShownUsers =

--- a/src/pages/ActiveUsers/ActiveUsers.tsx
+++ b/src/pages/ActiveUsers/ActiveUsers.tsx
@@ -94,7 +94,7 @@ const ActiveUsers = () => {
 
   // Derived states - what we get from API
   const userDataResponse = useGettingUserQuery({
-    searchValue,
+    searchValue: "",
     sizeLimit: 0,
     apiVersion: apiVersion || API_VERSION_BACKUP,
   } as UsersPayload);


### PR DESCRIPTION
Description: When filtering users check all the column attributes except for nsAccountLockout.  Also do not pass searchValue to the payload because it triggers all the users to be reloaded/refetched which is not necessary.

fixes: https://github.com/freeipa/freeipa-webui/issues/106

signed-off: Mark Reynolds <mreynolds@redhat.com>