### PR TITLE
[Services] Provide routes for sections

### DIFF
--- a/src/hooks/useServiceSettingsData.tsx
+++ b/src/hooks/useServiceSettingsData.tsx
@@ -1,0 +1,118 @@
+import { useState, useEffect } from "react";
+
+// RPC
+import { useGetObjectMetadataQuery } from "src/services/rpc";
+import { useGetServicesFullDataQuery } from "src/services/rpcServices";
+// Data types
+import { Service, Metadata } from "src/utils/datatypes/globalDataTypes";
+
+type ServiceSettingsData = {
+  isLoading: boolean;
+  isFetching: boolean;
+  modified: boolean;
+  setModified: (value: boolean) => void;
+  resetValues: () => void;
+  metadata: Metadata;
+  originalService: Partial<Service>;
+  service: Partial<Service>;
+  setService: (fqdn: Partial<Service>) => void;
+  refetch: () => void;
+  modifiedValues: () => Partial<Service>;
+  certData?: Record<string, unknown>;
+};
+
+const useServiceSettings = (serviceId: string): ServiceSettingsData => {
+  // [API call] Metadata
+  const metadataQuery = useGetObjectMetadataQuery();
+  const metadata = metadataQuery.data || {};
+  const metadataLoading = metadataQuery.isLoading;
+
+  // [API call] Service
+  const serviceFullDataQuery = useGetServicesFullDataQuery(serviceId);
+  const serviceFullData = serviceFullDataQuery.data;
+  const isFullDataLoading = serviceFullDataQuery.isLoading;
+
+  const [modified, setModified] = useState(false);
+
+  // Data displayed and modified by the user
+  const [service, setService] = useState<Partial<Service>>({});
+
+  useEffect(() => {
+    if (serviceFullData && !serviceFullDataQuery.isFetching) {
+      setService({ ...serviceFullData });
+    }
+  }, [serviceFullData, serviceFullDataQuery.isFetching]);
+
+  const settings = {
+    isLoading: metadataLoading || isFullDataLoading,
+    isFetching: serviceFullDataQuery.isFetching,
+    modified,
+    setModified,
+    metadata,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    resetValues: () => {},
+    originalService: service,
+    setService,
+    refetch: serviceFullDataQuery.refetch,
+    service,
+    modifiedValues: () => service,
+  } as ServiceSettingsData;
+
+  if (serviceFullData) {
+    settings.originalService = serviceFullData || {};
+  } else {
+    settings.originalService = {};
+  }
+
+  const getModifiedValues = (): Partial<Service> => {
+    if (!serviceFullData || !serviceFullData) {
+      return {};
+    }
+
+    const modifiedValues = {};
+    for (const [key, value] of Object.entries(service)) {
+      if (Array.isArray(value)) {
+        // Using 'JSON.stringify' when comparing arrays (to prevent data type false positives)
+        if (JSON.stringify(serviceFullData[key]) !== JSON.stringify(value)) {
+          modifiedValues[key] = value;
+        }
+      } else if (serviceFullData[key] !== value) {
+        modifiedValues[key] = value;
+      }
+    }
+    return modifiedValues;
+  };
+  settings.modifiedValues = getModifiedValues;
+
+  // Detect any change in 'originalService' and 'service' objects
+  useEffect(() => {
+    if (!serviceFullData) {
+      return;
+    }
+    let modified = false;
+    for (const [key, value] of Object.entries(service)) {
+      if (Array.isArray(value)) {
+        // Using 'JSON.stringify' when comparing arrays (to prevent data type false positives)
+        if (JSON.stringify(serviceFullData[key]) !== JSON.stringify(value)) {
+          modified = true;
+          break;
+        }
+      } else {
+        if (serviceFullData[key] !== value) {
+          modified = true;
+          break;
+        }
+      }
+    }
+    setModified(modified);
+  }, [service, serviceFullData]);
+
+  const onResetValues = () => {
+    setModified(false);
+  };
+  settings.resetValues = onResetValues;
+
+  return settings;
+};
+
+export { useServiceSettings };

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -108,7 +108,17 @@ export const AppRoutes = (): React.ReactElement => (
     </Route>
     <Route path="services">
       <Route path="" element={<Services />} />
-      <Route path="settings" element={<ServicesTabs />} />
+      <Route path=":id">
+        <Route path="" element={<ServicesTabs section="settings" />} />
+        <Route
+          path="memberof_role"
+          element={<ServicesTabs section="memberof" />}
+        />
+        <Route
+          path="managedby_host"
+          element={<ServicesTabs section="managedby" />}
+        />
+      </Route>
     </Route>
     <Route path="user-groups">
       <Route path="" element={<UserGroups />} />

--- a/src/pages/Services/ServicesMemberOf.tsx
+++ b/src/pages/Services/ServicesMemberOf.tsx
@@ -14,21 +14,49 @@ import {
 // Others
 import MemberOfToolbar from "src/components/MemberOf/MemberOfToolbarOld";
 import MemberOfTable from "src/components/MemberOf/MemberOfTable";
+import { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
 // Data types
 import { RolesOld, Service } from "src/utils/datatypes/globalDataTypes";
 // Redux
-import { useAppSelector } from "src/store/hooks";
+import { useAppDispatch, useAppSelector } from "src/store/hooks";
+import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
 // Repositories
 import { servicesRolesInitialData } from "src/utils/data/GroupRepositories";
 // Modals
 import MemberOfAddModal from "src/components/MemberOf/MemberOfAddModalOld";
 import MemberOfDeleteModal from "src/components/MemberOf/MemberOfDeleteModalOld";
+// React Router DOM
+import { useNavigate } from "react-router-dom";
 
 interface PropsToServicesMemberOf {
   service: Service;
 }
 
 const ServicesMemberOf = (props: PropsToServicesMemberOf) => {
+  const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+
+  // Update breadcrumb route
+  React.useEffect(() => {
+    if (!props.service.krbcanonicalname) {
+      // Redirect to the main page
+      navigate("/services");
+    } else {
+      const currentPath: BreadCrumbItem[] = [
+        {
+          name: "Services",
+          url: "../../services",
+        },
+        {
+          name: props.service.krbcanonicalname,
+          url: "../../services/" + props.service.krbcanonicalname,
+          isActive: true,
+        },
+      ];
+      dispatch(updateBreadCrumbPath(currentPath));
+    }
+  }, [props.service.krbcanonicalname]);
+
   // Retrieve Roles' list (Redux)
   let rolesList = useAppSelector((state) => state.roles.roleList);
 

--- a/src/pages/Services/ServicesTable.tsx
+++ b/src/pages/Services/ServicesTable.tsx
@@ -176,7 +176,10 @@ const ServicesTable = (props: PropsToTable) => {
         }}
       />
       <Td dataLabel={columnNames.principalName}>
-        <Link to={"/services/settings"} state={service}>
+        <Link
+          to={"/services/" + encodeURIComponent(service.krbcanonicalname[0])}
+          state={service}
+        >
           {service.krbcanonicalname[0]}
         </Link>
       </Td>

--- a/src/services/rpcServices.ts
+++ b/src/services/rpcServices.ts
@@ -38,7 +38,7 @@ const extendedApi = api.injectEndpoints({
         };
         return getCommand({
           method: "service_show",
-          params: [serviceName, params],
+          params: [[serviceName], params],
         });
       },
       transformResponse: (response: FindRPCResponse): Service => {
@@ -84,4 +84,8 @@ export const useGettingServicesQuery = (payloadData) => {
   payloadData["objAttr"] = "krbprincipalname";
   return useGettingGenericQuery(payloadData);
 };
-export const { useAddServiceMutation, useRemoveServicesMutation } = extendedApi;
+export const {
+  useGetServicesFullDataQuery,
+  useAddServiceMutation,
+  useRemoveServicesMutation,
+} = extendedApi;


### PR DESCRIPTION
The following Services-related sections need to be provided with valid routes: 
- `Settings`: `/services/<id>`
- `Is a member of`: `/services/<memberof_tab>`
- `Is managed by`: `/services/<managedby_tab>`

This solution doesn't include the parameters (i.e., routes for page number, page size, membership direction, and search input).