### PR TITLE
[Integration tests] 'User authentication types' field

### DIFF
--- a/tests/features/steps/common.ts
+++ b/tests/features/steps/common.ts
@@ -158,3 +158,34 @@ When("I click on kebab menu and select {string}", (buttonName: string) => {
   cy.get("#main-dropdown-kebab").click();
   cy.get("span.pf-v5-c-menu__item-text").contains(buttonName).click();
 });
+
+// Checkboxes
+Then("I should see the {string} checkbox checked", (checkboxName: string) => {
+  cy.get("div.pf-v5-c-check")
+    .find("label")
+    .contains(checkboxName)
+    .prev()
+    .should("be.checked");
+});
+
+Then("I should see the {string} checkbox unchecked", (checkboxName: string) => {
+  cy.get("div.pf-v5-c-check")
+    .find("label")
+    .contains(checkboxName)
+    .prev()
+    .should("not.be.checked");
+});
+
+When(
+  "I click on {string} checkbox in {string} section",
+  (checkboxName: string, section: string) => {
+    cy.get("div.pf-v5-c-form__group-label")
+      .contains(section)
+      .next()
+      .get("div.pf-v5-c-check")
+      .find("label")
+      .contains(checkboxName)
+      .prev()
+      .click();
+  }
+);

--- a/tests/features/user_details.feature
+++ b/tests/features/user_details.feature
@@ -266,3 +266,45 @@ Feature: User details
     Then I see a modal with text "Certificate test"
     When in the modal dialog I click on "Delete" button
     Then I should see "success" alert with text "Removed certificate mappings from user 'armadillo'"
+
+  Scenario: Select single user authentication type
+    When I click on "Password" checkbox in "User authentication types" section
+    Then I should see the "Password" checkbox checked
+    When I click on "Save" button
+    Then I should see "success" alert with text "User modified"
+    And I should see the "Password" checkbox checked
+    And I should see the "Two-factor authentication (password + OTP)" checkbox unchecked
+    And I should see the "RADIUS" checkbox unchecked
+    And I should see the "PKINIT" checkbox unchecked
+    And I should see the "Hardened password (by SPAKE or FAST)" checkbox unchecked
+    And I should see the "External Identity Provider" checkbox unchecked
+
+  Scenario: Select multiple selections of user authentication types
+    When I click on "Two-factor authentication (password + OTP)" checkbox in "User authentication types" section
+    Then I should see the "Two-factor authentication (password + OTP)" checkbox checked
+    When I click on "RADIUS" checkbox in "User authentication types" section
+    Then I should see the "RADIUS" checkbox checked
+    When I click on "PKINIT" checkbox in "User authentication types" section
+    Then I should see the "PKINIT" checkbox checked
+    When I click on "Save" button
+    Then I should see "success" alert with text "User modified"
+    And I should see the "Two-factor authentication (password + OTP)" checkbox checked
+    And I should see the "RADIUS" checkbox checked
+    And I should see the "PKINIT" checkbox checked
+    And I should see the "Hardened password (by SPAKE or FAST)" checkbox unchecked
+    And I should see the "External Identity Provider" checkbox unchecked
+
+  Scenario: Remove multiple selections of user authentication types
+    When I click on "Two-factor authentication (password + OTP)" checkbox in "User authentication types" section
+    Then I should see the "Two-factor authentication (password + OTP)" checkbox unchecked
+    When I click on "RADIUS" checkbox in "User authentication types" section
+    Then I should see the "RADIUS" checkbox unchecked
+    When I click on "PKINIT" checkbox in "User authentication types" section
+    Then I should see the "PKINIT" checkbox unchecked
+    When I click on "Save" button
+    Then I should see "success" alert with text "User modified"
+    And I should see the "Two-factor authentication (password + OTP)" checkbox unchecked
+    And I should see the "RADIUS" checkbox unchecked
+    And I should see the "PKINIT" checkbox unchecked
+    And I should see the "Hardened password (by SPAKE or FAST)" checkbox unchecked
+    And I should see the "External Identity Provider" checkbox unchecked


### PR DESCRIPTION
The integration tests should cover the 'User authentication types' field and manage the different interactions with the checkboxes.

Those tests are:
- Select single user authentication type
- Select multiple selections of user authentication types
- Remove multiple selections of user authentication types