### PR TITLE
Provide routes for the 'Hosts' pages

### DIFF
--- a/src/components/MemberOf/MemberOfTable.tsx
+++ b/src/components/MemberOf/MemberOfTable.tsx
@@ -44,7 +44,7 @@ interface ButtonData {
 export interface PropsToTable {
   group: MemberOfElement[];
   tableName: string;
-  activeTabKey: number;
+  activeTabKey: number | string; // TODO: Change to string
   changeSelectedGroups: (groups: string[]) => void;
   buttonData: ButtonData;
   showTableRows: boolean;
@@ -60,7 +60,7 @@ const MemberOfTable = (props: PropsToTable) => {
     description: "Description",
   };
   const netgroupsColumnNames: ColumnNames = {
-    name: "NetgroupOld name",
+    name: "Netgroup name",
     description: "Description",
   };
   const rolesColumnNames: ColumnNames = {
@@ -113,24 +113,22 @@ const MemberOfTable = (props: PropsToTable) => {
   // When moving to another tab, the column names must change
   useEffect(() => {
     switch (props.activeTabKey) {
-      case 0:
-        if (props.tableName === "User groups") {
-          setColumnNames(userGroupsColumnNames);
-        }
-        if (props.tableName === "Host groups") {
-          setColumnNames(hostGroupsColumnNames);
-        }
+      case "memberof_hostgroup":
+        setColumnNames(hostGroupsColumnNames);
         break;
-      case 1:
+      case "memberof_group":
+        setColumnNames(userGroupsColumnNames);
+        break;
+      case "memberof_netgroup":
         setColumnNames(netgroupsColumnNames);
         break;
-      case 2:
+      case "memberof_role":
         setColumnNames(rolesColumnNames);
         break;
-      case 3:
+      case "memberof_hbacrule":
         setColumnNames(hbacRulesColumnNames);
         break;
-      case 4:
+      case "memberof_sudorule":
         setColumnNames(sudoRulesColumnNames);
         break;
     }

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -78,7 +78,33 @@ export const AppRoutes = (): React.ReactElement => (
     </Route>
     <Route path="hosts">
       <Route path="" element={<Hosts />} />
-      <Route path="settings" element={<HostsTabs />} />
+      <Route path=":fqdn">
+        <Route path="" element={<HostsTabs section="settings" />} />
+        <Route
+          path="memberof_hostgroup"
+          element={<HostsTabs section="memberof_hostgroup" />}
+        />
+        <Route
+          path="memberof_netgroup"
+          element={<HostsTabs section="memberof_netgroup" />}
+        />
+        <Route
+          path="memberof_role"
+          element={<HostsTabs section="memberof_role" />}
+        />
+        <Route
+          path="memberof_hbacrule"
+          element={<HostsTabs section="memberof_hbacrule" />}
+        />
+        <Route
+          path="memberof_sudorule"
+          element={<HostsTabs section="memberof_sudorule" />}
+        />
+        <Route
+          path="managedby_host"
+          element={<HostsTabs section="managedby" />}
+        />
+      </Route>
     </Route>
     <Route path="services">
       <Route path="" element={<Services />} />

--- a/src/pages/Hosts/Hosts.tsx
+++ b/src/pages/Hosts/Hosts.tsx
@@ -57,10 +57,14 @@ import {
   useGettingHostQuery,
   useAutoMemberRebuildHostsMutation,
 } from "../../services/rpcHosts";
+// Navigation
+import { useSearchParams } from "react-router-dom";
 
 const Hosts = () => {
   // Dispatch (Redux)
   const dispatch = useAppDispatch();
+
+  const [searchParams, setSearchParams] = useSearchParams();
 
   // Update current route data to Redux and highlight the current page in the Nav bar
   const { browserTitle } = useUpdateRoute({ pathname: "hosts" });
@@ -89,8 +93,12 @@ const Hosts = () => {
   const modalErrors = useApiError([]);
 
   // Table comps
-  const [searchValue, setSearchValue] = React.useState("");
-  const [page, setPage] = useState<number>(1);
+  const [searchValue, setSearchValue] = React.useState(
+    searchParams.get("search") || ""
+  );
+  const [page, setPage] = useState<number>(
+    parseInt(searchParams.get("p") || "1")
+  );
   const [perPage, setPerPage] = useState<number>(10);
   const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
   const [totalCount, setHostsTotalCount] = useState<number>(0);
@@ -135,7 +143,7 @@ const Hosts = () => {
 
   // Derived states - what we get from API
   const hostDataResponse = useGettingHostQuery({
-    searchValue: "",
+    searchValue: searchValue,
     sizeLimit: 0,
     apiVersion: apiVersion || API_VERSION_BACKUP,
     startIdx: firstHostIdx,
@@ -196,6 +204,27 @@ const Hosts = () => {
       );
     }
   }, [hostDataResponse]);
+
+  // Handle URLs with pagination and search values
+  React.useEffect(() => {
+    let searchParamsNew = {};
+
+    if (page > 1) {
+      searchParamsNew = {
+        ...searchParamsNew,
+        p: page.toString(),
+      };
+    }
+
+    if (searchValue !== "") {
+      searchParamsNew = {
+        ...searchParamsNew,
+        search: searchValue,
+      };
+    }
+
+    setSearchParams(searchParamsNew, { replace: true });
+  }, [page, searchValue]);
 
   // Always refetch data when the component is loaded.
   // This ensures the data is always up-to-date.

--- a/src/pages/Hosts/HostsMemberOf.tsx
+++ b/src/pages/Hosts/HostsMemberOf.tsx
@@ -37,12 +37,17 @@ import {
 // Modals
 import MemberOfAddModal from "src/components/MemberOf/MemberOfAddModalOld";
 import MemberOfDeleteModal from "src/components/MemberOf/MemberOfDeleteModalOld";
+// Navigation
+import { useNavigate } from "react-router-dom";
 
 interface PropsToHostsMemberOf {
   host: Host;
+  tabSection: string;
 }
 
 const HostsMemberOf = (props: PropsToHostsMemberOf) => {
+  const navigate = useNavigate();
+
   // Retrieve each group list from Redux:
   let hostGroupsList = [] as HostGroupOld[];
   let netgroupsList = [] as NetgroupOld[];
@@ -225,13 +230,35 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
   };
 
   // -- Tab
-  const [activeTabKey, setActiveTabKey] = useState(0);
+  const [activeTabKey, setActiveTabKey] = useState("");
+  // This is a temporary solution to keep the active tab number
+  //  as it will be passed to the 'MemberOfDeleteModal' component
+  //  and this is being used by 'Services' component as well
+  const [activeTabNumber, setActiveTabNumber] = useState(0);
 
   const handleTabClick = (
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
-    setActiveTabKey(tabIndex as number);
+    switch (tabIndex) {
+      case "memberof_hostgroup":
+        setActiveTabNumber(0);
+        break;
+      case "memberof_netgroup":
+        setActiveTabNumber(1);
+        break;
+      case "memberof_role":
+        setActiveTabNumber(2);
+        break;
+      case "memberof_hbacrule":
+        setActiveTabNumber(3);
+        break;
+      case "memberof_sudorule":
+        setActiveTabNumber(4);
+        break;
+    }
+    setActiveTabKey(tabIndex as string);
+    navigate("/hosts/" + props.host.fqdn + "/" + tabIndex);
   };
 
   // -- Pagination
@@ -265,19 +292,19 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
       | SudoRulesOld[]
   ) => {
     switch (activeTabKey) {
-      case 0:
+      case "memberof_hostgroup":
         setShownHostGroupsList(value as HostGroupOld[]);
         break;
-      case 1:
+      case "memberof_netgroup":
         setShownNetgroupsList(value as NetgroupOld[]);
         break;
-      case 2:
+      case "memberof_role":
         setShownRolesList(value as RolesOld[]);
         break;
-      case 3:
+      case "memberof_hbacrule":
         setShownHBACRulesList(value as HBACRulesOld[]);
         break;
-      case 4:
+      case "memberof_sudorule":
         setShownSudoRulesList(value as SudoRulesOld[]);
         break;
     }
@@ -293,19 +320,19 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
   ) => {
     setPage(newPage);
     switch (activeTabKey) {
-      case 0:
+      case "memberof_hostgroup":
         setShownHostGroupsList(hostGroupsRepository.slice(startIdx, endIdx));
         break;
-      case 1:
+      case "memberof_netgroup":
         setShownNetgroupsList(netgroupsRepository.slice(startIdx, endIdx));
         break;
-      case 2:
+      case "memberof_role":
         setShownRolesList(rolesRepository.slice(startIdx, endIdx));
         break;
-      case 3:
+      case "memberof_hbacrule":
         setShownHBACRulesList(hbacRulesRepository.slice(startIdx, endIdx));
         break;
-      case 4:
+      case "memberof_sudorule":
         setShownSudoRulesList(sudoRulesRepository.slice(startIdx, endIdx));
         break;
     }
@@ -320,19 +347,19 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
   ) => {
     setPerPage(newPerPage);
     switch (activeTabKey) {
-      case 0:
+      case "memberof_hostgroup":
         setShownHostGroupsList(hostGroupsRepository.slice(startIdx, endIdx));
         break;
-      case 1:
+      case "memberof_netgroup":
         setShownNetgroupsList(netgroupsRepository.slice(startIdx, endIdx));
         break;
-      case 2:
+      case "memberof_role":
         setShownRolesList(rolesRepository.slice(startIdx, endIdx));
         break;
-      case 3:
+      case "memberof_hbacrule":
         setShownHBACRulesList(hbacRulesRepository.slice(startIdx, endIdx));
         break;
-      case 4:
+      case "memberof_sudorule":
         setShownSudoRulesList(sudoRulesRepository.slice(startIdx, endIdx));
         break;
     }
@@ -347,19 +374,19 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
   ) => {
     setPage(newPage);
     switch (activeTabKey) {
-      case 0:
+      case "memberof_hostgroup":
         setShownHostGroupsList(hostGroupsRepository.slice(startIdx, endIdx));
         break;
-      case 1:
+      case "memberof_netgroup":
         setShownNetgroupsList(netgroupsRepository.slice(startIdx, endIdx));
         break;
-      case 2:
+      case "memberof_role":
         setShownRolesList(rolesRepository.slice(startIdx, endIdx));
         break;
-      case 3:
+      case "memberof_hbacrule":
         setShownHBACRulesList(hbacRulesRepository.slice(startIdx, endIdx));
         break;
-      case 4:
+      case "memberof_sudorule":
         setShownSudoRulesList(sudoRulesRepository.slice(startIdx, endIdx));
         break;
     }
@@ -373,19 +400,19 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
   ) => {
     setPerPage(newPerPage);
     switch (activeTabKey) {
-      case 0:
+      case "memberof_hostgroup":
         setShownHostGroupsList(hostGroupsRepository.slice(startIdx, endIdx));
         break;
-      case 1:
+      case "memberof_netgroup":
         setShownNetgroupsList(netgroupsRepository.slice(startIdx, endIdx));
         break;
-      case 2:
+      case "memberof_role":
         setShownRolesList(rolesRepository.slice(startIdx, endIdx));
         break;
-      case 3:
+      case "memberof_hbacrule":
         setShownHBACRulesList(hbacRulesRepository.slice(startIdx, endIdx));
         break;
-      case 4:
+      case "memberof_sudorule":
         setShownSudoRulesList(sudoRulesRepository.slice(startIdx, endIdx));
         break;
     }
@@ -394,15 +421,15 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
   // Different number of items will be shown depending on the 'activeTabKey'
   const numberOfItems = () => {
     switch (activeTabKey) {
-      case 0:
+      case "memberof_hostgroup":
         return hostGroupsRepository.length;
-      case 1:
+      case "memberof_netgroup":
         return netgroupsRepository.length;
-      case 2:
+      case "memberof_role":
         return rolesRepository.length;
-      case 3:
+      case "memberof_hbacrule":
         return hbacRulesRepository.length;
-      case 4:
+      case "memberof_sudorule":
         return sudoRulesRepository.length;
     }
   };
@@ -439,23 +466,23 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
     if (showTableRows) setShowTableRows(false);
     setTimeout(() => {
       switch (activeTabKey) {
-        case 0:
+        case "memberof_hostgroup":
           setShownHostGroupsList(hostGroupsRepository.slice(0, perPage));
           setHostGroupsRepoLength(hostGroupsRepository.length);
           break;
-        case 1:
+        case "memberof_netgroup":
           setShownNetgroupsList(netgroupsRepository.slice(0, perPage));
           setNetgroupsRepoLength(netgroupsRepository.length);
           break;
-        case 2:
+        case "memberof_role":
           setShownRolesList(rolesRepository.slice(0, perPage));
           setRolesRepoLength(rolesRepository.length);
           break;
-        case 3:
+        case "memberof_hbacrule":
           setShownHBACRulesList(hbacRulesRepository.slice(0, perPage));
           setHbacRulesRepoLength(hbacRulesRepository.length);
           break;
-        case 4:
+        case "memberof_sudorule":
           setShownSudoRulesList(sudoRulesRepository.slice(0, perPage));
           setSudoRulesRepoLength(sudoRulesRepository.length);
           break;
@@ -521,7 +548,8 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
 
   const deleteTabData = {
     tabName,
-    activeTabKey,
+    // TODO: Replace it with the 'activeTabKey' state when 'Services' has been adapted
+    activeTabKey: activeTabNumber,
   };
 
   // - 'MemberOfToolbar' > 'SearchInputLayout'
@@ -531,6 +559,11 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
     updateSearchValue,
   };
 
+  React.useEffect(() => {
+    setActiveTabKey(props.tabSection);
+    navigate("/hosts/" + props.host.fqdn + "/" + props.tabSection);
+  }, [props.tabSection]);
+
   // Render component
   return (
     <Page>
@@ -539,9 +572,15 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
         isFilled={false}
         className="pf-v5-u-m-lg"
       >
-        <Tabs activeKey={activeTabKey} onSelect={handleTabClick} isBox={false}>
+        <Tabs
+          activeKey={activeTabKey}
+          onSelect={handleTabClick}
+          isBox={false}
+          mountOnEnter
+          unmountOnExit
+        >
           <Tab
-            eventKey={0}
+            eventKey={"memberof_hostgroup"}
             name="memberof_hostgroup"
             title={
               <TabTitleText>
@@ -573,7 +612,7 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
             />
           </Tab>
           <Tab
-            eventKey={1}
+            eventKey={"memberof_netgroup"}
             name="memberof_netgroup"
             title={
               <TabTitleText>
@@ -605,7 +644,7 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
             />
           </Tab>
           <Tab
-            eventKey={2}
+            eventKey={"memberof_role"}
             name="memberof_role"
             title={
               <TabTitleText>
@@ -637,7 +676,7 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
             />
           </Tab>
           <Tab
-            eventKey={3}
+            eventKey={"memberof_hbacrule"}
             name="memberof_hbacrule"
             title={
               <TabTitleText>
@@ -669,7 +708,7 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
             />
           </Tab>
           <Tab
-            eventKey={4}
+            eventKey={"memberof_sudorule"}
             name="memberof_sudorule"
             title={
               <TabTitleText>

--- a/src/pages/Hosts/HostsTable.tsx
+++ b/src/pages/Hosts/HostsTable.tsx
@@ -172,7 +172,7 @@ const HostsTable = (props: PropsToTable) => {
         }}
       />
       <Td dataLabel={columnNames.fqdn}>
-        <Link to={"/hosts/settings"} state={host}>
+        <Link to={"/hosts/" + host.fqdn} state={host}>
           {host.fqdn}
         </Link>
       </Td>


### PR DESCRIPTION
The routes for the 'host' page and its sections need to be added. Affecting:
- 'Settings'
- 'Is a member of' tabs
- 'Managed by' tabs
- Pagination and search input parameters