### PR TITLE
[Integration tests] 'Is a member of' section

### DIFF
--- a/src/components/MemberOf/MemberOfTableUserGroups.tsx
+++ b/src/components/MemberOf/MemberOfTableUserGroups.tsx
@@ -27,7 +27,7 @@ const UserGroupsTableBody = (props: {
   return (
     <>
       {userGroups.map((userGroup, index) => (
-        <Tr key={index}>
+        <Tr key={index} id={userGroup.cn}>
           {props.showCheckboxColumn && (
             <Td
               select={{

--- a/tests/features/steps/common.ts
+++ b/tests/features/steps/common.ts
@@ -359,3 +359,22 @@ Then(
       .should("not.exist");
   }
 );
+
+// Search
+When("I type {string} in the search field", (searchText: string) => {
+  cy.get("div.pf-v5-c-toolbar input[name=search]")
+    // cy.get("div.pf-v5-c-text-input-group__text-input")
+    .eq(0)
+    .type(searchText, { force: true });
+});
+
+Then(
+  "I should see the {string} text in the search input field",
+  (searchText: string) => {
+    cy.get("input[name=search]").should("have.value", searchText);
+  }
+);
+
+When("I click on the arrow icon to perform search", () => {
+  cy.get("button[aria-label=Search]").eq(0).click();
+});

--- a/tests/features/steps/user_handling.ts
+++ b/tests/features/steps/user_handling.ts
@@ -354,3 +354,141 @@ Then(
     ).type(text);
   }
 );
+
+// 'Is a member of' section
+Given("I click on the Is a member of section", () => {
+  cy.get("button[name=memberof-details]").click();
+});
+
+Then(
+  "I am on {string} user > Is a member of > {string} section",
+  (username: string, sectionName: string) => {
+    cy.url().then(($url) => {
+      if ($url.includes("settings")) {
+        cy.get(".pf-v5-c-breadcrumb__item")
+          .contains(username)
+          .should("be.visible");
+        cy.get("h1>p").contains(username).should("be.visible");
+        cy.get("button[name='memberof-details']")
+          .should("have.attr", "aria-selected", "true")
+          .contains("Is a member of");
+        cy.get("li.pf-v5-c-tabs__item")
+          .children()
+          .get("button[name='memberof_group']")
+          .contains(sectionName);
+        cy.wait(3000);
+      }
+    });
+  }
+);
+
+When(
+  "I click on the {string} tab within Is a member of section",
+  (tabName: string) => {
+    cy.get("button[name=memberof_group]").contains(tabName).click();
+  }
+);
+
+Then("I should see {string} tab is selected", (tabName: string) => {
+  cy.get("button[name=memberof_group]")
+    .should("have.attr", "aria-selected", "true")
+    .contains(tabName);
+});
+
+Then("I should see the table with {string} column", (columnName: string) => {
+  cy.get("th").contains(columnName).should("be.visible");
+});
+
+Then(
+  "I should see the element {string} in the table",
+  (tableElement: string) => {
+    cy.get("table>tbody")
+      .find("td")
+      .contains(tableElement)
+      .should("be.visible");
+  }
+);
+
+Then(
+  "I should not see the element {string} in the table",
+  (tableElement: string) => {
+    cy.get("table>tbody").find("td").contains(tableElement).should("not.exist");
+  }
+);
+
+// - Add
+When(
+  "I click on {string} button located in the toolbar",
+  (buttonName: string) => {
+    cy.get("div.pf-v5-c-toolbar").find("button").contains(buttonName).click();
+  }
+);
+
+Then("I should see the dialog with title {string}", (dialogTitle: string) => {
+  cy.get("div[role='dialog'")
+    .find("h1")
+    .contains(dialogTitle)
+    .should("be.visible");
+});
+
+When(
+  "I move user {string} from the available list and move it to the chosen options",
+  (userName: string) => {
+    // Select and add the 'userName' to the chosen list
+    cy.get("div[role='dialog'")
+      .find("div.pf-v5-c-dual-list-selector__menu")
+      .find("span")
+      .contains(userName)
+      .parent()
+      .parent()
+      .parent()
+      .click();
+    // Add the user to the chosen list
+    cy.get("button[aria-label='Add selected'").click();
+    // Check if 'userName' is in the chosen list
+    cy.get("div.pf-m-chosen")
+      .find("div.pf-v5-c-dual-list-selector__menu")
+      .find("span")
+      .contains(userName);
+  }
+);
+
+Then(
+  "I should not see the element {string} in the add list",
+  (elementName: string) => {
+    // Open 'Add' dialog
+    cy.get("div.pf-v5-c-toolbar").find("button").contains("Add").click();
+    // Check if 'elementName' is in the available list
+    cy.get("div[role='dialog'")
+      .find("div.pf-v5-c-dual-list-selector__menu")
+      .find("span")
+      .contains(elementName)
+      .should("not.exist");
+  }
+);
+
+// - Delete
+Then(
+  "the {string} group name should be in the dialog table",
+  (groupName: string) => {
+    cy.get("div[role='dialog'")
+      .find("table#member-of-table")
+      .find("td.pf-v5-c-table__td")
+      .contains(groupName)
+      .should("be.visible");
+  }
+);
+
+Then(
+  "removed element {string} is back to the add list",
+  (deletedElement: string) => {
+    // Open 'Add' dialog
+    cy.get("div.pf-v5-c-toolbar").find("button").contains("Add").click();
+    // Check if 'deletedElement' is in the available list
+    cy.get("div[role='dialog'")
+      .find("div.pf-v5-c-dual-list-selector__menu")
+      .find("span")
+      .contains(deletedElement)
+      .should("be.visible");
+  }
+);

--- a/tests/features/user_is_member_of.feature
+++ b/tests/features/user_is_member_of.feature
@@ -1,0 +1,90 @@
+Feature: User is a member of
+  Work with user Is a member of section and its operations in all the available tabs
+
+  # TODO: Add pending tests for:
+  #          - 'Roles', 'HBAC rules', and 'Sudo rules' tabs
+  #          - Elements to add match with the ones available (in other pages)
+  #          - Membership
+  #          - Pagination functionality (with more elements in the table)
+
+  Background:
+    Given I am logged in as "Administrator"
+    Given I am on "active-users" page
+    Given sample testing user "armadillo" exists
+    Given I click on "armadillo" entry in the data table
+    Given I click on the Is a member of section
+    Given I am on "armadillo" user > Is a member of > "User groups" section
+
+  # 'User groups' tab
+  Scenario: Default user groups are displayed in the table
+    When I click on the "User groups" tab within Is a member of section
+    Then I should see "User groups" tab is selected
+    And I should see the table with "Group name" column
+    And I should see the table with "GID" column
+    And I should see the table with "Description" column
+    And I should see the element "ipausers" in the table
+
+  Scenario: Add a set of users into the user groups
+    When I click on "Add" button located in the toolbar
+    Then I should see the dialog with title "Add 'armadillo' into User groups"
+    When I move user "editors" from the available list and move it to the chosen options
+    # TODO: Aditionally, add more users to the chosen options
+    And in the modal dialog I click on "Add" button
+    Then I should see the element "editors" in the table
+    And I should see the element "ipausers" in the table
+    * I should not see the element "editors" in the add list
+
+  Scenario: Search for a user group
+    When I type "editors" in the search field
+    Then I should see the "editors" text in the search input field
+    When I click on the arrow icon to perform search
+    Then I should see the element "editors" in the table
+    And I should not see the element "ipausers" in the table
+
+  Scenario: Delete a set of users from the user groups
+    When I select entry "editors" in the data table
+    # TODO: Additionally, select more users to remove
+    And I click on "Delete" button located in the toolbar
+    Then I should see the dialog with title "Delete user from user groups"
+    And the "editors" group name should be in the dialog table
+    When in the modal dialog I click on "Delete" button
+    Then I should see "success" alert with text "Removed members from user group 'armadillo'"
+    And I should not see the element "editors" in the table
+    * I should see the element "ipausers" in the table
+    * removed element "editors" is back to the add list
+
+  # 'Netgroups' tab
+  Scenario: Default user groups are displayed in the table
+    When I click on the "User groups" tab within Is a member of section
+    Then I should see "User groups" tab is selected
+    And I should see the table with "Group name" column
+    And I should see the table with "GID" column
+    And I should see the table with "Description" column
+    And I should see the element "ipausers" in the table
+
+  Scenario: Add a set of users into the user groups
+    When I click on "Add" button located in the toolbar
+    Then I should see the dialog with title "Add 'armadillo' into User groups"
+    When I move user "editors" from the available list and move it to the chosen options
+    # TODO: Aditionally, add more users to the chosen options
+    And in the modal dialog I click on "Add" button
+    Then I should see the element "editors" in the table
+    And I should see the element "ipausers" in the table
+
+  Scenario: Search for a user group
+    When I type "editors" in the search field
+    Then I should see the "editors" text in the search input field
+    When I click on the arrow icon to perform search
+    Then I should see the element "editors" in the table
+    And I should not see the element "ipausers" in the table
+
+  Scenario: Delete a set of users from the user groups
+    When I select entry "editors" in the data table
+    # TODO: Additionally, select more users to remove
+    And I click on "Delete" button located in the toolbar
+    Then I should see the dialog with title "Delete user from user groups"
+    And the "editors" group name should be in the dialog table
+    When in the modal dialog I click on "Delete" button
+    Then I should see "success" alert with text "Removed members from user group 'armadillo'"
+    And I should not see the element "editors" in the table
+    * I should see the element "ipausers" in the table


### PR DESCRIPTION
The integration tests for the 'Is a member of' section should cover (at least) the following cases for all the tabs (`User groups`, `Netgroups`, `Roles`, `HBAC rules`, `Sudo rules`):
- Check if the default elements are shown in the table
- Add new elements to the table
- Remove elements from the table
- Search an element from the table
- Show elements based on its membership

The solution provided doesn't cover all the specified cases because some areas/tabs are is still under development, so more tests will be added to this suite in the future.