### PR TITLE
[Hosts][Is a member of] Fix subpages not being loaded at refresh

### DIFF
--- a/src/pages/Hosts/HostsManagedBy.tsx
+++ b/src/pages/Hosts/HostsManagedBy.tsx
@@ -60,9 +60,14 @@ const HostsManagedBy = (props: PropsToHostsManagedBy) => {
         isFilled={false}
         className="pf-v5-u-m-lg"
       >
-        <Tabs activeKey={0} isBox={false}>
+        <Tabs
+          activeKey={"managedby_host"}
+          isBox={false}
+          mountOnEnter
+          unmountOnExit
+        >
           <Tab
-            eventKey={0}
+            eventKey={"managedby_host"}
             name="managedby_host"
             title={
               <TabTitleText>

--- a/src/pages/Hosts/HostsMemberOf.tsx
+++ b/src/pages/Hosts/HostsMemberOf.tsx
@@ -124,7 +124,7 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
   }, [host]);
 
   // Tab
-  const [activeTabKey, setActiveTabKey] = useState("");
+  const [activeTabKey, setActiveTabKey] = useState("memberof_hostgroup");
 
   const handleTabClick = (
     _event: React.MouseEvent<HTMLElement, MouseEvent>,

--- a/src/pages/Hosts/HostsTabs.tsx
+++ b/src/pages/Hosts/HostsTabs.tsx
@@ -39,7 +39,7 @@ const HostsTabs = ({ section }) => {
   const hostSettingsData = useHostSettings(fqdn as string);
 
   // Tab
-  const [activeTabKey, setActiveTabKey] = useState("settings");
+  const [activeTabKey, setActiveTabKey] = useState(section);
 
   const handleTabClick = (
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
@@ -82,6 +82,11 @@ const HostsTabs = ({ section }) => {
   React.useEffect(() => {
     if (!section) {
       navigate("/hosts/" + hostId);
+    }
+
+    // Case: any of the 'member of' sections is clicked
+    if (section !== "settings" && section !== "managedby") {
+      setActiveTabKey("memberof");
     }
   }, [section]);
 


### PR DESCRIPTION
The 'Hosts' > 'Is a member of' subpages are not being loaded correctly when the page was refreshed via browser. This is because the active tabs are not properly set. This was affecting the 'Is managed by' section as well.

Steps to reproduce:
1. Navigate to 'Hosts' > 'Is a member of' > Any subpage
2. Refresh the view via browser
3. The page is empty and/or is not being redirected to the proper section.