### PR TITLE
Bump CI Fedora version to 39

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 
 Vagrant.configure("2") do |config|
   config.vm.hostname = "server.ipa.demo"
-  config.vm.box = "fedora/38-cloud-base"
+  config.vm.box = "fedora/39-cloud-base"
 
   config.vm.synced_folder ".", "/vagrant", disabled: true
   config.vm.synced_folder ".", "/usr/src/freeipa-webui"
@@ -44,7 +44,7 @@ Vagrant.configure("2") do |config|
 
   # Install ipa server
   config.vm.provision "shell",
-    inline: "ipa-server-install -U -n server.ipa.demo -r IPA.DEMO -p Secret123 -a Secret123 --forwarder 8.8.8.8 --setup-dns --setup-kra"
+    inline: "ipa-server-install -U -n dom-server.ipa.demo -r DOM-IPA.DEMO -p Secret123 -a Secret123 --forwarder 8.8.8.8 --setup-dns --setup-kra"
 
   # Set SELinux to permissive mode
   config.vm.provision "shell", inline: <<~EOS

--- a/tests/features/active_users_handling.feature
+++ b/tests/features/active_users_handling.feature
@@ -141,7 +141,7 @@ Scenario: Re-enable multiple users at once
 
     When in the modal dialog I check "Delete" radio selector
     And in the modal dialog I click on "Delete" button
-    Then I see a modal with text "admin cannot be deleted"
+    Then I see a modal with text "admin cannot be deleted/modified"
     When in the modal dialog I click on "OK" button
     And in the modal dialog I click on "Cancel" button
     Then I should see "admin" entry in the data table
@@ -154,7 +154,7 @@ Scenario: Re-enable multiple users at once
 
     When in the modal dialog I check "Preserve" radio selector
     And in the modal dialog I click on "Preserve" button
-    Then I see a modal with text "admin cannot be deleted or disabled"
+    Then I see a modal with text "admin cannot be deleted/modified"
     When in the modal dialog I click on "OK" button
     And in the modal dialog I click on "Cancel" button
     Then I should see "admin" entry in the data table

--- a/tests/features/user_details.feature
+++ b/tests/features/user_details.feature
@@ -343,16 +343,16 @@ Feature: User details
     * I click on "Save" button
     Then I should see "success" alert with text "User modified"
     And I should see value "testmail1@server.ipa.demo" in any of the textboxes that belong to the field "Mail address"
-    * I should see value "testmail2@server.ipa.demo" in any of the textboxes that belong to the field "Mail address"
+    * I should see value "testmail2@dom-server.ipa.demo" in any of the textboxes that belong to the field "Mail address"
 
   Scenario: Remove multiple mail addresses
     When in the "Mail address" section I click the "Delete" button of the text input field with text "testmail1@server.ipa.demo"
     Then I should not see the text input field with text "testmail1@server.ipa.demo" under the field "Mail address"
-    When in the "Mail address" section I click the "Delete" button of the text input field with text "testmail2@server.ipa.demo"
-    Then I should not see the text input field with text "testmail2@server.ipa.demo" under the field "Mail address"
+    When in the "Mail address" section I click the "Delete" button of the text input field with text "testmail2@dom-server.ipa.demo"
+    Then I should not see the text input field with text "testmail2@dom-server.ipa.demo" under the field "Mail address"
     When I click on "Save" button
     Then I should see "success" alert with text "User modified"
-    And I should see value "armadillo@server.ipa.demo" in any of the textboxes that belong to the field "Mail address"
+    And I should see value "armadillo@dom-server.ipa.demo" in any of the textboxes that belong to the field "Mail address"
 
   # - Telephone number
   Scenario: Add multiple telephone numbers


### PR DESCRIPTION
Fedora 38 is EOL and was removed from vagrant boxes mirror. For F39 to function properly, domain and realm name are modified to differ from the hostname.

Adjust the tests to use new domain name, where applicable. Adjust the tests to use modified error messages that changed with the freeipa version bump.