### PR TITLE
Update routing data in pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,11 +7,6 @@ import { Spinner } from "@patternfly/react-core";
 import { AppLayout } from "./AppLayout";
 // Navigation
 import { AppRoutes } from "./navigation/AppRoutes";
-import {
-  getBreadCrumbByPath,
-  getGroupByPath,
-  getTitleByPath,
-} from "./navigation/NavRoutes";
 // RPC client
 import { Command, useBatchCommandQuery } from "./services/rpc";
 // Redux
@@ -26,50 +21,9 @@ import {
   updateCaIsEnabled,
   updateVaultConfiguration,
 } from "src/store/Global/global-slice";
-import {
-  updateBreadCrumbPath,
-  updateActivePageName,
-  updateActiveFirstLevel,
-  updateActiveSecondLevel,
-  updateBrowserTitle,
-} from "src/store/Global/routes-slice";
-// Router DOM
-import { useLocation } from "react-router-dom";
 
 const App: React.FunctionComponent = () => {
   const dispatch = useAppDispatch();
-  const { pathname } = useLocation();
-
-  // When accessing to a given URL directly from the browser, the routing data is loaded
-  useEffect(() => {
-    // Get group data based on current path
-    const loadedGroup = getGroupByPath(pathname);
-    if (loadedGroup.length > 0) {
-      let currentFirstLevel = loadedGroup[loadedGroup.length - 2];
-      const currentSecondLevel = loadedGroup[loadedGroup.length - 1];
-      // If no second level is present, first and second levels have the same value
-      // This allows the navbar item to be expanded and highlighted
-      // E.g.: ['', 'services']
-      if (currentFirstLevel === "") {
-        currentFirstLevel = currentSecondLevel;
-      }
-      dispatch(updateActiveFirstLevel(currentFirstLevel));
-      dispatch(updateActiveSecondLevel(currentSecondLevel));
-      dispatch(updateActivePageName(currentSecondLevel)); // Corresponds to the page name
-    }
-
-    // Get breadcrumb data based on current path
-    const loadedBreadCrumb = getBreadCrumbByPath(pathname);
-    if (loadedBreadCrumb.length > 0) {
-      dispatch(updateBreadCrumbPath(loadedBreadCrumb));
-    }
-
-    // Get browser title based on current path
-    const currentTitle = getTitleByPath(pathname);
-    if (currentTitle) {
-      dispatch(updateBrowserTitle(currentTitle));
-    }
-  }, []);
 
   // [API Call] Get initial data
   // TODO: Move this call into a sequential endpoint to execute this

--- a/src/hooks/useUpdateRoute.tsx
+++ b/src/hooks/useUpdateRoute.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
+import {
+  getBreadCrumbByPath,
+  getGroupByPath,
+  getTitleByPath,
+} from "src/navigation/NavRoutes";
+import {
+  updateActiveFirstLevel,
+  updateActivePageName,
+  updateActiveSecondLevel,
+  updateBreadCrumbPath,
+  updateBrowserTitle,
+} from "src/store/Global/routes-slice";
+import { useAppDispatch } from "src/store/hooks";
+
+/**
+ * Given a pathname, this hook updates the Redux route slice with the current route data.
+ * This allows to keep track of the current route and update the UI accordingly
+ * (e.g., keep the Nav links highlighted and expanded).
+ * @param pathname Current pathname
+ * @returns {loadedGroup, breadCrumbPath, browserTitle}
+ */
+
+export const useUpdateRoute = ({ pathname }) => {
+  const dispatch = useAppDispatch();
+
+  const [loadedGroup, setLoadedGroup] = React.useState<string[]>([]);
+  const [breadCrumbPath, setBreadCrumbPath] = React.useState<BreadCrumbItem[]>(
+    []
+  );
+  const [browserTitle, setBrowserTitle] = React.useState("");
+
+  // Get route data when the page is loaded
+  React.useEffect(() => {
+    const loadedGroup = getGroupByPath(pathname);
+    if (loadedGroup.length > 0) {
+      let currentFirstLevel = loadedGroup[loadedGroup.length - 2];
+      const currentSecondLevel = loadedGroup[loadedGroup.length - 1];
+
+      // If no second level is present, first and second levels have the same value
+      // This allows the navbar item to be expanded and highlighted
+      // E.g.: ['', 'services']
+      if (currentFirstLevel === "") {
+        currentFirstLevel = currentSecondLevel;
+      }
+
+      setLoadedGroup(loadedGroup);
+
+      dispatch(updateActiveFirstLevel(currentFirstLevel));
+      dispatch(updateActiveSecondLevel(currentSecondLevel));
+      dispatch(updateActivePageName(currentSecondLevel)); // Corresponds to the page name
+    }
+
+    // Get breadcrumb data based on current path
+    const loadedBreadCrumb = getBreadCrumbByPath(pathname);
+    if (loadedBreadCrumb.length > 0) {
+      setBreadCrumbPath(loadedBreadCrumb);
+      dispatch(updateBreadCrumbPath(loadedBreadCrumb));
+    }
+
+    // Get browser title based on current path
+    const currentTitle = getTitleByPath(pathname);
+    if (currentTitle) {
+      setBrowserTitle(currentTitle);
+      dispatch(updateBrowserTitle(currentTitle));
+    }
+  }, [pathname]);
+
+  return {
+    loadedGroup,
+    breadCrumbPath,
+    browserTitle,
+  };
+};
+
+export default useUpdateRoute;

--- a/src/pages/ActiveUsers/ActiveUsers.tsx
+++ b/src/pages/ActiveUsers/ActiveUsers.tsx
@@ -42,6 +42,7 @@ import DisableEnableUsers from "src/components/modals/DisableEnableUsers";
 import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
 // Hooks
 import { useAlerts } from "src/hooks/useAlerts";
+import useUpdateRoute from "src/hooks/useUpdateRoute";
 // Utils
 import { API_VERSION_BACKUP, isUserSelectable } from "src/utils/utils";
 // RPC client
@@ -64,6 +65,14 @@ const ActiveUsers = () => {
 
   // Dispatch (Redux)
   const dispatch = useAppDispatch();
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  const { browserTitle } = useUpdateRoute({ pathname: "active-users" });
+
+  // Set the page title to be shown in the browser tab
+  React.useEffect(() => {
+    document.title = browserTitle;
+  }, [browserTitle]);
 
   // Retrieve API version from environment data
   const apiVersion = useAppSelector(

--- a/src/pages/HostGroups/HostGroups.tsx
+++ b/src/pages/HostGroups/HostGroups.tsx
@@ -36,6 +36,7 @@ import { HostGroup } from "src/utils/datatypes/globalDataTypes";
 import { API_VERSION_BACKUP, isHostGroupSelectable } from "src/utils/utils";
 // Hooks
 import { useAlerts } from "src/hooks/useAlerts";
+import useUpdateRoute from "src/hooks/useUpdateRoute";
 // Errors
 import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
 import { SerializedError } from "@reduxjs/toolkit";
@@ -51,6 +52,14 @@ import { useGettingHostGroupsQuery } from "../../services/rpcHostGroups";
 const HostGroups = () => {
   // Dispatch (Redux)
   const dispatch = useAppDispatch();
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  const { browserTitle } = useUpdateRoute({ pathname: "host-groups" });
+
+  // Set the page title to be shown in the browser tab
+  React.useEffect(() => {
+    document.title = browserTitle;
+  }, [browserTitle]);
 
   // Retrieve API version from environment data
   const apiVersion = useAppSelector(

--- a/src/pages/Hosts/Hosts.tsx
+++ b/src/pages/Hosts/Hosts.tsx
@@ -41,6 +41,7 @@ import { Host, DNSZone } from "src/utils/datatypes/globalDataTypes";
 import { API_VERSION_BACKUP, isHostSelectable } from "src/utils/utils";
 // Hooks
 import { useAlerts } from "src/hooks/useAlerts";
+import useUpdateRoute from "src/hooks/useUpdateRoute";
 // Errors
 import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
 import { SerializedError } from "@reduxjs/toolkit";
@@ -56,9 +57,18 @@ import {
   useGettingHostQuery,
   useAutoMemberRebuildHostsMutation,
 } from "../../services/rpcHosts";
+
 const Hosts = () => {
   // Dispatch (Redux)
   const dispatch = useAppDispatch();
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  const { browserTitle } = useUpdateRoute({ pathname: "hosts" });
+
+  // Set the page title to be shown in the browser tab
+  React.useEffect(() => {
+    document.title = browserTitle;
+  }, [browserTitle]);
 
   // Define 'executeCommand' to execute simple commands (via Mutation)
   const [executeAutoMemberRebuild] = useAutoMemberRebuildHostsMutation();

--- a/src/pages/Netgroups/Netgroups.tsx
+++ b/src/pages/Netgroups/Netgroups.tsx
@@ -36,6 +36,7 @@ import { Netgroup } from "src/utils/datatypes/globalDataTypes";
 import { API_VERSION_BACKUP, isNetgroupSelectable } from "src/utils/utils";
 // Hooks
 import { useAlerts } from "src/hooks/useAlerts";
+import useUpdateRoute from "src/hooks/useUpdateRoute";
 // Errors
 import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
 import { SerializedError } from "@reduxjs/toolkit";
@@ -51,6 +52,14 @@ import { useGettingNetgroupsQuery } from "../../services/rpcNetgroups";
 const Netgroups = () => {
   // Dispatch (Redux)
   const dispatch = useAppDispatch();
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  const { browserTitle } = useUpdateRoute({ pathname: "netgroups" });
+
+  // Set the page title to be shown in the browser tab
+  React.useEffect(() => {
+    document.title = browserTitle;
+  }, [browserTitle]);
 
   // Retrieve API version from environment data
   const apiVersion = useAppSelector(

--- a/src/pages/PreservedUsers/PreservedUsers.tsx
+++ b/src/pages/PreservedUsers/PreservedUsers.tsx
@@ -37,6 +37,7 @@ import RestorePreservedUsers from "src/components/modals/RestorePreservedUsers";
 // Hooks
 import { updateUsersList } from "src/store/Identity/preservedUsers-slice";
 import { useAlerts } from "src/hooks/useAlerts";
+import useUpdateRoute from "src/hooks/useUpdateRoute";
 // Errors
 import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
 import { SerializedError } from "@reduxjs/toolkit";
@@ -55,6 +56,14 @@ const PreservedUsers = () => {
 
   // Initialize stage users list (Redux)
   const dispatch = useAppDispatch();
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  const { browserTitle } = useUpdateRoute({ pathname: "preserved-users" });
+
+  // Set the page title to be shown in the browser tab
+  React.useEffect(() => {
+    document.title = browserTitle;
+  }, [browserTitle]);
 
   // Alerts to show in the UI
   const alerts = useAlerts();

--- a/src/pages/Services/Services.tsx
+++ b/src/pages/Services/Services.tsx
@@ -38,6 +38,7 @@ import AddService from "../../components/modals/AddService";
 import DeleteServices from "../../components/modals/DeleteServices";
 // Hooks
 import { useAlerts } from "../../hooks/useAlerts";
+import useUpdateRoute from "src/hooks/useUpdateRoute";
 // Errors
 import useApiError from "../../hooks/useApiError";
 import GlobalErrors from "../../components/errors/GlobalErrors";
@@ -55,6 +56,14 @@ const Services = () => {
 
   // Dispatch (Redux)
   const dispatch = useAppDispatch();
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  const { browserTitle } = useUpdateRoute({ pathname: "services" });
+
+  // Set the page title to be shown in the browser tab
+  React.useEffect(() => {
+    document.title = browserTitle;
+  }, [browserTitle]);
 
   // Retrieve API version from environment data
   const apiVersion = useAppSelector(

--- a/src/pages/StageUsers/StageUsers.tsx
+++ b/src/pages/StageUsers/StageUsers.tsx
@@ -22,6 +22,7 @@ import { useAppDispatch, useAppSelector } from "src/store/hooks";
 // Hooks
 import { updateUsersList } from "src/store/Identity/stageUsers-slice";
 import { useAlerts } from "src/hooks/useAlerts";
+import useUpdateRoute from "src/hooks/useUpdateRoute";
 // Layouts
 import TitleLayout from "src/components/layouts/TitleLayout";
 import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
@@ -56,6 +57,14 @@ const StageUsers = () => {
 
   // Initialize stage users list (Redux)
   const dispatch = useAppDispatch();
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  const { browserTitle } = useUpdateRoute({ pathname: "stage-users" });
+
+  // Set the page title to be shown in the browser tab
+  React.useEffect(() => {
+    document.title = browserTitle;
+  }, [browserTitle]);
 
   // Alerts to show in the UI
   const alerts = useAlerts();

--- a/src/pages/UserGroups/UserGroups.tsx
+++ b/src/pages/UserGroups/UserGroups.tsx
@@ -36,6 +36,7 @@ import { UserGroup } from "src/utils/datatypes/globalDataTypes";
 import { API_VERSION_BACKUP, isUserGroupSelectable } from "src/utils/utils";
 // Hooks
 import { useAlerts } from "src/hooks/useAlerts";
+import useUpdateRoute from "src/hooks/useUpdateRoute";
 // Errors
 import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
 import { SerializedError } from "@reduxjs/toolkit";
@@ -51,6 +52,14 @@ import { useGettingGroupsQuery } from "../../services/rpcUserGroups";
 const UserGroups = () => {
   // Dispatch (Redux)
   const dispatch = useAppDispatch();
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  const { browserTitle } = useUpdateRoute({ pathname: "user-groups" });
+
+  // Set the page title to be shown in the browser tab
+  React.useEffect(() => {
+    document.title = browserTitle;
+  }, [browserTitle]);
 
   // Retrieve API version from environment data
   const apiVersion = useAppSelector(

--- a/src/store/Global/routes-slice.ts
+++ b/src/store/Global/routes-slice.ts
@@ -11,10 +11,10 @@ interface RoutesState {
 
 const initialState: RoutesState = {
   breadCrumbPath: null,
-  activePageName: "active-users",
-  activeFirstLevel: "users",
-  activeSecondLevel: "active-users",
-  browserTitle: "Active users",
+  activePageName: "",
+  activeFirstLevel: "",
+  activeSecondLevel: "",
+  browserTitle: "",
 };
 
 const routesSlice = createSlice({


### PR DESCRIPTION
The data handled by the `routes` Redux slice needs to be updated when a given page is being accessed with the data based on the data of the `NavRoutes.ts` file.

E.g., when navigate to the 'Active users' page, its corresponding node in the `Nav` element should be highlighted. Also, the browser title should appear in the tab information and keep track of the visited pages for the breadcrumb component.

This has been implemented by using the `useUpdateRoute` custom hook that takes the current `pathname` and obtain
the information based on `NavRoutes`. At the same time, it stores the current obtained data in Redux, so it keeps an updated track of the current visited page and its information.

This PR has been created on the top of this one and needs to be merged first: https://github.com/freeipa/freeipa-webui/pull/408