### PR TITLE
Reset page when changing membership type

### DIFF
--- a/src/components/MemberOf/MemberOfNetgroups.tsx
+++ b/src/components/MemberOf/MemberOfNetgroups.tsx
@@ -235,6 +235,7 @@ const memberOfNetgroups = (props: MemberOfNetroupsProps) => {
     } else {
       setShownNetgroups(netgroupsFromUser);
     }
+    setPage(1);
   }, [membershipDirection, props.user]);
 
   // Buttons functionality

--- a/src/components/MemberOf/MemberOfUserGroups.tsx
+++ b/src/components/MemberOf/MemberOfUserGroups.tsx
@@ -186,6 +186,7 @@ const MemberOfUserGroups = (props: MemberOfUserGroupsProps) => {
     } else {
       setShownUserGroups(userGroupsFromUser);
     }
+    setPage(1);
   }, [membershipDirection, props.user]);
 
   // Buttons functionality


### PR DESCRIPTION
The page index doesn't reset when changing the membership type, causing pagination errors and empty pages if the number of elements between `direct` and `indirect` don't match.

E.g., In 'Is a member of' section > 'User groups' tab, there are 12 elements in the direct table and 3 elements in the indirect one. The pagination is limited to 10 elements per page, and membership is set to `Direct`. The table elements dissapear when moving to the second page and changing the type to indirect.

Fixes: https://github.com/freeipa/freeipa-webui/issues/346