### PR TITLE
Issue 309 - merge totalCount into paginationData object

### DIFF
--- a/src/components/PaginationPrep.tsx
+++ b/src/components/PaginationPrep.tsx
@@ -11,11 +11,11 @@ interface PaginationData {
   showTableRows: boolean;
   updateSelectedPerPage: (selected: number) => void;
   updateShownElementsList: (newShownElementsList: any[]) => void;
+  totalCount: number;
 }
 
 interface PropsToPaginationPrep {
   list: any[];
-  totalCount?: number;
   paginationData: PaginationData;
   variant?: "top" | "bottom";
   widgetId?: string | undefined;
@@ -71,7 +71,7 @@ const PaginationPrep = (props: PropsToPaginationPrep) => {
   return (
     <PaginationLayout
       list={props.list}
-      totalCount={props.totalCount}
+      totalCount={props.paginationData.totalCount}
       perPage={props.paginationData.perPage}
       page={props.paginationData.page}
       handleSetPerPage={handlePerPageSelect}

--- a/src/pages/ActiveUsers/ActiveUsers.tsx
+++ b/src/pages/ActiveUsers/ActiveUsers.tsx
@@ -508,6 +508,7 @@ const ActiveUsers = () => {
     showTableRows,
     updateSelectedPerPage,
     updateShownElementsList: updateShownUsersList,
+    totalCount,
   };
 
   // - 'BulkSelectorUsersPrep'
@@ -705,7 +706,6 @@ const ActiveUsers = () => {
           paginationData={paginationData}
           widgetId="pagination-options-menu-top"
           isCompact={true}
-          totalCount={totalCount}
         />
       ),
       toolbarItemAlignment: { default: "alignRight" },
@@ -760,7 +760,6 @@ const ActiveUsers = () => {
           widgetId="pagination-options-menu-bottom"
           perPageComponent="button"
           className="pf-v5-u-pb-0 pf-v5-u-pr-md"
-          totalCount={totalCount}
         />
       </PageSection>
       <AddUser

--- a/src/pages/Hosts/Hosts.tsx
+++ b/src/pages/Hosts/Hosts.tsx
@@ -311,10 +311,6 @@ const Hosts = () => {
     }
   }, [isBatchLoading]);
 
-  const updateShowTableRows = (value: boolean) => {
-    setShowTableRows(value);
-  };
-
   // Dropdown kebab
   const [kebabIsOpen, setKebabIsOpen] = useState(false);
 
@@ -476,9 +472,9 @@ const Hosts = () => {
     updatePage,
     updatePerPage,
     showTableRows,
-    updateShowTableRows,
     updateSelectedPerPage,
     updateShownElementsList: updateShownHostsList,
+    totalCount,
   };
 
   // - 'BulkSelectorPrep'
@@ -636,7 +632,6 @@ const Hosts = () => {
           paginationData={paginationData}
           widgetId="pagination-options-menu-top"
           isCompact={true}
-          totalCount={totalCount}
         />
       ),
       toolbarItemAlignment: { default: "alignRight" },
@@ -680,7 +675,6 @@ const Hosts = () => {
         </div>
         <PaginationPrep
           list={hostsList}
-          totalCount={totalCount}
           paginationData={paginationData}
           variant={PaginationVariant.bottom}
           widgetId="pagination-options-menu-bottom"

--- a/src/pages/PreservedUsers/PreservedUsers.tsx
+++ b/src/pages/PreservedUsers/PreservedUsers.tsx
@@ -339,6 +339,7 @@ const PreservedUsers = () => {
     showTableRows,
     updateSelectedPerPage,
     updateShownElementsList: updateShownUsersList,
+    totalCount,
   };
 
   // - 'BulkSelectorPrep'
@@ -500,7 +501,6 @@ const PreservedUsers = () => {
           paginationData={paginationData}
           widgetId="pagination-options-menu-top"
           isCompact={true}
-          totalCount={totalCount}
         />
       ),
       toolbarItemAlignment: { default: "alignRight" },
@@ -555,7 +555,6 @@ const PreservedUsers = () => {
           widgetId="pagination-options-menu-bottom"
           perPageComponent="button"
           className="pf-v5-u-pb-0 pf-v5-u-pr-md"
-          totalCount={totalCount}
         />
       </PageSection>
       <ModalErrors errors={modalErrors.getAll()} />

--- a/src/pages/Services/Services.tsx
+++ b/src/pages/Services/Services.tsx
@@ -179,10 +179,6 @@ const Services = () => {
   // Show table rows
   const [showTableRows, setShowTableRows] = useState(false);
 
-  const updateShowTableRows = (value: boolean) => {
-    setShowTableRows(value);
-  };
-
   // Modals functionality
   const [showAddModal, setShowAddModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -379,9 +375,9 @@ const Services = () => {
     updatePage,
     updatePerPage,
     showTableRows,
-    updateShowTableRows,
     updateSelectedPerPage,
     updateShownElementsList: setHostsList,
+    totalCount,
   };
 
   // - 'ServicesTable'
@@ -502,7 +498,6 @@ const Services = () => {
           paginationData={paginationData}
           widgetId="pagination-options-menu-top"
           isCompact={true}
-          totalCount={totalCount}
         />
       ),
       toolbarItemAlignment: { default: "alignRight" },
@@ -552,7 +547,6 @@ const Services = () => {
           widgetId="pagination-options-menu-bottom"
           perPageComponent="button"
           className="pf-v5-u-pb-0 pf-v5-u-pr-md"
-          totalCount={totalCount}
         />
       </PageSection>
       <ModalErrors errors={modalErrors.getAll()} />

--- a/src/pages/StageUsers/StageUsers.tsx
+++ b/src/pages/StageUsers/StageUsers.tsx
@@ -343,6 +343,7 @@ const StageUsers = () => {
     showTableRows,
     updateSelectedPerPage,
     updateShownElementsList: updateShownUsersList,
+    totalCount,
   };
 
   // - 'BulkSelectorPrep'
@@ -503,7 +504,6 @@ const StageUsers = () => {
           paginationData={paginationData}
           widgetId="pagination-options-menu-top"
           isCompact={true}
-          totalCount={totalCount}
         />
       ),
       toolbarItemAlignment: { default: "alignRight" },
@@ -558,7 +558,6 @@ const StageUsers = () => {
           widgetId="pagination-options-menu-bottom"
           perPageComponent="button"
           className="pf-v5-u-pb-0 pf-v5-u-pr-md"
-          totalCount={totalCount}
         />
       </PageSection>
       <ModalErrors errors={modalErrors.getAll()} />


### PR DESCRIPTION
Current everywhere we use PaginationPrep we require paginationData object and totalCount. Really totalCount should be in the paginationData object.  This will also help reduce required props on some components.

fixes: https://github.com/freeipa/freeipa-webui/issues/309