### PR TITLE
Issue 317 - Selected entries from previous pages are not handled correctly

### DIFF
--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -99,11 +99,13 @@ const UserSettings = (props: PropsToUserSettings) => {
 
   // To handle the logic of the selectedUsersData (from
   //   the 'Disable / Enable' modal), lets use the 'selectedUsers' state
-  const uidArray: string[] = ([props.user.uid] as string[]) || [];
-  const [selectedUsers, setSelectedUsers] = React.useState<string[]>(uidArray);
+  const clearSelectedUsers = () => {
+    // Do nothing
+  };
+
   const [selectedUsersData, setSelectedUsersData] = React.useState({
-    selectedUsers: selectedUsers,
-    updateSelectedUsers: setSelectedUsers,
+    selectedUsers: [] as User[],
+    clearSelectedUsers,
   });
 
   // Data is updated on 'props.user' changes
@@ -113,10 +115,9 @@ const UserSettings = (props: PropsToUserSettings) => {
     }
 
     if (props.user.uid !== undefined) {
-      setSelectedUsers([props.user.uid]);
       setSelectedUsersData({
-        selectedUsers: [props.user.uid],
-        updateSelectedUsers: setSelectedUsers,
+        selectedUsers: [props.user] as User[],
+        clearSelectedUsers,
       });
     }
   }, [props.user]);
@@ -639,21 +640,21 @@ const UserSettings = (props: PropsToUserSettings) => {
       <ActivateStageUsers
         show={isActivateModalOpen}
         handleModalToggle={onCloseActivateModal}
-        selectedUids={selectedUsers}
+        selectedUsers={[props.user] as User[]}
         onSuccess={() => navigate(URL_PREFIX + "/stage-users")}
       />
       <StagePreservedUsers
         show={isStageModalOpen}
         handleModalToggle={onCloseStageModal}
-        selectedUsers={selectedUsers}
-        updateSelectedUsers={setSelectedUsers}
+        selectedUsers={[props.user] as User[]}
+        clearSelectedUsers={clearSelectedUsers}
         onSuccess={() => navigate(URL_PREFIX + "/preserved-users")}
       />
       <RestorePreservedUsers
         show={isRestoreModalOpen}
         handleModalToggle={onCloseRestoreModal}
-        selectedUids={selectedUsers}
-        updateSelectedUids={setSelectedUsers}
+        selectedUsers={[props.user] as User[]}
+        clearSelectedUsers={clearSelectedUsers}
         onSuccess={() => navigate(URL_PREFIX + "/preserved-users")}
       />
     </>

--- a/src/components/layouts/BulkSelectorLayout.tsx
+++ b/src/components/layouts/BulkSelectorLayout.tsx
@@ -11,6 +11,7 @@ interface PropsToBulkSelector {
   appendTo?: HTMLElement | (() => HTMLElement) | undefined;
   isOpenMenu?: boolean;
   ariaLabel?: string;
+  title?: string;
 }
 
 const BulkSelectorLayout = (props: PropsToBulkSelector) => {
@@ -19,6 +20,7 @@ const BulkSelectorLayout = (props: PropsToBulkSelector) => {
       key={props.menuKey}
       ref={props.containerRefMenu}
       className={props.selectorClassName}
+      title={props.title ? props.title : ""}
     >
       <Popper
         trigger={props.toggle}

--- a/src/components/modals/ActivateStageUsers.tsx
+++ b/src/components/modals/ActivateStageUsers.tsx
@@ -7,6 +7,8 @@ import {
   TextContent,
   TextVariants,
 } from "@patternfly/react-core";
+// Data types
+import { User } from "src/utils/datatypes/globalDataTypes";
 // Layouts
 import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
 // Tables
@@ -22,7 +24,7 @@ import useAlerts from "src/hooks/useAlerts";
 export interface PropsToActivateUsers {
   show: boolean;
   handleModalToggle: () => void;
-  selectedUids: string[];
+  selectedUsers: User[];
   onSuccess: () => void;
 }
 
@@ -52,12 +54,7 @@ const ActivateStageUsers = (props: PropsToActivateUsers) => {
     },
     {
       id: "activate-users-table",
-      pfComponent: (
-        <UsersDisplayTable
-          usersToDisplay={props.selectedUids}
-          from={"stage-users"}
-        />
-      ),
+      pfComponent: <UsersDisplayTable usersToDisplay={props.selectedUsers} />,
     },
     {
       id: "no-members",
@@ -83,17 +80,17 @@ const ActivateStageUsers = (props: PropsToActivateUsers) => {
   // Stage user
   const activateUsers = () => {
     // Prepare users params
-    const uidsToActivatePayload = props.selectedUids;
+    const usersToActivatePayload = props.selectedUsers;
 
     // [API call] activate elements
-    activateUsersCommand(uidsToActivatePayload).then((response) => {
+    activateUsersCommand(usersToActivatePayload).then((response) => {
       if ("data" in response) {
         if (response.data.result) {
           // Close modal
           props.handleModalToggle();
           // Update data from Redux
-          props.selectedUids.map((user) => {
-            dispatch(removeStageUser(user[0]));
+          props.selectedUsers.map((user) => {
+            dispatch(removeStageUser(user.uid[0]));
           });
           // Set alert: success
           alerts.addAlert(

--- a/src/components/modals/DeleteHosts.tsx
+++ b/src/components/modals/DeleteHosts.tsx
@@ -7,7 +7,7 @@ import {
   Button,
 } from "@patternfly/react-core";
 // Redux
-import { useAppDispatch, useAppSelector } from "src/store/hooks";
+import { useAppDispatch } from "src/store/hooks";
 import { removeHost } from "src/store/Identity/hosts-slice";
 // Layouts
 import ModalWithFormLayout from "../layouts/ModalWithFormLayout";
@@ -18,7 +18,7 @@ import useAlerts from "src/hooks/useAlerts";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
 import { SerializedError } from "@reduxjs/toolkit";
 // Data types
-import { ErrorData } from "src/utils/datatypes/globalDataTypes";
+import { ErrorData, Host } from "src/utils/datatypes/globalDataTypes";
 // Modals
 import ErrorModal from "./ErrorModal";
 import { BatchRPCResponse, useRemoveHostsMutation } from "src/services/rpc";
@@ -29,8 +29,8 @@ interface ButtonsData {
 }
 
 interface SelectedHostsData {
-  selectedHosts: string[];
-  updateSelectedHosts: (newSelectedHosts: string[]) => void;
+  selectedHosts: Host[];
+  clearSelectedHosts: () => void;
 }
 
 export interface PropsToDeleteHosts {
@@ -47,10 +47,6 @@ const DeleteHosts = (props: PropsToDeleteHosts) => {
 
   // Alerts
   const alerts = useAlerts();
-
-  // Retrieve all hosts list from Store and make a copy
-  const hostsList = useAppSelector((state) => state.hosts.hostsList);
-  const hostsListCopy = [...hostsList];
 
   // Define the column names that will be displayed on the confirmation table.
   // - NOTE: Camel-case should match with the property to show as it is defined in the data.
@@ -79,7 +75,6 @@ const DeleteHosts = (props: PropsToDeleteHosts) => {
         <DeletedElementsTable
           mode="passing_full_data"
           elementsToDelete={props.selectedHostsData.selectedHosts}
-          elementsList={hostsListCopy}
           columnNames={deleteHostsColumnNames}
           elementType="hosts"
           idAttr="fqdn"
@@ -160,10 +155,10 @@ const DeleteHosts = (props: PropsToDeleteHosts) => {
             } else {
               // Update data from Redux
               props.selectedHostsData.selectedHosts.map((host) => {
-                dispatch(removeHost(host));
+                dispatch(removeHost(host.fqdn[0]));
               });
 
-              props.selectedHostsData.updateSelectedHosts([]);
+              props.selectedHostsData.clearSelectedHosts();
               props.buttonsData.updateIsDeleteButtonDisabled(true);
               props.buttonsData.updateIsDeletion(true);
 

--- a/src/components/modals/DeleteServices.tsx
+++ b/src/components/modals/DeleteServices.tsx
@@ -7,7 +7,7 @@ import {
   Button,
 } from "@patternfly/react-core";
 // Redux
-import { useAppDispatch, useAppSelector } from "../../store/hooks";
+import { useAppDispatch } from "../../store/hooks";
 import { removeService } from "../../store/Identity/services-slice";
 // Layouts
 import ModalWithFormLayout from "../layouts/ModalWithFormLayout";
@@ -18,7 +18,7 @@ import useAlerts from "../../hooks/useAlerts";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
 import { SerializedError } from "@reduxjs/toolkit";
 // Data types
-import { ErrorData } from "../../utils/datatypes/globalDataTypes";
+import { ErrorData, Service } from "../../utils/datatypes/globalDataTypes";
 // Modals
 import ErrorModal from "./ErrorModal";
 import {
@@ -32,8 +32,8 @@ interface ButtonsData {
 }
 
 interface SelectedElementsData {
-  selectedElements: string[];
-  updateSelectedElements: (newSelectedElements: string[]) => void;
+  selectedElements: Service[];
+  clearSelectedServices: () => void;
 }
 
 interface PropsToDeleteServices {
@@ -50,10 +50,6 @@ const DeleteServices = (props: PropsToDeleteServices) => {
 
   // Alerts
   const alerts = useAlerts();
-
-  // Retrieve all service list from Store and make a copy
-  const servicesList = useAppSelector((state) => state.services.servicesList);
-  const servicesListCopy = [...servicesList];
 
   // Define the column names that will be displayed on the confirmation table.
   // - NOTE: Camel-case should match with the property to show as it is defined in the data.
@@ -82,7 +78,6 @@ const DeleteServices = (props: PropsToDeleteServices) => {
         <DeletedElementsTable
           mode="passing_full_data"
           elementsToDelete={props.selectedServicesData.selectedElements}
-          elementsList={servicesListCopy}
           columnNames={deleteServicesColumnNames}
           elementType="services"
           idAttr="krbprincipalname"
@@ -163,10 +158,10 @@ const DeleteServices = (props: PropsToDeleteServices) => {
             } else {
               // Update data from Redux
               props.selectedServicesData.selectedElements.map((service) => {
-                dispatch(removeService(service));
+                dispatch(removeService(service.krbcanonicalname));
               });
 
-              props.selectedServicesData.updateSelectedElements([]);
+              props.selectedServicesData.clearSelectedServices();
               props.buttonsData.updateIsDeleteButtonDisabled(true);
               props.buttonsData.updateIsDeletion(true);
 

--- a/src/components/modals/DisableEnableUsers.tsx
+++ b/src/components/modals/DisableEnableUsers.tsx
@@ -7,6 +7,7 @@ import {
 } from "@patternfly/react-core";
 // Layouts
 import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
+import { User } from "src/utils/datatypes/globalDataTypes";
 // Redux
 import { useAppDispatch } from "src/store/hooks";
 import { changeStatus as changeStatusActiveUser } from "src/store/Identity/activeUsers-slice";
@@ -37,8 +38,8 @@ interface ButtonsData {
 }
 
 interface SelectedUsersData {
-  selectedUsers: string[];
-  updateSelectedUsers: (newSelectedUsers: string[]) => void;
+  selectedUsers: User[];
+  clearSelectedUsers: () => void;
 }
 
 export interface PropsToDisableEnableUsers {
@@ -93,7 +94,7 @@ const DisableEnableUsers = (props: PropsToDisableEnableUsers) => {
   };
 
   // Update changes in Redux
-  const dispatchToRedux = (newStatus: boolean, selectedUsers: string[]) => {
+  const dispatchToRedux = (newStatus: boolean, selectedUsers: User[]) => {
     if (props.from === "active-users") {
       dispatch(
         changeStatusActiveUser({
@@ -159,7 +160,7 @@ const DisableEnableUsers = (props: PropsToDisableEnableUsers) => {
 
   // Modify user status for those pages not adapted to the C.L.
   // TODO: Remove this function when the C.L. is set in all user pages
-  const oldModifyStatus = (newStatus: boolean, selectedUsers: string[]) => {
+  const oldModifyStatus = (newStatus: boolean, selectedUsers: User[]) => {
     // Update changes to Redux
     dispatchToRedux(newStatus, selectedUsers);
 
@@ -180,13 +181,13 @@ const DisableEnableUsers = (props: PropsToDisableEnableUsers) => {
     }
 
     // Reset selected users
-    props.selectedUsersData.updateSelectedUsers([]);
+    props.selectedUsersData.clearSelectedUsers();
     closeModal();
   };
 
   // Modify user status using IPA commands
   // TODO: Better Adapt this function to several use-cases
-  const modifyStatus = (newStatus: boolean, selectedUsers: string[]) => {
+  const modifyStatus = (newStatus: boolean, selectedUsers: User[]) => {
     // Prepare users params
     const uidsToChangeStatusPayload: Command[] = [];
     const changeStatusParams = {};
@@ -194,10 +195,10 @@ const DisableEnableUsers = (props: PropsToDisableEnableUsers) => {
 
     // Make the API call (depending on 'singleUser' value)
     if (props.singleUser === undefined || !props.singleUser) {
-      selectedUsers.map((uid) => {
+      selectedUsers.map((user) => {
         const payloadItem = {
           method: option,
-          params: [uid, changeStatusParams],
+          params: [user.uid, changeStatusParams],
         } as Command;
 
         uidsToChangeStatusPayload.push(payloadItem);
@@ -258,7 +259,7 @@ const DisableEnableUsers = (props: PropsToDisableEnableUsers) => {
                 }
 
                 // Reset selected users
-                props.selectedUsersData.updateSelectedUsers([]);
+                props.selectedUsersData.clearSelectedUsers();
 
                 // Refresh data
                 if (props.onRefresh !== undefined) {
@@ -296,12 +297,12 @@ const DisableEnableUsers = (props: PropsToDisableEnableUsers) => {
             alerts.addAlert(
               "enable-user-success",
               "Enabled user account '" +
-                props.selectedUsersData.selectedUsers[0] +
+                props.selectedUsersData.selectedUsers[0].uid +
                 "'",
               "success"
             );
             // Reset selected users
-            props.selectedUsersData.updateSelectedUsers([]);
+            props.selectedUsersData.clearSelectedUsers();
             // Refresh data
             if (props.onRefresh !== undefined) {
               props.onRefresh();

--- a/src/components/modals/HostsSettings/CreateKeytabElementsDeleteModal.tsx
+++ b/src/components/modals/HostsSettings/CreateKeytabElementsDeleteModal.tsx
@@ -46,7 +46,6 @@ const CreateKeytabElementsDeleteModal = (props: PropsToDelete) => {
       pfComponent: (
         <DeletedElementsTable
           mode="passing_id"
-          elementsList={props.elementsToDelete.sort()}
           elementsToDelete={props.elementsToDelete.sort()}
           columnNames={props.columnNames}
           elementType={props.elementType}

--- a/src/components/modals/HostsSettings/RetrieveKeytabElementsDeleteModal.tsx
+++ b/src/components/modals/HostsSettings/RetrieveKeytabElementsDeleteModal.tsx
@@ -46,7 +46,6 @@ const RetrieveKeytabElementsDeleteModal = (props: PropsToDelete) => {
       pfComponent: (
         <DeletedElementsTable
           mode="passing_id"
-          elementsList={props.elementsToDelete.sort()}
           elementsToDelete={props.elementsToDelete.sort()}
           columnNames={props.columnNames}
           elementType={props.elementType}

--- a/src/components/modals/RestorePreservedUsers.tsx
+++ b/src/components/modals/RestorePreservedUsers.tsx
@@ -12,6 +12,8 @@ import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
 import UsersDisplayTable from "src/components/tables/UsersDisplayTable";
 // Redux
 import { useAppDispatch } from "src/store/hooks";
+// Data types
+import { User } from "src/utils/datatypes/globalDataTypes";
 import { removeUser as removePreservedUser } from "src/store/Identity/preservedUsers-slice";
 // RPC
 import { BatchRPCResponse, useRestoreUserMutation } from "src/services/rpc";
@@ -21,8 +23,8 @@ import useAlerts from "src/hooks/useAlerts";
 export interface PropsToPreservedUsers {
   show: boolean;
   handleModalToggle: () => void;
-  selectedUids: string[];
-  updateSelectedUids: (newSelectedUids: string[]) => void;
+  selectedUsers: User[];
+  clearSelectedUsers: () => void;
   onSuccess: () => void;
 }
 
@@ -50,12 +52,7 @@ const RestorePreservedUsers = (props: PropsToPreservedUsers) => {
     },
     {
       id: "restore-users-table",
-      pfComponent: (
-        <UsersDisplayTable
-          usersToDisplay={props.selectedUids}
-          from={"preserved-users"}
-        />
-      ),
+      pfComponent: <UsersDisplayTable usersToDisplay={props.selectedUsers} />,
     },
   ];
 
@@ -71,7 +68,7 @@ const RestorePreservedUsers = (props: PropsToPreservedUsers) => {
     setBtnSpinning(true);
 
     // Prepare users params
-    const uidsToRestorePayload = props.selectedUids;
+    const uidsToRestorePayload = props.selectedUsers;
 
     // [API call] Restore elements
     executeUserRestoreCommand(uidsToRestorePayload).then((response) => {
@@ -85,12 +82,12 @@ const RestorePreservedUsers = (props: PropsToPreservedUsers) => {
           closeModal();
 
           // Update data from Redux
-          props.selectedUids.map((user) => {
-            dispatch(removePreservedUser(user[0]));
+          props.selectedUsers.map((user) => {
+            dispatch(removePreservedUser(user.uid[0]));
           });
 
           // Reset selected values
-          props.updateSelectedUids([]);
+          props.clearSelectedUsers();
 
           // Show alert: success
           let successMessage = "";

--- a/src/components/modals/StagePreservedUsers.tsx
+++ b/src/components/modals/StagePreservedUsers.tsx
@@ -21,6 +21,8 @@ import {
 } from "src/services/rpc";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
 import { SerializedError } from "@reduxjs/toolkit";
+// Data types
+import { User } from "src/utils/datatypes/globalDataTypes";
 // Modals
 import ErrorModal from "./ErrorModal";
 // Data types
@@ -31,8 +33,8 @@ import useAlerts from "src/hooks/useAlerts";
 export interface PropsToStagePreservedUsers {
   show: boolean;
   handleModalToggle: () => void;
-  selectedUsers: string[];
-  updateSelectedUsers: (newSelectedUsers: string[]) => void;
+  selectedUsers: User[];
+  clearSelectedUsers: () => void;
   onSuccess: () => void;
 }
 
@@ -60,12 +62,7 @@ const StagePreservedUsers = (props: PropsToStagePreservedUsers) => {
     },
     {
       id: "stage-users-table",
-      pfComponent: (
-        <UsersDisplayTable
-          usersToDisplay={props.selectedUsers}
-          from={"preserved-users"}
-        />
-      ),
+      pfComponent: <UsersDisplayTable usersToDisplay={props.selectedUsers} />,
     },
   ];
 
@@ -122,10 +119,10 @@ const StagePreservedUsers = (props: PropsToStagePreservedUsers) => {
 
     setBtnSpinning(true);
 
-    props.selectedUsers.map((uid) => {
+    props.selectedUsers.map((user) => {
       const payloadItem = {
         method: "user_stage",
-        params: [[uid], {}],
+        params: [[user.uid], {}],
       } as Command;
       uidsToStagePayload.push(payloadItem);
     });
@@ -159,7 +156,7 @@ const StagePreservedUsers = (props: PropsToStagePreservedUsers) => {
             });
 
             // Reset selected values
-            props.updateSelectedUsers([]);
+            props.clearSelectedUsers();
 
             // Show alert: success
             alerts.addAlert("stage-users-success", "Users staged", "success");

--- a/src/components/tables/DeletedElementsTable.tsx
+++ b/src/components/tables/DeletedElementsTable.tsx
@@ -4,7 +4,8 @@ import React, { useEffect, useState } from "react";
 import { Td, Th, Tr } from "@patternfly/react-table";
 // Layout
 import TableLayout from "src/components/layouts/TableLayout";
-
+// Data types
+import { Host, Service } from "src/utils/datatypes/globalDataTypes";
 /*
  * Goal: Show already selected elements ready to delete in a table.
  *
@@ -34,8 +35,7 @@ import TableLayout from "src/components/layouts/TableLayout";
 
 export interface PropsToDeletedElementsTable {
   mode: "passing_id" | "passing_full_data";
-  elementsList?: any[];
-  elementsToDelete: string[];
+  elementsToDelete: string[] | Host[] | Service[];
   columnNames: string[];
   elementType: string;
   idAttr: string;
@@ -44,21 +44,11 @@ export interface PropsToDeletedElementsTable {
 const DeletedElementsTable = (props: PropsToDeletedElementsTable) => {
   // TODO: Check the columnNames against the actual variable name
   //   when retrieving data from the RPC server.
-
-  const elementsToDelete: any = [];
+  let elementsToDelete: any = [];
   switch (props.mode) {
     case "passing_full_data":
-      // Given the id, retrieve full element info to display into table
-      // const elementsToDelete: any = [];
-      if (props.elementsList !== undefined) {
-        props.elementsList.map((element) => {
-          props.elementsToDelete.map((selected) => {
-            if (element[props.idAttr][0] === selected[0]) {
-              elementsToDelete.push(element);
-            }
-          });
-        });
-      }
+      // We already have our list of objs to delete
+      elementsToDelete = props.elementsToDelete;
       break;
     case "passing_id":
       props.elementsToDelete.map((userName) => {

--- a/src/components/tables/UsersDisplayTable.tsx
+++ b/src/components/tables/UsersDisplayTable.tsx
@@ -5,74 +5,12 @@ import { Td, Th, Tr } from "@patternfly/react-table";
 import TableLayout from "src/components/layouts/TableLayout";
 // Data types
 import { User } from "src/utils/datatypes/globalDataTypes";
-// Redux
-import { useAppSelector } from "src/store/hooks";
 
 export interface PropsToDisplayUsersTable {
-  usersToDisplay: string[];
-  from: "active-users" | "stage-users" | "preserved-users";
+  usersToDisplay: User[];
 }
 
 const UsersDisplayTable = (props: PropsToDisplayUsersTable) => {
-  // Retrieve all users list from Store
-  // - Active users
-  const activeUsersList = useAppSelector(
-    (state) => state.activeUsers.usersList
-  );
-  const activeUsersListCopy = [...activeUsersList];
-
-  // - Stage users
-  const stageUsersList = useAppSelector((state) => state.stageUsers.usersList);
-  const stageUsersListCopy = [...stageUsersList];
-
-  // - Preserved users
-  const preservedUsersList = useAppSelector(
-    (state) => state.preservedUsers.usersList
-  );
-  const preservedUsersListCopy = [...preservedUsersList];
-
-  // Given userIds, retrieve full user info to display into table
-  const usersToDisplay: User[] = [];
-  const [usersToDisplayList, setUsersToDisplayList] = React.useState<User[]>(
-    []
-  );
-
-  // Given its `uids`, get full user info to display
-  React.useEffect(() => {
-    switch (props.from) {
-      case "active-users":
-        activeUsersListCopy.map((user) => {
-          props.usersToDisplay.map((selected) => {
-            if (user.uid[0] === selected[0] || user.uid[0] === selected) {
-              usersToDisplay.push(user);
-            }
-          });
-        });
-        setUsersToDisplayList(usersToDisplay);
-        break;
-      case "stage-users":
-        stageUsersListCopy.map((user) => {
-          props.usersToDisplay.map((selected) => {
-            if (user.uid[0] === selected[0] || user.uid[0] === selected) {
-              usersToDisplay.push(user);
-            }
-          });
-        });
-        setUsersToDisplayList(usersToDisplay);
-        break;
-      case "preserved-users":
-        preservedUsersListCopy.map((user) => {
-          props.usersToDisplay.map((selected) => {
-            if (user.uid[0] === selected[0] || user.uid[0] === selected) {
-              usersToDisplay.push(user);
-            }
-          });
-        });
-        setUsersToDisplayList(usersToDisplay);
-        break;
-    }
-  }, [props.usersToDisplay]);
-
   // Define column names
   const columnNames = {
     userLogin: "User login",
@@ -93,7 +31,7 @@ const UsersDisplayTable = (props: PropsToDisplayUsersTable) => {
     </Tr>
   );
 
-  const body = usersToDisplayList.map((user) => (
+  const body = props.usersToDisplay.map((user) => (
     <Tr key={user.uid} id={user.uid}>
       <Td dataLabel={columnNames.userLogin}>{user.uid}</Td>
       <Td dataLabel={columnNames.firstName}>{user.givenname}</Td>

--- a/src/pages/Hosts/HostsTable.tsx
+++ b/src/pages/Hosts/HostsTable.tsx
@@ -14,11 +14,10 @@ import { Link } from "react-router-dom";
 
 interface HostsData {
   isHostSelectable: (host: Host) => boolean;
-  selectedHostIds: string[];
-  changeSelectedHostIds: (newSelectedHostIds: string[]) => void; //
+  selectedHosts: Host[];
   selectableHostsTable: Host[];
   setHostSelected: (host: Host, isSelecting?: boolean) => void;
-  updateSelectedHosts: (newSelectedHosts: string[]) => void;
+  clearSelectedHosts: () => void;
 }
 
 interface ButtonsData {
@@ -116,8 +115,17 @@ const HostsTable = (props: PropsToTable) => {
     columnIndex,
   });
 
-  const isHostSelected = (host: Host) =>
-    props.hostsData.selectedHostIds.includes(host.fqdn);
+  const isHostSelected = (host: Host) => {
+    if (
+      props.hostsData.selectedHosts.find(
+        (selectedHost) => selectedHost.fqdn[0] === host.fqdn[0]
+      )
+    ) {
+      return true;
+    } else {
+      return false;
+    }
+  };
 
   // To allow shift+click to select/deselect multiple rows
   const [recentSelectedRowIndex, setRecentSelectedRowIndex] = useState<
@@ -152,44 +160,37 @@ const HostsTable = (props: PropsToTable) => {
     props.buttonsData.updateIsDeleteButtonDisabled(false);
 
     // Update hostIdsSelected array
-    let hostIdsSelectedArray = props.hostsData.selectedHostIds;
     if (isSelecting) {
-      hostIdsSelectedArray.push(host.fqdn);
       // Increment the elements selected per page (++)
       props.paginationData.updateSelectedPerPage(
         props.paginationData.selectedPerPage + 1
       );
     } else {
-      hostIdsSelectedArray = hostIdsSelectedArray.filter(
-        (hostId) => hostId !== host.fqdn
-      );
       // Decrement the elements selected per page (--)
       props.paginationData.updateSelectedPerPage(
         props.paginationData.selectedPerPage - 1
       );
     }
-    props.hostsData.changeSelectedHostIds(hostIdsSelectedArray);
-    props.hostsData.updateSelectedHosts(hostIdsSelectedArray);
   };
 
   // Reset 'selectedHostIds' array if a delete operation has been done
   useEffect(() => {
     if (props.buttonsData.isDeletion) {
-      props.hostsData.changeSelectedHostIds([]);
+      props.hostsData.clearSelectedHosts();
       props.buttonsData.updateIsDeletion(false);
     }
   }, [props.buttonsData.isDeletion]);
 
   // Enable 'Delete' button (if any host selected)
   useEffect(() => {
-    if (props.hostsData.selectedHostIds.length > 0) {
+    if (props.hostsData.selectedHosts.length > 0) {
       props.buttonsData.updateIsDeleteButtonDisabled(false);
     }
 
-    if (props.hostsData.selectedHostIds.length === 0) {
+    if (props.hostsData.selectedHosts.length === 0) {
       props.buttonsData.updateIsDeleteButtonDisabled(true);
     }
-  }, [props.hostsData.selectedHostIds]);
+  }, [props.hostsData.selectedHosts]);
 
   // Keyboard event
   useEffect(() => {

--- a/src/pages/Services/ServicesTable.tsx
+++ b/src/pages/Services/ServicesTable.tsx
@@ -14,11 +14,10 @@ import { Link } from "react-router-dom";
 
 interface ServicesData {
   isServiceSelectable: (service: Service) => boolean;
-  selectedServiceIds: string[];
-  changeSelectedServiceIds: (newSelectedServiceIds: string[]) => void;
+  selectedServices: Service[];
   selectableServicesTable: Service[];
   setServiceSelected: (service: Service, isSelecting?: boolean) => void;
-  updateSelectedServices: (newSelectedServices: string[]) => void;
+  clearSelectedServices: () => void;
 }
 
 interface ButtonsData {
@@ -108,8 +107,18 @@ const ServicesTable = (props: PropsToTable) => {
     columnIndex,
   });
 
-  const isServiceSelected = (service: Service) =>
-    props.servicesData.selectedServiceIds.includes(service.krbcanonicalname);
+  const isServiceSelected = (service: Service) => {
+    if (
+      props.servicesData.selectedServices.find(
+        (selectedService) =>
+          selectedService.krbcanonicalname[0] === service.krbcanonicalname[0]
+      )
+    ) {
+      return true;
+    } else {
+      return false;
+    }
+  };
 
   // To allow shift+click to select/deselect multiple rows
   const [recentSelectedRowIndex, setRecentSelectedRowIndex] = useState<
@@ -151,44 +160,37 @@ const ServicesTable = (props: PropsToTable) => {
     props.buttonsData.updateIsDeleteButtonDisabled(false);
 
     // Update serviceIdsSelected array
-    let serviceIdsSelectedArray = props.servicesData.selectedServiceIds;
     if (isSelecting) {
-      serviceIdsSelectedArray.push(service.krbcanonicalname);
       // Increment the elements selected per page (++)
       props.paginationData.updateSelectedPerPage(
         props.paginationData.selectedPerPage + 1
       );
     } else {
-      serviceIdsSelectedArray = serviceIdsSelectedArray.filter(
-        (serviceId) => serviceId !== service.krbcanonicalname
-      );
       // Decrement the elements selected per page (--)
       props.paginationData.updateSelectedPerPage(
         props.paginationData.selectedPerPage - 1
       );
     }
-    props.servicesData.changeSelectedServiceIds(serviceIdsSelectedArray);
-    props.servicesData.updateSelectedServices(serviceIdsSelectedArray);
   };
 
   // Reset 'selectedServiceIds' array if a delete operation has been done
   useEffect(() => {
     if (props.buttonsData.isDeletion) {
-      props.servicesData.changeSelectedServiceIds([]);
+      props.servicesData.clearSelectedServices();
       props.buttonsData.updateIsDeletion(false);
     }
   }, [props.buttonsData.isDeletion]);
 
   // Enable 'Delete' button (if any service selected)
   useEffect(() => {
-    if (props.servicesData.selectedServiceIds.length > 0) {
+    if (props.servicesData.selectedServices.length > 0) {
       props.buttonsData.updateIsDeleteButtonDisabled(false);
     }
 
-    if (props.servicesData.selectedServiceIds.length === 0) {
+    if (props.servicesData.selectedServices.length === 0) {
       props.buttonsData.updateIsDeleteButtonDisabled(true);
     }
-  }, [props.servicesData.selectedServiceIds]);
+  }, [props.servicesData.selectedServices]);
 
   // Keyboard event
   useEffect(() => {
@@ -223,7 +225,7 @@ const ServicesTable = (props: PropsToTable) => {
   );
 
   const body = shownServicesList.map((service, rowIndex) => (
-    <Tr key={service.krbcanonicalname} id={service.krbcanonicalname}>
+    <Tr key={service.krbcanonicalname[0]} id={service.krbcanonicalname[0]}>
       <Td
         dataLabel="checkbox"
         select={{
@@ -236,7 +238,7 @@ const ServicesTable = (props: PropsToTable) => {
       />
       <Td dataLabel={columnNames.principalName}>
         <Link to={URL_PREFIX + "/services/settings"} state={service}>
-          {service.krbcanonicalname}
+          {service.krbcanonicalname[0]}
         </Link>
       </Td>
     </Tr>

--- a/src/store/Identity/activeUsers-slice.ts
+++ b/src/store/Identity/activeUsers-slice.ts
@@ -9,7 +9,7 @@ interface ActiveUsersState {
 
 interface ChangeStatusData {
   newStatus: boolean;
-  selectedUsers: string[];
+  selectedUsers: User[];
 }
 
 const initialState: ActiveUsersState = {
@@ -41,12 +41,12 @@ const activeUsersSlice = createSlice({
     },
     changeStatus: (state, action: PayloadAction<ChangeStatusData>) => {
       const newStatus = action.payload.newStatus;
-      const selectedUsersIds = action.payload.selectedUsers;
+      const selectedUsers = action.payload.selectedUsers;
 
       // Convert selectedUsersIds to Map for easier search
       const selectedUsersIdMap = new Map<string, boolean>();
-      for (let i = 0; i < selectedUsersIds.length; i++) {
-        selectedUsersIdMap.set(selectedUsersIds[i], true);
+      for (let i = 0; i < selectedUsers.length; i++) {
+        selectedUsersIdMap.set(selectedUsers[i].uid[0], true);
       }
 
       // Update nsaccountlock of selected users

--- a/src/store/Identity/preservedUsers-slice.ts
+++ b/src/store/Identity/preservedUsers-slice.ts
@@ -9,7 +9,7 @@ interface PreservedUsersState {
 
 interface ChangeStatusData {
   newStatus: boolean;
-  selectedUsers: string[];
+  selectedUsers: User[];
 }
 
 const initialState: PreservedUsersState = {
@@ -40,12 +40,12 @@ const preservedUsersSlice = createSlice({
     },
     changeStatus: (state, action: PayloadAction<ChangeStatusData>) => {
       const newStatus = action.payload.newStatus;
-      const selectedUsersIds = action.payload.selectedUsers;
+      const selectedUsers = action.payload.selectedUsers;
 
       // Convert selectedUsersIds to Map for easier search
       const selectedUsersIdMap = new Map<string, boolean>();
-      for (let i = 0; i < selectedUsersIds.length; i++) {
-        selectedUsersIdMap.set(selectedUsersIds[i], true);
+      for (let i = 0; i < selectedUsers.length; i++) {
+        selectedUsersIdMap.set(selectedUsers[i].uid[0], true);
       }
 
       // Update nsaccountlock of selected users

--- a/src/store/Identity/stageUsers-slice.ts
+++ b/src/store/Identity/stageUsers-slice.ts
@@ -9,7 +9,7 @@ interface StageUsersState {
 
 interface ChangeStatusData {
   newStatus: boolean;
-  selectedUsers: string[];
+  selectedUsers: User[];
 }
 
 const initialState: StageUsersState = {
@@ -40,12 +40,12 @@ const stageUsersSlice = createSlice({
     },
     changeStatus: (state, action: PayloadAction<ChangeStatusData>) => {
       const newStatus = action.payload.newStatus;
-      const selectedUsersIds = action.payload.selectedUsers;
+      const selectedUsers = action.payload.selectedUsers;
 
       // Convert selectedUsersIds to Map for easier search
       const selectedUsersIdMap = new Map<string, boolean>();
-      for (let i = 0; i < selectedUsersIds.length; i++) {
-        selectedUsersIdMap.set(selectedUsersIds[i], true);
+      for (let i = 0; i < selectedUsers.length; i++) {
+        selectedUsersIdMap.set(selectedUsers[i].uid[0], true);
       }
 
       // Update nsaccountlock of selected users


### PR DESCRIPTION
When switching pages or "searching", the previously selected entries are not handled correctly in the main table and in the bulkSelector component.

To fix this we no longer use multiple lists of "id's" for selected entries, but instead just maintain a single list of the actual objects (User, Service, Host)

fixes: https://github.com/freeipa/freeipa-webui/issues/317