### PR TITLE
 Define new routes for active users sections 

### DIFF
--- a/src/components/MemberOf/MemberOfHbacRules.tsx
+++ b/src/components/MemberOf/MemberOfHbacRules.tsx
@@ -21,14 +21,29 @@ import {
 // Utils
 import { API_VERSION_BACKUP, paginate } from "src/utils/utils";
 import { apiToHBACRule } from "src/utils/hbacRulesUtils";
+// Navigation
+import { useNavigate, useParams } from "react-router-dom";
+import { URL_PREFIX } from "src/navigation/NavRoutes";
 
 interface MemberOfHbacRulesProps {
   user: Partial<User>;
+  from: string;
   isUserDataLoading: boolean;
   onRefreshUserData: () => void;
 }
 
 const MemberOfHbacRules = (props: MemberOfHbacRulesProps) => {
+  const navigate = useNavigate();
+  const { uid } = useParams();
+
+  React.useEffect(() => {
+    if (props.user && props.user.uid) {
+      navigate(
+        URL_PREFIX + "/" + props.from + "/" + uid + "/memberof_hbacrule"
+      );
+    }
+  }, [props.user]);
+
   // Alerts to show in the UI
   const alerts = useAlerts();
 

--- a/src/components/MemberOf/MemberOfNetgroups.tsx
+++ b/src/components/MemberOf/MemberOfNetgroups.tsx
@@ -22,14 +22,29 @@ import { apiToNetgroup } from "src/utils/netgroupsUtils";
 // Modals
 import MemberOfAddModal, { AvailableItems } from "./MemberOfAddModal";
 import MemberOfDeleteModal from "./MemberOfDeleteModal";
+// Navigation
+import { useNavigate, useParams } from "react-router-dom";
+import { URL_PREFIX } from "src/navigation/NavRoutes";
 
 interface MemberOfNetroupsProps {
   user: Partial<User>;
+  from: string;
   isUserDataLoading: boolean;
   onRefreshUserData: () => void;
 }
 
 const memberOfNetgroups = (props: MemberOfNetroupsProps) => {
+  const navigate = useNavigate();
+  const { uid } = useParams();
+
+  React.useEffect(() => {
+    if (props.user && props.user.uid) {
+      navigate(
+        URL_PREFIX + "/" + props.from + "/" + uid + "/memberof_netgroup"
+      );
+    }
+  }, [props.user]);
+
   // Alerts to show in the UI
   const alerts = useAlerts();
 

--- a/src/components/MemberOf/MemberOfRoles.tsx
+++ b/src/components/MemberOf/MemberOfRoles.tsx
@@ -21,13 +21,26 @@ import {
 // Utils
 import { API_VERSION_BACKUP, paginate } from "src/utils/utils";
 import { apiToRole } from "src/utils/rolesUtils";
+// Navigation
+import { useNavigate, useParams } from "react-router-dom";
+import { URL_PREFIX } from "src/navigation/NavRoutes";
 
 interface MemberOfRolesProps {
   user: Partial<User>;
+  from: string;
   isUserDataLoading: boolean;
   onRefreshUserData: () => void;
 }
 const MemberOfRoles = (props: MemberOfRolesProps) => {
+  const navigate = useNavigate();
+  const { uid } = useParams();
+
+  React.useEffect(() => {
+    if (props.user && props.user.uid) {
+      navigate(URL_PREFIX + "/" + props.from + "/" + uid + "/memberof_role");
+    }
+  }, [props.user]);
+
   // Alerts to show in the UI
   const alerts = useAlerts();
 

--- a/src/components/MemberOf/MemberOfUserGroups.tsx
+++ b/src/components/MemberOf/MemberOfUserGroups.tsx
@@ -21,14 +21,27 @@ import {
 // Utils
 import { API_VERSION_BACKUP, paginate } from "src/utils/utils";
 import { apiToGroup } from "src/utils/groupUtils";
+// Navigation
+import { useNavigate, useParams } from "react-router-dom";
+import { URL_PREFIX } from "src/navigation/NavRoutes";
 
 interface MemberOfUserGroupsProps {
   user: Partial<User>;
+  from: string;
   isUserDataLoading: boolean;
   onRefreshUserData: () => void;
 }
 
 const MemberOfUserGroups = (props: MemberOfUserGroupsProps) => {
+  const navigate = useNavigate();
+  const { uid } = useParams();
+
+  React.useEffect(() => {
+    if (props.user && props.user.uid) {
+      navigate(URL_PREFIX + "/" + props.from + "/" + uid + "/memberof_group");
+    }
+  }, [props.user]);
+
   // Alerts to show in the UI
   const alerts = useAlerts();
 

--- a/src/components/tables/UsersTable.tsx
+++ b/src/components/tables/UsersTable.tsx
@@ -240,7 +240,7 @@ const UsersTable = (props: PropsToTable) => {
         style={setStyleOnStatus(user.nsaccountlock)}
         dataLabel={columnNames.uid}
       >
-        <Link to={URL_PREFIX + "/" + props.from + "/settings"} state={user}>
+        <Link to={URL_PREFIX + "/" + props.from + "/" + user.uid} state={user}>
           {user.uid}
         </Link>
       </Td>

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -40,7 +40,29 @@ export const AppRoutes = (): React.ReactElement => (
     <Route path={URL_PREFIX}>
       <Route path="active-users">
         <Route path="" element={<ActiveUsers />} />
-        <Route path="settings" element={<ActiveUsersTabs />} />
+        <Route path=":uid">
+          <Route path="" element={<ActiveUsersTabs memberof="" />} />
+          <Route
+            path="memberof_group"
+            element={<ActiveUsersTabs memberof="group" />}
+          />
+          <Route
+            path="memberof_netgroup"
+            element={<ActiveUsersTabs memberof="netgroup" />}
+          />
+          <Route
+            path="memberof_role"
+            element={<ActiveUsersTabs memberof="role" />}
+          />
+          <Route
+            path="memberof_hbacrule"
+            element={<ActiveUsersTabs memberof="hbacrule" />}
+          />
+          <Route
+            path="memberof_rule"
+            element={<ActiveUsersTabs memberof="sudorule" />}
+          />
+        </Route>
       </Route>
       <Route path="stage-users">
         <Route path="" element={<StageUsers />} />

--- a/src/pages/ActiveUsers/UserMemberOf.tsx
+++ b/src/pages/ActiveUsers/UserMemberOf.tsx
@@ -23,6 +23,8 @@ import { convertToString } from "src/utils/ipaObjectUtils";
 
 interface PropsToUserMemberOf {
   user: User;
+  tab: string;
+  from: string;
 }
 
 const UserMemberOf = (props: PropsToUserMemberOf) => {
@@ -106,7 +108,13 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
         isFilled={false}
         className="pf-v5-u-m-lg"
       >
-        <Tabs activeKey={activeTabKey} onSelect={handleTabClick} isBox={false}>
+        <Tabs
+          activeKey={activeTabKey}
+          onSelect={handleTabClick}
+          isBox={false}
+          mountOnEnter
+          unmountOnExit
+        >
           <Tab
             eventKey={0}
             name="memberof_group"
@@ -121,6 +129,7 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
           >
             <MemberOfUserGroups
               user={user}
+              from={props.from}
               isUserDataLoading={userQuery.isFetching}
               onRefreshUserData={onRefreshUserData}
             />
@@ -139,6 +148,7 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
           >
             <MemberOfNetgroups
               user={user}
+              from={props.from}
               isUserDataLoading={userQuery.isFetching}
               onRefreshUserData={onRefreshUserData}
             />
@@ -157,6 +167,7 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
           >
             <MemberOfRoles
               user={user}
+              from={props.from}
               isUserDataLoading={userQuery.isFetching}
               onRefreshUserData={onRefreshUserData}
             />
@@ -175,6 +186,7 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
           >
             <MemberOfHbacRules
               user={user}
+              from={props.from}
               isUserDataLoading={userQuery.isFetching}
               onRefreshUserData={onRefreshUserData}
             />

--- a/src/services/rpcUsers.ts
+++ b/src/services/rpcUsers.ts
@@ -459,7 +459,7 @@ export const useGettingPreservedUserQuery = (payloadData) => {
 export const useGetUsersFullQuery = (userId: string) => {
   // Active and preserved users
   const query_args = {
-    userId: userId,
+    userId: [userId],
     user_type: "active",
     version: API_VERSION_BACKUP,
   };


### PR DESCRIPTION
The different routes from the Active users
page should be adapted as follows:
```ts
<Route path="active-users">
 <Route path="" element={<ActiveUsers />} />
 <Route path=":uid">
   <Route path="" element={<ActiveUsersTabs memberof="" />} />
   <Route
     path="memberof_group"
     element={<ActiveUsersTabs memberof="group" />}
   />
   <Route
     path="memberof_netgroup"
     element={<ActiveUsersTabs memberof="netgroup" />}
   />
   <Route
     path="memberof_role"
     element={<ActiveUsersTabs memberof="role" />}
   />
   <Route
     path="memberof_hbacrule"
     element={<ActiveUsersTabs memberof="hbacrule" />}
   />
   <Route
     path="memberof_rule"
     element={<ActiveUsersTabs memberof="sudorule" />}
   />
 </Route>
</Route>
```
NOTE: This solution has not been applied to the Active users > 'Is a member of' > 'Sudo groups' as this section has been not merged yet (see https://github.com/freeipa/freeipa-webui/pull/364). this will be handled in a different PR. 

This PR depends on this one to be merged: https://github.com/freeipa/freeipa-webui/pull/376