### PR TITLE
Provide pagination, search, and membership direction parameters

### DIFF
--- a/src/components/MemberOf/MemberOfHbacRules.tsx
+++ b/src/components/MemberOf/MemberOfHbacRules.tsx
@@ -21,6 +21,8 @@ import {
 // Utils
 import { API_VERSION_BACKUP, paginate } from "src/utils/utils";
 import { apiToHBACRule } from "src/utils/hbacRulesUtils";
+// React Router DOM
+import { useSearchParams } from "react-router-dom";
 
 interface MemberOfHbacRulesProps {
   user: Partial<User>;
@@ -33,22 +35,30 @@ const MemberOfHbacRules = (props: MemberOfHbacRulesProps) => {
   // Alerts to show in the UI
   const alerts = useAlerts();
 
+  const [searchParams, setSearchParams] = useSearchParams();
+
   // Page indexes
-  const [page, setPage] = React.useState(1);
+  const [page, setPage] = React.useState(
+    parseInt(searchParams.get("p") || "1")
+  );
   const [perPage, setPerPage] = React.useState(10);
 
   // Other states
   const [hbacRulesSelected, setHbacRulesSelected] = React.useState<string[]>(
     []
   );
-  const [searchValue, setSearchValue] = React.useState("");
+  const [searchValue, setSearchValue] = React.useState(
+    searchParams.get("search") || ""
+  );
 
   // Loaded HBAC rules based on paging and member attributes
   const [hbacRules, setHbacRules] = React.useState<HBACRule[]>([]);
 
   // Membership direction and HBAC rules
   const [membershipDirection, setMembershipDirection] =
-    React.useState<MembershipDirection>("direct");
+    React.useState<MembershipDirection>(
+      (searchParams.get("membership") as MembershipDirection) || "direct"
+    );
 
   const memberof_hbacrule = props.user.memberof_hbacrule || [];
   const memberofindirect_hbacrule = props.user.memberofindirect_hbacrule || [];
@@ -73,6 +83,23 @@ const MemberOfHbacRules = (props: MemberOfHbacRulesProps) => {
     toLoad = paginate(toLoad, page, perPage);
     return toLoad;
   };
+
+  // Handle URLs with pagination and search values
+  React.useEffect(() => {
+    const searchParamsNew: { [key: string]: string } = {};
+
+    if (page > 1) {
+      searchParamsNew.p = page.toString();
+    }
+    if (searchValue !== "") {
+      searchParamsNew.search = searchValue;
+    }
+    if (membershipDirection !== "direct") {
+      searchParamsNew.membership = membershipDirection;
+    }
+
+    setSearchParams(searchParamsNew, { replace: true });
+  }, [page, searchValue, membershipDirection]);
 
   const [hbacRulesNamesToLoad, setHbacRulesNamesToLoad] = React.useState<
     string[]

--- a/src/components/MemberOf/MemberOfNetgroups.tsx
+++ b/src/components/MemberOf/MemberOfNetgroups.tsx
@@ -22,6 +22,8 @@ import { apiToNetgroup } from "src/utils/netgroupsUtils";
 // Modals
 import MemberOfAddModal, { AvailableItems } from "./MemberOfAddModal";
 import MemberOfDeleteModal from "./MemberOfDeleteModal";
+// React Router DOM
+import { useSearchParams } from "react-router-dom";
 
 interface MemberOfNetroupsProps {
   user: Partial<User>;
@@ -34,22 +36,30 @@ const memberOfNetgroups = (props: MemberOfNetroupsProps) => {
   // Alerts to show in the UI
   const alerts = useAlerts();
 
+  const [searchParams, setSearchParams] = useSearchParams();
+
   // Page indexes
-  const [page, setPage] = React.useState(1);
+  const [page, setPage] = React.useState(
+    parseInt(searchParams.get("p") || "1")
+  );
   const [perPage, setPerPage] = React.useState(10);
 
   // Other states
   const [netgroupsSelected, setNetgroupsSelected] = React.useState<string[]>(
     []
   );
-  const [searchValue, setSearchValue] = React.useState("");
+  const [searchValue, setSearchValue] = React.useState(
+    searchParams.get("search") || ""
+  );
 
   // Loaded netgroups based on paging and member attributes
   const [netgroups, setNetgroups] = React.useState<Netgroup[]>([]);
 
   // Membership direction and netgroups
   const [membershipDirection, setMembershipDirection] =
-    React.useState<MembershipDirection>("direct");
+    React.useState<MembershipDirection>(
+      (searchParams.get("membership") as MembershipDirection) || "direct"
+    );
 
   // Choose the correct netgroups based on the membership direction
   const memberof_netgroup = props.user.memberof_netgroup || [];
@@ -76,6 +86,23 @@ const memberOfNetgroups = (props: MemberOfNetroupsProps) => {
 
     return toLoad;
   };
+
+  // Handle URLs with pagination and search values
+  React.useEffect(() => {
+    const searchParamsNew: { [key: string]: string } = {};
+
+    if (page > 1) {
+      searchParamsNew.p = page.toString();
+    }
+    if (searchValue !== "") {
+      searchParamsNew.search = searchValue;
+    }
+    if (membershipDirection !== "direct") {
+      searchParamsNew.membership = membershipDirection;
+    }
+
+    setSearchParams(searchParamsNew, { replace: true });
+  }, [page, searchValue, membershipDirection]);
 
   const [netgroupNamesToLoad, setNetgroupNamesToLoad] = React.useState<
     string[]

--- a/src/components/MemberOf/MemberOfRoles.tsx
+++ b/src/components/MemberOf/MemberOfRoles.tsx
@@ -21,6 +21,8 @@ import {
 // Utils
 import { API_VERSION_BACKUP, paginate } from "src/utils/utils";
 import { apiToRole } from "src/utils/rolesUtils";
+// React Router DOM
+import { useSearchParams } from "react-router-dom";
 
 interface MemberOfRolesProps {
   user: Partial<User>;
@@ -32,20 +34,28 @@ const MemberOfRoles = (props: MemberOfRolesProps) => {
   // Alerts to show in the UI
   const alerts = useAlerts();
 
+  const [searchParams, setSearchParams] = useSearchParams();
+
   // Page indexes
-  const [page, setPage] = React.useState(1);
+  const [page, setPage] = React.useState(
+    parseInt(searchParams.get("p") || "1")
+  );
   const [perPage, setPerPage] = React.useState(10);
 
   // Other states
   const [rolesSelected, setRolesSelected] = React.useState<string[]>([]);
-  const [searchValue, setSearchValue] = React.useState("");
+  const [searchValue, setSearchValue] = React.useState(
+    searchParams.get("search") || ""
+  );
 
   // Loaded roles based on paging and member attributes
   const [roles, setRoles] = React.useState<Role[]>([]);
 
   // Membership direction and roles
   const [membershipDirection, setMembershipDirection] =
-    React.useState<MembershipDirection>("direct");
+    React.useState<MembershipDirection>(
+      (searchParams.get("membership") as MembershipDirection) || "direct"
+    );
 
   // Choose the correct roles based on the membership direction
   const memberof_role = props.user.memberof_role || [];
@@ -70,6 +80,23 @@ const MemberOfRoles = (props: MemberOfRolesProps) => {
 
     return toLoad;
   };
+
+  // Handle URLs with pagination and search values
+  React.useEffect(() => {
+    const searchParamsNew: { [key: string]: string } = {};
+
+    if (page > 1) {
+      searchParamsNew.p = page.toString();
+    }
+    if (searchValue !== "") {
+      searchParamsNew.search = searchValue;
+    }
+    if (membershipDirection !== "direct") {
+      searchParamsNew.membership = membershipDirection;
+    }
+
+    setSearchParams(searchParamsNew, { replace: true });
+  }, [page, searchValue, membershipDirection]);
 
   const [roleNamesToLoad, setRoleNamesToLoad] = React.useState<string[]>(
     getRolesNameToLoad()

--- a/src/components/MemberOf/MemberOfSubIds.tsx
+++ b/src/components/MemberOf/MemberOfSubIds.tsx
@@ -15,6 +15,8 @@ import {
 } from "src/services/rpcSubIds";
 // Utils
 import { API_VERSION_BACKUP, paginate } from "src/utils/utils";
+// React Router DOM
+import { useSearchParams } from "react-router-dom";
 
 interface MemberOfSubIdsProps {
   user: Partial<User>;
@@ -26,11 +28,15 @@ const MemberOfSubIds = (props: MemberOfSubIdsProps) => {
   // Alerts to show in the UI
   const alerts = useAlerts();
 
+  const [searchParams, setSearchParams] = useSearchParams();
+
   // API calls
   const [assignSubIds] = useAssignSubIdsMutation();
 
   // Page indexes
-  const [page, setPage] = React.useState(1);
+  const [page, setPage] = React.useState(
+    parseInt(searchParams.get("p") || "1")
+  );
   const [perPage, setPerPage] = React.useState(10);
 
   // Other states
@@ -59,6 +65,20 @@ const MemberOfSubIds = (props: MemberOfSubIdsProps) => {
     subIdsList: subIdsNamesToLoad,
     version: API_VERSION_BACKUP,
   });
+
+  // Handle URLs with pagination and search values
+  React.useEffect(() => {
+    let searchParamsNew = {};
+
+    if (page > 1) {
+      searchParamsNew = {
+        ...searchParamsNew,
+        p: page.toString(),
+      };
+    }
+
+    setSearchParams(searchParamsNew, { replace: true });
+  }, [page]);
 
   // Refresh Subordinate IDs
   React.useEffect(() => {

--- a/src/components/MemberOf/MemberOfSudoRules.tsx
+++ b/src/components/MemberOf/MemberOfSudoRules.tsx
@@ -21,6 +21,8 @@ import {
 import { API_VERSION_BACKUP, paginate } from "src/utils/utils";
 import { apiToSudoRule } from "src/utils/sudoRulesUtils";
 import { ErrorResult } from "src/services/rpc";
+// React Router DOM
+import { useSearchParams } from "react-router-dom";
 
 interface MemberOfSudoRulesProps {
   user: Partial<User>;
@@ -33,22 +35,30 @@ const MemberOfSudoRules = (props: MemberOfSudoRulesProps) => {
   // Alerts to show in the UI
   const alerts = useAlerts();
 
+  const [searchParams, setSearchParams] = useSearchParams();
+
   // Page indexes
-  const [page, setPage] = React.useState(1);
+  const [page, setPage] = React.useState(
+    parseInt(searchParams.get("p") || "1")
+  );
   const [perPage, setPerPage] = React.useState(10);
 
   // Other states
   const [sudoRulesSelected, setSudoRulesSelected] = React.useState<string[]>(
     []
   );
-  const [searchValue, setSearchValue] = React.useState("");
+  const [searchValue, setSearchValue] = React.useState(
+    searchParams.get("search") || ""
+  );
 
   // Loaded Sudo rules based on paging and member attributes
   const [sudoRules, setSudoRules] = React.useState<SudoRule[]>([]);
 
   // Membership direction and Sudo rules
   const [membershipDirection, setMembershipDirection] =
-    React.useState<MembershipDirection>("direct");
+    React.useState<MembershipDirection>(
+      (searchParams.get("membership") as MembershipDirection) || "direct"
+    );
 
   const memberof_sudorule = props.user.memberof_sudorule || [];
   const memberofindirect_sudorule = props.user.memberofindirect_sudorule || [];
@@ -73,6 +83,23 @@ const MemberOfSudoRules = (props: MemberOfSudoRulesProps) => {
     toLoad = paginate(toLoad, page, perPage);
     return toLoad;
   };
+
+  // Handle URLs with pagination and search values
+  React.useEffect(() => {
+    const searchParamsNew: { [key: string]: string } = {};
+
+    if (page > 1) {
+      searchParamsNew.p = page.toString();
+    }
+    if (searchValue !== "") {
+      searchParamsNew.search = searchValue;
+    }
+    if (membershipDirection !== "direct") {
+      searchParamsNew.membership = membershipDirection;
+    }
+
+    setSearchParams(searchParamsNew, { replace: true });
+  }, [page, searchValue, membershipDirection]);
 
   const [sudoRulesNamesToLoad, setSudoRulesNamesToLoad] = React.useState<
     string[]

--- a/src/components/MemberOf/MemberOfUserGroups.tsx
+++ b/src/components/MemberOf/MemberOfUserGroups.tsx
@@ -21,6 +21,8 @@ import {
 // Utils
 import { API_VERSION_BACKUP, paginate } from "src/utils/utils";
 import { apiToGroup } from "src/utils/groupUtils";
+// React Router DOM
+import { useSearchParams } from "react-router-dom";
 
 interface MemberOfUserGroupsProps {
   user: Partial<User>;
@@ -33,22 +35,30 @@ const MemberOfUserGroups = (props: MemberOfUserGroupsProps) => {
   // Alerts to show in the UI
   const alerts = useAlerts();
 
+  const [searchParams, setSearchParams] = useSearchParams();
+
   // Page indexes
-  const [page, setPage] = React.useState(1);
+  const [page, setPage] = React.useState(
+    parseInt(searchParams.get("p") || "1")
+  );
   const [perPage, setPerPage] = React.useState(10);
 
   // Other states
   const [userGroupsSelected, setUserGroupsSelected] = React.useState<string[]>(
     []
   );
-  const [searchValue, setSearchValue] = React.useState("");
+  const [searchValue, setSearchValue] = React.useState(
+    searchParams.get("search") || ""
+  );
 
   // Loaded User groups based on paging and member attributes
   const [userGroups, setUserGroups] = React.useState<UserGroup[]>([]);
 
   // Membership direction and User groups
   const [membershipDirection, setMembershipDirection] =
-    React.useState<MembershipDirection>("direct");
+    React.useState<MembershipDirection>(
+      (searchParams.get("membership") as MembershipDirection) || "direct"
+    );
 
   // Choose the correct User groups based on the membership direction
   const memberof_group = props.user.memberof_group || [];
@@ -73,6 +83,23 @@ const MemberOfUserGroups = (props: MemberOfUserGroupsProps) => {
 
     return toLoad;
   };
+
+  // Handle URLs with pagination and search values
+  React.useEffect(() => {
+    const searchParamsNew: { [key: string]: string } = {};
+
+    if (page > 1) {
+      searchParamsNew.p = page.toString();
+    }
+    if (searchValue !== "") {
+      searchParamsNew.search = searchValue;
+    }
+    if (membershipDirection !== "direct") {
+      searchParamsNew.membership = membershipDirection;
+    }
+
+    setSearchParams(searchParamsNew, { replace: true });
+  }, [page, searchValue, membershipDirection]);
 
   const [userGroupNamesToLoad, setUserGroupNamesToLoad] = React.useState<
     string[]


### PR DESCRIPTION
The Users > 'Is a member of' pages need the pagination, search, and membership direction parameters in order to show in the browser URL the navigated page and search text (if it exists).

This has been applied to the following tab sections:
- User groups
- Netgroups
- Roles
- HBAC rules
- Sudo rules
- Subordinate IDs