### PR TITLE
[Active users][Is a member of] Fix showing incorrect data when adding new memberships

### DIFF
--- a/src/components/MemberOf/MemberOfUserGroups.tsx
+++ b/src/components/MemberOf/MemberOfUserGroups.tsx
@@ -172,7 +172,7 @@ const MemberOfUserGroups = (props: MemberOfUserGroupsProps) => {
           title: userGroup.cn,
         });
       }
-      items = items.filter((item) => !userGroupNamesToLoad.includes(item.key));
+      items = items.filter((item) => !memberof_group.includes(item.key));
 
       setAvailableUserGroups(avalUserGroups);
       setAvailableItems(items);


### PR DESCRIPTION
This bug is affecting `Active users` > `Is a member of` page section tabs.

The data available to add is incorrect because the filtering is being done taking as reference the current page data
and not the full elements that are already member of.

Steps to reproduce in `User groups` tab:
- Add 14 user groups from the `User groups ` main page. Those will be the total data.
- Go to `Active users` > `Is a member of` > `User groups` tab and add **all** the already created elements.
- Set the pagination size as 10 elements per page.
- Click `Add` button. Even though there should not be any data available, some items are shown.