### PR TITLE
Issue 291- host table - host enrollment not properly checked

### DIFF
--- a/src/pages/Hosts/HostsTable.tsx
+++ b/src/pages/Hosts/HostsTable.tsx
@@ -248,7 +248,7 @@ const HostsTable = (props: PropsToTable) => {
       </Td>
       <Td dataLabel={columnNames.description}>{host.description}</Td>
       <Td dataLabel={columnNames.enrolled}>
-        {host.enrolledby !== "" ? "True" : "False"}
+        {host.has_keytab ? "True" : "False"}
       </Td>
     </Tr>
   ));


### PR DESCRIPTION
If a host is enrolled or not, it is listed as enrolled in the main Hosts table. Correct how enrollment is determined by using has_keytab

fixes: https://github.com/freeipa/freeipa-webui/issues/291