### PR TITLE
fix: remove double "Available options" text in MemberOfAddModal

### DIFF
--- a/src/components/MemberOf/MemberOfAddModal.tsx
+++ b/src/components/MemberOf/MemberOfAddModal.tsx
@@ -125,7 +125,7 @@ const MemberOfAddModal = (props: PropsToAdd) => {
     >
       <Form id={"is-member-of-add-modal"}>
         {fields.map((field) => (
-          <FormGroup key={field.id} label={field.name} fieldId={field.id}>
+          <FormGroup key={field.id} fieldId={field.id}>
             {field.pfComponent}
           </FormGroup>
         ))}


### PR DESCRIPTION
"Available options" was displayed twice - in FormGroup and int the DualListSelector component.

It is removed from the form group.

Fixes: https://github.com/freeipa/freeipa-webui/issues/294