### PR TITLE
Refactor: 'User groups' and 'Netgroups' tabs

### DIFF
--- a/tests/features/steps/user_handling.ts
+++ b/tests/features/steps/user_handling.ts
@@ -385,18 +385,43 @@ Then(
 When(
   "I click on the {string} tab within Is a member of section",
   (tabName: string) => {
-    cy.get("button[name=memberof_group]").contains(tabName).click();
+    cy.get("button").contains(tabName).click();
   }
 );
 
 Then("I should see {string} tab is selected", (tabName: string) => {
-  cy.get("button[name=memberof_group]")
+  let name = "group";
+  switch (tabName) {
+    case "User groups":
+      name = "group";
+      break;
+    case "Netgroups":
+      name = "netgroup";
+      break;
+    case "Roles":
+      name = "role";
+      break;
+    case "HBAC rules":
+      name = "hbacrule";
+      break;
+    case "Sudo rules":
+      name = "sudorule";
+      break;
+  }
+
+  cy.get("button[name=memberof_" + name + "]")
     .should("have.attr", "aria-selected", "true")
     .contains(tabName);
 });
 
 Then("I should see the table with {string} column", (columnName: string) => {
   cy.get("th").contains(columnName).should("be.visible");
+});
+
+Then("I should see an empty table", () => {
+  cy.get("table#member-of-table")
+    .find("h2.pf-v5-c-empty-state__title-text")
+    .contains("No results found");
 });
 
 Then(
@@ -469,7 +494,7 @@ Then(
 
 // - Delete
 Then(
-  "the {string} group name should be in the dialog table",
+  "the {string} element should be in the dialog table",
   (groupName: string) => {
     cy.get("div[role='dialog'")
       .find("table#member-of-table")

--- a/tests/features/user_is_member_of.feature
+++ b/tests/features/user_is_member_of.feature
@@ -26,7 +26,7 @@ Feature: User is a member of
 
   Scenario: Add a set of users into the user groups
     When I click on "Add" button located in the toolbar
-    Then I should see the dialog with title "Add 'armadillo' into User groups"
+    Then I should see the dialog with title "Assign user groups to user armadillo"
     When I move user "editors" from the available list and move it to the chosen options
     # TODO: Aditionally, add more users to the chosen options
     And in the modal dialog I click on "Add" button
@@ -45,8 +45,8 @@ Feature: User is a member of
     When I select entry "editors" in the data table
     # TODO: Additionally, select more users to remove
     And I click on "Delete" button located in the toolbar
-    Then I should see the dialog with title "Delete user from user groups"
-    And the "editors" group name should be in the dialog table
+    Then I should see the dialog with title "Delete user from User groups"
+    And the "editors" element should be in the dialog table
     When in the modal dialog I click on "Delete" button
     Then I should see "success" alert with text "Removed members from user group 'armadillo'"
     And I should not see the element "editors" in the table
@@ -54,37 +54,7 @@ Feature: User is a member of
     * removed element "editors" is back to the add list
 
   # 'Netgroups' tab
-  Scenario: Default user groups are displayed in the table
-    When I click on the "User groups" tab within Is a member of section
-    Then I should see "User groups" tab is selected
-    And I should see the table with "Group name" column
-    And I should see the table with "GID" column
-    And I should see the table with "Description" column
-    And I should see the element "ipausers" in the table
-
-  Scenario: Add a set of users into the user groups
-    When I click on "Add" button located in the toolbar
-    Then I should see the dialog with title "Add 'armadillo' into User groups"
-    When I move user "editors" from the available list and move it to the chosen options
-    # TODO: Aditionally, add more users to the chosen options
-    And in the modal dialog I click on "Add" button
-    Then I should see the element "editors" in the table
-    And I should see the element "ipausers" in the table
-
-  Scenario: Search for a user group
-    When I type "editors" in the search field
-    Then I should see the "editors" text in the search input field
-    When I click on the arrow icon to perform search
-    Then I should see the element "editors" in the table
-    And I should not see the element "ipausers" in the table
-
-  Scenario: Delete a set of users from the user groups
-    When I select entry "editors" in the data table
-    # TODO: Additionally, select more users to remove
-    And I click on "Delete" button located in the toolbar
-    Then I should see the dialog with title "Delete user from user groups"
-    And the "editors" group name should be in the dialog table
-    When in the modal dialog I click on "Delete" button
-    Then I should see "success" alert with text "Removed members from user group 'armadillo'"
-    And I should not see the element "editors" in the table
-    * I should see the element "ipausers" in the table
+  Scenario: Default netgroups are displayed in the table
+    When I click on the "Netgroups" tab within Is a member of section
+    Then I should see "Netgroups" tab is selected
+    And I should see an empty table


### PR DESCRIPTION
The `User groups` and `Netgroups` tab needs to be refactored to follow the same code consistency as the other tab sections. This refactor optimizes the usage of some components to make a better use of the API calls and the information
shown in the table.