### PR TITLE
[Is a member of][Sudo rules] 'Refresh' button functionality

### DIFF
--- a/src/components/MemberOf/MemberOfSudoRules.tsx
+++ b/src/components/MemberOf/MemberOfSudoRules.tsx
@@ -103,6 +103,11 @@ const MemberOfSudoRules = (props: MemberOfSudoRulesProps) => {
   const someItemSelected = sudoRulesSelected.length > 0;
   const showTableRows = sudoRules.length > 0;
 
+  // Buttons functionality
+  // - Refresh
+  const isRefreshButtonEnabled =
+    !fullSudoRulesQuery.isFetching && !props.isUserDataLoading;
+
   return (
     <>
       <alerts.ManagedAlerts />
@@ -111,7 +116,7 @@ const MemberOfSudoRules = (props: MemberOfSudoRulesProps) => {
         onSearchTextChange={setSearchValue}
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         onSearch={() => {}}
-        refreshButtonEnabled={true}
+        refreshButtonEnabled={isRefreshButtonEnabled}
         onRefreshButtonClick={props.onRefreshUserData}
         deleteButtonEnabled={someItemSelected}
         // eslint-disable-next-line @typescript-eslint/no-empty-function


### PR DESCRIPTION
The 'Refresh' button should refetch the data related to the Sudo rules of a given user.

This PR depends on this one to be merged: https://github.com/freeipa/freeipa-webui/pull/364