### PR TITLE
Fix: ariaLabel for password and krb5 principal expiration datepicker

### DIFF
--- a/src/components/Form/IpaCalendar.tsx
+++ b/src/components/Form/IpaCalendar.tsx
@@ -75,7 +75,7 @@ const IpaCalendar = (props: IPAParamDefinition) => {
       datetime={value}
       onChange={onDateChange}
       name={props.name}
-      ariaLabel="Kerberos principal expiration date"
+      ariaLabel={props.ariaLabel}
       isDisabled={readOnly}
     />
   );

--- a/src/components/UsersSections/UsersAccountSettings.tsx
+++ b/src/components/UsersSections/UsersAccountSettings.tsx
@@ -153,6 +153,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
             >
               <IpaCalendar
                 name={"krbpasswordexpiration"}
+                ariaLabel={"Kerberos password expiration date"}
                 ipaObject={ipaObject}
                 onChange={recordOnChange}
                 objectName="user"
@@ -194,6 +195,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
             >
               <IpaCalendar
                 name={"krbprincipalexpiration"}
+                ariaLabel={"Kerberos principal expiration date"}
                 ipaObject={ipaObject}
                 onChange={recordOnChange}
                 objectName="user"

--- a/src/utils/ipaObjectUtils.ts
+++ b/src/utils/ipaObjectUtils.ts
@@ -15,6 +15,7 @@ export interface IPAParamDefinition {
   alwaysWritable?: boolean;
   readOnly?: boolean;
   required?: boolean;
+  ariaLabel?: string;
 }
 
 export interface ParamProperties {


### PR DESCRIPTION
ipaCalendar object had hard-coded ariaLabel param; provide this param as part of prop.

Fixes: https://github.com/freeipa/freeipa-webui/issues/371