### PR TITLE
Issue 167 - Revise ssh key component

### DIFF
--- a/src/components/Form/IpaSshPublicKeys.tsx
+++ b/src/components/Form/IpaSshPublicKeys.tsx
@@ -1,20 +1,38 @@
 import React from "react";
 // PatternFly
-import { Button, Flex, FlexItem } from "@patternfly/react-core";
+import {
+  Button,
+  Flex,
+  FlexItem,
+  Form,
+  FormGroup,
+  Modal,
+  TextArea,
+} from "@patternfly/react-core";
 // Components
 import SecondaryButton from "../layouts/SecondaryButton";
 import TextLayout from "../layouts/TextLayout";
 // Modals
-import ModalWithTextAreaLayout from "../layouts/ModalWithTextAreaLayout";
+import DeletionConfirmationModal from "../modals/DeletionConfirmationModal";
 // Data types
 import { Metadata } from "src/utils/datatypes/globalDataTypes";
 // ipaObject utils
-import { getParamProperties, updateIpaObject } from "src/utils/ipaObjectUtils";
+import { getParamProperties } from "src/utils/ipaObjectUtils";
+import KeyIcon from "@patternfly/react-icons/dist/esm/icons/key-icon";
+// Hooks
+import useAlerts from "src/hooks/useAlerts";
+import {
+  Command,
+  ErrorResult,
+  useSimpleMutCommandMutation,
+} from "src/services/rpc";
 
 interface PropsToSshPublicKeysModal {
   ipaObject: Record<string, unknown>;
   onChange: (ipaObject: Record<string, unknown>) => void;
   metadata: Metadata;
+  onRefresh: () => void;
+  from: "active-users" | "stage-users" | "preserved-users";
 }
 
 const IpaSshPublicKeys = (props: PropsToSshPublicKeysModal) => {
@@ -25,6 +43,9 @@ const IpaSshPublicKeys = (props: PropsToSshPublicKeysModal) => {
     objectName: "user",
   });
 
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
   // States
   const [textAreaSshPublicKeysValue, setTextAreaSshPublicKeysValue] =
     React.useState("");
@@ -33,9 +54,148 @@ const IpaSshPublicKeys = (props: PropsToSshPublicKeysModal) => {
   const [sshPublicKeysList, setSshPublicKeysList] = React.useState<string[]>(
     (value as string[]) || []
   );
+
   const [idxSelected, setIdxSelected] = React.useState<number | null>(null);
-  const [originalIpaObject] = React.useState(props.ipaObject);
   const [isSetButtonDisabled, setIsSetButtonDisabled] = React.useState(true);
+  // Deletion modal
+  const [isDeletionModalOpen, setIsDeletionModalOpen] = React.useState(false);
+  const [idxToDelete, setIdxToDelete] = React.useState<number>(999); // Asumption: There will never be 999 entries
+  const [deletionMessage, setDeletionMessage] = React.useState("");
+
+  // Updates SSH public keys list on every change
+  React.useEffect(() => {
+    if (value !== undefined) {
+      setSshPublicKeysList(value as string[]);
+    }
+  }, [value]);
+
+  // RPC hooks
+  const [updateSSHKey] = useSimpleMutCommandMutation();
+
+  const onCloseDeletionModal = () => {
+    setIsDeletionModalOpen(false);
+  };
+
+  const deletionModalActions = [
+    <Button
+      key="del-ssh-key"
+      variant="danger"
+      onClick={() => onRemoveSSHKey(idxToDelete)}
+    >
+      Delete
+    </Button>,
+    <Button key="cancel" variant="link" onClick={onCloseDeletionModal}>
+      Cancel
+    </Button>,
+  ];
+
+  // Operation when deleting an entry
+  const onDeleteSshKey = (idx: number) => {
+    setIdxToDelete(idx);
+    setDeletionMessage(sshPublicKeysList[idx]);
+    setIsDeletionModalOpen(true);
+  };
+
+  // Remove data (API call)
+  const onRemoveSSHKey = (idx: number) => {
+    let method = "user_mod";
+    if (props.from === "stage-users") {
+      method = "stageuser_mod";
+    }
+    // Prepare payload
+    const payload: Command = {
+      method: method,
+      params: [
+        [props.ipaObject.uid],
+        {
+          delattr: "ipasshpubkey=" + sshPublicKeysList[idx],
+        },
+      ],
+    };
+
+    updateSSHKey(payload).then((response) => {
+      if ("data" in response) {
+        if (response.data.result) {
+          // Set alert: success
+          alerts.addAlert(
+            "remove-ssh-public-key-success",
+            "Removed SSH public key from user '" + props.ipaObject.uid + "'",
+            "success"
+          );
+          // Update internal list
+          const newSshPublicKeysList = [...sshPublicKeysList];
+          newSshPublicKeysList.splice(idx, 1);
+          setSshPublicKeysList(newSshPublicKeysList);
+          // Close things up and refresh
+          setIsDeletionModalOpen(false);
+        } else if (response.data.error) {
+          // Set alert: error
+          const errorMessage = response.data.error as ErrorResult;
+          alerts.addAlert(
+            "remove-ssh-public-key-error",
+            errorMessage.message,
+            "danger"
+          );
+          // Reset fields' values
+          setIsDeletionModalOpen(false);
+        }
+        // Refresh data to show new changes in the UI
+        props.onRefresh();
+      }
+    });
+  };
+
+  // On click 'Set' button (within modal)
+  const onClickSetTextAreaSshPublicKeys = () => {
+    // Prepare payload
+    let method = "user_mod";
+    if (props.from === "stage-users") {
+      method = "stageuser_mod";
+    }
+
+    // Get all the ssh keys
+    const key_list = [...sshPublicKeysList, textAreaSshPublicKeysValue];
+
+    // Prepare payload
+    const payload: Command = {
+      method: method,
+      params: [
+        [props.ipaObject.uid],
+        {
+          ipasshpubkey: key_list,
+        },
+      ],
+    };
+
+    updateSSHKey(payload).then((response) => {
+      if ("data" in response) {
+        if (response.data.result) {
+          // Close the modal
+          setIsTextAreaSshPublicKeysOpen(false);
+          // Set alert: success
+          alerts.addAlert(
+            "add-ssh-public-key-success",
+            "Added SSH public key to user '" + props.ipaObject.uid + "'",
+            "success"
+          );
+          // Update intenral list
+          const newSshPublicKeysList = [...sshPublicKeysList];
+          newSshPublicKeysList.push(textAreaSshPublicKeysValue);
+          setSshPublicKeysList(newSshPublicKeysList);
+        } else if (response.data.error) {
+          // Set alert: error
+          const errorMessage = response.data.error as ErrorResult;
+          alerts.addAlert(
+            "add-ssh-public-key-error",
+            errorMessage.message,
+            "danger"
+          );
+        }
+        // Refresh data to show new changes in the UI
+        props.onRefresh();
+      }
+    });
+  };
 
   const onChangeTextAreaSshPublicKeysValue = (value: string) => {
     // Update text area state
@@ -46,35 +206,6 @@ const IpaSshPublicKeys = (props: PropsToSshPublicKeysModal) => {
     } else {
       setIsSetButtonDisabled(true);
     }
-  };
-
-  // On click 'Set' button (within modal)
-  const onClickSetTextAreaSshPublicKeys = () => {
-    // Store new entry
-    const newSshPublicKeysList = [...sshPublicKeysList];
-    // Takes 'idxSelected' as reference to determine whether the entry is new or not
-    if (idxSelected !== null) {
-      // Existing entries
-      newSshPublicKeysList[idxSelected] = textAreaSshPublicKeysValue;
-    } else {
-      // New entries
-      newSshPublicKeysList.push(textAreaSshPublicKeysValue);
-    }
-
-    setSshPublicKeysList(newSshPublicKeysList);
-    // No element index selected
-    setIdxSelected(null);
-    // Closes the modal
-    setIsTextAreaSshPublicKeysOpen(false);
-    // Update ipaObject
-    updateIpaObject(
-      props.ipaObject,
-      props.onChange,
-      newSshPublicKeysList,
-      "ipasshpubkey"
-    );
-    // Disable 'Set' button
-    setIsSetButtonDisabled(true);
   };
 
   // on click 'Cancel' button (within modal)
@@ -102,29 +233,31 @@ const IpaSshPublicKeys = (props: PropsToSshPublicKeysModal) => {
     setIsTextAreaSshPublicKeysOpen(true);
   };
 
-  // Delete entry on the ssh public key list
-  const onDeleteSshKey = (idx: number) => {
-    const newSshPublicKeysList = [...sshPublicKeysList];
-    newSshPublicKeysList.splice(idx, 1);
-    setSshPublicKeysList(newSshPublicKeysList);
-    // Update ipaObject when deleting the last changes (to disable 'Revert' and 'Save' button)
-    if (
-      JSON.stringify(newSshPublicKeysList) ===
-      JSON.stringify(originalIpaObject["ipasshpubkey"])
-    ) {
-      updateIpaObject(
-        props.ipaObject,
-        props.onChange,
-        newSshPublicKeysList,
-        "ipasshpubkey"
-      );
-    }
-    // TODO: When 'ipaObject[<name>]' is undefined, the 'Revert' button is not disabled
-  };
+  const modal_actions = [
+    <SecondaryButton
+      key="set"
+      onClickHandler={onClickSetTextAreaSshPublicKeys}
+      isDisabled={isSetButtonDisabled}
+    >
+      Set
+    </SecondaryButton>,
+    <Button
+      key="cancel"
+      variant="link"
+      onClick={onClickCancelTextAreaSshPublicKeys}
+    >
+      Cancel
+    </Button>,
+  ];
+
+  if (idxSelected !== null) {
+    modal_actions.shift();
+  }
 
   // Render component
   return (
     <>
+      <alerts.ManagedAlerts />
       {sshPublicKeysList !== undefined
         ? sshPublicKeysList.map((publicKey, idx) => {
             return (
@@ -133,22 +266,27 @@ const IpaSshPublicKeys = (props: PropsToSshPublicKeysModal) => {
                   {publicKey !== "" && (
                     <>
                       <FlexItem>
-                        <TextLayout>New: key set</TextLayout>
+                        <TextLayout component="small">
+                          <KeyIcon /> Key (
+                          {sshPublicKeysList[idx].split(" ")[0]})
+                        </TextLayout>
                       </FlexItem>
                       <FlexItem>
                         <SecondaryButton
                           onClickHandler={() => onShowSetSshKey(idx, publicKey)}
                           isDisabled={readOnly}
+                          isSmall
                         >
-                          Show/Set key
+                          Show Key
                         </SecondaryButton>
                       </FlexItem>
                       <FlexItem className="pf-u-mb-md">
                         <SecondaryButton
                           onClickHandler={() => onDeleteSshKey(idx)}
                           isDisabled={readOnly}
+                          isSmall
                         >
-                          Undo
+                          Delete
                         </SecondaryButton>
                       </FlexItem>
                     </>
@@ -158,42 +296,41 @@ const IpaSshPublicKeys = (props: PropsToSshPublicKeysModal) => {
             );
           })
         : null}
-      <ModalWithTextAreaLayout
-        value={textAreaSshPublicKeysValue}
-        onChange={onChangeTextAreaSshPublicKeysValue}
+      <Modal
+        variant="small"
+        title="Set SSH key"
         isOpen={isTextAreaSshPublicKeysOpen}
         onClose={onClickCancelTextAreaSshPublicKeys}
-        actions={[
-          <SecondaryButton
-            key="set"
-            onClickHandler={onClickSetTextAreaSshPublicKeys}
-            isDisabled={isSetButtonDisabled}
-          >
-            Set
-          </SecondaryButton>,
-          <Button
-            key="cancel"
-            variant="link"
-            onClick={onClickCancelTextAreaSshPublicKeys}
-          >
-            Cancel
-          </Button>,
-        ]}
-        title="Set SSH key"
-        subtitle="SSH public key:"
-        ariaLabel="new ssh public key modal text area"
-        cssStyle={{ height: "422px" }}
-        name={"ipasshpubkey"}
-        objectName="user"
-        ipaObject={props.ipaObject}
-        metadata={props.metadata}
-      />
+        actions={modal_actions}
+      >
+        <Form>
+          <FormGroup label="SSH public key:" type="string" fieldId="selection">
+            <TextArea
+              value={textAreaSshPublicKeysValue}
+              name={"ipasshpubkey"}
+              onChange={onChangeTextAreaSshPublicKeysValue}
+              aria-label="new ssh public key modal text area"
+              resizeOrientation="vertical"
+              style={{ height: "422px" }}
+              isDisabled={idxSelected !== null}
+            />
+          </FormGroup>
+        </Form>
+      </Modal>
       <SecondaryButton
         onClickHandler={openSshPublicKeysModal}
         isDisabled={readOnly}
+        isSmall
       >
-        Add
+        Add Key
       </SecondaryButton>
+      <DeletionConfirmationModal
+        title={"Remove SSH Public Key"}
+        isOpen={isDeletionModalOpen}
+        onClose={onCloseDeletionModal}
+        actions={deletionModalActions}
+        messageText={deletionMessage}
+      />
     </>
   );
 };

--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -261,6 +261,7 @@ const UserSettings = (props: PropsToUserSettings) => {
                 radiusProxyConf={props.radiusProxyData || []}
                 idpConf={props.idpData || []}
                 certData={props.certData}
+                from={props.from}
               />
               <TitleLayout
                 key={2}

--- a/src/components/UsersSections/UsersAccountSettings.tsx
+++ b/src/components/UsersSections/UsersAccountSettings.tsx
@@ -40,6 +40,7 @@ interface PropsToUsersAccountSettings {
   radiusProxyConf: RadiusServer[];
   idpConf: IDPServer[];
   certData: Record<string, unknown>;
+  from: "active-users" | "stage-users" | "preserved-users";
 }
 
 // Generic data to pass to the Textbox adder
@@ -358,6 +359,8 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
                 ipaObject={ipaObject}
                 onChange={recordOnChange}
                 metadata={props.metadata}
+                onRefresh={props.onRefresh}
+                from={props.from}
               />
             </FormGroup>
             <FormGroup label="Certificates" fieldId="certificates">

--- a/src/components/layouts/SecondaryButton.tsx
+++ b/src/components/layouts/SecondaryButton.tsx
@@ -12,6 +12,7 @@ interface PropsToSecondaryButton {
   isActive?: boolean;
   isBlock?: boolean;
   isInLine?: boolean;
+  isSmall?: boolean;
   ouijaId?: number | string;
   ouijaSafe?: boolean;
   innerRef?: React.Ref<any>;
@@ -32,6 +33,7 @@ const SecondaryButton = (props: PropsToSecondaryButton) => {
       isActive={props.isActive}
       isBlock={props.isBlock}
       isInline={props.isInLine}
+      isSmall={props.isSmall}
       ouiaId={props.ouijaId}
       ouiaSafe={props.ouijaSafe}
       onClick={props.onClickHandler}

--- a/src/components/layouts/TextLayout.tsx
+++ b/src/components/layouts/TextLayout.tsx
@@ -39,6 +39,7 @@ const TextLayout = (props: PropsToTextLayout) => {
         isVisitedLink={props.isvisitedLink}
         ouiaId={props.ouiaId}
         ouiaSafe={props.ouiaSafe}
+        className={props.className}
       >
         {props.children}
       </Text>

--- a/src/components/modals/AddUser.tsx
+++ b/src/components/modals/AddUser.tsx
@@ -110,10 +110,6 @@ const AddUser = (props: PropsToAddUser) => {
     React.useRef() as React.MutableRefObject<HTMLInputElement>;
   const userClassRef =
     React.useRef() as React.MutableRefObject<HTMLInputElement>;
-  const newPasswordRef =
-    React.useRef() as React.MutableRefObject<HTMLInputElement>;
-  const verifyNewPasswordRef =
-    React.useRef() as React.MutableRefObject<HTMLInputElement>;
 
   // Validation fields
   const [userLoginValidation, setUserLoginValidation] = useState({

--- a/src/components/modals/PrincipalAliasDeleteModal.tsx
+++ b/src/components/modals/PrincipalAliasDeleteModal.tsx
@@ -1,6 +1,4 @@
 import React from "react";
-// PatternFly
-import { TextInput } from "@patternfly/react-core";
 // Layouts
 import ModalWithFormLayout from "../layouts/ModalWithFormLayout";
 import TextLayout from "../layouts/TextLayout";

--- a/src/pages/PreservedUsers/PreservedUsersTabs.tsx
+++ b/src/pages/PreservedUsers/PreservedUsersTabs.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 // PatternFly
 import {
   Title,

--- a/src/pages/StageUsers/StageUsersTabs.tsx
+++ b/src/pages/StageUsers/StageUsersTabs.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 // PatternFly
 import {
   Title,

--- a/src/store/Identity/services-slice.ts
+++ b/src/store/Identity/services-slice.ts
@@ -1,5 +1,4 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import type { RootState } from "src/store/store";
 // User data (JSON file)
 import servicesJson from "./services.json";
 // Data types


### PR DESCRIPTION
The previous ssh key UI management used ipaConfigObject to handle adding/removing keys, but this coimplicated how the existing buttons worked.

Instead I used the same approach as the Certficate Mapping Data design, where we apply the update to the keys immediately and not reply on the main page's "Save" button.

Also added the Key icon for each ssh key to make each key standout

fixes: https://github.com/freeipa/freeipa-webui/issues/167

signed-off: Mark Reynolds <mreynolds@redhat.com>