### PR TITLE
[Integration tests] 'Certificate mapping data' field

### DIFF
--- a/src/components/Form/IpaCertificateMappingData.tsx
+++ b/src/components/Form/IpaCertificateMappingData.tsx
@@ -303,8 +303,9 @@ const IpaCertificateMappingData = (props: PropsToIpaCertificateMappingData) => {
                 flex={{ default: "flex_1" }}
                 className="pf-v5-u-mb-sm"
                 flexWrap={{ default: "nowrap" }}
+                name={"flex-certmapdata-" + idx}
               >
-                <FlexItem>
+                <FlexItem name={"flexitem-certmapdata-" + idx}>
                   <MapIcon /> {certMapData}
                 </FlexItem>
                 <FlexItem>

--- a/tests/features/steps/common.ts
+++ b/tests/features/steps/common.ts
@@ -81,7 +81,7 @@ Then("button {string} should be disabled", function (buttonText: string) {
 When(
   "in the modal dialog I click on {string} button",
   function (buttonText: string) {
-    cy.get("[role=dialog] button").contains(buttonText).click();
+    cy.get("[role=dialog] footer button").contains(buttonText).click();
     cy.wait(1000);
   }
 );

--- a/tests/features/steps/user_handling.ts
+++ b/tests/features/steps/user_handling.ts
@@ -268,3 +268,89 @@ Then("file with extension {string} should be downloaded", (ext: string) => {
   // @ts-ignore
   cy.verifyDownload("." + ext, { contains: true });
 });
+
+// Certificate mapping data
+// - Add certificate mapping data
+When("I click on Add key in the Certificate mappings section", () => {
+  cy.get('button[name="add-certificate-mapping-data"]').click();
+});
+
+When(
+  "in the modal dialog I click on {string} button under the Certificate mapping data section",
+  (buttonText: string) => {
+    cy.get("button[name=add-ipacertmapdata]").contains(buttonText).click();
+  }
+);
+
+When(
+  "I type {string} into the text input in the Certificate mapping data modal",
+  (text: string) => {
+    cy.get("div.pf-v5-c-form__group-control input[id=cert-map-data]").type(
+      text
+    );
+  }
+);
+
+Then(
+  "I should see certificate mappings with the {string} text in the Certificate mappings section",
+  (text: string) => {
+    cy.get("div.pf-v5-c-form__group").contains(text);
+  }
+);
+
+// - Add multiple certificate mapping data entries from the certificate mapping data radio button
+When(
+  "I type {string} into the text input with index {int} in the Certificate mapping data modal",
+  (text: string, idx: number) => {
+    cy.get(
+      "div.pf-v5-c-form__group-control input[name=ipacertmapdata-" + idx + "]"
+    ).type(text);
+  }
+);
+
+// - Remove certificate mapping data
+When(
+  "I click on Delete button for certificate mapping data number {int} in the Certificate mappings section",
+  (index: number) => {
+    cy.get(
+      "button[name=remove-certificate-mapping-data-" + (index - 1) + "]"
+    ).click();
+  }
+);
+
+// - Add Certificate from the 'Certificate mapping data' radio button
+When(
+  "in the modal dialog I click on Add button under the Certificate subsection",
+  () => {
+    cy.get("div[name=certificate]").next().click();
+  }
+);
+
+When(
+  "I put Certificate named {string} into the text area with index {int} in the Certificate mapping data modal",
+  (certName: string, index: number) => {
+    let selectedKey = "";
+    if (certName == "valid sample 1") {
+      selectedKey = userCert_valid_1.body;
+    } else if (certName == "valid sample 2") {
+      selectedKey = userCert_valid_2.body;
+    }
+    cy.get(
+      "div.pf-v5-c-form__group-control textarea[name=certificate-" +
+        (index - 1) +
+        "]"
+    ).type(selectedKey, { delay: 0 });
+  }
+);
+
+// - Add Issuer and object
+Then(
+  "I type {string} into the {string} text input in the Certificate mapping data modal",
+  (text: string, textInputName: string) => {
+    cy.get(
+      "div.pf-v5-c-form__group-control input[name=" +
+        textInputName.toLowerCase() +
+        "]"
+    ).type(text);
+  }
+);

--- a/tests/features/user_details.feature
+++ b/tests/features/user_details.feature
@@ -214,3 +214,55 @@ Feature: User details
       | remains | name                     | serial                                          |
       | 1       | krunoslav.hrnjak@hops.hr | 264374074076456325397645183544606453821         |
       | 0       | mshelley                 | 11594046475060613235605226731133545093594498279 |
+
+  Scenario: Adding a single Certificate mapping data from the 'Certificate mapping data' radio button
+    When I click on Add key in the Certificate mappings section
+    When in the modal dialog I check "Certificate mapping data" radio selector
+    When in the modal dialog I click on "Add" button under the Certificate mapping data section
+    When I type "Certificate test 123" into the text input in the Certificate mapping data modal
+    When in the modal dialog I click on "Add" button
+    Then I should see certificate mappings with the "Certificate test 123" text in the Certificate mappings section
+    Then I should see "success" alert with text "Added certificate mappings to user 'armadillo'"
+
+  Scenario: Add multiple Certificate mapping data entries from the 'Certificate mapping data' radio button
+    When I click on Add key in the Certificate mappings section
+    When in the modal dialog I check "Certificate mapping data" radio selector
+    When in the modal dialog I click on "Add" button under the Certificate mapping data section
+    When I type "Certificate test 321" into the text input with index 0 in the Certificate mapping data modal
+    When in the modal dialog I click on "Add" button under the Certificate mapping data section
+    When I type "Certificate test 234" into the text input with index 1 in the Certificate mapping data modal
+    When in the modal dialog I click on "Add" button under the Certificate mapping data section
+    When I type "Certificate test 345" into the text input with index 2 in the Certificate mapping data modal
+    When in the modal dialog I click on "Add" button
+    Then I should see certificate mappings with the "Certificate test 321" text in the Certificate mappings section
+    Then I should see certificate mappings with the "Certificate test 234" text in the Certificate mappings section
+    Then I should see certificate mappings with the "Certificate test 345" text in the Certificate mappings section
+    Then I should see "success" alert with text "Added certificate mappings to user 'armadillo'"
+
+  Scenario: Delete certificate mapping data entry
+    When I click on Delete button for certificate mapping data number 1 in the Certificate mappings section
+    Then I see a modal with text "Certificate test 123"
+    When in the modal dialog I click on "Delete" button
+    Then I should see "success" alert with text "Removed certificate mappings from user 'armadillo'"
+
+  Scenario: Add Certificate from the 'Certificate mapping data' radio button
+    When I click on Add key in the Certificate mappings section
+    When in the modal dialog I check "Certificate mapping data" radio selector
+    When in the modal dialog I click on Add button under the Certificate subsection
+    When I put Certificate named "valid sample 1" into the text area with index 1 in the Certificate mapping data modal
+    When in the modal dialog I click on "Add" button
+    Then I should see "success" alert with text "Added certificate mappings to user 'armadillo'"
+
+  Scenario: Add Issuer and object
+    When I click on Add key in the Certificate mappings section
+    When in the modal dialog I check "Issuer and subject" radio selector
+    When I type "O=EXAMPLE.ORG,CN=Issuer 123" into the "Issuer" text input in the Certificate mapping data modal
+    When I type "O=EXAMPLE.ORG,CN=Subject 123" into the "Subject" text input in the Certificate mapping data modal
+    When in the modal dialog I click on "Add" button
+    Then I should see "success" alert with text "Added certificate mappings to user 'armadillo'"
+
+  Scenario: Remove certificate mapping data entry
+    When I click on Delete button for certificate mapping data number 1 in the Certificate mappings section
+    Then I see a modal with text "Certificate test"
+    When in the modal dialog I click on "Delete" button
+    Then I should see "success" alert with text "Removed certificate mappings from user 'armadillo'"

--- a/tests/features/user_details.feature
+++ b/tests/features/user_details.feature
@@ -37,8 +37,8 @@ Feature: User details
     And I should see value "<firstName> <lastName>" in the field "GECOS"
     And I should see value "<class>" in the field "Class"
     Examples:
-     | firstName | lastName | jobTitle |  class   |
-     | Reginald  | Barclay  | engineer |  ipauser |
+      | firstName | lastName | jobTitle | class   |
+      | Reginald  | Barclay  | engineer | ipauser |
 
   Scenario: Change the account settings - login, password, home
     When I click in the field "User login"
@@ -57,41 +57,41 @@ Feature: User details
     And I should see value "/home/rbarclay" in the field "Home directory"
 
   Scenario: Change the account settings - SSH keys addition
-      When I click on Add key in the SSH public keys section
-      Then I see "Set SSH key" modal
-      When I put SSH key named "valid sample 1" into the text area
-      And in the modal dialog I click on "Set" button
-      Then I should see "success" alert with text "Added SSH public key to 'armadillo'"
-      And I should see 1 SSH keys in the SSH public keys section
-      When I click on Show key button for key number 1
-      Then the SSH key should match "valid sample 1"
-      * in the modal dialog I click on "Cancel" button
-      # Duplicate key
-      When I click on Add key in the SSH public keys section
-      Then I see "Set SSH key" modal
-      When I put SSH key named "valid sample 1" into the text area
-      And in the modal dialog I click on "Set" button
-      Then I should see "danger" alert with text "no modifications to be performed"
-      * in the modal dialog I click on "Cancel" button
-      And I should see 1 SSH keys in the SSH public keys section
-      # Invalid key
-      When I click on Add key in the SSH public keys section
-      Then I see "Set SSH key" modal
-      When I put SSH key named "invalid sample" into the text area
-      And in the modal dialog I click on "Set" button
-      Then I should see "danger" alert with text "invalid 'sshpubkey': invalid SSH public key"
-      * in the modal dialog I click on "Cancel" button
-      And I should see 1 SSH keys in the SSH public keys section
-      # Another valid key
-      When I click on Add key in the SSH public keys section
-      Then I see "Set SSH key" modal
-      When I put SSH key named "valid sample 2" into the text area
-      And in the modal dialog I click on "Set" button
-      Then I should see "success" alert with text "Added SSH public key to 'armadillo'"
-      And I should see 2 SSH keys in the SSH public keys section
-      When I click on Show key button for key number 2
-      Then the SSH key should match "valid sample 2"
-      * in the modal dialog I click on "Cancel" button
+    When I click on Add key in the SSH public keys section
+    Then I see "Set SSH key" modal
+    When I put SSH key named "valid sample 1" into the text area
+    And in the modal dialog I click on "Set" button
+    Then I should see "success" alert with text "Added SSH public key to 'armadillo'"
+    And I should see 1 SSH keys in the SSH public keys section
+    When I click on Show key button for key number 1
+    Then the SSH key should match "valid sample 1"
+    * in the modal dialog I click on "Cancel" button
+    # Duplicate key
+    When I click on Add key in the SSH public keys section
+    Then I see "Set SSH key" modal
+    When I put SSH key named "valid sample 1" into the text area
+    And in the modal dialog I click on "Set" button
+    Then I should see "danger" alert with text "no modifications to be performed"
+    * in the modal dialog I click on "Cancel" button
+    And I should see 1 SSH keys in the SSH public keys section
+    # Invalid key
+    When I click on Add key in the SSH public keys section
+    Then I see "Set SSH key" modal
+    When I put SSH key named "invalid sample" into the text area
+    And in the modal dialog I click on "Set" button
+    Then I should see "danger" alert with text "invalid 'sshpubkey': invalid SSH public key"
+    * in the modal dialog I click on "Cancel" button
+    And I should see 1 SSH keys in the SSH public keys section
+    # Another valid key
+    When I click on Add key in the SSH public keys section
+    Then I see "Set SSH key" modal
+    When I put SSH key named "valid sample 2" into the text area
+    And in the modal dialog I click on "Set" button
+    Then I should see "success" alert with text "Added SSH public key to 'armadillo'"
+    And I should see 2 SSH keys in the SSH public keys section
+    When I click on Show key button for key number 2
+    Then the SSH key should match "valid sample 2"
+    * in the modal dialog I click on "Cancel" button
 
   Scenario: Change the account settings - SSH keys deletion
     When I click on Delete button for key number 1
@@ -171,10 +171,10 @@ Feature: User details
     And I see a modal with text "<validTo>"
     * in the modal dialog I click on "Close" button
     * I toggle the kebab menu for certificate number <number>
- Examples:
-    | number | name                     | serial                                            | issuer        | validFrom                     | validTo                       | cn                |
-    | 1      | krunoslav.hrnjak@hops.hr | 264374074076456325397645183544606453821           | Fina RDC 2015 | Mon Oct 14 12:13:20 2019 UTC  | Thu Oct 14 12:13:20 2021 UTC  | KRUNOSLAV HRNJAK  |
-    | 2      | mshelley                 | 11594046475060613235605226731133545093594498279   | mshelley      | Wed Sep 27 09:17:49 2023 UTC  | Thu Sep 26 09:17:49 2024 UTC  | mshelley          |
+    Examples:
+      | number | name                     | serial                                          | issuer        | validFrom                    | validTo                      | cn               |
+      | 1      | krunoslav.hrnjak@hops.hr | 264374074076456325397645183544606453821         | Fina RDC 2015 | Mon Oct 14 12:13:20 2019 UTC | Thu Oct 14 12:13:20 2021 UTC | KRUNOSLAV HRNJAK |
+      | 2      | mshelley                 | 11594046475060613235605226731133545093594498279 | mshelley      | Wed Sep 27 09:17:49 2023 UTC | Thu Sep 26 09:17:49 2024 UTC | mshelley         |
 
   Scenario: Certificates - show raw certificate
     Given certificate number 1 has name "krunoslav.hrnjak@hops.hr"
@@ -197,10 +197,10 @@ Feature: User details
     And in the opened certificate kebab menu, I click on "Download" button
     Then file with extension "pem" should be downloaded
     * I toggle the kebab menu for certificate number <number>
-  Examples:
-    | number  | name                      |
-    | 1       | krunoslav.hrnjak@hops.hr  |
-    | 2       | mshelley                  |
+    Examples:
+      | number | name                     |
+      | 1      | krunoslav.hrnjak@hops.hr |
+      | 2      | mshelley                 |
 
   Scenario Outline: Certificates - deletion
     Given certificate number 1 has name "<name>"
@@ -210,7 +210,7 @@ Feature: User details
     And I see a modal with text "<serial>"
     When in the modal dialog I click on "Delete" button
     Then I should see <remains> certificates in the Certificates section
-  Examples:
-    | remains  | name                       | serial                                          |
-    | 1        | krunoslav.hrnjak@hops.hr   | 264374074076456325397645183544606453821         |
-    | 0        | mshelley                   | 11594046475060613235605226731133545093594498279 |
+    Examples:
+      | remains | name                     | serial                                          |
+      | 1       | krunoslav.hrnjak@hops.hr | 264374074076456325397645183544606453821         |
+      | 0       | mshelley                 | 11594046475060613235605226731133545093594498279 |


### PR DESCRIPTION
Tests to cover the following 'Certificate mapping data' functionality:
- Adding a single Certificate mapping data from the 'Certificate mapping data' radio button
- Add multiple Certificate mapping data entries from the 'Certificate mapping data' radio button
- Delete certificate mapping data entry
- Add Certificate from the 'Certificate mapping data' radio button
- Add Issuer and object
- Remove certificate mapping data entry