### PR TITLE
Fix available elements not shown in add

### DIFF
--- a/src/components/MemberOf/MemberOfNetgroups.tsx
+++ b/src/components/MemberOf/MemberOfNetgroups.tsx
@@ -71,7 +71,7 @@ const memberOfNetgroups = (props: MemberOfNetroupsProps) => {
     no_user: uid,
     apiVersion: API_VERSION_BACKUP,
     startIdx: firstUserIdx,
-    stopIdx: lastUserIdx,
+    stopIdx: 100, // Limited to max. 100 netgroups to show in the dual selector
   });
 
   const [netgroupsFullList, setNetgroupsFullList] = React.useState<Netgroup[]>(

--- a/src/hooks/useUserMemberOfData.tsx
+++ b/src/hooks/useUserMemberOfData.tsx
@@ -36,7 +36,7 @@ const useUserMemberOfData = ({
     no_user: uid,
     apiVersion: API_VERSION_BACKUP,
     startIdx: firstUserIdx,
-    stopIdx: lastUserIdx,
+    stopIdx: 100, // Limited to max. 100 groups to show in the dual selector
   });
 
   const [userGroupsFullList, setUserGroupsFullList] = React.useState<


### PR DESCRIPTION
Not all the available elements are being shown in the dual selector when opening the 'Add' modal, preventing those to be
added. This is due to the limitation performed in the query when retrieving the elements that are not being assigned
to a given user.

This issue was affecting the following elements: `User groups`, `Netgroups`.

Fixes: https://github.com/freeipa/freeipa-webui/issues/348