### PR TITLE
Fix stage users table not showing

### DIFF
--- a/src/services/rpc.ts
+++ b/src/services/rpc.ts
@@ -693,7 +693,7 @@ export const api = createApi({
             id = idResponseData.result.result[i] as fqdnType;
           } else if (objName === "service") {
             id = idResponseData.result.result[i] as servicesType;
-          } else if (objName === "user" || objName === "stage") {
+          } else if (objName === "user" || objName === "stageuser") {
             id = idResponseData.result.result[i] as UIDType;
           } else {
             // Unknown, should never happen


### PR DESCRIPTION
The stage users table is showing an error instead of the data. This is due to the wrong `objName` assigned to the stage users' API call when assigning uids from the previous call.