### PR TITLE
Update stale.yml to mark issues after 365 days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,6 +8,7 @@ name: Mark stale issues and pull requests
 on:
   schedule:
     - cron: "25 12 * * *"
+  workflow_dispatch:
 
 jobs:
   stale:
@@ -20,8 +21,8 @@ jobs:
       - uses: actions/stale@v5
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: "This issue has not received any attention in 120 days."
+          stale-issue-message: "This issue has not received any attention in 365 days."
           stale-pr-message: "This PR has not received any attention in 60 days."
-          days-before-issue-stale: 120
+          days-before-issue-stale: 365
           stale-issue-label: "stale"
           stale-pr-label: "stale"


### PR DESCRIPTION
Mark issue as stale if it receives no attention for more than 365 days.
    
Signed-off-by: Michal Polovka <mpolovka@redhat.com>