### PR TITLE
Provide search input route to user main pages

### DIFF
--- a/src/pages/ActiveUsers/ActiveUsers.tsx
+++ b/src/pages/ActiveUsers/ActiveUsers.tsx
@@ -83,7 +83,9 @@ const ActiveUsers = () => {
   const modalErrors = useApiError([]);
 
   // Main states - what user can define / what we could use in page URL
-  const [searchValue, setSearchValue] = React.useState("");
+  const [searchValue, setSearchValue] = React.useState(
+    searchParams.get("search") || ""
+  );
   const [page, setPage] = useState<number>(
     parseInt(searchParams.get("p") || "1")
   );
@@ -100,7 +102,7 @@ const ActiveUsers = () => {
 
   // Derived states - what we get from API
   const userDataResponse = useGettingActiveUserQuery({
-    searchValue: "",
+    searchValue: searchValue,
     sizeLimit: 0,
     apiVersion: apiVersion || API_VERSION_BACKUP,
     startIdx: firstUserIdx,
@@ -163,7 +165,7 @@ const ActiveUsers = () => {
     }
   }, [userDataResponse]);
 
-  // Handle URLs with pagination
+  // Handle URLs with pagination and search values
   React.useEffect(() => {
     let searchParamsNew = {};
 
@@ -173,9 +175,15 @@ const ActiveUsers = () => {
         p: page.toString(),
       };
     }
+    if (searchValue !== "") {
+      searchParamsNew = {
+        ...searchParamsNew,
+        search: searchValue,
+      };
+    }
 
     setSearchParams(searchParamsNew, { replace: true });
-  }, [page]);
+  }, [page, searchValue]);
 
   // Refresh button handling
   const refreshUsersData = () => {
@@ -274,6 +282,8 @@ const ActiveUsers = () => {
     setShowTableRows(false);
     setSearchIsDisabled(true);
     setUsersTotalCount(0);
+
+    // Make search via API call
     retrieveUser({
       searchValue: searchValue,
       sizeLimit: 0,

--- a/src/pages/PreservedUsers/PreservedUsers.tsx
+++ b/src/pages/PreservedUsers/PreservedUsers.tsx
@@ -72,7 +72,9 @@ const PreservedUsers = () => {
   const modalErrors = useApiError([]);
 
   // Main states - what user can define / what we could use in page URL
-  const [searchValue, setSearchValue] = React.useState("");
+  const [searchValue, setSearchValue] = React.useState(
+    searchParams.get("search") || ""
+  );
   const [page, setPage] = useState<number>(
     parseInt(searchParams.get("p") || "1")
   );
@@ -86,7 +88,7 @@ const PreservedUsers = () => {
 
   // Derived states - what we get from API
   const userDataResponse = useGettingPreservedUserQuery({
-    searchValue: "",
+    searchValue: searchValue,
     sizeLimit: 0,
     apiVersion: apiVersion || API_VERSION_BACKUP,
     startIdx: firstUserIdx,
@@ -147,7 +149,7 @@ const PreservedUsers = () => {
     }
   }, [userDataResponse]);
 
-  // Handle URLs with pagination
+  // Handle URLs with pagination and search values
   React.useEffect(() => {
     let searchParamsNew = {};
 
@@ -158,8 +160,15 @@ const PreservedUsers = () => {
       };
     }
 
+    if (searchValue !== "") {
+      searchParamsNew = {
+        ...searchParamsNew,
+        search: searchValue,
+      };
+    }
+
     setSearchParams(searchParamsNew, { replace: true });
-  }, [page]);
+  }, [page, searchValue]);
 
   // Refresh button handling
   const refreshUsersData = () => {
@@ -229,6 +238,7 @@ const PreservedUsers = () => {
     setShowTableRows(false);
     setUsersTotalCount(0);
     setSearchIsDisabled(true);
+
     retrieveUser({
       searchValue: searchValue,
       sizeLimit: 0,

--- a/src/pages/StageUsers/StageUsers.tsx
+++ b/src/pages/StageUsers/StageUsers.tsx
@@ -73,7 +73,9 @@ const StageUsers = () => {
   const modalErrors = useApiError([]);
 
   // Main states - what user can define / what we could use in page URL
-  const [searchValue, setSearchValue] = React.useState("");
+  const [searchValue, setSearchValue] = React.useState(
+    searchParams.get("search") || ""
+  );
   const [page, setPage] = useState<number>(
     parseInt(searchParams.get("p") || "1")
   );
@@ -87,7 +89,7 @@ const StageUsers = () => {
 
   // Derived states - what we get from API
   const userDataResponse = useGettingStageUserQuery({
-    searchValue: "",
+    searchValue: searchValue,
     sizeLimit: 0,
     apiVersion: apiVersion || API_VERSION_BACKUP,
     startIdx: firstUserIdx,
@@ -148,7 +150,7 @@ const StageUsers = () => {
     }
   }, [userDataResponse]);
 
-  // Handle URLs with pagination
+  // Handle URLs with pagination and search values
   React.useEffect(() => {
     let searchParamsNew = {};
 
@@ -159,8 +161,15 @@ const StageUsers = () => {
       };
     }
 
+    if (searchValue !== "") {
+      searchParamsNew = {
+        ...searchParamsNew,
+        search: searchValue,
+      };
+    }
+
     setSearchParams(searchParamsNew, { replace: true });
-  }, [page]);
+  }, [page, searchValue]);
 
   // Refresh button handling
   const refreshUsersData = () => {
@@ -230,6 +239,7 @@ const StageUsers = () => {
     setShowTableRows(false);
     setUsersTotalCount(0);
     setSearchIsDisabled(true);
+
     retrieveUser({
       searchValue: searchValue,
       sizeLimit: 0,


### PR DESCRIPTION
The route should be adapted to manage the search input params from the users' main pages.

This PR has been built on the top of this one: https://github.com/freeipa/freeipa-webui/pull/405