### PR TITLE
[Is a member of][Sudo Rules] Sync table data

### DIFF
--- a/src/components/MemberOf/MemberOfAddModalOld.tsx
+++ b/src/components/MemberOf/MemberOfAddModalOld.tsx
@@ -9,7 +9,7 @@ import {
   NetgroupOld,
   RolesOld,
   HBACRulesOld,
-  SudoRules,
+  SudoRulesOld,
   HostGroup,
 } from "src/utils/datatypes/globalDataTypes";
 
@@ -30,7 +30,7 @@ export interface PropsToAdd {
     | NetgroupOld[]
     | RolesOld[]
     | HBACRulesOld[]
-    | SudoRules[]
+    | SudoRulesOld[]
     | HostGroup[];
   groupRepository: unknown[];
   updateGroupRepository: (
@@ -39,7 +39,7 @@ export interface PropsToAdd {
       | NetgroupOld[]
       | RolesOld[]
       | HBACRulesOld[]
-      | SudoRules[]
+      | SudoRulesOld[]
       | HostGroup[]
   ) => void;
   updateAvOptionsList: (args: unknown[]) => void;
@@ -51,7 +51,7 @@ export interface PropsToAdd {
 // To display all the possible data types for all the tabs (and not only the mandatory ones)
 //   an extra interface 'MemberOfElement' will be defined. This will be called when assigning
 //   a new group instead of refering to each type (UserGroupOld | NetgroupOld | Roles | HBACRulesOld |
-//   SudoRules | HostGroup).
+//   SudoRulesOld | HostGroup).
 interface MemberOfElement {
   hostGroup?: string;
   name: string;
@@ -184,9 +184,9 @@ const MemberOfAddModal = (props: PropsToAdd) => {
               optionData.description !== undefined && optionData.description,
             gid: optionData.gid !== undefined && optionData.gid,
             status: optionData.status !== undefined && optionData.status,
-          } as SudoRules);
+          } as SudoRulesOld);
           // Send updated data to table
-          props.updateGroupRepository(props.groupRepository as SudoRules[]);
+          props.updateGroupRepository(props.groupRepository as SudoRulesOld[]);
         }
         // Host groups
         if (props.tabData.tabName === "Host groups") {

--- a/src/components/MemberOf/MemberOfDeleteModalOld.tsx
+++ b/src/components/MemberOf/MemberOfDeleteModalOld.tsx
@@ -15,7 +15,7 @@ import MemberOfDeletedGroupsTable from "src/components/MemberOf/MemberOfDeletedG
 //  its variables. Just the mandatory ones ('name' and 'description') are accessible at this point.
 // To display all the possible data types for all the tabs (and not only the mandatory ones)
 //   an extra interface 'MemberOfElement' will be defined. This will be called in the 'PropsToTable'
-//   interface instead of each type (UserGroupOld | NetgroupOld | Roles | HBACRulesOld | SudoRules).
+//   interface instead of each type (UserGroupOld | NetgroupOld | Roles | HBACRulesOld | SudoRulesOld).
 interface MemberOfElement {
   name: string;
   gid?: string;

--- a/src/components/MemberOf/MemberOfDeletedGroupsTable.tsx
+++ b/src/components/MemberOf/MemberOfDeletedGroupsTable.tsx
@@ -9,7 +9,7 @@ import TableLayout from "src/components/layouts/TableLayout";
 // To display all the possible data types for all the tabs (and not only the mandatory ones)
 //   an extra interface 'MemberOfElement' will be defined. This will be assigned in the
 //   'PropsToDeleteOnTable' interface instead of each type (UserGroupOld | NetgroupOld | Roles
-//   | HBACRulesOld | SudoRules).
+//   | HBACRulesOld | SudoRulesOld).
 interface MemberOfElement {
   name: string;
   gid?: string;

--- a/src/components/MemberOf/MemberOfSudoRules.tsx
+++ b/src/components/MemberOf/MemberOfSudoRules.tsx
@@ -1,0 +1,152 @@
+import React from "react";
+// PatternFly
+import { Pagination, PaginationVariant } from "@patternfly/react-core";
+// Data types
+import { User, SudoRule } from "src/utils/datatypes/globalDataTypes";
+// Components
+import MemberOfToolbar, { MembershipDirection } from "./MemberOfToolbar";
+import MemberOfTableSudoRules from "./MemberOfTableSudoRules";
+// Hooks
+import useAlerts from "src/hooks/useAlerts";
+// RPC
+import { useGetSudoRulesInfoByNameQuery } from "src/services/rpcSudoRules";
+// Utils
+import { API_VERSION_BACKUP, paginate } from "src/utils/utils";
+
+interface MemberOfSudoRulesProps {
+  user: Partial<User>;
+  isUserDataLoading: boolean;
+  onRefreshUserData: () => void;
+}
+
+const MemberOfSudoRules = (props: MemberOfSudoRulesProps) => {
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
+  // Page indexes
+  const [page, setPage] = React.useState(1);
+  const [perPage, setPerPage] = React.useState(10);
+
+  // Other states
+  const [sudoRulesSelected, setSudoRulesSelected] = React.useState<string[]>(
+    []
+  );
+  const [searchValue, setSearchValue] = React.useState("");
+
+  // Loaded Sudo rules based on paging and member attributes
+  const [sudoRules, setSudoRules] = React.useState<SudoRule[]>([]);
+
+  // Membership direction and Sudo rules
+  const [membershipDirection, setMembershipDirection] =
+    React.useState<MembershipDirection>("direct");
+
+  const memberof_sudorule = props.user.memberof_sudorule || [];
+  const memberofindirect_sudorule = props.user.memberofindirect_sudorule || [];
+  let sudoRuleNames =
+    membershipDirection === "direct"
+      ? memberof_sudorule
+      : memberofindirect_sudorule;
+  sudoRuleNames = [...sudoRuleNames];
+
+  const getSudoRulesNameToLoad = (): string[] => {
+    let toLoad = [...sudoRuleNames];
+    toLoad.sort();
+
+    // Filter by search
+    if (searchValue) {
+      toLoad = toLoad.filter((name) =>
+        name.toLowerCase().includes(searchValue.toLowerCase())
+      );
+    }
+
+    // Apply paging
+    toLoad = paginate(toLoad, page, perPage);
+    return toLoad;
+  };
+
+  const [sudoRulesNamesToLoad, setSudoRulesNamesToLoad] = React.useState<
+    string[]
+  >(getSudoRulesNameToLoad());
+
+  // Load Sudo rules
+  const fullSudoRulesQuery = useGetSudoRulesInfoByNameQuery({
+    sudoRuleNamesList: sudoRulesNamesToLoad,
+    no_members: true,
+    version: API_VERSION_BACKUP,
+  });
+
+  // Reset page on direction change
+  React.useEffect(() => {
+    setPage(1);
+  }, [membershipDirection]);
+
+  // Refresh Sudo rules
+  React.useEffect(() => {
+    const sudoRulesNames = getSudoRulesNameToLoad();
+    setSudoRulesNamesToLoad(sudoRulesNames);
+  }, [props.user, membershipDirection, searchValue, page, perPage]);
+
+  React.useEffect(() => {
+    if (sudoRulesNamesToLoad.length > 0) {
+      fullSudoRulesQuery.refetch();
+    }
+  }, [sudoRulesNamesToLoad]);
+
+  // Update Sudo rules
+  React.useEffect(() => {
+    if (fullSudoRulesQuery.data && !fullSudoRulesQuery.isFetching) {
+      setSudoRules(fullSudoRulesQuery.data);
+    }
+  }, [fullSudoRulesQuery.data, fullSudoRulesQuery.isFetching]);
+
+  // Computed "states"
+  const someItemSelected = sudoRulesSelected.length > 0;
+  const showTableRows = sudoRules.length > 0;
+
+  return (
+    <>
+      <alerts.ManagedAlerts />
+      <MemberOfToolbar
+        searchText={searchValue}
+        onSearchTextChange={setSearchValue}
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        onSearch={() => {}}
+        refreshButtonEnabled={true}
+        onRefreshButtonClick={props.onRefreshUserData}
+        deleteButtonEnabled={someItemSelected}
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        onDeleteButtonClick={() => {}}
+        addButtonEnabled={true}
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        onAddButtonClick={() => {}}
+        membershipDirectionEnabled={true}
+        membershipDirection={membershipDirection}
+        onMembershipDirectionChange={setMembershipDirection}
+        helpIconEnabled={true}
+        totalItems={sudoRuleNames.length}
+        perPage={perPage}
+        page={page}
+        onPerPageChange={setPerPage}
+        onPageChange={setPage}
+      />
+      <MemberOfTableSudoRules
+        sudoRules={sudoRules}
+        checkedItems={sudoRulesSelected}
+        onCheckItemsChange={setSudoRulesSelected}
+        showTableRows={showTableRows}
+      />
+      <Pagination
+        className="pf-v5-u-pb-0 pf-v5-u-pr-md"
+        itemCount={sudoRuleNames.length}
+        widgetId="pagination-options-menu-bottom"
+        perPage={perPage}
+        page={page}
+        variant={PaginationVariant.bottom}
+        onSetPage={(_e, page) => setPage(page)}
+        onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+      />
+    </>
+  );
+};
+
+export default MemberOfSudoRules;

--- a/src/components/MemberOf/MemberOfTable.tsx
+++ b/src/components/MemberOf/MemberOfTable.tsx
@@ -27,7 +27,7 @@ interface ColumnNames {
 //  its variables. Just the mandatory ones ('name' and 'description') are accessible at this point.
 // To display all the possible data types for all the tabs (and not only the mandatory ones)
 //   an extra interface 'MemberOfElement' will be defined. This will be called in the 'PropsToTable'
-//   interface instead of each type (UserGroupOld | NetgroupOld | Roles | HBACRulesOld | SudoRules | HostGroup).
+//   interface instead of each type (UserGroupOld | NetgroupOld | Roles | HBACRulesOld | SudoRulesOld | HostGroup).
 interface MemberOfElement {
   name: string;
   gid?: string;

--- a/src/components/MemberOf/MemberOfTableSudoRules.tsx
+++ b/src/components/MemberOf/MemberOfTableSudoRules.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+// PatternFly
+import { Table, Tr, Th, Td, Thead, Tbody } from "@patternfly/react-table";
+// Data types
+import { SudoRule } from "src/utils/datatypes/globalDataTypes";
+// Components
+import SkeletonOnTableLayout from "../layouts/Skeleton/SkeletonOnTableLayout";
+import EmptyBodyTable from "../tables/EmptyBodyTable";
+// Utils
+import { parseEmptyString } from "src/utils/utils";
+
+export interface MemberOfSudoRulesTableProps {
+  sudoRules: SudoRule[];
+  checkedItems?: string[];
+  onCheckItemsChange?: (checkedItems: string[]) => void;
+  showTableRows: boolean;
+}
+
+// Body
+const SudoRulesTableBody = (props: {
+  sudoRules: SudoRule[];
+  showCheckboxColumn: boolean;
+  checkedItems: string[];
+  onCheckboxChange: (checked: boolean, sudoRuleName: string) => void;
+}) => {
+  const { sudoRules } = props;
+  return (
+    <>
+      {sudoRules.map((sudoRule, index) => (
+        <Tr key={index} id={sudoRule.cn}>
+          {props.showCheckboxColumn && (
+            <Td
+              select={{
+                rowIndex: index,
+                onSelect: (_e, isSelected) =>
+                  props.onCheckboxChange(isSelected, sudoRule.cn),
+                isSelected: props.checkedItems.includes(sudoRule.cn),
+              }}
+            />
+          )}
+          <Td>{sudoRule.cn}</Td>
+          <Td>{sudoRule.ipaenabledflag ? "Enabled" : "Disabled"}</Td>
+          <Td>{parseEmptyString(sudoRule.description)}</Td>
+        </Tr>
+      ))}
+    </>
+  );
+};
+
+// Define skeleton
+const skeleton = (
+  <SkeletonOnTableLayout
+    rows={4}
+    colSpan={4}
+    screenreaderText={"Loading table rows"}
+  />
+);
+
+export default function MemberOfSudoRulesTable(
+  props: MemberOfSudoRulesTableProps
+) {
+  const { sudoRules } = props;
+  if (!sudoRules || sudoRules.length <= 0) {
+    return null; // return empty placeholder
+  }
+
+  const showCheckboxColumn = props.onCheckItemsChange !== undefined;
+
+  const onCheckboxChange = (checked: boolean, groupName: string) => {
+    const originalItems = props.checkedItems || [];
+    let newItems: string[] = [];
+    if (checked) {
+      newItems = [...originalItems, groupName];
+    } else {
+      newItems = originalItems.filter((name) => name !== groupName);
+    }
+    if (props.onCheckItemsChange) {
+      props.onCheckItemsChange(newItems);
+    }
+  };
+
+  return (
+    <Table
+      aria-label="member of table"
+      name="cn"
+      variant="compact"
+      borders
+      className={"pf-v5-u-mt-md"}
+      id="member-of-table"
+      isStickyHeader
+    >
+      <Thead>
+        <Tr>
+          {props.onCheckItemsChange && <Th />}
+          <Th modifier="wrap">Rule name</Th>
+          <Th modifier="wrap">Status</Th>
+          <Th modifier="wrap">Description</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {!props.showTableRows ? (
+          skeleton
+        ) : sudoRules.length === 0 ? (
+          <EmptyBodyTable />
+        ) : (
+          <SudoRulesTableBody
+            sudoRules={sudoRules}
+            showCheckboxColumn={showCheckboxColumn}
+            onCheckboxChange={onCheckboxChange}
+            checkedItems={props.checkedItems || []}
+          />
+        )}
+      </Tbody>
+    </Table>
+  );
+}

--- a/src/components/MemberOf/MemberOfToolbarOld.tsx
+++ b/src/components/MemberOf/MemberOfToolbarOld.tsx
@@ -25,7 +25,7 @@ import {
   NetgroupOld,
   RolesOld,
   HBACRulesOld,
-  SudoRules,
+  SudoRulesOld,
   HostGroup,
 } from "src/utils/datatypes/globalDataTypes";
 // Layout
@@ -61,7 +61,7 @@ interface SettersData {
       | NetgroupOld[]
       | RolesOld[]
       | HBACRulesOld[]
-      | SudoRules[]
+      | SudoRulesOld[]
       | HostGroup[]
   ) => void;
   changeTabName: (name: string) => void;
@@ -78,14 +78,14 @@ export interface PropsToToolbar {
     | NetgroupOld[]
     | RolesOld[]
     | HBACRulesOld[]
-    | SudoRules[]
+    | SudoRulesOld[]
     | HostGroup[];
   shownItems:
     | UserGroupOld[]
     | NetgroupOld[]
     | RolesOld[]
     | HBACRulesOld[]
-    | SudoRules[]
+    | SudoRulesOld[]
     | HostGroup[];
   toolbar:
     | "user groups"

--- a/src/pages/ActiveUsers/UserMemberOf.tsx
+++ b/src/pages/ActiveUsers/UserMemberOf.tsx
@@ -15,7 +15,7 @@ import MemberOfTable from "src/components/MemberOf/MemberOfTable";
 import {
   RolesOld,
   HBACRulesOld,
-  SudoRules,
+  SudoRulesOld,
   User,
 } from "src/utils/datatypes/globalDataTypes";
 // Redux
@@ -46,7 +46,7 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
 
   // Alter the available options list to keep the state of the recently added / removed items
   const updateSudoRulesList = (newAvOptionsList: unknown[]) => {
-    sudoRulesList = newAvOptionsList as SudoRules[];
+    sudoRulesList = newAvOptionsList as SudoRulesOld[];
   };
 
   // Page indexes
@@ -132,7 +132,7 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
   };
 
   // Available data to be added as member of
-  const sudoRulesFilteredData: SudoRules[] = filterSudoRulesData();
+  const sudoRulesFilteredData: SudoRulesOld[] = filterSudoRulesData();
 
   // Number of items on the list for each repository
   const [sudoRulesRepoLength, setSudoRulesRepoLength] = useState(
@@ -144,11 +144,11 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
   //  - The slice of data to show (considering the pagination)
   //  - Number of items for a specific list
   const updateGroupRepository = (
-    groupRepository: RolesOld[] | HBACRulesOld[] | SudoRules[]
+    groupRepository: RolesOld[] | HBACRulesOld[] | SudoRulesOld[]
   ) => {
     switch (tabName) {
       case "Sudo rules":
-        setSudoRulesRepository(groupRepository as SudoRules[]);
+        setSudoRulesRepository(groupRepository as SudoRulesOld[]);
         setShownSudoRulesList(sudoRulesRepository.slice(0, perPage));
         setSudoRulesRepoLength(sudoRulesRepository.length);
         break;
@@ -199,11 +199,11 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
 
   // Update pagination
   const changeMemberGroupsList = (
-    value: RolesOld[] | HBACRulesOld[] | SudoRules[]
+    value: RolesOld[] | HBACRulesOld[] | SudoRulesOld[]
   ) => {
     switch (activeTabKey) {
       case 4:
-        setShownSudoRulesList(value as SudoRules[]);
+        setShownSudoRulesList(value as SudoRulesOld[]);
         break;
     }
   };

--- a/src/pages/Hosts/HostsMemberOf.tsx
+++ b/src/pages/Hosts/HostsMemberOf.tsx
@@ -20,7 +20,7 @@ import {
   NetgroupOld,
   RolesOld,
   HBACRulesOld,
-  SudoRules,
+  SudoRulesOld,
   Host,
 } from "src/utils/datatypes/globalDataTypes";
 // Redux
@@ -66,7 +66,7 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
     hbacRulesList = newAvOptionsList as HBACRulesOld[];
   };
   const updateSudoRulesList = (newAvOptionsList: unknown[]) => {
-    sudoRulesList = newAvOptionsList as SudoRules[];
+    sudoRulesList = newAvOptionsList as SudoRulesOld[];
   };
 
   // List of default dummy data (for each tab option)
@@ -140,7 +140,7 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
   const netgroupsFilteredData: NetgroupOld[] = filterNetgroupsData();
   const rolesFilteredData: RolesOld[] = filterRolesData();
   const hbacRulesFilteredData: HBACRulesOld[] = filterHbacRulesData();
-  const sudoRulesFilteredData: SudoRules[] = filterSudoRulesData();
+  const sudoRulesFilteredData: SudoRulesOld[] = filterSudoRulesData();
 
   // Number of items on the list for each repository
   const [hostGroupsRepoLength, setHostGroupsRepoLength] = useState(
@@ -169,7 +169,7 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
       | NetgroupOld[]
       | RolesOld[]
       | HBACRulesOld[]
-      | SudoRules[]
+      | SudoRulesOld[]
   ) => {
     switch (tabName) {
       case "Host groups":
@@ -193,7 +193,7 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
         setHbacRulesRepoLength(hbacRulesRepository.length);
         break;
       case "Sudo rules":
-        setSudoRulesRepository(groupRepository as SudoRules[]);
+        setSudoRulesRepository(groupRepository as SudoRulesOld[]);
         setShownSudoRulesList(sudoRulesRepository.slice(0, perPage));
         setSudoRulesRepoLength(sudoRulesRepository.length);
         break;
@@ -264,7 +264,7 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
       | NetgroupOld[]
       | RolesOld[]
       | HBACRulesOld[]
-      | SudoRules[]
+      | SudoRulesOld[]
   ) => {
     switch (activeTabKey) {
       case 0:
@@ -280,7 +280,7 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
         setShownHBACRulesList(value as HBACRulesOld[]);
         break;
       case 4:
-        setShownSudoRulesList(value as SudoRules[]);
+        setShownSudoRulesList(value as SudoRulesOld[]);
         break;
     }
   };

--- a/src/pages/SudoRules/SudoRules.tsx
+++ b/src/pages/SudoRules/SudoRules.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { EmptyPage } from "src/components/errors/PageErrors";
 
-const SudoRules = () => {
+const SudoRulesOld = () => {
   return <EmptyPage />;
 };
 
-export default SudoRules;
+export default SudoRulesOld;

--- a/src/services/rpc.ts
+++ b/src/services/rpc.ts
@@ -136,7 +136,8 @@ export interface GenericPayload {
     | "group"
     | "netgroups"
     | "role"
-    | "hbacrule";
+    | "hbacrule"
+    | "sudorule";
 }
 
 export interface GetEntriesPayload {
@@ -312,6 +313,18 @@ export const api = createApi({
           }
         }
 
+        if (objName === "sudorule") {
+          if (cn) {
+            params["cn"] = cn;
+          }
+          if (description) {
+            params["description"] = description;
+          }
+          if (timelimit) {
+            params["timelimit"] = timelimit;
+          }
+        }
+
         // Prevent searchValue to be null
         let parsedSearchValue = searchValue;
         if (searchValue === null || searchValue === undefined) {
@@ -347,6 +360,8 @@ export const api = createApi({
           } else if (objName === "role") {
             id = idResponseData.result.result[i] as roleType;
           } else if (objName === "hbacrule") {
+            id = idResponseData.result.result[i] as cnType;
+          } else if (objName === "sudorule") {
             id = idResponseData.result.result[i] as cnType;
           } else {
             // Unknown, should never happen

--- a/src/services/rpcSudoRules.ts
+++ b/src/services/rpcSudoRules.ts
@@ -1,0 +1,85 @@
+import {
+  api,
+  Command,
+  getBatchCommand,
+  BatchRPCResponse,
+  useGettingGenericQuery,
+} from "./rpc";
+import { apiToSudoRule } from "src/utils/sudoRulesUtils";
+import { API_VERSION_BACKUP } from "../utils/utils";
+import { SudoRule } from "../utils/datatypes/globalDataTypes";
+
+/**
+ * Sudo rules-related endpoints: getSudoRulesInfoByName
+ *
+ * API commands:
+ * - sudorule_show: https://freeipa.readthedocs.io/en/latest/api/hbacrule_show.html
+ */
+
+export interface SudoRulesShowPayload {
+  sudoRuleNamesList: string[];
+  no_members: boolean | true;
+  version: string;
+}
+
+export interface SudoRulePayload {
+  no_members: boolean | true;
+  cn?: string;
+  description?: string;
+  ipaenabledflag?: boolean;
+  usercategory?: "all";
+  hostcategory?: "all";
+  cmdcategory?: "all";
+  ipasudorunasusercategory?: "all";
+  ipasudorunasgroupcategory?: "all";
+  sudoorder?: number | 0;
+  externaluser?: string;
+  externalhost?: string;
+  ipasudorunasextuser?: string;
+  ipasudorunasextgroup?: string;
+  timelimit?: number;
+  sizelimit?: number;
+}
+
+const extendedApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    /**
+     * Given a list of Sudo rules names, show the full data of those Sudo rules
+     * @param {sudoRulesShowPayload} - Payload with Sudo rule names and options
+     * @returns {BatchRPCResponse} - Batch response
+     */
+    getSudoRulesInfoByName: build.query<SudoRule[], SudoRulesShowPayload>({
+      query: (payload) => {
+        const sudoRuleNames = payload.sudoRuleNamesList;
+        const noMembers = payload.no_members || false;
+        const apiVersion = payload.version || API_VERSION_BACKUP;
+        const sudoRuleNamesShowCommands: Command[] = sudoRuleNames.map(
+          (sudoRuleName) => ({
+            method: "sudorule_show",
+            params: [[sudoRuleName], { no_members: noMembers }],
+          })
+        );
+        return getBatchCommand(sudoRuleNamesShowCommands, apiVersion);
+      },
+      transformResponse: (response: BatchRPCResponse): SudoRule[] => {
+        const sudoRulesList: SudoRule[] = [];
+        const results = response.result.results;
+        const count = response.result.count;
+        for (let i = 0; i < count; i++) {
+          const sudoRuleData = apiToSudoRule(results[i].result);
+          sudoRulesList.push(sudoRuleData);
+        }
+        return sudoRulesList;
+      },
+    }),
+  }),
+  overrideExisting: false,
+});
+
+export const useGettingSudoRulesQuery = (payloadData) => {
+  payloadData["objName"] = "sudorule";
+  payloadData["objAttr"] = "cn";
+  return useGettingGenericQuery(payloadData);
+};
+
+export const { useGetSudoRulesInfoByNameQuery } = extendedApi;

--- a/src/store/Policy/sudoRules-slice.ts
+++ b/src/store/Policy/sudoRules-slice.ts
@@ -2,10 +2,10 @@ import { createSlice } from "@reduxjs/toolkit";
 import type { RootState } from "../store";
 import sudoRulesJson from "./sudoRules.json";
 // Data type
-import { SudoRules } from "src/utils/datatypes/globalDataTypes";
+import { SudoRulesOld } from "src/utils/datatypes/globalDataTypes";
 
 interface SudoRulesState {
-  sudoRulesList: SudoRules[];
+  sudoRulesList: SudoRulesOld[];
 }
 
 const initialState: SudoRulesState = {

--- a/src/utils/data/GroupRepositories.ts
+++ b/src/utils/data/GroupRepositories.ts
@@ -12,7 +12,7 @@ import {
   NetgroupOld,
   RolesOld,
   HBACRulesOld,
-  SudoRules,
+  SudoRulesOld,
   HostGroup,
 } from "../datatypes/globalDataTypes";
 
@@ -122,7 +122,7 @@ export let hbacRulesInitialData: HBACRulesOld[] = [
 ];
 
 // 'Sudo rules' initial data
-export let sudoRulesInitialData: SudoRules[] = [];
+export let sudoRulesInitialData: SudoRulesOld[] = [];
 
 // HOSTS
 // - 'Host groups' initial data
@@ -159,7 +159,7 @@ export let hostsHbacRulesInitialData: HBACRulesOld[] = [
 ];
 
 // - 'Sudo rules' initial data
-export let hostsSudoRulesInitialData: SudoRules[] = [];
+export let hostsSudoRulesInitialData: SudoRulesOld[] = [];
 
 // SERVICES
 // - 'Roles' initial data

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -185,9 +185,16 @@ export interface HBACRule {
   dn: string;
 }
 
-export interface SudoRules {
+export interface SudoRulesOld {
   name: string;
   status: string;
+  description: string;
+}
+
+export interface SudoRule {
+  cn: string;
+  ipaenabledflag: boolean;
+  dn: string;
   description: string;
 }
 

--- a/src/utils/sudoRulesUtils.tsx
+++ b/src/utils/sudoRulesUtils.tsx
@@ -1,0 +1,37 @@
+// Data types
+import { SudoRule } from "src/utils/datatypes/globalDataTypes";
+// Utils
+import { convertApiObj } from "./ipaObjectUtils";
+
+const simpleValues = new Set(["cn", "ipaenabledflag", "dn", "description"]);
+const dateValues = new Set([]);
+
+export function apiToSudoRule(apiRecord: Record<string, unknown>): SudoRule {
+  const converted = convertApiObj(
+    apiRecord,
+    simpleValues,
+    dateValues
+  ) as Partial<SudoRule>;
+  return partialSudoRuleToSudoRule(converted) as SudoRule;
+}
+
+export function partialSudoRuleToSudoRule(
+  partialSudoRule: Partial<SudoRule>
+): SudoRule {
+  return {
+    ...createEmptySudoRule(),
+    ...partialSudoRule,
+  };
+}
+
+// Get empty User object initialized with default values
+export function createEmptySudoRule(): SudoRule {
+  const sudoRule: SudoRule = {
+    cn: "",
+    ipaenabledflag: true,
+    dn: "",
+    description: "",
+  };
+
+  return sudoRule;
+}


### PR DESCRIPTION
The `MemberOfSudoRules` component will hold all the logic related to the 'Sudo rules' tab (i.e., table elements, action buttons, and other components). The table data was using dummy data that has been replaced by the real IPA data.