### PR TITLE
[Hosts][Is a member of][Host groups] Fix showing incorrect data on add and delete

### DIFF
--- a/src/components/MemberOf/MemberOfHostGroups.tsx
+++ b/src/components/MemberOf/MemberOfHostGroups.tsx
@@ -50,10 +50,13 @@ const MemberOfHostGroups = (props: MemberOfHostGroupsProps) => {
     React.useState<MembershipDirection>("direct");
 
   // Choose the correct Host groups based on the membership direction
-  const memberof_group = props.host.memberof_hostgroup || [];
-  const memberofindirect_group = props.host.memberofindirect_hostgroup || [];
+  const memberof_hostgroup = props.host.memberof_hostgroup || [];
+  const memberofindirect_hostgroup =
+    props.host.memberofindirect_hostgroup || [];
   let hostGroupNames =
-    membershipDirection === "direct" ? memberof_group : memberofindirect_group;
+    membershipDirection === "direct"
+      ? memberof_hostgroup
+      : memberofindirect_hostgroup;
   hostGroupNames = [...hostGroupNames];
 
   const getHostGroupsNameToLoad = (): string[] => {
@@ -168,7 +171,7 @@ const MemberOfHostGroups = (props: MemberOfHostGroupsProps) => {
           title: userGroup.cn,
         });
       }
-      items = items.filter((item) => !hostGroupNamesToLoad.includes(item.key));
+      items = items.filter((item) => !memberof_hostgroup.includes(item.key));
 
       setAvailableHostGroups(avalHostGroups);
       setAvailableItems(items);
@@ -242,6 +245,8 @@ const MemberOfHostGroups = (props: MemberOfHostGroupsProps) => {
             setShowDeleteModal(false);
             // Refresh
             props.onRefreshHostData();
+            // Return to first page
+            setPage(1);
           } else if (response.data.error) {
             // Set alert: error
             const errorMessage = response.data.error as unknown as ErrorResult;
@@ -315,7 +320,7 @@ const MemberOfHostGroups = (props: MemberOfHostGroupsProps) => {
           onDelete={onDeleteHostGroup}
         >
           <MemberOfHostGroupsTable
-            hostGroups={hostGroups.filter((hostgroup) =>
+            hostGroups={availableHostGroups.filter((hostgroup) =>
               hostGroupsSelected.includes(hostgroup.cn)
             )}
             showTableRows

--- a/src/components/MemberOf/MemberOfTableHostGroups.tsx
+++ b/src/components/MemberOf/MemberOfTableHostGroups.tsx
@@ -60,7 +60,22 @@ export default function MemberOfHostGroupsTable(
 ) {
   const { hostGroups } = props;
   if (!hostGroups || hostGroups.length <= 0) {
-    return null; // return empty placeholder
+    // return empty placeholder
+    return (
+      <Table
+        aria-label="member of table"
+        name="cn"
+        variant="compact"
+        borders
+        className={"pf-v5-u-mt-md"}
+        id="member-of-table"
+        isStickyHeader
+      >
+        <Tbody>
+          <EmptyBodyTable />
+        </Tbody>
+      </Table>
+    );
   }
 
   const showCheckboxColumn = props.onCheckItemsChange !== undefined;


### PR DESCRIPTION
This bug is similar to this one[1] and also affects the 'Delete' functionality in the `Hosts` > `Is a member of` > `Host groups`.

Steps to reproduce it:
- Add 14 host groups from the Host groups main page. Those will be the total data.
- Go to `Hosts` > `Is a member of` > `Hosts groups` tab and add all the already created elements.
- Set the pagination size as 10 elements per page.
- Select one element from the first page and other from the second page. 
- Click `Delete` button to see the about-to-delete elements. Only the element of the current page is being shown.

[1] - https://github.com/freeipa/freeipa-webui/pull/432
Signed-off-by: Carla Martinez <carlmart@redhat.com>