### PR TITLE
Issue 228 - use smaller button size for user settings

### DIFF
--- a/src/components/Form/IpaCertificateMappingData.tsx
+++ b/src/components/Form/IpaCertificateMappingData.tsx
@@ -306,6 +306,7 @@ const IpaCertificateMappingData = (props: PropsToIpaCertificateMappingData) => {
       <SecondaryButton
         name={"add-certificate-mapping-data"}
         onClickHandler={() => setIsOpen(true)}
+        isSmall
       >
         Add
       </SecondaryButton>

--- a/src/components/Form/IpaCertificates.tsx
+++ b/src/components/Form/IpaCertificates.tsx
@@ -543,6 +543,7 @@ const IpaCertificates = (props: PropsToIpaCertificates) => {
         name={"add-certificate"}
         onClickHandler={onOpenModal}
         isDisabled={readOnly}
+        isSmall
       >
         Add
       </SecondaryButton>

--- a/src/components/Form/IpaTextInputFromList.tsx
+++ b/src/components/Form/IpaTextInputFromList.tsx
@@ -62,6 +62,7 @@ const IpaTextInputFromList = (props: PropsToTextInputFromList) => {
                   name={"remove-principal-alias-" + idx}
                   onClickHandler={() => props.onRemove(idx)}
                   isDisabled={readOnly}
+                  isSmall
                 >
                   Delete
                 </SecondaryButton>
@@ -74,6 +75,7 @@ const IpaTextInputFromList = (props: PropsToTextInputFromList) => {
         name="add-principal-alias"
         onClickHandler={props.onOpenModal}
         isDisabled={readOnly}
+        isSmall
       >
         Add
       </SecondaryButton>

--- a/src/components/Form/IpaTextboxList.tsx
+++ b/src/components/Form/IpaTextboxList.tsx
@@ -81,6 +81,7 @@ const IpaTextboxList = (props: PropsToIpaTextboxList) => {
               <SecondaryButton
                 name={"remove-" + props.name + "-" + idx}
                 onClickHandler={() => onRemoveHandler(idx)}
+                isSmall
               >
                 Delete
               </SecondaryButton>
@@ -92,6 +93,7 @@ const IpaTextboxList = (props: PropsToIpaTextboxList) => {
         classname="pf-u-mt-sm"
         name={"add-" + props.name}
         onClickHandler={onAddHandler}
+        isSmall
       >
         Add
       </SecondaryButton>

--- a/src/components/Form/PrincipalAliasMultiTextBox.tsx
+++ b/src/components/Form/PrincipalAliasMultiTextBox.tsx
@@ -108,10 +108,16 @@ const PrincipalAliasMultiTextBox = (props: PrincipalAliasMultiTextBoxProps) => {
       key="del-principal-alias"
       variant="danger"
       onClick={() => onRemovePrincipalAlias(aliasIdxToDelete)}
+      isSmall
     >
       Delete
     </Button>,
-    <Button key="cancel" variant="link" onClick={onCloseDeletionConfModal}>
+    <Button
+      key="cancel"
+      variant="link"
+      isSmall
+      onClick={onCloseDeletionConfModal}
+    >
       Cancel
     </Button>,
   ];


### PR DESCRIPTION
There is a button prop "isSmall" and I feel that the current buttons are very large compared to the label for that component. Making the button slightly smaller IMHO looks a lot cleaner

relates: https://github.com/freeipa/freeipa-webui/issues/228