### PR TITLE
Change custom hook name `useRoutingParams`

### DIFF
--- a/src/components/MemberOf/MemberOfHbacRules.tsx
+++ b/src/components/MemberOf/MemberOfHbacRules.tsx
@@ -10,7 +10,7 @@ import MemberOfAddModal, { AvailableItems } from "./MemberOfAddModal";
 import MemberOfDeleteModal from "./MemberOfDeleteModal";
 // Hooks
 import useAlerts from "src/hooks/useAlerts";
-import useRoutingParams from "src/hooks/useRoutingParams";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 // RPC
 import { ErrorResult } from "src/services/rpc";
 import {
@@ -44,7 +44,7 @@ const MemberOfHbacRules = (props: MemberOfHbacRulesProps) => {
     setSearchValue,
     membershipDirection,
     setMembershipDirection,
-  } = useRoutingParams();
+  } = useListPageSearchParams();
 
   // Other states
   const [hbacRulesSelected, setHbacRulesSelected] = React.useState<string[]>(

--- a/src/components/MemberOf/MemberOfNetgroups.tsx
+++ b/src/components/MemberOf/MemberOfNetgroups.tsx
@@ -8,7 +8,7 @@ import MemberOfToolbar from "./MemberOfToolbar";
 import MemberOfTableNetgroups from "./MemberOfTableNetgroups";
 // Hooks
 import useAlerts from "src/hooks/useAlerts";
-import useRoutingParams from "src/hooks/useRoutingParams";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 // RPC
 import { ErrorResult } from "src/services/rpc";
 import {
@@ -45,7 +45,7 @@ const memberOfNetgroups = (props: MemberOfNetroupsProps) => {
     setSearchValue,
     membershipDirection,
     setMembershipDirection,
-  } = useRoutingParams();
+  } = useListPageSearchParams();
 
   // Other states
   const [netgroupsSelected, setNetgroupsSelected] = React.useState<string[]>(

--- a/src/components/MemberOf/MemberOfRoles.tsx
+++ b/src/components/MemberOf/MemberOfRoles.tsx
@@ -10,7 +10,7 @@ import MemberOfAddModal, { AvailableItems } from "./MemberOfAddModal";
 import MemberOfDeleteModal from "./MemberOfDeleteModal";
 // Hooks
 import useAlerts from "src/hooks/useAlerts";
-import useRoutingParams from "src/hooks/useRoutingParams";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 // RPC
 import { ErrorResult } from "src/services/rpc";
 import {
@@ -43,7 +43,7 @@ const MemberOfRoles = (props: MemberOfRolesProps) => {
     setSearchValue,
     membershipDirection,
     setMembershipDirection,
-  } = useRoutingParams();
+  } = useListPageSearchParams();
 
   // Other states
   const [rolesSelected, setRolesSelected] = React.useState<string[]>([]);

--- a/src/components/MemberOf/MemberOfSudoRules.tsx
+++ b/src/components/MemberOf/MemberOfSudoRules.tsx
@@ -10,7 +10,7 @@ import MemberOfAddModal, { AvailableItems } from "./MemberOfAddModal";
 import MemberOfDeleteModal from "./MemberOfDeleteModal";
 // Hooks
 import useAlerts from "src/hooks/useAlerts";
-import useRoutingParams from "src/hooks/useRoutingParams";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 // RPC
 import {
   useGetSudoRulesInfoByNameQuery,
@@ -44,7 +44,7 @@ const MemberOfSudoRules = (props: MemberOfSudoRulesProps) => {
     setSearchValue,
     membershipDirection,
     setMembershipDirection,
-  } = useRoutingParams();
+  } = useListPageSearchParams();
 
   // Other states
   const [sudoRulesSelected, setSudoRulesSelected] = React.useState<string[]>(

--- a/src/components/MemberOf/MemberOfUserGroups.tsx
+++ b/src/components/MemberOf/MemberOfUserGroups.tsx
@@ -10,7 +10,7 @@ import MemberOfAddModal, { AvailableItems } from "./MemberOfAddModal";
 import MemberOfDeleteModal from "./MemberOfDeleteModal";
 // Hooks
 import useAlerts from "src/hooks/useAlerts";
-import useRoutingParams from "src/hooks/useRoutingParams";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 // RPC
 import { ErrorResult } from "src/services/rpc";
 import {
@@ -43,7 +43,7 @@ const MemberOfUserGroups = (props: MemberOfUserGroupsProps) => {
     setSearchValue,
     membershipDirection,
     setMembershipDirection,
-  } = useRoutingParams();
+  } = useListPageSearchParams();
 
   // Other states
   const [userGroupsSelected, setUserGroupsSelected] = React.useState<string[]>(

--- a/src/hooks/useListPageSearchParams.tsx
+++ b/src/hooks/useListPageSearchParams.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useSearchParams } from "react-router-dom";
 import { MembershipDirection } from "src/components/MemberOf/MemberOfToolbar";
 
-const useRoutingParams = () => {
+const useListPageSearchParams = () => {
   const [params, setParams] = useSearchParams();
 
   // States
@@ -92,4 +92,4 @@ const useRoutingParams = () => {
   };
 };
 
-export default useRoutingParams;
+export default useListPageSearchParams;


### PR DESCRIPTION
The name of the custom hook should be replaced by a more specific one as the name could be misleading.

Fixes: https://github.com/freeipa/freeipa-webui/issues/437