### PR TITLE
Add vagrant condition for render pages

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -65,6 +65,9 @@ Vagrant.configure("2") do |config|
       Satisfy Any
       Require all granted
       RewriteEngine On
+      RewriteRule ^(.*)/js/(.*)\.(js|map)$ js/$2.$3 [L]
+      RewriteRule ^(.*)/public/images/(.*)$ public/images/$2 [L]
+      RewriteRule ^(.*)/(.*)\.(css|ico|woff2)$ $2.$3 [L]
       RewriteCond %{REQUEST_FILENAME} !-f
       RewriteRule ^ index.html [QSA,L]
     </Directory>


### PR DESCRIPTION
With the last configuration it was possible to directly access some main pages by writing the URL in the browser (e.g. Active users, Stage users, Hosts, etc.). But it was not possible to access subsections within those main pages (E.g. active users settings, 'Is a member of' section, etc.).

The current solution adds these lines to the `Vagrantfile` to rewrite the rules that make reference to the components. This
also works alongside with Webpack.

Steps to test it:
- If you have a vagrant instance running up already:
  - Access your vagrant instance via `vagrant ssh`
  - Copy the solution lines and add them to the file located in `/etc/httpd/conf.d/ipa.conf`
  - Restart httpd: `systemctl restart httpd`
- If you don't have any instance running:
  - Run `vagrant up` and the `Vagrantfile` file will take the new configuration