### PR TITLE
Provide custom hook to handle parameters

### DIFF
--- a/src/components/MemberOf/MemberOfHbacRules.tsx
+++ b/src/components/MemberOf/MemberOfHbacRules.tsx
@@ -4,12 +4,13 @@ import { Pagination, PaginationVariant } from "@patternfly/react-core";
 // Data types
 import { User, HBACRule, Host } from "src/utils/datatypes/globalDataTypes";
 // Components
-import MemberOfToolbar, { MembershipDirection } from "./MemberOfToolbar";
+import MemberOfToolbar from "./MemberOfToolbar";
 import MemberOfHbacRulesTable from "./MemberOfTableHbacRules";
 import MemberOfAddModal, { AvailableItems } from "./MemberOfAddModal";
 import MemberOfDeleteModal from "./MemberOfDeleteModal";
 // Hooks
 import useAlerts from "src/hooks/useAlerts";
+import useRoutingParams from "src/hooks/useRoutingParams";
 // RPC
 import { ErrorResult } from "src/services/rpc";
 import {
@@ -21,8 +22,6 @@ import {
 // Utils
 import { API_VERSION_BACKUP, paginate } from "src/utils/utils";
 import { apiToHBACRule } from "src/utils/hbacRulesUtils";
-// React Router DOM
-import { useSearchParams } from "react-router-dom";
 
 interface MemberOfHbacRulesProps {
   entity: Partial<User> | Partial<Host>;
@@ -36,34 +35,29 @@ const MemberOfHbacRules = (props: MemberOfHbacRulesProps) => {
   // Alerts to show in the UI
   const alerts = useAlerts();
 
-  const [searchParams, setSearchParams] = useSearchParams();
-
-  // Page indexes
-  const [page, setPage] = React.useState(
-    parseInt(searchParams.get("p") || "1")
-  );
-  const [perPage, setPerPage] = React.useState(10);
+  const {
+    page,
+    setPage,
+    perPage,
+    setPerPage,
+    searchValue,
+    setSearchValue,
+    membershipDirection,
+    setMembershipDirection,
+  } = useRoutingParams();
 
   // Other states
   const [hbacRulesSelected, setHbacRulesSelected] = React.useState<string[]>(
     []
   );
-  const [searchValue, setSearchValue] = React.useState(
-    searchParams.get("search") || ""
-  );
 
   // Loaded HBAC rules based on paging and member attributes
   const [hbacRules, setHbacRules] = React.useState<HBACRule[]>([]);
 
-  // Membership direction and HBAC rules
-  const [membershipDirection, setMembershipDirection] =
-    React.useState<MembershipDirection>(
-      (searchParams.get("membership") as MembershipDirection) || "direct"
-    );
-
   const memberof_hbacrule = props.entity.memberof_hbacrule || [];
   const memberofindirect_hbacrule =
     props.entity.memberofindirect_hbacrule || [];
+
   let hbacRuleNames =
     membershipDirection === "direct"
       ? memberof_hbacrule
@@ -85,23 +79,6 @@ const MemberOfHbacRules = (props: MemberOfHbacRulesProps) => {
     toLoad = paginate(toLoad, page, perPage);
     return toLoad;
   };
-
-  // Handle URLs with pagination and search values
-  React.useEffect(() => {
-    const searchParamsNew: { [key: string]: string } = {};
-
-    if (page > 1) {
-      searchParamsNew.p = page.toString();
-    }
-    if (searchValue !== "") {
-      searchParamsNew.search = searchValue;
-    }
-    if (membershipDirection !== "direct") {
-      searchParamsNew.membership = membershipDirection;
-    }
-
-    setSearchParams(searchParamsNew, { replace: true });
-  }, [page, searchValue, membershipDirection]);
 
   const [hbacRulesNamesToLoad, setHbacRulesNamesToLoad] = React.useState<
     string[]

--- a/src/components/MemberOf/MemberOfNetgroups.tsx
+++ b/src/components/MemberOf/MemberOfNetgroups.tsx
@@ -4,10 +4,11 @@ import { Pagination, PaginationVariant } from "@patternfly/react-core";
 // Data types
 import { User, Netgroup, Host } from "src/utils/datatypes/globalDataTypes";
 // Components
-import MemberOfToolbar, { MembershipDirection } from "./MemberOfToolbar";
+import MemberOfToolbar from "./MemberOfToolbar";
 import MemberOfTableNetgroups from "./MemberOfTableNetgroups";
 // Hooks
 import useAlerts from "src/hooks/useAlerts";
+import useRoutingParams from "src/hooks/useRoutingParams";
 // RPC
 import { ErrorResult } from "src/services/rpc";
 import {
@@ -22,8 +23,6 @@ import { apiToNetgroup } from "src/utils/netgroupsUtils";
 // Modals
 import MemberOfAddModal, { AvailableItems } from "./MemberOfAddModal";
 import MemberOfDeleteModal from "./MemberOfDeleteModal";
-// React Router DOM
-import { useSearchParams } from "react-router-dom";
 
 interface MemberOfNetroupsProps {
   entity: Partial<User> | Partial<Host>;
@@ -37,30 +36,24 @@ const memberOfNetgroups = (props: MemberOfNetroupsProps) => {
   // Alerts to show in the UI
   const alerts = useAlerts();
 
-  const [searchParams, setSearchParams] = useSearchParams();
-
-  // Page indexes
-  const [page, setPage] = React.useState(
-    parseInt(searchParams.get("p") || "1")
-  );
-  const [perPage, setPerPage] = React.useState(10);
+  const {
+    page,
+    setPage,
+    perPage,
+    setPerPage,
+    searchValue,
+    setSearchValue,
+    membershipDirection,
+    setMembershipDirection,
+  } = useRoutingParams();
 
   // Other states
   const [netgroupsSelected, setNetgroupsSelected] = React.useState<string[]>(
     []
   );
-  const [searchValue, setSearchValue] = React.useState(
-    searchParams.get("search") || ""
-  );
 
   // Loaded netgroups based on paging and member attributes
   const [netgroups, setNetgroups] = React.useState<Netgroup[]>([]);
-
-  // Membership direction and netgroups
-  const [membershipDirection, setMembershipDirection] =
-    React.useState<MembershipDirection>(
-      (searchParams.get("membership") as MembershipDirection) || "direct"
-    );
 
   // Choose the correct netgroups based on the membership direction
   const memberof_netgroup = props.entity.memberof_netgroup || [];
@@ -88,23 +81,6 @@ const memberOfNetgroups = (props: MemberOfNetroupsProps) => {
 
     return toLoad;
   };
-
-  // Handle URLs with pagination and search values
-  React.useEffect(() => {
-    const searchParamsNew: { [key: string]: string } = {};
-
-    if (page > 1) {
-      searchParamsNew.p = page.toString();
-    }
-    if (searchValue !== "") {
-      searchParamsNew.search = searchValue;
-    }
-    if (membershipDirection !== "direct") {
-      searchParamsNew.membership = membershipDirection;
-    }
-
-    setSearchParams(searchParamsNew, { replace: true });
-  }, [page, searchValue, membershipDirection]);
 
   const [netgroupNamesToLoad, setNetgroupNamesToLoad] = React.useState<
     string[]

--- a/src/components/MemberOf/MemberOfRoles.tsx
+++ b/src/components/MemberOf/MemberOfRoles.tsx
@@ -4,12 +4,13 @@ import { Pagination, PaginationVariant } from "@patternfly/react-core";
 // Data types
 import { User, Role, Host } from "src/utils/datatypes/globalDataTypes";
 // Components
-import MemberOfToolbar, { MembershipDirection } from "./MemberOfToolbar";
+import MemberOfToolbar from "./MemberOfToolbar";
 import MemberOfTableRoles from "./MemberOfTableRoles";
 import MemberOfAddModal, { AvailableItems } from "./MemberOfAddModal";
 import MemberOfDeleteModal from "./MemberOfDeleteModal";
 // Hooks
 import useAlerts from "src/hooks/useAlerts";
+import useRoutingParams from "src/hooks/useRoutingParams";
 // RPC
 import { ErrorResult } from "src/services/rpc";
 import {
@@ -21,8 +22,6 @@ import {
 // Utils
 import { API_VERSION_BACKUP, paginate } from "src/utils/utils";
 import { apiToRole } from "src/utils/rolesUtils";
-// React Router DOM
-import { useSearchParams } from "react-router-dom";
 
 interface MemberOfRolesProps {
   entity: Partial<User> | Partial<Host>;
@@ -35,28 +34,22 @@ const MemberOfRoles = (props: MemberOfRolesProps) => {
   // Alerts to show in the UI
   const alerts = useAlerts();
 
-  const [searchParams, setSearchParams] = useSearchParams();
-
-  // Page indexes
-  const [page, setPage] = React.useState(
-    parseInt(searchParams.get("p") || "1")
-  );
-  const [perPage, setPerPage] = React.useState(10);
+  const {
+    page,
+    setPage,
+    perPage,
+    setPerPage,
+    searchValue,
+    setSearchValue,
+    membershipDirection,
+    setMembershipDirection,
+  } = useRoutingParams();
 
   // Other states
   const [rolesSelected, setRolesSelected] = React.useState<string[]>([]);
-  const [searchValue, setSearchValue] = React.useState(
-    searchParams.get("search") || ""
-  );
 
   // Loaded roles based on paging and member attributes
   const [roles, setRoles] = React.useState<Role[]>([]);
-
-  // Membership direction and roles
-  const [membershipDirection, setMembershipDirection] =
-    React.useState<MembershipDirection>(
-      (searchParams.get("membership") as MembershipDirection) || "direct"
-    );
 
   // Choose the correct roles based on the membership direction
   const memberof_role = props.entity.memberof_role || [];
@@ -81,23 +74,6 @@ const MemberOfRoles = (props: MemberOfRolesProps) => {
 
     return toLoad;
   };
-
-  // Handle URLs with pagination and search values
-  React.useEffect(() => {
-    const searchParamsNew: { [key: string]: string } = {};
-
-    if (page > 1) {
-      searchParamsNew.p = page.toString();
-    }
-    if (searchValue !== "") {
-      searchParamsNew.search = searchValue;
-    }
-    if (membershipDirection !== "direct") {
-      searchParamsNew.membership = membershipDirection;
-    }
-
-    setSearchParams(searchParamsNew, { replace: true });
-  }, [page, searchValue, membershipDirection]);
 
   const [roleNamesToLoad, setRoleNamesToLoad] = React.useState<string[]>(
     getRolesNameToLoad()

--- a/src/components/MemberOf/MemberOfSudoRules.tsx
+++ b/src/components/MemberOf/MemberOfSudoRules.tsx
@@ -4,12 +4,13 @@ import { Pagination, PaginationVariant } from "@patternfly/react-core";
 // Data types
 import { User, SudoRule, Host } from "src/utils/datatypes/globalDataTypes";
 // Components
-import MemberOfToolbar, { MembershipDirection } from "./MemberOfToolbar";
+import MemberOfToolbar from "./MemberOfToolbar";
 import MemberOfTableSudoRules from "./MemberOfTableSudoRules";
 import MemberOfAddModal, { AvailableItems } from "./MemberOfAddModal";
 import MemberOfDeleteModal from "./MemberOfDeleteModal";
 // Hooks
 import useAlerts from "src/hooks/useAlerts";
+import useRoutingParams from "src/hooks/useRoutingParams";
 // RPC
 import {
   useGetSudoRulesInfoByNameQuery,
@@ -21,8 +22,6 @@ import {
 import { API_VERSION_BACKUP, paginate } from "src/utils/utils";
 import { apiToSudoRule } from "src/utils/sudoRulesUtils";
 import { ErrorResult } from "src/services/rpc";
-// React Router DOM
-import { useSearchParams } from "react-router-dom";
 
 interface MemberOfSudoRulesProps {
   entity: Partial<User> | Partial<Host>;
@@ -36,34 +35,29 @@ const MemberOfSudoRules = (props: MemberOfSudoRulesProps) => {
   // Alerts to show in the UI
   const alerts = useAlerts();
 
-  const [searchParams, setSearchParams] = useSearchParams();
-
-  // Page indexes
-  const [page, setPage] = React.useState(
-    parseInt(searchParams.get("p") || "1")
-  );
-  const [perPage, setPerPage] = React.useState(10);
+  const {
+    page,
+    setPage,
+    perPage,
+    setPerPage,
+    searchValue,
+    setSearchValue,
+    membershipDirection,
+    setMembershipDirection,
+  } = useRoutingParams();
 
   // Other states
   const [sudoRulesSelected, setSudoRulesSelected] = React.useState<string[]>(
     []
   );
-  const [searchValue, setSearchValue] = React.useState(
-    searchParams.get("search") || ""
-  );
 
   // Loaded Sudo rules based on paging and member attributes
   const [sudoRules, setSudoRules] = React.useState<SudoRule[]>([]);
 
-  // Membership direction and Sudo rules
-  const [membershipDirection, setMembershipDirection] =
-    React.useState<MembershipDirection>(
-      (searchParams.get("membership") as MembershipDirection) || "direct"
-    );
-
   const memberof_sudorule = props.entity.memberof_sudorule || [];
   const memberofindirect_sudorule =
     props.entity.memberofindirect_sudorule || [];
+
   let sudoRuleNames =
     membershipDirection === "direct"
       ? memberof_sudorule
@@ -85,23 +79,6 @@ const MemberOfSudoRules = (props: MemberOfSudoRulesProps) => {
     toLoad = paginate(toLoad, page, perPage);
     return toLoad;
   };
-
-  // Handle URLs with pagination and search values
-  React.useEffect(() => {
-    const searchParamsNew: { [key: string]: string } = {};
-
-    if (page > 1) {
-      searchParamsNew.p = page.toString();
-    }
-    if (searchValue !== "") {
-      searchParamsNew.search = searchValue;
-    }
-    if (membershipDirection !== "direct") {
-      searchParamsNew.membership = membershipDirection;
-    }
-
-    setSearchParams(searchParamsNew, { replace: true });
-  }, [page, searchValue, membershipDirection]);
 
   const [sudoRulesNamesToLoad, setSudoRulesNamesToLoad] = React.useState<
     string[]

--- a/src/components/MemberOf/MemberOfUserGroups.tsx
+++ b/src/components/MemberOf/MemberOfUserGroups.tsx
@@ -4,12 +4,13 @@ import { Pagination, PaginationVariant } from "@patternfly/react-core";
 // Data types
 import { User, UserGroup } from "src/utils/datatypes/globalDataTypes";
 // Components
-import MemberOfToolbar, { MembershipDirection } from "./MemberOfToolbar";
+import MemberOfToolbar from "./MemberOfToolbar";
 import MemberOfUserGroupsTable from "./MemberOfTableUserGroups";
 import MemberOfAddModal, { AvailableItems } from "./MemberOfAddModal";
 import MemberOfDeleteModal from "./MemberOfDeleteModal";
 // Hooks
 import useAlerts from "src/hooks/useAlerts";
+import useRoutingParams from "src/hooks/useRoutingParams";
 // RPC
 import { ErrorResult } from "src/services/rpc";
 import {
@@ -21,8 +22,6 @@ import {
 // Utils
 import { API_VERSION_BACKUP, paginate } from "src/utils/utils";
 import { apiToGroup } from "src/utils/groupUtils";
-// React Router DOM
-import { useSearchParams } from "react-router-dom";
 
 interface MemberOfUserGroupsProps {
   user: Partial<User>;
@@ -35,30 +34,24 @@ const MemberOfUserGroups = (props: MemberOfUserGroupsProps) => {
   // Alerts to show in the UI
   const alerts = useAlerts();
 
-  const [searchParams, setSearchParams] = useSearchParams();
-
-  // Page indexes
-  const [page, setPage] = React.useState(
-    parseInt(searchParams.get("p") || "1")
-  );
-  const [perPage, setPerPage] = React.useState(10);
+  const {
+    page,
+    setPage,
+    perPage,
+    setPerPage,
+    searchValue,
+    setSearchValue,
+    membershipDirection,
+    setMembershipDirection,
+  } = useRoutingParams();
 
   // Other states
   const [userGroupsSelected, setUserGroupsSelected] = React.useState<string[]>(
     []
   );
-  const [searchValue, setSearchValue] = React.useState(
-    searchParams.get("search") || ""
-  );
 
   // Loaded User groups based on paging and member attributes
   const [userGroups, setUserGroups] = React.useState<UserGroup[]>([]);
-
-  // Membership direction and User groups
-  const [membershipDirection, setMembershipDirection] =
-    React.useState<MembershipDirection>(
-      (searchParams.get("membership") as MembershipDirection) || "direct"
-    );
 
   // Choose the correct User groups based on the membership direction
   const memberof_group = props.user.memberof_group || [];
@@ -83,23 +76,6 @@ const MemberOfUserGroups = (props: MemberOfUserGroupsProps) => {
 
     return toLoad;
   };
-
-  // Handle URLs with pagination and search values
-  React.useEffect(() => {
-    const searchParamsNew: { [key: string]: string } = {};
-
-    if (page > 1) {
-      searchParamsNew.p = page.toString();
-    }
-    if (searchValue !== "") {
-      searchParamsNew.search = searchValue;
-    }
-    if (membershipDirection !== "direct") {
-      searchParamsNew.membership = membershipDirection;
-    }
-
-    setSearchParams(searchParamsNew, { replace: true });
-  }, [page, searchValue, membershipDirection]);
 
   const [userGroupNamesToLoad, setUserGroupNamesToLoad] = React.useState<
     string[]

--- a/src/hooks/useRoutingParams.tsx
+++ b/src/hooks/useRoutingParams.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { useSearchParams } from "react-router-dom";
+import { MembershipDirection } from "src/components/MemberOf/MemberOfToolbar";
+
+const useRoutingParams = () => {
+  const [params, setParams] = useSearchParams();
+
+  // States
+  // Page indexes
+  // - Ensure that the page index is always a positive integer
+  const getPageParam = () => {
+    const pageParam = params.get("p");
+    if (pageParam && (parseInt(pageParam) < 1 || isNaN(parseInt(pageParam)))) {
+      return 1;
+    } else {
+      return parseInt(pageParam || "1");
+    }
+  };
+
+  const getPerPageParam = () => {
+    const pageParam = params.get("size");
+    if (pageParam && (parseInt(pageParam) < 1 || isNaN(parseInt(pageParam)))) {
+      return 10;
+    } else {
+      return parseInt(pageParam || "10");
+    }
+  };
+
+  const [page, setPage] = React.useState(getPageParam());
+  const [perPage, setPerPage] = React.useState(getPerPageParam());
+
+  // Search value
+  const [searchValue, setSearchValue] = React.useState(
+    params.get("search") || ""
+  );
+
+  // Membership direction
+  // - Ensure that the teo possible options are "direct" and "indirect"
+  const getMembershipParam = () => {
+    if (
+      params.get("membership") !== "indirect" ||
+      params.get("membership") !== "direct"
+    ) {
+      return "direct";
+    } else {
+      return params.get("membership") as MembershipDirection;
+    }
+  };
+
+  const [membershipDirection, setMembershipDirection] =
+    React.useState<MembershipDirection>(getMembershipParam());
+
+  // Handle URLs with navigation parameters
+  React.useEffect(() => {
+    let searchParamsNew = {};
+
+    if (page > 1) {
+      searchParamsNew = {
+        ...searchParamsNew,
+        p: page.toString(),
+      };
+    }
+    if (searchValue !== "") {
+      searchParamsNew = {
+        ...searchParamsNew,
+        search: searchValue,
+      };
+    }
+    if (membershipDirection !== "direct") {
+      searchParamsNew = {
+        ...searchParamsNew,
+        membership: membershipDirection,
+      };
+    }
+    searchParamsNew = {
+      ...searchParamsNew,
+      size: perPage.toString(),
+    };
+
+    setParams(searchParamsNew, { replace: true });
+  }, [page, searchValue, membershipDirection, perPage]);
+
+  return {
+    page,
+    setPage,
+    perPage,
+    setPerPage,
+    searchValue,
+    setSearchValue,
+    membershipDirection,
+    setMembershipDirection,
+  };
+};
+
+export default useRoutingParams;


### PR DESCRIPTION
A custom hook has been implemented to handle all the 'Is a member of' parameters (instead of doing so in multiple lines of code):
- Page number
- Page size
- Membership direction
- Search input value