### PR TITLE
Define route for the 'Active users' > 'Is a member of' > 'Subordinate IDs' section

### DIFF
--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -62,6 +62,10 @@ export const AppRoutes = (): React.ReactElement => (
             path="memberof_sudorule"
             element={<ActiveUsersTabs memberof="sudorule" />}
           />
+          <Route
+            path="memberof_subid"
+            element={<ActiveUsersTabs memberof="subid" />}
+          />
         </Route>
       </Route>
       <Route path="stage-users">

--- a/src/pages/ActiveUsers/UserMemberOf.tsx
+++ b/src/pages/ActiveUsers/UserMemberOf.tsx
@@ -242,7 +242,7 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
             />
           </Tab>
           <Tab
-            eventKey={5}
+            eventKey={"subid"}
             name="memberof_subid"
             title={
               <TabTitleText>


### PR DESCRIPTION
The 'Is a member of' > 'Subordinate IDs' section should have its proper route and be accessible to the 'Is a member of' tab option.

This PR depends on this one to be merged: https://github.com/freeipa/freeipa-webui/pull/393