### PR TITLE
Fix stage users wrong redirection

### DIFF
--- a/src/components/modals/DeleteUsers.tsx
+++ b/src/components/modals/DeleteUsers.tsx
@@ -274,7 +274,13 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
               );
             }
             // Redirect to main page
-            navigate(URL_PREFIX + "/active-users");
+            if (props.from === "active-users") {
+              navigate(URL_PREFIX + "/active-users");
+            } else if (props.from === "stage-users") {
+              navigate(URL_PREFIX + "/stage-users");
+            } else if (props.from === "preserved-users") {
+              navigate(URL_PREFIX + "/preserved-users");
+            }
             // Close modal
             closeModal();
           }


### PR DESCRIPTION
There is a redirection to the 'Active users' page every time a new user is removed from the 'Stage users' page. This is
because the redirection doesn't take into account from which page the deletion is taking place.