### PR TITLE
refactor: simplify {user,krbpolicy,pwpolicy}Utils

### DIFF
--- a/src/utils/ipaObjectUtils.ts
+++ b/src/utils/ipaObjectUtils.ts
@@ -1,4 +1,5 @@
 import { Metadata, ParamMetadata } from "src/utils/datatypes/globalDataTypes";
+import { parseAPIDatetime } from "./utils";
 
 export type BasicType = string | number | boolean | null | undefined | [];
 
@@ -179,8 +180,7 @@ export function convertApiObj(
       if (simpleValues.has(key)) {
         obj[key] = convertToString(value as BasicType);
       } else if (dateValues.has(key)) {
-        // TODO convert to Datetime object
-        obj[key] = value;
+        obj[key] = parseAPIDatetime(value);
       } else {
         obj[key] = value;
       }

--- a/src/utils/krbPolicyUtils.tsx
+++ b/src/utils/krbPolicyUtils.tsx
@@ -2,7 +2,6 @@
 import { KrbPolicy } from "./datatypes/globalDataTypes";
 // Utils
 import { convertApiObj } from "src/utils/ipaObjectUtils";
-import { parseAPIDatetime } from "./utils";
 
 const simpleValues = new Set([
   "cn",
@@ -23,34 +22,35 @@ export function apiToKrbPolicy(apiRecord: Record<string, unknown>) {
     simpleValues,
     dateValues
   ) as Partial<KrbPolicy>;
-  return objectToKrbPolicy(converted);
+  return partialKrbPolicyToKrbPolicy(converted);
 }
 
-// Convert an partial KrbPolicy object into a full KrbPolicy object
-// (initializing the undefined params with default empty values)
-export const objectToKrbPolicy = (
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  partialKrbPolicy: any | Partial<KrbPolicy>
-) => {
-  const krbPolicy: KrbPolicy = {
-    attributelevelrights: partialKrbPolicy.attributelevelrights || {},
-    cn: partialKrbPolicy.cn || "",
-    ipacertmapdata: partialKrbPolicy.ipacertmapdata || [],
-    ipantsecurityidentifier: partialKrbPolicy.ipantsecurityidentifier || "",
-    ipasshpubkey: partialKrbPolicy.ipasshpubkey || [],
-    ipauniqueid: partialKrbPolicy.ipauniqueid || "",
-    krbcanonicalname: partialKrbPolicy.krbcanonicalname || "",
-    krbmaxrenewableage: partialKrbPolicy.krbmaxrenewableage || "",
-    krbmaxticketlife: partialKrbPolicy.krbmaxticketlife || "",
-    krbprincipalexpiration: parseAPIDatetime(
-      partialKrbPolicy.krbprincipalexpiration
-    ),
-    krbprincipalname: partialKrbPolicy.krbprincipalname || [],
-    loginshell: partialKrbPolicy.loginshell || "",
-    mail: partialKrbPolicy.mail || [],
-    memberof: partialKrbPolicy.memberof || "",
-    mepmanagedentry: partialKrbPolicy.mepmanagedentry || "",
-    usercertificatebinary: partialKrbPolicy.usercertificatebinary || [],
+export function partialKrbPolicyToKrbPolicy(
+  partialKrbPolicy: Partial<KrbPolicy>
+) {
+  return {
+    ...createEmptyKrbPolicy(),
+    ...partialKrbPolicy,
   };
-  return krbPolicy;
-};
+}
+
+export function createEmptyKrbPolicy(): KrbPolicy {
+  return {
+    attributelevelrights: {},
+    cn: "",
+    ipacertmapdata: [],
+    ipantsecurityidentifier: "",
+    ipasshpubkey: [],
+    ipauniqueid: "",
+    krbcanonicalname: "",
+    krbmaxrenewableage: "",
+    krbmaxticketlife: "",
+    krbprincipalexpiration: null,
+    krbprincipalname: [],
+    loginshell: "",
+    mail: [],
+    memberof: "",
+    mepmanagedentry: "",
+    usercertificatebinary: [],
+  };
+}

--- a/src/utils/pwPolicyUtils.tsx
+++ b/src/utils/pwPolicyUtils.tsx
@@ -23,27 +23,29 @@ export function apiToPwPolicy(apiRecord: Record<string, unknown>): PwPolicy {
     simpleValues,
     dateValues
   ) as Partial<PwPolicy>;
-  return objectToPwPolicy(converted);
+  return partialPwPolicyToPwPolicy(converted);
 }
 
-// Convert an partial PwPolicy object into a full PwPolicy object
-// (initializing the undefined params with default empty values)
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const objectToPwPolicy = (partialPwPolicy: any | Partial<PwPolicy>) => {
-  const pwPolicy: PwPolicy = {
-    attributelevelrights: partialPwPolicy.attributelevelrights || {},
-    name: partialPwPolicy.cn || partialPwPolicy.name || "",
-    dn: partialPwPolicy.dn || "",
-    krbmaxpwdlife: partialPwPolicy.krbmaxpwdlife || "",
-    krbminpwdlife: partialPwPolicy.krbminpwdlife || "",
-    krbpwdfailurecountinterval:
-      partialPwPolicy.krbpwdfailurecountinterval || "",
-    krbpwdhistorylength: partialPwPolicy.krbpwdhistorylength || "",
-    krbpwdlockoutduration: partialPwPolicy.krbpwdlockoutduration || "",
-    krbpwdmaxfailure: partialPwPolicy.krbpwdmaxfailure || "",
-    krbpwdmindiffchars: partialPwPolicy.krbpwdmindiffchars || "",
-    krbpwdminlength: partialPwPolicy.krbpwdminlength || "",
-    passwordgracelimit: partialPwPolicy.passwordgracelimit || "",
+export function partialPwPolicyToPwPolicy(partialPwPolicy: Partial<PwPolicy>) {
+  return {
+    ...createEmptyPwPolicy(),
+    ...partialPwPolicy,
   };
-  return pwPolicy;
-};
+}
+
+export function createEmptyPwPolicy(): PwPolicy {
+  return {
+    attributelevelrights: {},
+    name: "",
+    dn: "",
+    krbmaxpwdlife: "",
+    krbminpwdlife: "",
+    krbpwdfailurecountinterval: "",
+    krbpwdhistorylength: "",
+    krbpwdlockoutduration: "",
+    krbpwdmaxfailure: "",
+    krbpwdmindiffchars: "",
+    krbpwdminlength: "",
+    passwordgracelimit: "",
+  };
+}

--- a/src/utils/userUtils.tsx
+++ b/src/utils/userUtils.tsx
@@ -2,7 +2,6 @@
 import { User } from "src/utils/datatypes/globalDataTypes";
 // Utils
 import { convertApiObj } from "src/utils/ipaObjectUtils";
-import { parseAPIDatetime } from "./utils";
 
 // Parse the 'textInputField' data into expected data type
 // - TODO: Adapt it to work with many types of data
@@ -82,169 +81,106 @@ export function apiToUser(apiRecord: Record<string, unknown>): User {
     simpleValues,
     dateValues
   ) as Partial<User>;
-  return objectToUser(converted) as User;
+  return partialUserToUser(converted) as User;
 }
 
-// Determines whether a given property name is a simple value or is it multivalue (Array)
-//  - Returns: boolean
-export const isSimpleValue = (propertyName) => {
-  return simpleValues.has(propertyName);
-};
+export function partialUserToUser(partialUser: Partial<User>): User {
+  return {
+    ...createEmptyUser(),
+    ...partialUser,
+  };
+}
 
-// Covert an partial User object into a full User object
-// (initializing the undefined params with default empty values)
-export const objectToUser = (
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  partialUser: Record<string, any> | Partial<User>,
-  oldUserObject?: Partial<User> // Optional: To override the current object values
-): User => {
+// Get empty User object initialized with default values
+export function createEmptyUser(): User {
   const user: User = {
     // identity
-    title: partialUser.title || oldUserObject?.title || "",
-    givenname: partialUser.givenname || oldUserObject?.givenname || "",
-    sn: partialUser.sn || oldUserObject?.sn || "",
-    cn: partialUser.cn || oldUserObject?.cn || "",
-    displayname: partialUser.displayname || oldUserObject?.displayname || "",
-    initials: partialUser.initials || oldUserObject?.initials || "",
-    gecos: partialUser.gecos || oldUserObject?.gecos || "",
-    userclass: partialUser.userclass || oldUserObject?.userclass || [],
+    title: "",
+    givenname: "",
+    sn: "",
+    cn: "",
+    displayname: "",
+    initials: "",
+    gecos: "",
+    userclass: [],
     // account
-    uid: partialUser.uid || oldUserObject?.uid || "",
-    has_password:
-      partialUser.has_password || oldUserObject?.has_password || false,
-    krbpasswordexpiration: parseAPIDatetime(partialUser.krbpasswordexpiration),
-    uidnumber: partialUser.uidnumber || oldUserObject?.uidnumber || "",
-    gidnumber: partialUser.gidnumber || oldUserObject?.gidnumber || "",
-    krbprincipalname:
-      partialUser.krbprincipalname || oldUserObject?.krbprincipalname || [],
-    krbprincipalexpiration: parseAPIDatetime(
-      partialUser.krbprincipalexpiration
-    ),
-    loginshell: partialUser.loginshell || oldUserObject?.loginshell || "",
-    homedirectory:
-      partialUser.homedirectory || oldUserObject?.homedirectory || "",
-    ipasshpubkey: partialUser.ipasshpubkey || oldUserObject?.ipasshpubkey || [],
-    usercertificate:
-      partialUser.usercertificate || oldUserObject?.usercertificate || [],
-    ipacertmapdata:
-      partialUser.ipacertmapdata || oldUserObject?.ipacertmapdata || [],
-    ipauserauthtype:
-      partialUser.ipauserauthtype || oldUserObject?.ipauserauthtype || [],
-    ipatokenradiusconfiglink:
-      partialUser.ipatokenradiusconfiglink ||
-      oldUserObject?.ipatokenradiusconfiglink ||
-      "",
-    ipatokenradiususername:
-      partialUser.ipatokenradiususername ||
-      oldUserObject?.ipatokenradiususername ||
-      "",
-    ipaidpconfiglink:
-      partialUser.ipaidpconfiglink || oldUserObject?.ipaidpconfiglink || "",
-    ipaidpsub: partialUser.ipaidpsub || oldUserObject?.ipaidpsub || "",
+    uid: "",
+    has_password: false,
+    krbpasswordexpiration: null,
+    uidnumber: "",
+    gidnumber: "",
+    krbprincipalname: [],
+    krbprincipalexpiration: null,
+    loginshell: "",
+    homedirectory: "",
+    ipasshpubkey: [],
+    usercertificate: [],
+    ipacertmapdata: [],
+    ipauserauthtype: [],
+    ipatokenradiusconfiglink: "",
+    ipatokenradiususername: "",
+    ipaidpconfiglink: "",
+    ipaidpsub: "",
     // pwpolicy
-    krbmaxpwdlife:
-      partialUser.krbmaxpwdlife || oldUserObject?.krbmaxpwdlife || "",
-    krbminpwdlife:
-      partialUser.krbminpwdlife || oldUserObject?.krbminpwdlife || "",
-    krbpwdhistorylength:
-      partialUser.krbpwdhistorylength ||
-      oldUserObject?.krbpwdhistorylength ||
-      "",
-    krbpwdmindiffchars:
-      partialUser.krbpwdmindiffchars || oldUserObject?.krbpwdmindiffchars || "",
-    krbpwdminlength:
-      partialUser.krbpwdminlength || oldUserObject?.krbpwdminlength || "",
-    krbpwdmaxfailure:
-      partialUser.krbpwdmaxfailure || oldUserObject?.krbpwdmaxfailure || "",
-    krbpwdfailurecountinterval:
-      partialUser.krbpwdfailurecountinterval ||
-      oldUserObject?.krbpwdfailurecountinterval ||
-      "",
-    krbpwdlockoutduration:
-      partialUser.krbpwdlockoutduration ||
-      oldUserObject?.krbpwdlockoutduration ||
-      "",
-    passwordgracelimit:
-      partialUser.passwordgracelimit || oldUserObject?.passwordgracelimit || "",
+    krbmaxpwdlife: "",
+    krbminpwdlife: "",
+    krbpwdhistorylength: "",
+    krbpwdmindiffchars: "",
+    krbpwdminlength: "",
+    krbpwdmaxfailure: "",
+    krbpwdfailurecountinterval: "",
+    krbpwdlockoutduration: "",
+    passwordgracelimit: "",
     // krbtpolicy
-    krbmaxrenewableage:
-      partialUser.krbmaxrenewableage || oldUserObject?.krbmaxrenewableage || "",
-    krbmaxticketlife:
-      partialUser.krbmaxticketlife || oldUserObject?.krbmaxticketlife || "",
+    krbmaxrenewableage: "",
+    krbmaxticketlife: "",
     // contact
-    mail: partialUser.mail || oldUserObject?.mail || [],
-    telephonenumber:
-      partialUser.telephonenumber || oldUserObject?.telephonenumber || [],
-    pager: partialUser.pager || oldUserObject?.pager || [],
-    mobile: partialUser.mobile || oldUserObject?.mobile || [],
-    facsimiletelephonenumber:
-      partialUser.facsimiletelephonenumber ||
-      oldUserObject?.facsimiletelephonenumber ||
-      [],
+    mail: [],
+    telephonenumber: [],
+    pager: [],
+    mobile: [],
+    facsimiletelephonenumber: [],
     // mailing
-    street: partialUser.street || oldUserObject?.street || "",
-    l: partialUser.l || oldUserObject?.l || "",
-    st: partialUser.st || oldUserObject?.st || "",
-    postalcode: partialUser.postalcode || oldUserObject?.postalcode || "",
+    street: "",
+    l: "",
+    st: "",
+    postalcode: "",
     // employee
-    ou: partialUser.ou || oldUserObject?.ou || "",
-    manager: partialUser.manager || oldUserObject?.manager || "",
-    departmentnumber:
-      partialUser.departmentnumber || oldUserObject?.departmentnumber || [],
-    employeenumber:
-      partialUser.employeenumber || oldUserObject?.employeenumber || "",
-    employeetype: partialUser.employeetype || oldUserObject?.employeetype || "",
-    preferredlanguage:
-      partialUser.preferredlanguage || oldUserObject?.preferredlanguage || "",
+    ou: "",
+    manager: "",
+    departmentnumber: [],
+    employeenumber: "",
+    employeetype: "",
+    preferredlanguage: "",
     // misc
-    carlicense: partialUser.carlicense || oldUserObject?.carlicense || [],
+    carlicense: [],
     // smb_attributes
-    ipantlogonscript:
-      partialUser.ipantlogonscript || oldUserObject?.ipantlogonscript || "",
-    ipantprofilepath:
-      partialUser.ipantprofilepath || oldUserObject?.ipantprofilepath || "",
-    ipanthomedirectory:
-      partialUser.ipanthomedirectory || oldUserObject?.ipanthomedirectory || "",
-    ipanthomedirectorydrive:
-      partialUser.ipanthomedirectorydrive ||
-      oldUserObject?.ipanthomedirectorydrive ||
-      "",
+    ipantlogonscript: "",
+    ipantprofilepath: "",
+    ipanthomedirectory: "",
+    ipanthomedirectorydrive: "",
     // 'Member of' data
-    memberof_group:
-      partialUser.memberof_group || oldUserObject?.memberof_group || [],
-    memberof_subid:
-      partialUser.memberof_subid || oldUserObject?.memberof_subid || [],
+    memberof_group: [],
+    memberof_subid: [],
     // 'Managed by' data
-    mepmanagedentry:
-      partialUser.mepmanagedentry || oldUserObject?.mepmanagedentry || [],
+    mepmanagedentry: [],
     // other
-    krbcanonicalname:
-      partialUser.krbcanonicalname || oldUserObject?.krbcanonicalname || [],
-    nsaccountlock:
-      partialUser.nsaccountlock || oldUserObject?.nsaccountlock || false,
-    objectclass: partialUser.objectclass || oldUserObject?.objectclass || [],
-    ipauniqueid: partialUser.ipauniqueid || oldUserObject?.ipauniqueid || "",
-    ipantsecurityidentifier:
-      partialUser.ipantsecurityidentifier ||
-      oldUserObject?.ipantsecurityidentifier ||
-      "",
-    attributelevelrights:
-      partialUser.attributelevelrights ||
-      oldUserObject?.attributelevelrights ||
-      {},
-    has_keytab: partialUser.has_keytab || oldUserObject?.has_keytab || false,
-    preserved: partialUser.preserved || oldUserObject?.preserved || false,
-    dn: partialUser.dn || oldUserObject?.dn || "",
-    sshpubkeyfp: partialUser.sshpubkeyfp || oldUserObject?.sshpubkeyfp || [],
-    krbextradata: partialUser.krbextradata || oldUserObject?.krbextradata || "",
-    krblastadminunlock: parseAPIDatetime(partialUser.krblastadminunlock),
-    krblastfailedauth: parseAPIDatetime(partialUser.krblastfailedauth),
-    krblastpwdchange: parseAPIDatetime(partialUser.krblastpwdchange),
-    krbloginfailedcount:
-      partialUser.krbloginfailedcount ||
-      oldUserObject?.krbloginfailedcount ||
-      "",
+    krbcanonicalname: [],
+    nsaccountlock: false,
+    objectclass: [],
+    ipauniqueid: "",
+    ipantsecurityidentifier: "",
+    attributelevelrights: {},
+    has_keytab: false,
+    preserved: false,
+    dn: "",
+    sshpubkeyfp: [],
+    krbextradata: "",
+    krblastadminunlock: null,
+    krblastfailedauth: null,
+    krblastpwdchange: null,
+    krbloginfailedcount: "",
   };
 
   return user;
-};
+}


### PR DESCRIPTION
Added Datetime parser to `ipaObjectUtils.convertApiObj` so that it can converted attributes defined by `dateValues`.

With this it's no longer needed to use the datetime parsing in former objectToUser.

This and the fact that there is no usage of `objectToUser` with the second parameter, allowed to replace `objectToUser` with `partialUserToUser` and `createEmptyUser` functions that are much imore simpler and reusable.

The same for pw and krb policy objects.