### PR TITLE
[Is a member of][Netgroups] 'Refresh' button functionality (Netgroups)

### DIFF
--- a/src/components/MemberOf/MemberOfNetgroups.tsx
+++ b/src/components/MemberOf/MemberOfNetgroups.tsx
@@ -84,6 +84,10 @@ const memberOfNetgroups = (props: MemberOfNetroupsProps) => {
     }
   }, [netgroupsFullList]);
 
+  React.useEffect(() => {
+    netgroupsQuery.refetch();
+  }, [props.user]);
+
   // Other states
   const [netgroupsSelected, setNetgroupsSelected] = React.useState<string[]>(
     []
@@ -105,6 +109,11 @@ const memberOfNetgroups = (props: MemberOfNetroupsProps) => {
     setShownNetgroups(paginate(netgroupsFromUser, page, perPage));
   }, [netgroupsFromUser]);
 
+  // Buttons functionality
+  // - Refresh
+  const isRefreshButtonEnabled =
+    !netgroupsQuery.isFetching && !props.isUserDataLoading;
+
   return (
     <>
       <alerts.ManagedAlerts />
@@ -113,7 +122,7 @@ const memberOfNetgroups = (props: MemberOfNetroupsProps) => {
         onSearchTextChange={setSearchValue}
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         onSearch={() => {}}
-        refreshButtonEnabled={true}
+        refreshButtonEnabled={isRefreshButtonEnabled}
         onRefreshButtonClick={props.onRefreshUserData}
         deleteButtonEnabled={someItemSelected}
         // eslint-disable-next-line @typescript-eslint/no-empty-function


### PR DESCRIPTION
The 'Refresh' button should refetch the data related to the netgroups of a given user. The solution has been implemented
taking the `refetch` functionality.