### PR TITLE
Issue 330 - Add tests for Hosts page

### DIFF
--- a/src/components/modals/AddHost.tsx
+++ b/src/components/modals/AddHost.tsx
@@ -331,13 +331,13 @@ const AddHost = (props: PropsToAddHost) => {
       ),
     },
     {
-      id: "description",
+      id: "host-desc",
       name: "Description",
       pfComponent: (
         <TextInput
           type="text"
           id="modal-form-host-desc"
-          name="description"
+          name="modal-form-host-desc"
           value={description}
           onChange={(_event, value: string) => hostDescHandler(value)}
           ref={hostDescRef}
@@ -351,7 +351,7 @@ const AddHost = (props: PropsToAddHost) => {
         <TextInput
           type="text"
           id="modal-form-host-class"
-          name="userclass"
+          name="modal-form-host-class"
           value={hostClass}
           onChange={(_event, value: string) => hostClassHandler(value)}
           ref={hostClassRef}
@@ -366,7 +366,7 @@ const AddHost = (props: PropsToAddHost) => {
           <TextInput
             type="text"
             id="modal-form-host-ip-address"
-            name="ip_address"
+            name="modal-form-host-ip-address"
             value={hostIpAddress}
             onChange={(_event, value: string) => hostIpAddressHandler(value)}
             ref={hostIpAddressRef}
@@ -394,7 +394,7 @@ const AddHost = (props: PropsToAddHost) => {
             isChecked={forceCheckbox}
             aria-label="force host name checkbox"
             id="forceCheckbox"
-            name="force"
+            name="forceCheckbox"
             value="force"
             onChange={handleForceCheckbox}
             isDisabled={hostIpAddressValidation.isError || hostIpAddress === ""}
@@ -416,7 +416,7 @@ const AddHost = (props: PropsToAddHost) => {
           isChecked={generateOtpCheckbox}
           aria-label="Generate OTP checkbox"
           id="generateOtpCheckbox"
-          name="random"
+          name="generateOtpCheckbox"
           value="generateotp"
           onChange={handleOtpCheckbox}
         />
@@ -431,7 +431,7 @@ const AddHost = (props: PropsToAddHost) => {
           isChecked={noMembershipCheckbox}
           aria-label="Suppress membership attributes checkbox"
           id="noMembershipCheckbox"
-          name="nomembership"
+          name="noMembershipCheckbox"
           value="nomembership"
           onChange={handleNoMembershipCheckbox}
           className="pf-v5-u-mb-md"

--- a/tests/features/host_handling.feature
+++ b/tests/features/host_handling.feature
@@ -1,0 +1,90 @@
+Feature: Host manipulationaddfullhost
+  Create, and delete hosts
+
+  Background:
+    Given I am logged in as "Administrator"
+    Given I am on "hosts" page
+
+  Scenario: Add a new host
+    When I click on "Add" button
+    * I type in the field "Host name" text "myfirstserver"
+    * in the modal dialog I click on "Add" button
+    * I should see "success" alert with text "New host added"
+    Then I should see partial "myfirstserver" entry in the data table
+
+  Scenario: Add a new host with all fields set
+    When I click on "Add" button
+    * I type in the field "Host name" text "addfullhost"
+    * I type in the field "Description" text "my description"
+    * I type in the field "Class" text "test class"
+    When in the modal dialog I click on "Add" button
+    * I should see "success" alert with text "New host added"
+    Then I should see partial "addfullhost" entry in the data table
+    * entry "addfullhost" should have attribute "Description" set to "my description"
+
+  Scenario: Add a new host with all checkboxes set
+    When I click on "Add" button
+    * I type in the field "Host name" text "addChkBoxhost"
+    * I type in the field "IP address" text "1.1.1.1"
+    * I click on "Force" checkbox in modal
+    * I click on "Generate OTP" checkbox in modal
+    * I click on "Suppress processing" checkbox in modal
+    When in the modal dialog I click on "Add" button
+    * I should see "success" alert with text "New host added"
+    Then I should see partial "addchkboxhost" entry in the data table
+
+  Scenario: Add one user after another
+    When I click on "Add" button
+    * I type in the field "Host name" text "myserver2"
+    * in the modal dialog I click on "Add and add another" button
+    * I should see "success" alert with text "New host added"
+    * I type in the field "Host name" text "myserver3"
+    * in the modal dialog I click on "Add" button
+    * I should see "success" alert with text "New host added"
+    Then I should see partial "myfirstserver" entry in the data table
+    Then I should see partial "myserver2" entry in the data table
+    Then I should see partial "myserver3" entry in the data table
+
+  Scenario: Delete a host
+    Given I should see partial "myfirstserver" entry in the data table
+    Given I should see partial "addfullhost" entry in the data table
+    Then I select partial entry "myfirstserver" in the data table
+    Then I select partial entry "addfullhost" in the data table
+    When I click on "Delete" button
+    * I see "Remove hosts" modal
+    * I should see partial "myfirstserver" entry in the data table
+    * I should see partial "addfullhost" entry in the data table
+    When in the modal dialog I click on "Delete" button
+    * I should see "success" alert with text "Hosts removed"
+    Then I should not see "myfirstserver" entry in the data table
+    Then I should not see "addfullhost" entry in the data table
+
+  Scenario: Delete many hosts
+    Given I should see partial "myserver2" entry in the data table
+    Given I should see partial "myserver3" entry in the data table
+    Given I should see partial "addchkboxhost" entry in the data table
+    Then I select partial entry "myserver2" in the data table
+    Then I select partial entry "myserver3" in the data table
+    Then I select partial entry "addchkboxhost" in the data table
+    When I click on "Delete" button
+    * I see "Remove hosts" modal
+    * I should see partial "myserver2" entry in the data table
+    * I should see partial "myserver3" entry in the data table
+    * I should see partial "addchkboxhost" entry in the data table
+    When in the modal dialog I click on "Delete" button
+    * I should see "success" alert with text "Hosts removed"
+    Then I should not see "myserver2" entry in the data table
+    Then I should not see "myserver3" entry in the data table
+    Then I should not see "addchkboxhost" entry in the data table
+
+  Scenario: Cancel creation of a host
+    When I click on "Add" button
+    * I type in the field "Host name" text "cancelhost"
+    * in the modal dialog I click on "Cancel" button
+    Then I should not see "cancelhost" entry in the data table
+
+  Scenario: Rebuild auto membership
+    When I click on kebab menu and select "Rebuild auto membership"
+    * I see "Confirmation" modal
+    When in the modal dialog I click on "OK" button
+    * I should see "success" alert with text "Success alert:Automember rebuild membership task completed"

--- a/tests/features/steps/common.ts
+++ b/tests/features/steps/common.ts
@@ -138,12 +138,28 @@ Then("I should see {string} entry in the data table", (name: string) => {
 Then("I should not see {string} entry in the data table", (name: string) => {
   cy.get("tr[id=" + name + "]").should("not.exist");
 });
+
 Then(
   "entry {string} should have attribute {string} set to {string}",
   function (name: string, column: string, value: string) {
-    cy.get("tr[id=" + name + "] td[data-label=" + column + "]").contains(value);
+    cy.get("tr[id^=" + name + "] td[data-label=" + column + "]").contains(
+      value
+    );
   }
 );
+
+// Data table - but we only know the starting value of the entry so we
+// use "id^="
+Then(
+  "I should see partial {string} entry in the data table",
+  (name: string) => {
+    cy.get("tr[id^=" + name + "]").should("be.visible");
+  }
+);
+
+When("I select partial entry {string} in the data table", (name: string) => {
+  cy.get("tr[id^=" + name + "] input[type=checkbox]").check();
+});
 
 // Notifications
 Then(
@@ -189,6 +205,14 @@ When(
       .click();
   }
 );
+
+When("I click on {string} checkbox in modal", (checkboxName: string) => {
+  cy.get("div.pf-v5-c-check")
+    .find("label")
+    .contains(checkboxName)
+    .prev()
+    .click();
+});
 
 // Selectors
 When("I click in the {string} selector field", (selectorName: string) => {


### PR DESCRIPTION
Add tests for adding/deleting hosts, and automember rebuild

Since we don't know the host name I created "partial" functions for elements that "start with" a value, instead of searching for the entire value.

Fixes: https://github.com/freeipa/freeipa-webui/issues/330