### PR TITLE
Fix inconsistent onFocus behaviour in  datetime pickers

### DIFF
--- a/src/components/Form/DateTimeSelector.tsx
+++ b/src/components/Form/DateTimeSelector.tsx
@@ -61,6 +61,9 @@ const DateTimeSelector = (props: PropsToDateTimeSelector) => {
     if (props.datetime && isValidDate(props.datetime)) {
       updatedFromDate = cloneDate(props.datetime);
     }
+
+    if (!updatedFromDate || isValidDate(updatedFromDate)) return;
+
     updatedFromDate.setHours(hour);
     updatedFromDate.setMinutes(minute);
     if (props.onChange) {


### PR DESCRIPTION
If the time entered is not valid (i.e. not complete), do not render default value, but wait for complete input.

Resolves: https://github.com/freeipa/freeipa-webui/issues/373