### PR TITLE
[Active users > Settings] Adapt the 'Password policy' subsection fields

### DIFF
--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -269,7 +269,7 @@ const UserSettings = (props: PropsToUserSettings) => {
                 id="password-policy"
                 text="Password policy"
               />
-              <UsersPasswordPolicy />
+              <UsersPasswordPolicy pwdPolicyData={props.pwPolicyData || []} />
               <TitleLayout
                 key={3}
                 headingLevel="h2"

--- a/src/components/UsersSections/UsersPasswordPolicy.tsx
+++ b/src/components/UsersSections/UsersPasswordPolicy.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 // PatternFly
 import {
   Flex,
@@ -8,18 +8,12 @@ import {
   TextInput,
 } from "@patternfly/react-core";
 
-const UsersPasswordPolicy = () => {
-  // TODO: This state variables should update the user data via the IPA API (`pwpolicy_mod`)
-  const [maxLifetimeDays] = useState("");
-  const [minLifetimeHours] = useState("");
-  const [historySize] = useState("");
-  const [characterClasses] = useState("");
-  const [minLength] = useState("");
-  const [maxFailures] = useState("");
-  const [futureResetInterval] = useState("");
-  const [lockoutDuration] = useState("");
-  const [graceLoginLimit] = useState("");
+interface PropsToPasswordPolicy {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  pwdPolicyData: Record<string, any>;
+}
 
+const UsersPasswordPolicy = (props: PropsToPasswordPolicy) => {
   return (
     <Flex direction={{ default: "column", md: "row" }}>
       <FlexItem flex={{ default: "flex_1" }}>
@@ -28,20 +22,20 @@ const UsersPasswordPolicy = () => {
             <TextInput
               id="max-lifetime-days"
               name="krbmaxpwdlife"
-              value={maxLifetimeDays}
+              value={props.pwdPolicyData.krbmaxpwdlife}
               type="text"
               aria-label="max lifetime in days"
-              isDisabled
+              readOnlyVariant="plain"
             />
           </FormGroup>
           <FormGroup label="Min lifetime (hours)" fieldId="mini-lifetime-hours">
             <TextInput
               id="min-lifetime-hours"
               name="krbminpwdlife"
-              value={minLifetimeHours}
+              value={props.pwdPolicyData.krbminpwdlife}
               type="text"
               aria-label="min lifetime in hours"
-              isDisabled
+              readOnlyVariant="plain"
             />
           </FormGroup>
           <FormGroup
@@ -51,30 +45,30 @@ const UsersPasswordPolicy = () => {
             <TextInput
               id="history-size"
               name="krbpwdhistorylength"
-              value={historySize}
+              value={props.pwdPolicyData.krbpwdhistorylength}
               type="text"
               aria-label="history size"
-              isDisabled
+              readOnlyVariant="plain"
             />
           </FormGroup>
           <FormGroup label="Character classes" fieldId="character-classes">
             <TextInput
               id="character-classes"
               name="krbpwdmindiffchars"
-              value={characterClasses}
+              value={props.pwdPolicyData.krbpwdmindiffchars}
               type="text"
               aria-label="character classes"
-              isDisabled
+              readOnlyVariant="plain"
             />
           </FormGroup>
           <FormGroup label="Min length" fieldId="min-length">
             <TextInput
               id="min-length"
               name="krbpwdminlength"
-              value={minLength}
+              value={props.pwdPolicyData.krbpwdminlength}
               type="text"
               aria-label="min length"
-              isDisabled
+              readOnlyVariant="plain"
             />
           </FormGroup>
         </Form>
@@ -84,11 +78,11 @@ const UsersPasswordPolicy = () => {
           <FormGroup label="Max failures" fieldId="max-failures">
             <TextInput
               id="max-failures"
-              name="krbpwdminlength"
-              value={maxFailures}
+              name="krbpwdmaxfailure"
+              value={props.pwdPolicyData.krbpwdmaxfailure}
               type="text"
               aria-label="max failures"
-              isDisabled
+              readOnlyVariant="plain"
             />
           </FormGroup>
           <FormGroup
@@ -98,10 +92,10 @@ const UsersPasswordPolicy = () => {
             <TextInput
               id="future-reset-interval"
               name="krbpwdfailurecountinterval"
-              value={futureResetInterval}
+              value={props.pwdPolicyData.krbpwdfailurecountinterval}
               type="text"
               aria-label="future reset interval in seconds"
-              isDisabled
+              readOnlyVariant="plain"
             />
           </FormGroup>
           <FormGroup
@@ -111,20 +105,20 @@ const UsersPasswordPolicy = () => {
             <TextInput
               id="lockout-duration"
               name="krbpwdlockoutduration"
-              value={lockoutDuration}
+              value={props.pwdPolicyData.krbpwdlockoutduration}
               type="text"
               aria-label="lockout duration in seconds"
-              isDisabled
+              readOnlyVariant="plain"
             />
           </FormGroup>
           <FormGroup label="Grace login limit" fieldId="grace-login-limit">
             <TextInput
               id="grace-login-limit"
               name="passwordgracelimit"
-              value={graceLoginLimit}
+              value={props.pwdPolicyData.passwordgracelimit}
               type="text"
               aria-label="grace login limit"
-              isDisabled
+              readOnlyVariant="plain"
             />
           </FormGroup>
         </Form>


### PR DESCRIPTION
The fields of the 'Password policy' subsection need to be adapted to synchronize with the data from the `pwpolicy_show` JSON RPC method (previously adapted in the RPC wrapper and used through the `useUserSettingsData` custom hook).