### PR TITLE
Issue 352 - paginate function uses wrong ending index

### DIFF
--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -322,6 +322,6 @@ export function paginate<Type>(
   perPage: number
 ): Type[] {
   const startIdx = (page - 1) * perPage;
-  const endIdx = perPage * page - 1;
+  const endIdx = perPage * page;
   return array.slice(startIdx, endIdx);
 }


### PR DESCRIPTION
Javascript slice() function does not include the ending index. In paginate() we assume that it does, and it's always one index short of the desired result.

Fixes: https://github.com/freeipa/freeipa-webui/issues/352