### PR TITLE
Refactor `MemberOfRoles` component

### DIFF
--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -322,6 +322,6 @@ export function paginate<Type>(
   perPage: number
 ): Type[] {
   const startIdx = (page - 1) * perPage;
-  const endIdx = perPage * page - 1;
+  const endIdx = perPage * page;
   return array.slice(startIdx, endIdx);
 }


### PR DESCRIPTION
The `MemberOfRoles` component can be refactored to improve how the data is retrieved and managed to display elements based on `direct` and `indirect` members. This can also help to prevent pagination errors or missing elements in any of the tables (main section page or 'Add' modal one).

In this PR solution:
- Fixes an error in the paginate function: the last element was ignored. Also mentioned here: https://github.com/freeipa/freeipa-webui/pull/353
- Provides a more efficient way to get direct and indirect data and manage the results retrieved from the API calls.
- Sorts the elements to display on direct and indirect tables.
- Resets the pagination when switching the membership type.
- Applies pagination directly in the retrieved data (i.e., this is not made as part of the API call, thus preventing limitation on the data)
- Buttons enabled/disabled based on direct and indirect data status.
- Available elements (shown in 'Add' modal) updated after 'Add' and 'Delete' operations.

This PR depends on this one to be merged: https://github.com/freeipa/freeipa-webui/pull/351