### PR TITLE
[Preserved users][Settings][Kebab] Add 'Restore' option

### DIFF
--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -57,6 +57,7 @@ import IssueNewCertificate from "./modals/IssueNewCertificate";
 import AddOtpToken from "./modals/AddOtpToken";
 import ActivateStageUsers from "./modals/ActivateStageUsers";
 import StagePreservedUsers from "./modals/StagePreservedUsers";
+import RestorePreservedUsers from "./modals/RestorePreservedUsers";
 // Utils
 import { API_VERSION_BACKUP } from "src/utils/utils";
 // Navigate
@@ -253,6 +254,12 @@ const UserSettings = (props: PropsToUserSettings) => {
     setIsStageModalOpen(false);
   };
 
+  // Preserved users - 'Restore' option
+  const [isRestoreModalOpen, setIsRestoreModalOpen] = React.useState(false);
+  const onCloseRestoreModal = () => {
+    setIsRestoreModalOpen(false);
+  };
+
   // Kebab
   const [isKebabOpen, setIsKebabOpen] = useState(false);
 
@@ -327,7 +334,9 @@ const UserSettings = (props: PropsToUserSettings) => {
     <DropdownItem key="stage" onClick={() => setIsStageModalOpen(true)}>
       Stage
     </DropdownItem>,
-    <DropdownItem key="restore">Restore</DropdownItem>,
+    <DropdownItem key="restore" onClick={() => setIsRestoreModalOpen(true)}>
+      Restore
+    </DropdownItem>,
     <DropdownItem key="delete" onClick={() => setIsDeleteModalOpen(true)}>
       Delete
     </DropdownItem>,
@@ -638,6 +647,13 @@ const UserSettings = (props: PropsToUserSettings) => {
         handleModalToggle={onCloseStageModal}
         selectedUsers={selectedUsers}
         updateSelectedUsers={setSelectedUsers}
+        onSuccess={() => navigate(URL_PREFIX + "/preserved-users")}
+      />
+      <RestorePreservedUsers
+        show={isRestoreModalOpen}
+        handleModalToggle={onCloseRestoreModal}
+        selectedUids={selectedUsers}
+        updateSelectedUids={setSelectedUsers}
         onSuccess={() => navigate(URL_PREFIX + "/preserved-users")}
       />
     </>

--- a/src/pages/PreservedUsers/PreservedUsers.tsx
+++ b/src/pages/PreservedUsers/PreservedUsers.tsx
@@ -496,7 +496,8 @@ const PreservedUsers = () => {
       <RestorePreservedUsers
         show={showRestoreModal}
         handleModalToggle={onRestoreModalToggle}
-        selectedUsersData={selectedUsersData}
+        selectedUids={selectedUsers.map((uid) => uid[0])}
+        updateSelectedUids={updateSelectedUsers}
         onSuccess={refreshUsersData}
       />
       <StagePreservedUsers

--- a/src/services/rpc.ts
+++ b/src/services/rpc.ts
@@ -786,6 +786,22 @@ export const api = createApi({
         );
       },
     }),
+    restoreUser: build.mutation<BatchRPCResponse, string[]>({
+      query: (query_args) => {
+        const batchPayload: Command[] = [];
+        query_args.map((uid) => {
+          batchPayload.push({
+            method: "user_undel",
+            params: [[uid], {}],
+          });
+        });
+
+        return getBatchCommand(
+          batchPayload,
+          query_args["version"] || API_VERSION_BACKUP
+        );
+      },
+    }),
   }),
 });
 
@@ -859,4 +875,5 @@ export const {
   useAddOtpTokenMutation,
   useGenerateSubIdsMutation,
   useActivateUserMutation,
+  useRestoreUserMutation,
 } = api;


### PR DESCRIPTION
The 'Restore' options moves a given user from 'Preserved' to 'Active' state. 

The `RestorePreservedUsers` component has been optimized for simplification, removing the `ErrorModal` component and relying on the output messages on the `Alert` one.

Also, instead of using the generalistic one (`useSimpleMutCommandMutation`), a new endpoint `useRestoreUserMutation` has been created.