### PR TITLE
Fix: Replace Mac-OS runner by Ubuntu

### DIFF
--- a/.github/workflows/gating.yml
+++ b/.github/workflows/gating.yml
@@ -57,35 +57,41 @@ jobs:
   integration-tests:
     name: Integration tests
     needs: audit-and-build
-    runs-on: macos-12
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install vagrant
+        run: |
+          sudo apt -y install apt-transport-https ca-certificates curl software-properties-common
+          wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+          sudo apt update
+          sudo apt install vagrant vagrant-sshfs virtualbox
 
       - uses: actions/download-artifact@v3
         with:
           name: freeipa-webui-build
           path: dist
 
-      - name: Cache Vagrant boxes
-        uses: actions/cache@v3
-        with:
-          path: ~/.vagrant.d/boxes
-          key: ${{ runner.os }}-vagrant-${{ hashFiles('Vagrantfile') }}
-          restore-keys: |
-            ${{ runner.os }}-vagrant-
-
       - name: Run vagrant up
-        run: vagrant up --no-provision
+        run: vagrant up --no-provision --provider=virtualbox
 
       - name: Run vagrant provision
         run: vagrant provision
 
       - name: Put IPA Server's IP to /etc/hosts
-        run: sudo echo "192.168.56.101 server.ipa.demo" | sudo tee -a /etc/hosts
+        run: sudo echo "$(vagrant ssh -c "hostname -I|sed 's/10\.0\.2\.15//'") server.ipa.demo" | sudo tee -a /etc/hosts
+
+      - name: Save server's IP address to env
+        run: echo "SERVER_IP=$(vagrant ssh -c "hostname -I|sed 's/10\.0\.2\.15//'")" >> $GITHUB_ENV
+
+      - name: Print exported variable
+        run: echo "$SERVER_IP"
 
       - name: Run Cypress tests
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         with:
           browser: firefox
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,6 +10,7 @@ Vagrant.configure("2") do |config|
 
   # Needed by Cypress - optional if you edit your /etc/hosts
   config.vm.network "forwarded_port", guest: 443, host: 443
+  config.vm.network "forwarded_port", guest: 80, host: 80
   if ENV['GITHUB_CI']
     config.vm.network "private_network",
               :ip => "192.168.56.10",
@@ -39,7 +40,7 @@ Vagrant.configure("2") do |config|
 
   # Add eth0 ip address to /etc/hosts
   config.vm.provision "shell",
-    inline: "echo \"192.168.56.10 server.ipa.demo\" | tee -a /etc/hosts"
+    inline: "echo \"$(hostname -I|sed 's/10\.0\.2\.15//') server.ipa.demo\" | tee -a /etc/hosts"
 
   # Install ipa server
   config.vm.provision "shell",
@@ -74,6 +75,5 @@ Vagrant.configure("2") do |config|
 
   # Print instructions
   config.vm.provision "shell",
-    inline: "echo \"Please append the line below to the /etc/hosts file on your machine:\n$(hostname -I)server.ipa.demo\""
-
+    inline: "echo \"Please append the line below to the /etc/hosts file on your machine:\n$(hostname -I|sed 's/10\.0\.2\.15//') server.ipa.demo\""
 end


### PR DESCRIPTION
Due to the issues with Vagrant in GitHub's mac-os runners, change the runner to Ubuntu.
Assign IP address dynamically from specified range.
Ignore Vagrant's internal IP address.
    
Signed-off-by: Michal Polovka <mpolovka@redhat.com>
