### PR TITLE
Cypress: Enable experimental memory management

### DIFF
--- a/cypress/cypress.config.ts
+++ b/cypress/cypress.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     specPattern: "**/*.feature",
     baseUrl: "https://server.ipa.demo/",
     testIsolation: false,
-
+    experimentalMemoryManagement: true,
     async setupNodeEvents(
       on: Cypress.PluginEvents,
       config: Cypress.PluginConfigOptions


### PR DESCRIPTION
To avoid crashes with massive test suites, enable experimental memory management.

Documentation: https://docs.cypress.io/guides/references/experiments