### PR TITLE
Fix 'current_password' required

### DIFF
--- a/src/services/rpcUsers.ts
+++ b/src/services/rpcUsers.ts
@@ -66,6 +66,15 @@ export type UserFullData = {
 export interface PasswordChangePayload {
   uid: string;
   password: string;
+  currentPassword?: string;
+  otp?: string;
+}
+
+interface PasswordChangePayloadParams {
+  password: string;
+  current_password?: string;
+  otp?: string;
+  version: string;
 }
 
 const extendedApi = api.injectEndpoints({
@@ -376,13 +385,27 @@ const extendedApi = api.injectEndpoints({
     }),
     changePassword: build.mutation<FindRPCResponse, PasswordChangePayload>({
       query: (payload) => {
-        const params = [
-          [payload.uid],
-          {
-            password: payload.password,
-            version: API_VERSION_BACKUP,
-          },
-        ];
+        let payloadArgs: PasswordChangePayloadParams = {
+          password: payload.password,
+          version: API_VERSION_BACKUP,
+        };
+
+        // Add optional parameters if they exist
+        if (payload.currentPassword !== undefined) {
+          payloadArgs = {
+            ...payloadArgs,
+            current_password: payload.currentPassword,
+          };
+        }
+
+        if (payload.otp !== undefined) {
+          payloadArgs = {
+            ...payloadArgs,
+            otp: payload.otp,
+          };
+        }
+
+        const params = [[payload.uid], payloadArgs];
 
         return getCommand({
           method: "passwd",

--- a/src/store/Global/global-slice.ts
+++ b/src/store/Global/global-slice.ts
@@ -3,7 +3,7 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 interface GlobalState {
   // TODO: Specify data types
   ipaServerConfiguration: Record<string, unknown>;
-  loggedUserInfo: Record<string, unknown>;
+  loggedUserInfo: LoggedUserInfo;
   environment: Record<string, unknown>;
   dnsIsEnabled: Record<string, unknown>;
   trustConfiguration: Record<string, unknown>;
@@ -12,9 +12,21 @@ interface GlobalState {
   vaultConfiguration: Record<string, unknown>;
 }
 
+interface LoggedUserInfo {
+  arguments: string;
+  command: string;
+  error: Record<string, unknown>;
+  object: string;
+}
+
 const initialState: GlobalState = {
   ipaServerConfiguration: {},
-  loggedUserInfo: {},
+  loggedUserInfo: {
+    arguments: "",
+    command: "",
+    error: {},
+    object: "",
+  },
   environment: {},
   dnsIsEnabled: {},
   trustConfiguration: {},
@@ -39,7 +51,7 @@ const globalSlice = createSlice({
       action: PayloadAction<Record<string, unknown>>
     ) => {
       const newLoggedUserInfo = action.payload;
-      state.loggedUserInfo = newLoggedUserInfo;
+      state.loggedUserInfo = { ...state.loggedUserInfo, ...newLoggedUserInfo };
     },
     updateEnvironment: (
       state,


### PR DESCRIPTION
There is an error when a given user try to update its own password being logged in. This is due to a missing parameter
`current_password` needed from the API call.

Fixes: https://github.com/freeipa/freeipa-webui/issues/368