### PR TITLE
Fix the breadcrumb routes for 'Is a member of' sections in 'Active users' and 'Hosts' pages

### DIFF
--- a/src/pages/ActiveUsers/UserMemberOf.tsx
+++ b/src/pages/ActiveUsers/UserMemberOf.tsx
@@ -23,6 +23,10 @@ import { useGetUserByUidQuery } from "src/services/rpcUsers";
 import { convertToString } from "src/utils/ipaObjectUtils";
 // Navigation
 import { useNavigate } from "react-router-dom";
+import { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
+// Redux
+import { useAppDispatch } from "src/store/hooks";
+import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
 
 interface PropsToUserMemberOf {
   user: User;
@@ -32,6 +36,29 @@ interface PropsToUserMemberOf {
 
 const UserMemberOf = (props: PropsToUserMemberOf) => {
   const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+
+  // Update breadcrumb route
+  React.useEffect(() => {
+    if (!props.user.uid) {
+      // Redirect to the main page
+      navigate("/" + props.from);
+    } else {
+      const currentPath: BreadCrumbItem[] = [
+        {
+          name:
+            props.from[0].toUpperCase() + props.from.slice(1).replace("-", " "),
+          url: "../../" + props.from,
+        },
+        {
+          name: props.user.uid,
+          url: "../../" + props.from + "/" + props.user.uid,
+          isActive: true,
+        },
+      ];
+      dispatch(updateBreadCrumbPath(currentPath));
+    }
+  }, [props.user.uid]);
 
   // User's full data
   const userQuery = useGetUserByUidQuery(convertToString(props.user.uid));

--- a/src/pages/Hosts/HostsMemberOf.tsx
+++ b/src/pages/Hosts/HostsMemberOf.tsx
@@ -14,6 +14,7 @@ import {
 // Others
 import MemberOfToolbar from "src/components/MemberOf/MemberOfToolbarOld";
 import MemberOfTable from "src/components/MemberOf/MemberOfTable";
+import { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
 // Data types
 import {
   HostGroupOld,
@@ -24,8 +25,8 @@ import {
   Host,
 } from "src/utils/datatypes/globalDataTypes";
 // Redux
-import { useAppSelector } from "src/store/hooks";
-
+import { useAppDispatch, useAppSelector } from "src/store/hooks";
+import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
 // Repositories
 import {
   hostsHostGroupsInitialData,
@@ -47,6 +48,28 @@ interface PropsToHostsMemberOf {
 
 const HostsMemberOf = (props: PropsToHostsMemberOf) => {
   const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+
+  // Update breadcrumb route
+  React.useEffect(() => {
+    if (!props.host.fqdn) {
+      // Redirect to the main page
+      navigate("/hosts");
+    } else {
+      const currentPath: BreadCrumbItem[] = [
+        {
+          name: "Hosts",
+          url: "../../hosts",
+        },
+        {
+          name: props.host.fqdn,
+          url: "../../hosts/" + props.host.fqdn,
+          isActive: true,
+        },
+      ];
+      dispatch(updateBreadCrumbPath(currentPath));
+    }
+  }, [props.host.fqdn]);
 
   // Retrieve each group list from Redux:
   let hostGroupsList = [] as HostGroupOld[];


### PR DESCRIPTION
The breadcrumb routes in 'Active users' and 'Hosts' > 'Is a member of' sections were redirecting to `/<page>/<id>/<page>`
instead of `/<page>`.

This PR depends on this one to be merged: https://github.com/freeipa/freeipa-webui/pull/411