### PR TITLE
[UI] Show user login in the Masthead

### DIFF
--- a/public/images/avatarImg.svg
+++ b/public/images/avatarImg.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 24.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 36 36" style="enable-background:new 0 0 36 36;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#F0F0F0;}
+	.st1{fill-rule:evenodd;clip-rule:evenodd;fill:#D2D2D2;}
+	.st2{fill:#B8BBBE;}
+	.st3{fill:#D2D2D2;}
+</style>
+<rect class="st0" width="36" height="36"/>
+<path class="st1" d="M17.7,20.1c-3.5,0-6.4-2.9-6.4-6.4s2.9-6.4,6.4-6.4s6.4,2.9,6.4,6.4S21.3,20.1,17.7,20.1z"/>
+<path class="st2" d="M13.3,36l0-6.7c-2,0.4-2.9,1.4-3.1,3.5L10.1,36H13.3z"/>
+<path class="st3" d="M10.1,36l0.1-3.2c0.2-2.1,1.1-3.1,3.1-3.5l0,6.7h9.4l0-6.7c2,0.4,2.9,1.4,3.1,3.5l0.1,3.2h4.7
+	c-0.4-3.9-1.3-9-2.9-11c-1.1-1.4-2.3-2.2-3.5-2.6s-1.8-0.6-6.3-0.6s-6.1,0.7-6.1,0.7c-1.2,0.4-2.4,1.2-3.4,2.6
+	C6.7,27,5.8,32.2,5.4,36H10.1z"/>
+<path class="st2" d="M25.9,36l-0.1-3.2c-0.2-2.1-1.1-3.1-3.1-3.5l0,6.7H25.9z"/>
+</svg>

--- a/src/AppLayout.tsx
+++ b/src/AppLayout.tsx
@@ -1,4 +1,8 @@
 import {
+  Avatar,
+  Dropdown,
+  DropdownItem,
+  DropdownToggle,
   Masthead,
   MastheadBrand,
   MastheadContent,
@@ -11,14 +15,66 @@ import {
   Toolbar,
 } from "@patternfly/react-core";
 import React from "react";
+// Icons
 import BarsIcon from "@patternfly/react-icons/dist/esm/icons/bars-icon";
+import UserIcon from "@patternfly/react-icons/dist/esm/icons/user-icon";
+import KeyIcon from "@patternfly/react-icons/dist/esm/icons/key-icon";
+import CogIcon from "@patternfly/react-icons/dist/esm/icons/cog-icon";
+import UnknownIcon from "@patternfly/react-icons/dist/esm/icons/unknown-icon";
+import ShareSquareIcon from "@patternfly/react-icons/dist/esm/icons/share-square-icon";
 // Navigation
 import Navigation from "./navigation/Nav";
 // Images
 import headerLogo from "public/images/header-logo.png";
+import avatarImg from "public/images/avatarImg.svg";
 
 const AppLayout = ({ children }: { children: React.ReactNode }) => {
   const headerToolbar = <Toolbar id="toolbar" />;
+
+  // Dropdown
+  const [isDropdownOpen, setIsDropdownOpen] = React.useState(false);
+
+  const onDropdownToggle = (isOpen: boolean) => {
+    setIsDropdownOpen(isOpen);
+  };
+
+  const onDropdownSelect = () => {
+    setIsDropdownOpen(false);
+  };
+
+  const dropdownItems = [
+    <DropdownItem key="profile" component="button">
+      <UserIcon /> Profile
+    </DropdownItem>,
+    <DropdownItem key="change-password" component="button">
+      <KeyIcon /> Change password
+    </DropdownItem>,
+    <DropdownItem key="customization" component="button">
+      <CogIcon /> Customization
+    </DropdownItem>,
+    <DropdownItem key="about" component="button">
+      <UnknownIcon /> About
+    </DropdownItem>,
+    <DropdownItem key="logout" component="button">
+      <ShareSquareIcon /> Log out
+    </DropdownItem>,
+  ];
+
+  // TODO: Show the proper user login
+  const dropdown = (
+    <Dropdown
+      isText
+      isPlain
+      onSelect={onDropdownSelect}
+      toggle={
+        <DropdownToggle id="toggle-plain-text" onToggle={onDropdownToggle}>
+          Administrator
+        </DropdownToggle>
+      }
+      isOpen={isDropdownOpen}
+      dropdownItems={dropdownItems}
+    />
+  );
 
   const Header = (
     <Masthead>
@@ -32,7 +88,13 @@ const AppLayout = ({ children }: { children: React.ReactNode }) => {
           <img src={headerLogo} alt="FreeIPA Logo" />
         </MastheadBrand>
       </MastheadMain>
-      <MastheadContent>{headerToolbar}</MastheadContent>
+      <MastheadContent>
+        <>
+          {headerToolbar}
+          {dropdown}
+          <Avatar src={avatarImg} alt="avatar" size="md" />
+        </>
+      </MastheadContent>
     </Masthead>
   );
 


### PR DESCRIPTION
![image](https://github.com/freeipa/freeipa-webui/assets/8112750/01ebeaeb-2922-483d-9b0d-f160969d4d2c)

The username of the logged-in user should be shown on the top right side of the masthead.

As this is a UI-based solution, this has been adapted to show only the 'Administrator' name (it will be adapted in the future to take the currently logged user).

The current solution includes the following PatternFly 4 components:
- [Avatar](http://v4-archive.patternfly.org/v4/components/avatar)[1]
- Dropdown ([plain](http://v4-archive.patternfly.org/v4/components/dropdown#plain-text-toggle)[2])

[1] - http://v4-archive.patternfly.org/v4/components/avatar
[2] - http://v4-archive.patternfly.org/v4/components/dropdown#plain-text-toggle
Related: https://github.com/freeipa/freeipa-webui/issues/179
Signed-off-by: Carla Martinez <carlmart@redhat.com>