### PR TITLE
[Active users > Settings] Adapt 'Attrs. for SMB services' subsection fields

### DIFF
--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -308,7 +308,11 @@ const UserSettings = (props: PropsToUserSettings) => {
                 id="smb-services"
                 text="User attributes for SMB services"
               />
-              <UsersAttributesSMB />
+              <UsersAttributesSMB
+                user={props.user}
+                onUserChange={props.onUserChange}
+                metadata={props.metadata}
+              />
             </Flex>
           </SidebarContent>
         </Sidebar>

--- a/src/components/UsersSections/UsersAttributesSMB.tsx
+++ b/src/components/UsersSections/UsersAttributesSMB.tsx
@@ -1,92 +1,73 @@
-import React, { useState } from "react";
+import React from "react";
 // PatternFly
-import {
-  SelectVariant,
-  Flex,
-  FlexItem,
-  Form,
-  FormGroup,
-  Select,
-  SelectOption,
-  TextInput,
-} from "@patternfly/react-core";
+import { Flex, FlexItem, Form, FormGroup } from "@patternfly/react-core";
 // Layout
 import PopoverWithIconLayout from "../layouts/PopoverWithIconLayout";
+// Data types
+import { Metadata, User } from "src/utils/datatypes/globalDataTypes";
+// Form
+import IpaTextInput from "../Form/IpaTextInput";
+import IpaSelect from "../Form/IpaSelect";
+// Utils
+import { asRecord } from "src/utils/userUtils";
 
-const UsersAttributesSMB = () => {
-  // TODO: This state variables should update the user data via the IPA API
-  const [SMBLogonScriptPath, setSMBLogonScriptPath] = useState("");
-  const [SMBProfilePath, setSMBProfilePath] = useState("");
-  const [SMBHomeDirectory, setSMBHomeDirectory] = useState("");
+interface PropsToSmbServices {
+  user: Partial<User>;
+  onUserChange: (element: Partial<User>) => void;
+  metadata: Metadata;
+}
 
-  const onChangeSMBLogonScriptPath = (value: string) => {
-    setSMBLogonScriptPath(value);
-  };
+const UsersAttributesSMB = (props: PropsToSmbServices) => {
+  // Get 'ipaObject' and 'recordOnChange' to use in 'IpaTextInput'
+  const { ipaObject, recordOnChange } = asRecord(
+    props.user,
+    props.onUserChange
+  );
 
+  // Tooltip messages
   const SBMLogonScriptPathMessage = () => (
     <div>Path to a script executed on a Windows system at logon</div>
   );
-
-  const onChangeSMBProfilePath = (value: string) => {
-    setSMBProfilePath(value);
-  };
 
   const SMBProfilePathMessage = () => (
     <div>Path to an user profile, in UNC format \\server\share</div>
   );
 
-  const onChangeSMBHomeDirectory = (value: string) => {
-    setSMBHomeDirectory(value);
-  };
-
   const SMBHomeDirectoryMessage = () => (
     <div>Path to an user home directory, in UNC format</div>
   );
 
-  // Dropdown 'SMB profile path'
-  const [isSMBHomeDirectoryDriveOpen, setIsSMBHomeDirectoryDriveOpen] =
-    useState(false);
-  const [SMBHomeDirectoryDriveSelected, setSMBHomeDirectoryDriveSelected] =
-    useState("");
-  const SMBHomeDirectoryDriveOptions = [
-    { value: "A:", disabled: false },
-    { value: "B:", disabled: false },
-    { value: "C:", disabled: false },
-    { value: "D:", disabled: false },
-    { value: "E:", disabled: false },
-    { value: "F:", disabled: false },
-    { value: "G:", disabled: false },
-    { value: "H:", disabled: false },
-    { value: "I:", disabled: false },
-    { value: "J:", disabled: false },
-    { value: "K:", disabled: false },
-    { value: "L:", disabled: false },
-    { value: "M:", disabled: false },
-    { value: "N:", disabled: false },
-    { value: "O:", disabled: false },
-    { value: "P:", disabled: false },
-    { value: "Q:", disabled: false },
-    { value: "R:", disabled: false },
-    { value: "S:", disabled: false },
-    { value: "T:", disabled: false },
-    { value: "U:", disabled: false },
-    { value: "V:", disabled: false },
-    { value: "W:", disabled: false },
-    { value: "X:", disabled: false },
-    { value: "Y:", disabled: false },
-    { value: "Z:", disabled: false },
-  ];
-  const SMBHomeDirectoryDriveOnToggle = (isOpen: boolean) => {
-    setIsSMBHomeDirectoryDriveOpen(isOpen);
-  };
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const SMBHomeDirectoryDriveOnSelect = (selection: any) => {
-    setSMBHomeDirectoryDriveSelected(selection.target.textContent);
-    setIsSMBHomeDirectoryDriveOpen(false);
-  };
-
   const SMBHomeDirectoryDriveMessage = "Drive to mount a home directory";
+
+  // Dropdown 'SMB profile path' options
+  const SMBHomeDirectoryDriveOptions = [
+    "A:",
+    "B:",
+    "C:",
+    "D:",
+    "E:",
+    "F:",
+    "G:",
+    "H:",
+    "I:",
+    "J:",
+    "K:",
+    "L:",
+    "M:",
+    "N:",
+    "O:",
+    "P:",
+    "Q:",
+    "R:",
+    "S:",
+    "T:",
+    "U:",
+    "V:",
+    "W:",
+    "X:",
+    "Y:",
+    "Z:",
+  ];
 
   return (
     <Flex direction={{ default: "column", md: "row" }}>
@@ -99,13 +80,12 @@ const UsersAttributesSMB = () => {
               <PopoverWithIconLayout message={SBMLogonScriptPathMessage} />
             }
           >
-            <TextInput
-              id="smb-logon-script-path"
-              name="ipantlogonscript"
-              value={SMBLogonScriptPath}
-              type="text"
-              aria-label="smb logon script path"
-              onChange={onChangeSMBLogonScriptPath}
+            <IpaTextInput
+              name={"ipantlogonscript"}
+              ipaObject={ipaObject}
+              onChange={recordOnChange}
+              objectName="user"
+              metadata={props.metadata}
             />
           </FormGroup>
           <FormGroup
@@ -115,13 +95,12 @@ const UsersAttributesSMB = () => {
               <PopoverWithIconLayout message={SMBProfilePathMessage} />
             }
           >
-            <TextInput
-              id="smb-profile-path"
-              name="ipantprofilepath"
-              value={SMBProfilePath}
-              type="text"
-              aria-label="smb profile path"
-              onChange={onChangeSMBProfilePath}
+            <IpaTextInput
+              name={"ipantprofilepath"}
+              ipaObject={ipaObject}
+              onChange={recordOnChange}
+              objectName="user"
+              metadata={props.metadata}
             />
           </FormGroup>
         </Form>
@@ -138,13 +117,12 @@ const UsersAttributesSMB = () => {
               />
             }
           >
-            <TextInput
-              id="smb-home-directory"
-              name="ipanthomedirectory"
-              value={SMBHomeDirectory}
-              type="text"
-              aria-label="smb home directory"
-              onChange={onChangeSMBHomeDirectory}
+            <IpaTextInput
+              name={"ipanthomedirectory"}
+              ipaObject={ipaObject}
+              onChange={recordOnChange}
+              objectName="user"
+              metadata={props.metadata}
             />
           </FormGroup>
           <FormGroup
@@ -157,28 +135,15 @@ const UsersAttributesSMB = () => {
               />
             }
           >
-            <Select
+            <IpaSelect
               id="smb-home-directory-drive"
               name="ipanthomedirectorydrive"
-              variant={SelectVariant.single}
-              direction={"up"}
-              placeholderText=" "
-              aria-label="Select samba home directory drive"
-              onToggle={SMBHomeDirectoryDriveOnToggle}
-              onSelect={SMBHomeDirectoryDriveOnSelect}
-              selections={SMBHomeDirectoryDriveSelected}
-              isOpen={isSMBHomeDirectoryDriveOpen}
-              aria-labelledby="smb-directory-drive"
-              maxHeight="280px"
-            >
-              {SMBHomeDirectoryDriveOptions.map((option, index) => (
-                <SelectOption
-                  isDisabled={option.disabled}
-                  key={index}
-                  value={option.value}
-                />
-              ))}
-            </Select>
+              options={SMBHomeDirectoryDriveOptions}
+              ipaObject={ipaObject}
+              setIpaObject={recordOnChange}
+              objectName="user"
+              metadata={props.metadata}
+            />
           </FormGroup>
         </Form>
       </FlexItem>


### PR DESCRIPTION
The fields of the 'Attributes for SMB services' subsection need to be adapted to synchronize with the data from the `user_show` JSON RPC method (previously adapted in the RPC wrapper and used through the `useUserSettingsData` custom hook).