### PR TITLE
Fix inconsistent label attributes

### DIFF
--- a/src/components/Form/IpaCalendar.tsx
+++ b/src/components/Form/IpaCalendar.tsx
@@ -197,7 +197,7 @@ const IpaCalendar = (props: IPAParamDefinition) => {
   return (
     <InputGroup>
       <DatePicker
-        name={props.name}
+        name={"add-date-" + props.name}
         value={valueDate !== null ? yyyyMMddFormat(valueDate) : ""}
         onChange={onDateChange}
         aria-label="Kerberos principal expiration date"
@@ -205,7 +205,7 @@ const IpaCalendar = (props: IPAParamDefinition) => {
         isDisabled={readOnly}
       />
       <TimePicker
-        name={props.name}
+        name={"add-time-" + props.name}
         time={valueDate !== null ? hhMMFormat(valueDate) : ""}
         aria-label="Kerberos principal expiration time"
         onChange={onTimeChange}

--- a/src/components/Form/IpaCertificateMappingData.tsx
+++ b/src/components/Form/IpaCertificateMappingData.tsx
@@ -293,6 +293,7 @@ const IpaCertificateMappingData = (props: PropsToIpaCertificateMappingData) => {
                 <FlexItem>
                   <SecondaryButton
                     onClickHandler={() => onDeleteCertMapData(idx)}
+                    name={"remove-certificate-mapping-data-" + idx}
                   >
                     Delete
                   </SecondaryButton>
@@ -302,7 +303,10 @@ const IpaCertificateMappingData = (props: PropsToIpaCertificateMappingData) => {
           })
         : null}
 
-      <SecondaryButton onClickHandler={() => setIsOpen(true)}>
+      <SecondaryButton
+        name={"add-certificate-mapping-data"}
+        onClickHandler={() => setIsOpen(true)}
+      >
         Add
       </SecondaryButton>
       <Modal

--- a/src/components/Form/IpaCertificates.tsx
+++ b/src/components/Form/IpaCertificates.tsx
@@ -539,7 +539,11 @@ const IpaCertificates = (props: PropsToIpaCertificates) => {
             );
           })
         : null}
-      <SecondaryButton onClickHandler={onOpenModal} isDisabled={readOnly}>
+      <SecondaryButton
+        name={"add-certificate"}
+        onClickHandler={onOpenModal}
+        isDisabled={readOnly}
+      >
         Add
       </SecondaryButton>
       <ModalWithTextAreaLayout

--- a/src/components/Form/IpaSshPublicKeys.tsx
+++ b/src/components/Form/IpaSshPublicKeys.tsx
@@ -274,6 +274,7 @@ const IpaSshPublicKeys = (props: PropsToSshPublicKeysModal) => {
                       <FlexItem>
                         <SecondaryButton
                           onClickHandler={() => onShowSetSshKey(idx, publicKey)}
+                          name={"show-ssh-public-key-" + idx}
                           isDisabled={readOnly}
                           isSmall
                         >
@@ -283,6 +284,7 @@ const IpaSshPublicKeys = (props: PropsToSshPublicKeysModal) => {
                       <FlexItem className="pf-u-mb-md">
                         <SecondaryButton
                           onClickHandler={() => onDeleteSshKey(idx)}
+                          name={"remove-ssh-public-key-" + idx}
                           isDisabled={readOnly}
                           isSmall
                         >
@@ -319,6 +321,7 @@ const IpaSshPublicKeys = (props: PropsToSshPublicKeysModal) => {
       </Modal>
       <SecondaryButton
         onClickHandler={openSshPublicKeysModal}
+        name={"add-ssh-public-key"}
         isDisabled={readOnly}
         isSmall
       >

--- a/src/components/Form/IpaTextInputFromList.tsx
+++ b/src/components/Form/IpaTextInputFromList.tsx
@@ -59,7 +59,7 @@ const IpaTextInputFromList = (props: PropsToTextInputFromList) => {
                 order={{ default: "-1" }}
               >
                 <SecondaryButton
-                  name="remove"
+                  name={"remove-principal-alias-" + idx}
                   onClickHandler={() => props.onRemove(idx)}
                   isDisabled={readOnly}
                 >
@@ -71,7 +71,7 @@ const IpaTextInputFromList = (props: PropsToTextInputFromList) => {
       </Flex>
       <SecondaryButton
         classname="pf-u-mt-md"
-        name="add"
+        name="add-principal-alias"
         onClickHandler={props.onOpenModal}
         isDisabled={readOnly}
       >

--- a/src/components/Form/IpaTextboxList.tsx
+++ b/src/components/Form/IpaTextboxList.tsx
@@ -79,7 +79,7 @@ const IpaTextboxList = (props: PropsToIpaTextboxList) => {
             </FlexItem>
             <FlexItem key={props.name + "-" + idx + "-delete-button"}>
               <SecondaryButton
-                name="remove"
+                name={"remove-" + props.name + "-" + idx}
                 onClickHandler={() => onRemoveHandler(idx)}
               >
                 Delete
@@ -90,7 +90,7 @@ const IpaTextboxList = (props: PropsToIpaTextboxList) => {
       </Flex>
       <SecondaryButton
         classname="pf-u-mt-sm"
-        name="add"
+        name={"add-" + props.name}
         onClickHandler={onAddHandler}
       >
         Add

--- a/src/components/UsersSections/UsersAccountSettings.tsx
+++ b/src/components/UsersSections/UsersAccountSettings.tsx
@@ -43,12 +43,6 @@ interface PropsToUsersAccountSettings {
   from: "active-users" | "stage-users" | "preserved-users";
 }
 
-// Generic data to pass to the Textbox adder
-interface ElementData {
-  id: string | number;
-  element: string;
-}
-
 const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
   // TODO: Handle the `has_password` variable (boolean) by another Ipa component
   const [password] = useState("");
@@ -134,7 +128,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
       <Flex direction={{ default: "column", lg: "row" }}>
         <FlexItem flex={{ default: "flex_1" }}>
           <Form className="pf-u-mb-lg">
-            <FormGroup label="User login" fieldId="user-login">
+            <FormGroup label="User login" fieldId="uid">
               <IpaTextInput
                 name={"uid"}
                 ipaObject={ipaObject}
@@ -155,7 +149,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
             </FormGroup>
             <FormGroup
               label="Password expiration"
-              fieldId="password-expiration"
+              fieldId="krbpasswordexpiration"
             >
               <IpaCalendar
                 name={"krbpasswordexpiration"}
@@ -165,7 +159,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
                 metadata={props.metadata}
               />
             </FormGroup>
-            <FormGroup label="UID" fieldId="uid">
+            <FormGroup label="UID" fieldId="uidnumber">
               <IpaTextInput
                 name={"uidnumber"}
                 ipaObject={ipaObject}
@@ -174,7 +168,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
                 metadata={props.metadata}
               />
             </FormGroup>
-            <FormGroup label="GID" fieldId="gid">
+            <FormGroup label="GID" fieldId="gidnumber">
               <IpaTextInput
                 name={"gidnumber"}
                 ipaObject={ipaObject}
@@ -185,7 +179,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
             </FormGroup>
             <FormGroup
               label="Kerberos principal alias"
-              fieldId="kerberos-principal-alias"
+              fieldId="krbprincipalname"
             >
               <PrincipalAliasMultiTextBox
                 ipaObject={ipaObject}
@@ -196,7 +190,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
             </FormGroup>
             <FormGroup
               label="Kerberos principal expiration (UTC)"
-              fieldId="kerberos-principal-expiration"
+              fieldId="krbprincipalexpiration"
             >
               <IpaCalendar
                 name={"krbprincipalexpiration"}
@@ -206,7 +200,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
                 metadata={props.metadata}
               />
             </FormGroup>
-            <FormGroup label="Login shell" fieldId="login-shell">
+            <FormGroup label="Login shell" fieldId="loginshell">
               <IpaTextInput
                 name={"loginshell"}
                 ipaObject={ipaObject}
@@ -219,7 +213,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
         </FlexItem>
         <FlexItem flex={{ default: "flex_1" }} className="pf-u-w-50">
           <Form className="pf-u-mb-lg">
-            <FormGroup label="Home directory" fieldId="home-directory">
+            <FormGroup label="Home directory" fieldId="homedirectory">
               <IpaTextInput
                 name={"homedirectory"}
                 ipaObject={ipaObject}
@@ -228,7 +222,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
                 metadata={props.metadata}
               />
             </FormGroup>
-            <FormGroup label="SSH public keys" fieldId="ssh-public-keys">
+            <FormGroup label="SSH public keys" fieldId="ipasshpubkey">
               <IpaSshPublicKeys
                 ipaObject={ipaObject}
                 onChange={recordOnChange}
@@ -237,7 +231,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
                 from={props.from}
               />
             </FormGroup>
-            <FormGroup label="Certificates" fieldId="certificates">
+            <FormGroup label="Certificates" fieldId="usercertificate">
               <IpaCertificates
                 ipaObject={ipaObject}
                 onChange={recordOnChange}
@@ -248,7 +242,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
             </FormGroup>
             <FormGroup
               label="Certificate mapping data"
-              fieldId="certificate-mapping-data"
+              fieldId="ipacertmapdata"
               labelIcon={
                 <PopoverWithIconLayout
                   message={certificateMappingDataMessage}
@@ -270,7 +264,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
             </FormGroup>
             <FormGroup
               label="User authentication types"
-              fieldId="user-authentication-types"
+              fieldId="ipauserauthtype"
               labelIcon={
                 <PopoverWithIconLayout message={userAuthTypesMessage} />
               }
@@ -311,7 +305,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
             </FormGroup>
             <FormGroup
               label="Radius proxy configuration"
-              fieldId="radius-proxy-configuration"
+              fieldId="ipatokenradiusconfiglink"
             >
               <IpaSelect
                 id="radius-proxy-configuration"
@@ -325,7 +319,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
             </FormGroup>
             <FormGroup
               label="Radius proxy username"
-              fieldId="radius-proxy-username"
+              fieldId="ipatokenradiususername"
             >
               <IpaTextInput
                 name={"ipatokenradiususername"}
@@ -337,7 +331,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
             </FormGroup>
             <FormGroup
               label="External IdP configuration"
-              fieldId="external-idp-configuration"
+              fieldId="ipaidpconfiglink"
             >
               <IpaSelect
                 id="external-idp-configuration"
@@ -349,10 +343,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
                 metadata={props.metadata}
               />
             </FormGroup>
-            <FormGroup
-              label="External IdP user identifier"
-              fieldId="external-idp-user-identifier"
-            >
+            <FormGroup label="External IdP user identifier" fieldId="ipaidpsub">
               <IpaTextInput
                 name={"ipaidpsub"}
                 ipaObject={ipaObject}

--- a/src/components/UsersSections/UsersAttributesSMB.tsx
+++ b/src/components/UsersSections/UsersAttributesSMB.tsx
@@ -75,7 +75,7 @@ const UsersAttributesSMB = (props: PropsToSmbServices) => {
         <Form className="pf-u-mb-lg">
           <FormGroup
             label="SMB logon script path"
-            fieldId="smb-logon-script-path"
+            fieldId="ipantlogonscript"
             labelIcon={
               <PopoverWithIconLayout message={SBMLogonScriptPathMessage} />
             }
@@ -90,7 +90,7 @@ const UsersAttributesSMB = (props: PropsToSmbServices) => {
           </FormGroup>
           <FormGroup
             label="SMB profile path"
-            fieldId="smb-profile-path"
+            fieldId="ipantprofilepath"
             labelIcon={
               <PopoverWithIconLayout message={SMBProfilePathMessage} />
             }
@@ -109,7 +109,7 @@ const UsersAttributesSMB = (props: PropsToSmbServices) => {
         <Form className="pf-u-mb-lg">
           <FormGroup
             label="SMB home directory"
-            fieldId="smb-home-directory"
+            fieldId="ipanthomedirectory"
             labelIcon={
               <PopoverWithIconLayout
                 message={SMBHomeDirectoryMessage}
@@ -127,7 +127,7 @@ const UsersAttributesSMB = (props: PropsToSmbServices) => {
           </FormGroup>
           <FormGroup
             label="SMB home directory drive"
-            fieldId="smb-home-directory-drive"
+            fieldId="ipanthomedirectorydrive"
             labelIcon={
               <PopoverWithIconLayout
                 message={SMBHomeDirectoryDriveMessage}

--- a/src/components/UsersSections/UsersContactSettings.tsx
+++ b/src/components/UsersSections/UsersContactSettings.tsx
@@ -25,7 +25,7 @@ const UsersContactSettings = (props: PropsToUsersContactSettings) => {
     <Flex direction={{ default: "column", md: "row" }}>
       <FlexItem flex={{ default: "flex_1" }}>
         <Form className="pf-u-mb-lg">
-          <FormGroup label="Mail address" fieldId="mail-address">
+          <FormGroup label="Mail address" fieldId="mail">
             <IpaTextboxList
               ipaObject={ipaObject}
               setIpaObject={recordOnChange}
@@ -33,7 +33,7 @@ const UsersContactSettings = (props: PropsToUsersContactSettings) => {
               ariaLabel={"email address list"}
             />
           </FormGroup>
-          <FormGroup label="Telephone number" fieldId="telephone-number">
+          <FormGroup label="Telephone number" fieldId="telephonenumber">
             <IpaTextboxList
               ipaObject={ipaObject}
               setIpaObject={recordOnChange}
@@ -41,7 +41,7 @@ const UsersContactSettings = (props: PropsToUsersContactSettings) => {
               ariaLabel={"telephone number list"}
             />
           </FormGroup>
-          <FormGroup label="Pager number" fieldId="pager-number">
+          <FormGroup label="Pager number" fieldId="pager">
             <IpaTextboxList
               ipaObject={ipaObject}
               setIpaObject={recordOnChange}
@@ -53,7 +53,7 @@ const UsersContactSettings = (props: PropsToUsersContactSettings) => {
       </FlexItem>
       <FlexItem flex={{ default: "flex_1" }}>
         <Form className="pf-u-mb-lg">
-          <FormGroup label="Mobile phone number" fieldId="mobile-phone-number">
+          <FormGroup label="Mobile phone number" fieldId="mobile">
             <IpaTextboxList
               ipaObject={ipaObject}
               setIpaObject={recordOnChange}

--- a/src/components/UsersSections/UsersEmployeeInfo.tsx
+++ b/src/components/UsersSections/UsersEmployeeInfo.tsx
@@ -33,7 +33,7 @@ const UsersEmployeeInfo = (props: PropsToEmployeeInfo) => {
     <Flex direction={{ default: "column", md: "row" }}>
       <FlexItem flex={{ default: "flex_1" }}>
         <Form className="pf-u-mb-lg">
-          <FormGroup label="Org. unit" fieldId="org-unit">
+          <FormGroup label="Org. unit" fieldId="ou">
             <IpaTextInput
               name={"ou"}
               ipaObject={ipaObject}
@@ -53,7 +53,7 @@ const UsersEmployeeInfo = (props: PropsToEmployeeInfo) => {
               metadata={props.metadata}
             />
           </FormGroup>
-          <FormGroup label="Department number" fieldId="department-number">
+          <FormGroup label="Department number" fieldId="departmentnumber">
             <IpaTextboxList
               ipaObject={ipaObject}
               setIpaObject={recordOnChange}
@@ -65,7 +65,7 @@ const UsersEmployeeInfo = (props: PropsToEmployeeInfo) => {
       </FlexItem>
       <FlexItem flex={{ default: "flex_1" }}>
         <Form className="pf-u-mb-lg">
-          <FormGroup label="Employee number" fieldId="employee-number">
+          <FormGroup label="Employee number" fieldId="employeenumber">
             <IpaTextInput
               name={"employeenumber"}
               ipaObject={ipaObject}
@@ -74,7 +74,7 @@ const UsersEmployeeInfo = (props: PropsToEmployeeInfo) => {
               metadata={props.metadata}
             />
           </FormGroup>
-          <FormGroup label="Employee type" fieldId="employee-type">
+          <FormGroup label="Employee type" fieldId="employeetype">
             <IpaTextInput
               name={"employeetype"}
               ipaObject={ipaObject}
@@ -83,7 +83,7 @@ const UsersEmployeeInfo = (props: PropsToEmployeeInfo) => {
               metadata={props.metadata}
             />
           </FormGroup>
-          <FormGroup label="Preferred language" fieldId="preferred-language">
+          <FormGroup label="Preferred language" fieldId="preferredlanguage">
             <IpaTextInput
               name={"preferredlanguage"}
               ipaObject={ipaObject}

--- a/src/components/UsersSections/UsersIdentity.tsx
+++ b/src/components/UsersSections/UsersIdentity.tsx
@@ -90,26 +90,26 @@ const UsersIdentity = (props: PropsToUsersIdentity) => {
     <Flex direction={{ default: "column", lg: "row" }}>
       <FlexItem flex={{ default: "flex_1" }}>
         <Form className="pf-u-mb-lg">
-          <FormGroup label="First name" fieldId="first-name" isRequired>
+          <FormGroup label="First name" fieldId="givenname" isRequired>
             {firstNameTextInput}
           </FormGroup>
-          <FormGroup label="Last name" fieldId="last-name" isRequired>
+          <FormGroup label="Last name" fieldId="sn" isRequired>
             {lastNameTextInput}
           </FormGroup>
-          <FormGroup label="Full name" fieldId="full-name" isRequired>
+          <FormGroup label="Full name" fieldId="cn" isRequired>
             {fullNameTextInput}
           </FormGroup>
         </Form>
       </FlexItem>
       <FlexItem flex={{ default: "flex_1" }}>
         <Form className="pf-u-mb-lg">
-          <FormGroup label="Job title" fieldId="job-title">
+          <FormGroup label="Job title" fieldId="title">
             {jobTitleTextInput}
           </FormGroup>
           <FormGroup label="GECOS" fieldId="gecos">
             {gecosTextInput}
           </FormGroup>
-          <FormGroup label="Class" fieldId="class-field">
+          <FormGroup label="Class" fieldId="userclass">
             {userClassTextInput}
           </FormGroup>
         </Form>

--- a/src/components/UsersSections/UsersMailingAddress.tsx
+++ b/src/components/UsersSections/UsersMailingAddress.tsx
@@ -25,7 +25,7 @@ const UsersMailingAddress = (props: PropsToUsersMailingAddress) => {
     <Flex direction={{ default: "column", md: "row" }}>
       <FlexItem flex={{ default: "flex_1" }}>
         <Form className="pf-u-mb-lg">
-          <FormGroup label="Street address" fieldId="street-address">
+          <FormGroup label="Street address" fieldId="street">
             <IpaTextInput
               name={"street"}
               ipaObject={ipaObject}
@@ -34,7 +34,7 @@ const UsersMailingAddress = (props: PropsToUsersMailingAddress) => {
               metadata={props.metadata}
             />
           </FormGroup>
-          <FormGroup label="City" fieldId="city">
+          <FormGroup label="City" fieldId="l">
             <IpaTextInput
               name={"l"}
               ipaObject={ipaObject}
@@ -47,7 +47,7 @@ const UsersMailingAddress = (props: PropsToUsersMailingAddress) => {
       </FlexItem>
       <FlexItem flex={{ default: "flex_1" }}>
         <Form className="pf-u-mb-lg">
-          <FormGroup label="State/province" fieldId="state-province">
+          <FormGroup label="State/province" fieldId="st">
             <IpaTextInput
               name={"st"}
               ipaObject={ipaObject}
@@ -56,7 +56,7 @@ const UsersMailingAddress = (props: PropsToUsersMailingAddress) => {
               metadata={props.metadata}
             />
           </FormGroup>
-          <FormGroup label="ZIP" fieldId="zip">
+          <FormGroup label="ZIP" fieldId="postalcode">
             <IpaTextInput
               name={"postalcode"}
               ipaObject={ipaObject}


### PR DESCRIPTION
The `fieldId` parameter should match with the `name` for the fields mentioned in the [issue](https://github.com/freeipa/freeipa-webui/issues/204) mentioned below.

The buttons available on the 'Settings' page should also have their own independent `name`. This has been implemented using the following format:

`<action>-<fieldName>[-<idx>]`
(Being `idx` >= 0)

E.g.1: `add-krb-principal-alias`
E.g.2: `remove-certificate-mapping-data-1`

Fixes: https://github.com/freeipa/freeipa-webui/issues/204