### PR TITLE
[Is a member of][User groups] 'Refresh' button functionality

### DIFF
--- a/src/components/MemberOf/MemberOfUserGroups.tsx
+++ b/src/components/MemberOf/MemberOfUserGroups.tsx
@@ -40,6 +40,8 @@ function filterUserGroupsData<Type extends TypeWithCN>(
 
 interface MemberOfUserGroupsProps {
   user: Partial<User>;
+  isUserDataLoading: boolean;
+  onRefreshUserData: () => void;
 }
 
 const MemberOfUserGroups = (props: MemberOfUserGroupsProps) => {
@@ -85,6 +87,10 @@ const MemberOfUserGroups = (props: MemberOfUserGroupsProps) => {
     }
   }, [fullUserGroupsQuery]);
 
+  React.useEffect(() => {
+    fullUserGroupsQuery.refetch();
+  }, [props.user]);
+
   const [groupsNamesSelected, setGroupsNamesSelected] = React.useState<
     string[]
   >([]);
@@ -121,6 +127,10 @@ const MemberOfUserGroups = (props: MemberOfUserGroupsProps) => {
   };
   const availableUserGroupsItems: AvailableItems[] = parseAvailableItems();
 
+  // Buttons functionality
+  // - Refresh
+  const isRefreshButtonEnabled = !props.isUserDataLoading;
+
   // 'Add' function
   // TODO: Adapt to work with real data
   const onAddUserGroup = (items: AvailableItems[]) => {
@@ -145,7 +155,8 @@ const MemberOfUserGroups = (props: MemberOfUserGroupsProps) => {
       <MemberOfToolbarUserGroups
         searchText={searchValue}
         onSearchTextChange={setSearchValue}
-        refreshButtonEnabled={true}
+        refreshButtonEnabled={isRefreshButtonEnabled}
+        onRefreshButtonClick={props.onRefreshUserData}
         deleteButtonEnabled={someItemSelected}
         onDeleteButtonClick={() => setShowDeleteModal(true)}
         addButtonEnabled={true}

--- a/src/pages/ActiveUsers/UserMemberOf.tsx
+++ b/src/pages/ActiveUsers/UserMemberOf.tsx
@@ -82,6 +82,10 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
     }
   }, [userData, userQuery.isFetching]);
 
+  const onRefreshUserData = () => {
+    userQuery.refetch();
+  };
+
   // 'User groups' length to show in tab badge
   const [userGroupsLength, setUserGroupLength] = React.useState(0);
 
@@ -454,7 +458,11 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
               </TabTitleText>
             }
           >
-            <MemberOfUserGroups user={user} />
+            <MemberOfUserGroups
+              user={user}
+              isUserDataLoading={userQuery.isFetching}
+              onRefreshUserData={onRefreshUserData}
+            />
           </Tab>
           <Tab
             eventKey={1}


### PR DESCRIPTION
The 'Refresh' button should re-fetch the data related to the user groups of a given user.

The solution has been implemented by taking the `refetch` functionality retrieved from the `useGetUserByUidQuery` hook and the button is disabled during the operation.

This PR depends on this one to be merged: https://github.com/freeipa/freeipa-webui/pull/293