### PR TITLE
refactor: user member of roles with load after paging

### DIFF
--- a/src/components/MemberOf/MemberOfAddModal.tsx
+++ b/src/components/MemberOf/MemberOfAddModal.tsx
@@ -31,6 +31,19 @@ const MemberOfAddModal = (props: PropsToAdd) => {
   const [availableOptions, setAvailableOptions] = useState<ReactNode[]>(data);
   const [chosenOptions, setChosenOptions] = useState<ReactNode[]>([]);
 
+  // Update available and chosen options when props.availableItems changes
+  useEffect(() => {
+    const newAval = data.filter((d) => !chosenOptions.includes(d));
+    setAvailableOptions(newAval);
+  }, [props.availableItems]);
+
+  // reset dialog on close
+  useEffect(() => {
+    if (!props.showModal) {
+      cleanData();
+    }
+  }, [props.showModal]);
+
   const listChange = (
     newAvailableOptions: ReactNode[],
     newChosenOptions: ReactNode[]
@@ -48,6 +61,9 @@ const MemberOfAddModal = (props: PropsToAdd) => {
           isSearchable
           availableOptions={availableOptions}
           chosenOptions={chosenOptions}
+          onAvailableOptionsSearchInputChanged={(_event, searchText) =>
+            props.onSearchTextChange(searchText)
+          }
           onListChange={(
             _event,
             newAvailableOptions: ReactNode[],
@@ -82,7 +98,7 @@ const MemberOfAddModal = (props: PropsToAdd) => {
   }, [chosenOptions]);
 
   // Add group option
-  const onClickAddGroupHandler = () => {
+  const onClickAddHandler = () => {
     const optionsToAdd: AvailableItems[] = [];
     chosenOptions.map((opt) => {
       optionsToAdd.push({
@@ -103,7 +119,7 @@ const MemberOfAddModal = (props: PropsToAdd) => {
       variant="secondary"
       isDisabled={buttonDisabled}
       form="modal-form"
-      onClick={onClickAddGroupHandler}
+      onClick={onClickAddHandler}
     >
       Add
     </Button>,

--- a/src/services/rpc.ts
+++ b/src/services/rpc.ts
@@ -1639,10 +1639,10 @@ export const useGettingNetgroupsQuery = (payloadData) => {
   return useGettingGenericQuery(payloadData);
 };
 // Roles
-export const useGettingRolesQuery = (payloadData) => {
+export const useGettingRolesQuery = (payloadData, options) => {
   payloadData["objName"] = "role";
   payloadData["objAttr"] = "cn";
-  return useGettingGenericQuery(payloadData);
+  return useGettingGenericQuery(payloadData, options);
 };
 
 // Full search wrappers


### PR DESCRIPTION
This changes users member of role page to load the roles details after paging happens and thus won't load the details of all pages right on component mount.

This might save good chunk of queries if user would be member of a lot of roles.

It also delays a search for roles and makes search window in "available items" working.

This PR was created mostly as an example, but might be also ready if liked.