### PR TITLE
[Integration tests] Add tests for `Selector` fields (Settings page)

### DIFF
--- a/tests/features/steps/common.ts
+++ b/tests/features/steps/common.ts
@@ -189,3 +189,57 @@ When(
       .click();
   }
 );
+
+// Selectors
+When("I click in the {string} selector field", (selectorName: string) => {
+  cy.get("div.pf-v5-c-form__group-label")
+    .contains(selectorName)
+    .parent()
+    .next()
+    .find("button.pf-v5-c-menu-toggle")
+    .click();
+});
+
+Then(
+  "in the {string} selector I should see the {string} option available to be checked",
+  (selectorName: string, option: string) => {
+    const options = cy
+      .get("div.pf-v5-c-form__group-label")
+      .contains(selectorName)
+      .parent()
+      .next()
+      .find("div.pf-v5-c-menu__content");
+    options.should("contain", option);
+  }
+);
+
+When(
+  "I select {string} option in the {string} selector",
+  (option: string, selectorName: string) => {
+    const selectorNameFound = cy
+      .get("div.pf-v5-c-form__group-label")
+      .contains(selectorName);
+    if (selectorNameFound) {
+      const itemsOptionsList = selectorNameFound
+        .parent()
+        .next()
+        .get("div.pf-v5-c-menu");
+      const itemOptionSelected = itemsOptionsList.contains(option);
+      if (itemOptionSelected) {
+        itemOptionSelected.click({ force: true });
+      }
+    }
+  }
+);
+
+Then(
+  "I should see the option {string} selected in the {string} selector",
+  (option: string, selectorName: string) => {
+    cy.get("div.pf-v5-c-form__group-label")
+      .contains(selectorName)
+      .parent()
+      .next()
+      .find("span.pf-v5-c-menu-toggle__text")
+      .contains(option);
+  }
+);

--- a/tests/features/user_details.feature
+++ b/tests/features/user_details.feature
@@ -308,3 +308,25 @@ Feature: User details
     And I should see the "PKINIT" checkbox unchecked
     And I should see the "Hardened password (by SPAKE or FAST)" checkbox unchecked
     And I should see the "External Identity Provider" checkbox unchecked
+
+  # Selector fields
+  # TODO: 'Radius proxy configuration', 'External identity provider'
+  # - 'Manager'
+  Scenario: Set 'Manager' field
+    When I click in the "Manager" selector field
+    Then in the "Manager" selector I should see the "admin" option available to be checked
+    When I select "admin" option in the "Manager" selector
+    Then I should see the option 'admin' selected in the "Manager" selector
+    When I click on "Save" button
+    Then I should see "success" alert with text "User modified"
+    Then I should see the option "admin" selected in the "Manager" selector
+
+  # - 'SMB home directory drive'
+  Scenario: Set 'SMB home directory drive' field
+    When I click in the "SMB home directory drive" selector field
+    Then in the "SMB home directory drive" selector I should see the "H:" option available to be checked
+    When I select "H:" option in the "SMB home directory drive" selector
+    Then I should see the option 'H:' selected in the "SMB home directory drive" selector
+    When I click on "Save" button
+    Then I should see "success" alert with text "User modified"
+    Then I should see the option "H:" selected in the "SMB home directory drive" selector


### PR DESCRIPTION
The integration tests cover the `Selector` fields and their interactions (in the Settings page).

Those fields are:
- `Manager` (Employee information)
- `SMB home directly drive` (User attributes for SMB services)

Some fields have not been covered because it requires first implementing the corresponding sections to add new values to the selectors (otherwise, the `No selection` option may be available only). Those are:
- `Radius proxy configuration`
- `External IdP configuration`