### PR TITLE
fix lint warnings

### DIFF
--- a/src/components/HostsSections/HostSettings.tsx
+++ b/src/components/HostsSections/HostSettings.tsx
@@ -88,31 +88,12 @@ const HostSettings = (props: PropsToHostSettings) => {
     setMacAddressList(macAddressListCopy);
   };
 
-  // - 'Change MAC address' handler
-  const onHandleMacAddressChange = (
-    value: string,
-    event: React.FormEvent<HTMLInputElement>,
-    idx: number
-  ) => {
-    const macAddressListCopy = [...macAddressList];
-    macAddressListCopy[idx]["element"] = (
-      event.target as HTMLInputElement
-    ).value;
-    setMacAddressList(macAddressListCopy);
-  };
-
   // - 'Remove MAC address' handler
   const onRemoveMacAddressHandler = (idx: number) => {
     const macAddressListCopy = [...macAddressList];
     macAddressListCopy.splice(idx, 1);
     setMacAddressList(macAddressListCopy);
   };
-
-  // Authentication indicators - checkboxes
-  const [radiusCheckbox] = useState(false);
-  const [tpaCheckbox] = useState(false);
-  const [pkinitCheckbox] = useState(false);
-  const [hardenedPassCheckbox] = useState(false);
 
   const AuthIndicatorsTypesMessage = () => (
     <div>

--- a/src/hooks/useHostSettingsData.tsx
+++ b/src/hooks/useHostSettingsData.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect } from "react";
 
 // RPC
 import {
-  useGetActiveUsersQuery,
   useGetObjectMetadataQuery,
   useGetHostsFullDataQuery,
 } from "src/services/rpc";

--- a/src/pages/AutoMemHostRules/AutoMemHostRules.tsx
+++ b/src/pages/AutoMemHostRules/AutoMemHostRules.tsx
@@ -3,7 +3,7 @@ import { EmptyPage } from "src/components/errors/PageErrors";
 
 // Automembership host group rules
 const AutoMemHostRules = () => {
-  return EmptyPage();
+  return <EmptyPage />;
 };
 
 export default AutoMemHostRules;

--- a/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
+++ b/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
@@ -3,7 +3,7 @@ import { EmptyPage } from "src/components/errors/PageErrors";
 
 // Automembership user group rules
 const AutoMemUserRules = () => {
-  return EmptyPage();
+  return <EmptyPage />;
 };
 
 export default AutoMemUserRules;

--- a/src/pages/HBACRules/HBACRules.tsx
+++ b/src/pages/HBACRules/HBACRules.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { EmptyPage } from "src/components/errors/PageErrors";
 
 const HBACRules = () => {
-  return EmptyPage();
+  return <EmptyPage />;
 };
 
 export default HBACRules;

--- a/src/pages/HBACServiceGroups/HBACServiceGroups.tsx
+++ b/src/pages/HBACServiceGroups/HBACServiceGroups.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { EmptyPage } from "src/components/errors/PageErrors";
 
 const HBACServiceGroups = () => {
-  return EmptyPage();
+  return <EmptyPage />;
 };
 
 export default HBACServiceGroups;

--- a/src/pages/HBACServices/HBACServices.tsx
+++ b/src/pages/HBACServices/HBACServices.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { EmptyPage } from "src/components/errors/PageErrors";
 
 const HBACServices = () => {
-  return EmptyPage();
+  return <EmptyPage />;
 };
 
 export default HBACServices;

--- a/src/pages/HBACTest/HBACTest.tsx
+++ b/src/pages/HBACTest/HBACTest.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { EmptyPage } from "src/components/errors/PageErrors";
 
 const HBACTest = () => {
-  return EmptyPage();
+  return <EmptyPage />;
 };
 
 export default HBACTest;

--- a/src/pages/HostGroups/HostGroups.tsx
+++ b/src/pages/HostGroups/HostGroups.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { EmptyPage } from "src/components/errors/PageErrors";
 
 const HostGroups = () => {
-  return EmptyPage();
+  return <EmptyPage />;
 };
 
 export default HostGroups;

--- a/src/pages/IDViews/IDViews.tsx
+++ b/src/pages/IDViews/IDViews.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { EmptyPage } from "src/components/errors/PageErrors";
 
 const IDViews = () => {
-  return EmptyPage();
+  return <EmptyPage />;
 };
 
 export default IDViews;

--- a/src/pages/KrbTicketPolicy/KrbTicketPolicy.tsx
+++ b/src/pages/KrbTicketPolicy/KrbTicketPolicy.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { EmptyPage } from "src/components/errors/PageErrors";
 
 const KrbTicketPolicy = () => {
-  return EmptyPage();
+  return <EmptyPage />;
 };
 
 export default KrbTicketPolicy;

--- a/src/pages/Netgroups/Netgroups.tsx
+++ b/src/pages/Netgroups/Netgroups.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { EmptyPage } from "src/components/errors/PageErrors";
 
 const Netgroups = () => {
-  return EmptyPage();
+  return <EmptyPage />;
 };
 
 export default Netgroups;

--- a/src/pages/PasswordPolicies/PasswordPolicies.tsx
+++ b/src/pages/PasswordPolicies/PasswordPolicies.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { EmptyPage } from "src/components/errors/PageErrors";
 
 const PasswordPolicies = () => {
-  return EmptyPage();
+  return <EmptyPage />;
 };
 
 export default PasswordPolicies;

--- a/src/pages/SELinuxUserMaps/SELinuxUserMaps.tsx
+++ b/src/pages/SELinuxUserMaps/SELinuxUserMaps.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { EmptyPage } from "src/components/errors/PageErrors";
 
 const SELinuxUserMaps = () => {
-  return EmptyPage();
+  return <EmptyPage />;
 };
 
 export default SELinuxUserMaps;

--- a/src/pages/Services/Services.tsx
+++ b/src/pages/Services/Services.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 // PatternFly
 import {
-  DropdownItem,
   Page,
   PageSection,
   PageSectionVariants,
@@ -118,32 +117,6 @@ const Services = () => {
       updateSelectedPerPage(0);
     }, 1000);
   }, [servicesList]);
-
-  // Dropdown kebab
-  const [kebabIsOpen, setKebabIsOpen] = useState(false);
-
-  const dropdownItems = [
-    <DropdownItem key="rebuild auto membership" component="button">
-      Rebuild auto membership
-    </DropdownItem>,
-  ];
-
-  const onKebabToggle = () => {
-    setKebabIsOpen(!kebabIsOpen);
-  };
-
-  const onFocus = () => {
-    const element = document.getElementById("main-dropdown-kebab");
-    element?.focus();
-  };
-
-  const onDropdownSelect = (
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _event: React.MouseEvent<Element, MouseEvent> | undefined
-  ) => {
-    setKebabIsOpen(!kebabIsOpen);
-    onFocus();
-  };
 
   // Modals functionality
   const [showAddModal, setShowAddModal] = useState(false);

--- a/src/pages/SudoCmdGroups/SudoCmdGroups.tsx
+++ b/src/pages/SudoCmdGroups/SudoCmdGroups.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { EmptyPage } from "src/components/errors/PageErrors";
 
 const SudoCmdGroups = () => {
-  return EmptyPage();
+  return <EmptyPage />;
 };
 
 export default SudoCmdGroups;

--- a/src/pages/SudoCmds/SudoCmds.tsx
+++ b/src/pages/SudoCmds/SudoCmds.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { EmptyPage } from "src/components/errors/PageErrors";
 
 const SudoCmds = () => {
-  return EmptyPage();
+  return <EmptyPage />;
 };
 
 export default SudoCmds;

--- a/src/pages/SudoRules/SudoRules.tsx
+++ b/src/pages/SudoRules/SudoRules.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { EmptyPage } from "src/components/errors/PageErrors";
 
 const SudoRules = () => {
-  return EmptyPage();
+  return <EmptyPage />;
 };
 
 export default SudoRules;

--- a/src/pages/UserGroups/UserGroups.tsx
+++ b/src/pages/UserGroups/UserGroups.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { EmptyPage } from "src/components/errors/PageErrors";
 
 const UserGroups = () => {
-  return EmptyPage();
+  return <EmptyPage />;
 };
 
 export default UserGroups;


### PR DESCRIPTION
Fixes:
```
npm run lint

> freeipa-webui@0.1.0 lint
> eslint --color src/

freeipa-webui/src/components/HostsSections/HostSettings.tsx
   92:9   warning  'onHandleMacAddressChange' is assigned a value but never used  @typescript-eslint/no-unused-vars
  112:10  warning  'radiusCheckbox' is assigned a value but never used            @typescript-eslint/no-unused-vars
  113:10  warning  'tpaCheckbox' is assigned a value but never used               @typescript-eslint/no-unused-vars
  114:10  warning  'pkinitCheckbox' is assigned a value but never used            @typescript-eslint/no-unused-vars
  115:10  warning  'hardenedPassCheckbox' is assigned a value but never used      @typescript-eslint/no-unused-vars

freeipa-webui/src/hooks/useHostSettingsData.tsx
  5:3  warning  'useGetActiveUsersQuery' is defined but never used  @typescript-eslint/no-unused-vars

freeipa-webui/src/pages/AutoMemHostRules/AutoMemHostRules.tsx
  1:8  warning  'React' is defined but never used  @typescript-eslint/no-unused-vars

freeipa-webui/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
  1:8  warning  'React' is defined but never used  @typescript-eslint/no-unused-vars

freeipa-webui/src/pages/HBACRules/HBACRules.tsx
  1:8  warning  'React' is defined but never used  @typescript-eslint/no-unused-vars

freeipa-webui/src/pages/HBACServiceGroups/HBACServiceGroups.tsx
  1:8  warning  'React' is defined but never used  @typescript-eslint/no-unused-vars

freeipa-webui/src/pages/HBACServices/HBACServices.tsx
  1:8  warning  'React' is defined but never used  @typescript-eslint/no-unused-vars

freeipa-webui/src/pages/HBACTest/HBACTest.tsx
  1:8  warning  'React' is defined but never used  @typescript-eslint/no-unused-vars

freeipa-webui/src/pages/HostGroups/HostGroups.tsx
  1:8  warning  'React' is defined but never used  @typescript-eslint/no-unused-vars

freeipa-webui/src/pages/IDViews/IDViews.tsx
  1:8  warning  'React' is defined but never used  @typescript-eslint/no-unused-vars

freeipa-webui/src/pages/KrbTicketPolicy/KrbTicketPolicy.tsx
  1:8  warning  'React' is defined but never used  @typescript-eslint/no-unused-vars

freeipa-webui/src/pages/Netgroups/Netgroups.tsx
  1:8  warning  'React' is defined but never used  @typescript-eslint/no-unused-vars

freeipa-webui/src/pages/PasswordPolicies/PasswordPolicies.tsx
  1:8  warning  'React' is defined but never used  @typescript-eslint/no-unused-vars

freeipa-webui/src/pages/SELinuxUserMaps/SELinuxUserMaps.tsx
  1:8  warning  'React' is defined but never used  @typescript-eslint/no-unused-vars

freeipa-webui/src/pages/Services/Services.tsx
  125:9  warning  'dropdownItems' is assigned a value but never used     @typescript-eslint/no-unused-vars
  131:9  warning  'onKebabToggle' is assigned a value but never used     @typescript-eslint/no-unused-vars
  140:9  warning  'onDropdownSelect' is assigned a value but never used  @typescript-eslint/no-unused-vars

freeipa-webui/src/pages/SudoCmdGroups/SudoCmdGroups.tsx
  1:8  warning  'React' is defined but never used  @typescript-eslint/no-unused-vars

freeipa-webui/src/pages/SudoCmds/SudoCmds.tsx
  1:8  warning  'React' is defined but never used  @typescript-eslint/no-unused-vars

freeipa-webui/src/pages/SudoRules/SudoRules.tsx
  1:8  warning  'React' is defined but never used  @typescript-eslint/no-unused-vars

freeipa-webui/src/pages/UserGroups/UserGroups.tsx
  1:8  warning  'React' is defined but never used  @typescript-eslint/no-unused-vars

✖ 25 problems (0 errors, 25 warnings)
```