### PR TITLE
Fix highlighted Nav links on subpages

### DIFF
--- a/src/components/HostsSections/HostSettings.tsx
+++ b/src/components/HostsSections/HostSettings.tsx
@@ -23,6 +23,8 @@ import PopoverWithIconLayout from "../layouts/PopoverWithIconLayout";
 import PrincipalAliasMultiTextBox from "../Form/PrincipalAliasMultiTextBox";
 // Utils
 import { asRecord } from "../../utils/hostUtils";
+// Hooks
+import useUpdateRoute from "src/hooks/useUpdateRoute";
 
 interface PrincipalAlias {
   id: number | string;
@@ -43,6 +45,9 @@ const HostSettings = (props: PropsToHostSettings) => {
     fqdn = props.host.fqdn;
   }
   const [hostName] = useState(fqdn);
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  useUpdateRoute({ pathname: "hosts" });
 
   // Get krb realms
   const krbrealms = props.host.krbprincipalname;

--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -47,6 +47,7 @@ import {
 } from "src/services/rpcUsers";
 // Hooks
 import useAlerts from "src/hooks/useAlerts";
+import useUpdateRoute from "src/hooks/useUpdateRoute";
 // Modals
 import DisableEnableUsers from "./modals/DisableEnableUsers";
 import DeleteUsers from "./modals/DeleteUsers";
@@ -89,6 +90,9 @@ const UserSettings = (props: PropsToUserSettings) => {
 
   // Navigate
   const navigate = useNavigate();
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  useUpdateRoute({ pathname: props.from });
 
   // RTK hook: save user (acive/preserved and stage)
   let [saveUser] = useSaveUserMutation();

--- a/src/hooks/useUpdateRoute.tsx
+++ b/src/hooks/useUpdateRoute.tsx
@@ -67,6 +67,11 @@ export const useUpdateRoute = ({ pathname }) => {
     }
   }, [pathname]);
 
+  // Set the page title to be shown in the browser tab
+  React.useEffect(() => {
+    document.title = browserTitle;
+  }, [browserTitle]);
+
   return {
     loadedGroup,
     breadCrumbPath,

--- a/src/pages/ActiveUsers/UserMemberOf.tsx
+++ b/src/pages/ActiveUsers/UserMemberOf.tsx
@@ -27,6 +27,8 @@ import { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
 // Redux
 import { useAppDispatch } from "src/store/hooks";
 import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
+// Hooks
+import useUpdateRoute from "src/hooks/useUpdateRoute";
 
 interface PropsToUserMemberOf {
   user: User;
@@ -59,6 +61,9 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
       dispatch(updateBreadCrumbPath(currentPath));
     }
   }, [props.user.uid]);
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  useUpdateRoute({ pathname: props.from });
 
   // User's full data
   const userQuery = useGetUserByUidQuery(convertToString(props.user.uid));

--- a/src/pages/Hosts/HostsManagedBy.tsx
+++ b/src/pages/Hosts/HostsManagedBy.tsx
@@ -21,6 +21,8 @@ import ManagedByToolbar from "src/components/ManagedBy/ManagedByToolbar";
 // Modals
 import ManagedByAddModal from "src/components/ManagedBy/ManagedByAddModal";
 import ManagedByDeleteModal from "src/components/ManagedBy/ManagedByDeleteModal";
+// Hooks
+import useUpdateRoute from "src/hooks/useUpdateRoute";
 
 interface PropsToHostsManagedBy {
   host: Host;
@@ -29,6 +31,9 @@ interface PropsToHostsManagedBy {
 const HostsManagedBy = (props: PropsToHostsManagedBy) => {
   // List of currents elements on the list (Dummy data)
   const [hostsList, setHostsList] = useState<Host[]>([props.host]);
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  useUpdateRoute({ pathname: "hosts" });
 
   // Some data is updated when any group list is altered
   //  - The whole list itself

--- a/src/pages/Hosts/HostsMemberOf.tsx
+++ b/src/pages/Hosts/HostsMemberOf.tsx
@@ -36,6 +36,8 @@ import MemberOfAddModal from "src/components/MemberOf/MemberOfAddModalOld";
 import MemberOfDeleteModal from "src/components/MemberOf/MemberOfDeleteModalOld";
 // Navigation
 import { useNavigate } from "react-router-dom";
+// Hooks
+import useUpdateRoute from "src/hooks/useUpdateRoute";
 // RPC
 import { useGetHostByIdQuery } from "src/services/rpcHosts";
 import MemberOfHostGroups from "src/components/MemberOf/MemberOfHostGroups";
@@ -94,6 +96,9 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
       setHostGroupLength(host.memberof_hostgroup.length);
     }
   }, [host]);
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  useUpdateRoute({ pathname: "hosts" });
 
   // Retrieve each group list from Redux:
   let netgroupsList = [] as NetgroupOld[];


### PR DESCRIPTION
The Navigation links should remain highlighted when refreshing the current page, applied for the following subsections:
- Users:
  - Settings
  - Is a member of
- Hosts
  - Settings
  - Is a member of
  - Is managed by