### PR TITLE
Issue 276 - Redesign search input behavior

### DIFF
--- a/src/components/layouts/SearchInputLayout.tsx
+++ b/src/components/layouts/SearchInputLayout.tsx
@@ -6,6 +6,7 @@ import { SearchInput } from "@patternfly/react-core";
 interface SearchValueData {
   searchValue: string;
   updateSearchValue: (value: string) => void;
+  submitSearchValue?: () => void;
 }
 
 interface PropsToSearchInput {
@@ -13,6 +14,7 @@ interface PropsToSearchInput {
   ariaLabel?: string;
   placeholder?: string;
   searchValueData: SearchValueData;
+  isDisabled?: boolean;
 }
 
 const SearchInputLayout = (props: PropsToSearchInput) => {
@@ -27,14 +29,26 @@ const SearchInputLayout = (props: PropsToSearchInput) => {
     props.searchValueData.updateSearchValue("");
   };
 
+  const onSubmit = () => {
+    if (props.searchValueData.submitSearchValue) {
+      props.searchValueData.submitSearchValue();
+    }
+  };
+
   return (
     <SearchInput
       name={props.name}
       aria-label={props.ariaLabel}
       placeholder={props.placeholder}
       value={props.searchValueData.searchValue}
+      onSearch={
+        props.searchValueData.submitSearchValue
+          ? onSubmit
+          : () => void undefined
+      }
       onChange={onSearchChange}
       onClear={onSearchClean}
+      isDisabled={props.isDisabled}
     />
   );
 };

--- a/src/components/tables/UsersTable.tsx
+++ b/src/components/tables/UsersTable.tsx
@@ -70,41 +70,6 @@ const UsersTable = (props: PropsToTable) => {
     title: "Job title",
   };
 
-  // Filter (SearchInput)
-  // - When a user is search using the Search Input
-  const onFilter = (user: User) => {
-    if (props.searchValue === "") {
-      return true;
-    }
-
-    let input: RegExp;
-    try {
-      // Find matches that begin with the pattern
-      input = new RegExp("^" + props.searchValue, "i");
-    } catch (err) {
-      input = new RegExp(
-        props.searchValue.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
-        "i"
-      );
-    }
-
-    for (const attr of Object.keys(columnNames)) {
-      if (
-        attr !== "nsaccountlock" &&
-        user[attr] !== undefined &&
-        user[attr][0].search(input) >= 0
-      ) {
-        return true;
-      }
-    }
-    return false;
-  };
-
-  const filteredShownUsers =
-    props.searchValue === ""
-      ? shownUsersList
-      : props.elementsList.filter(onFilter);
-
   // Index of the currently sorted column
   // Note: if you intend to make columns reorderable, you may instead want to use a non-numeric key
   // as the identifier of the sorted column. See the "Compound expandable" example.
@@ -391,7 +356,7 @@ const UsersTable = (props: PropsToTable) => {
     </Tr>
   );
 
-  const body = filteredShownUsers.map((user, rowIndex) => (
+  const body = shownUsersList.map((user, rowIndex) => (
     <Tr key={user.uid} id={user.uid}>
       <Td
         dataLabel="checkbox"

--- a/src/pages/Hosts/HostsTable.tsx
+++ b/src/pages/Hosts/HostsTable.tsx
@@ -53,40 +53,6 @@ const HostsTable = (props: PropsToTable) => {
     enrolled: "Enrolled",
   };
 
-  // Filter (SearchInput)
-  // - When a host is search using the Search Input
-  const onFilter = (host: Host) => {
-    if (props.searchValue === "") {
-      return true;
-    }
-
-    let input: RegExp;
-    try {
-      input = new RegExp(props.searchValue, "i");
-    } catch (err) {
-      input = new RegExp(
-        props.searchValue.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
-        "i"
-      );
-    }
-
-    for (const attr of Object.keys(columnNames)) {
-      if (
-        host[attr] !== undefined &&
-        host[attr] !== "enrolled" &&
-        host[attr][0].search(input) >= 0
-      ) {
-        return true;
-      }
-    }
-    return false;
-  };
-
-  const filteredShownHosts =
-    props.searchValue === ""
-      ? shownHostsList
-      : props.elementsList.filter(onFilter);
-
   // Index of the currently sorted column
   // Note: if you intend to make columns reorderable, you may instead want to use a non-numeric key
   // as the identifier of the sorted column. See the "Compound expandable" example.
@@ -263,7 +229,7 @@ const HostsTable = (props: PropsToTable) => {
     </Tr>
   );
 
-  const body = filteredShownHosts.map((host, rowIndex) => (
+  const body = shownHostsList.map((host, rowIndex) => (
     <Tr key={host.fqdn} id={host.fqdn}>
       <Td
         dataLabel="checkbox"

--- a/src/pages/Services/ServicesTable.tsx
+++ b/src/pages/Services/ServicesTable.tsx
@@ -51,30 +51,6 @@ const ServicesTable = (props: PropsToTable) => {
     principalName: "Principal name",
   };
 
-  // Filter (SearchInput)
-  // - When a service is search using the Search Input
-  const onFilter = (service: Service) => {
-    if (props.searchValue === "") {
-      return true;
-    }
-
-    let input: RegExp;
-    try {
-      input = new RegExp(props.searchValue, "i");
-    } catch (err) {
-      input = new RegExp(
-        props.searchValue.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
-        "i"
-      );
-    }
-    return service.krbcanonicalname.search(input) >= 0;
-  };
-
-  const filteredShownServices =
-    props.searchValue === ""
-      ? shownServicesList
-      : props.elementsList.filter(onFilter);
-
   // Index of the currently sorted column
   // Note: if you intend to make columns reorderable, you may instead want to use a non-numeric key
   // as the identifier of the sorted column. See the "Compound expandable" example.
@@ -246,7 +222,7 @@ const ServicesTable = (props: PropsToTable) => {
     </Tr>
   );
 
-  const body = filteredShownServices.map((service, rowIndex) => (
+  const body = shownServicesList.map((service, rowIndex) => (
     <Tr key={service.krbcanonicalname} id={service.krbcanonicalname}>
       <Td
         dataLabel="checkbox"

--- a/src/services/rpc.ts
+++ b/src/services/rpc.ts
@@ -131,16 +131,7 @@ export interface BatchCommand {
   batch: CommandWithSingleParam[];
 }
 
-export interface UsersPayload {
-  searchValue: string;
-  sizeLimit: number;
-  apiVersion: string;
-  userType?: string;
-  startIdx: number;
-  stopIdx: number;
-}
-
-// Convert to BasicPayload (use for Hosts services, etc)
+// Basic Payload for getting lists of entries
 export interface GenericPayload {
   method: string;
   searchValue: string;
@@ -150,6 +141,7 @@ export interface GenericPayload {
   stopIdx: number;
   objName?: string;
   objAttr?: string;
+  entryType?: "user" | "stage" | "preserved" | "host" | "service";
 }
 
 export interface HostAddPayload {
@@ -720,7 +712,7 @@ export const api = createApi({
         // Prepare payload
         const payloadDataBatch: Command[] = ids.map((name) => ({
           method: objName + "_show",
-          params: [[name], {}],
+          params: [[name], { no_members: true }],
         }));
 
         // Make call using 'fetchWithBQ'
@@ -729,10 +721,124 @@ export const api = createApi({
         );
 
         const response = partialInfoResult.data as BatchRPCResponse;
-        response.result.totalCount = itemsCount;
+        if (response) {
+          response.result.totalCount = itemsCount;
+        }
 
         // Return results
-        return partialInfoResult.data
+        return response
+          ? { data: response }
+          : {
+              error: partialInfoResult.error as unknown as FetchBaseQueryError,
+            };
+      },
+    }),
+    // Refresh entries by search value (mutation instead of query)
+    searchEntries: build.mutation<BatchRPCResponse, GenericPayload>({
+      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
+        const {
+          searchValue,
+          sizeLimit,
+          apiVersion,
+          startIdx,
+          stopIdx,
+          entryType,
+        } = payloadData;
+
+        if (apiVersion === undefined) {
+          return {
+            error: {
+              status: "CUSTOM_ERROR",
+              data: "",
+              error: "API version not available",
+            } as FetchBaseQueryError,
+          };
+        }
+
+        // Prepare search parameters
+        const params = {
+          pkey_only: true,
+          sizelimit: sizeLimit,
+          version: apiVersion,
+          all: true,
+        };
+
+        let method = "";
+        let show_method = "";
+        if (entryType === "user") {
+          method = "user_find";
+          show_method = "user_show";
+        } else if (entryType === "stage") {
+          method = "stageuser_find";
+          show_method = "stageuser_show";
+        } else if (entryType === "preserved") {
+          method = "user_find";
+          show_method = "user_show";
+          params["preserved"] = true;
+        } else if (entryType === "host") {
+          method = "host_find";
+          show_method = "host_show";
+        } else if (entryType === "service") {
+          method = "service_find";
+          show_method = "service_show";
+        }
+
+        // Prepare payload
+        const payloadDataIds: Command = {
+          method: method,
+          params: [[searchValue], params],
+        };
+
+        // Make call using 'fetchWithBQ'
+        const getGroupIDsResult = await fetchWithBQ(getCommand(payloadDataIds));
+        // Return possible errors
+        if (getGroupIDsResult.error) {
+          return { error: getGroupIDsResult.error as FetchBaseQueryError };
+        }
+        // If no error: cast and assign 'ids'
+        const responseData = getGroupIDsResult.data as FindRPCResponse;
+
+        const ids: string[] = [];
+        const itemsCount = responseData.result.result.length as number;
+        for (let i = startIdx; i < itemsCount && i < stopIdx; i++) {
+          if (
+            entryType === "user" ||
+            entryType === "stage" ||
+            entryType === "preserved"
+          ) {
+            const userId = responseData.result.result[i] as UIDType;
+            const { uid } = userId;
+            ids.push(uid[0] as string);
+          } else if (entryType === "host") {
+            const hostId = responseData.result.result[i] as fqdnType;
+            const { fqdn } = hostId;
+            ids.push(fqdn[0] as string);
+          } else if (entryType === "service") {
+            const serviceId = responseData.result.result[i] as servicesType;
+            const { krbprincipalname } = serviceId;
+            ids.push(krbprincipalname[0] as string);
+          }
+        }
+
+        // 2ND CALL - GET PARTIAL INFO
+        // Prepare payload
+        const payloadDataBatch: Command[] = ids.map((id) => ({
+          method: show_method,
+          params: [[id], { no_members: true }],
+        }));
+
+        // Make call using 'fetchWithBQ'
+        const partialInfoResult = await fetchWithBQ(
+          getBatchCommand(payloadDataBatch as Command[], apiVersion)
+        );
+
+        const response = partialInfoResult.data as BatchRPCResponse;
+        if (response) {
+          response.result.totalCount = itemsCount;
+        }
+
+        // Return results
+        return response
           ? { data: response }
           : {
               error: partialInfoResult.error as unknown as FetchBaseQueryError,
@@ -979,24 +1085,39 @@ export const useGetHostsListQuery = () => {
   return useGetGenericListQuery("host");
 };
 
+// Wrappers for getting entry lists
+// Active Users
 export const useGettingActiveUserQuery = (payloadData) => {
   payloadData["objName"] = "user";
   payloadData["objAttr"] = "uid";
   return useGettingGenericQuery(payloadData);
 };
-
+// Stage Users
 export const useGettingStageUserQuery = (payloadData) => {
   payloadData["objName"] = "stageuser";
   payloadData["objAttr"] = "uid";
   return useGettingGenericQuery(payloadData);
 };
-
+// Preserved users
 export const useGettingPreservedUserQuery = (payloadData) => {
   payloadData["objName"] = "preserved";
   payloadData["objAttr"] = "uid";
   return useGettingGenericQuery(payloadData);
 };
+// Hosts
+export const useGettingHostQuery = (payloadData) => {
+  payloadData["objName"] = "host";
+  payloadData["objAttr"] = "fqdn";
+  return useGettingGenericQuery(payloadData);
+};
+// Services
+export const useGettingServicesQuery = (payloadData) => {
+  payloadData["objName"] = "service";
+  payloadData["objAttr"] = "krbprincipalname";
+  return useGettingGenericQuery(payloadData);
+};
 
+// Full search wrappers
 export const useGetUsersFullQuery = (userId: string) => {
   // Active and preserved users
   const query_args = {
@@ -1014,18 +1135,6 @@ export const useGetStageUsersFullQuery = (userId: string) => {
     version: API_VERSION_BACKUP,
   };
   return useGetGenericUsersFullDataQuery(query_args);
-};
-
-export const useGettingHostQuery = (payloadData) => {
-  payloadData["objName"] = "host";
-  payloadData["objAttr"] = "fqdn";
-  return useGettingGenericQuery(payloadData);
-};
-
-export const useGettingServicesQuery = (payloadData) => {
-  payloadData["objName"] = "service";
-  payloadData["objAttr"] = "krbprincipalname";
-  return useGettingGenericQuery(payloadData);
 };
 
 export const {
@@ -1072,4 +1181,5 @@ export const {
   useGettingGenericQuery,
   useGetGenericListQuery,
   useRemoveServicesMutation,
+  useSearchEntriesMutation,
 } = api;


### PR DESCRIPTION
Previously the SearchInput for user/host/services tables would simply filter the entries on the page. With the new paging design this would make it impossible to search the entire database.

Instead the SearchInput should query the database using the searchValue instead of filtering the existing entries.

Created a generic searchEntries rpc hook where the entry type is passed in so it knows what methods/params to apply to the search.

fixes: https://github.com/freeipa/freeipa-webui/issues/276