### PR TITLE
User pages: Use custom hook to manage URL params

### DIFF
--- a/src/pages/ActiveUsers/ActiveUsers.tsx
+++ b/src/pages/ActiveUsers/ActiveUsers.tsx
@@ -43,6 +43,7 @@ import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
 // Hooks
 import { useAlerts } from "src/hooks/useAlerts";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 // Utils
 import { API_VERSION_BACKUP, isUserSelectable } from "src/utils/utils";
 // RPC client
@@ -57,12 +58,8 @@ import { SerializedError } from "@reduxjs/toolkit";
 import useApiError from "src/hooks/useApiError";
 import GlobalErrors from "src/components/errors/GlobalErrors";
 import ModalErrors from "src/components/errors/ModalErrors";
-// Navigation
-import { useSearchParams } from "react-router-dom";
 
 const ActiveUsers = () => {
-  const [searchParams, setSearchParams] = useSearchParams();
-
   // Dispatch (Redux)
   const dispatch = useAppDispatch();
 
@@ -87,18 +84,15 @@ const ActiveUsers = () => {
   // Alerts to show in the UI
   const alerts = useAlerts();
 
+  // URL parameters: page number, page size, search value
+  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+    useListPageSearchParams();
+
   // Handle API calls errors
   const globalErrors = useApiError([]);
   const modalErrors = useApiError([]);
 
   // Main states - what user can define / what we could use in page URL
-  const [searchValue, setSearchValue] = React.useState(
-    searchParams.get("search") || ""
-  );
-  const [page, setPage] = useState<number>(
-    parseInt(searchParams.get("p") || "1")
-  );
-  const [perPage, setPerPage] = useState<number>(10);
   const [totalCount, setUsersTotalCount] = useState<number>(0);
   const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
@@ -173,26 +167,6 @@ const ActiveUsers = () => {
       );
     }
   }, [userDataResponse]);
-
-  // Handle URLs with pagination and search values
-  React.useEffect(() => {
-    let searchParamsNew = {};
-
-    if (page > 1) {
-      searchParamsNew = {
-        ...searchParamsNew,
-        p: page.toString(),
-      };
-    }
-    if (searchValue !== "") {
-      searchParamsNew = {
-        ...searchParamsNew,
-        search: searchValue,
-      };
-    }
-
-    setSearchParams(searchParamsNew, { replace: true });
-  }, [page, searchValue]);
 
   // Refresh button handling
   const refreshUsersData = () => {

--- a/src/pages/PreservedUsers/PreservedUsers.tsx
+++ b/src/pages/PreservedUsers/PreservedUsers.tsx
@@ -38,6 +38,7 @@ import RestorePreservedUsers from "src/components/modals/RestorePreservedUsers";
 import { updateUsersList } from "src/store/Identity/preservedUsers-slice";
 import { useAlerts } from "src/hooks/useAlerts";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 // Errors
 import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
 import { SerializedError } from "@reduxjs/toolkit";
@@ -48,14 +49,14 @@ import { useGettingPreservedUserQuery } from "../../services/rpcUsers";
 import useApiError from "src/hooks/useApiError";
 import GlobalErrors from "src/components/errors/GlobalErrors";
 import ModalErrors from "src/components/errors/ModalErrors";
-// Navigation
-import { useSearchParams } from "react-router-dom";
 
 const PreservedUsers = () => {
-  const [searchParams, setSearchParams] = useSearchParams();
-
   // Initialize stage users list (Redux)
   const dispatch = useAppDispatch();
+
+  // URL parameters: page number, page size, search value
+  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+    useListPageSearchParams();
 
   // Update current route data to Redux and highlight the current page in the Nav bar
   const { browserTitle } = useUpdateRoute({ pathname: "preserved-users" });
@@ -81,13 +82,6 @@ const PreservedUsers = () => {
   const modalErrors = useApiError([]);
 
   // Main states - what user can define / what we could use in page URL
-  const [searchValue, setSearchValue] = React.useState(
-    searchParams.get("search") || ""
-  );
-  const [page, setPage] = useState<number>(
-    parseInt(searchParams.get("p") || "1")
-  );
-  const [perPage, setPerPage] = useState<number>(10);
   const [totalCount, setUsersTotalCount] = useState<number>(0);
   const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
@@ -157,27 +151,6 @@ const PreservedUsers = () => {
       );
     }
   }, [userDataResponse]);
-
-  // Handle URLs with pagination and search values
-  React.useEffect(() => {
-    let searchParamsNew = {};
-
-    if (page > 1) {
-      searchParamsNew = {
-        ...searchParamsNew,
-        p: page.toString(),
-      };
-    }
-
-    if (searchValue !== "") {
-      searchParamsNew = {
-        ...searchParamsNew,
-        search: searchValue,
-      };
-    }
-
-    setSearchParams(searchParamsNew, { replace: true });
-  }, [page, searchValue]);
 
   // Refresh button handling
   const refreshUsersData = () => {

--- a/src/pages/StageUsers/StageUsers.tsx
+++ b/src/pages/StageUsers/StageUsers.tsx
@@ -23,6 +23,7 @@ import { useAppDispatch, useAppSelector } from "src/store/hooks";
 import { updateUsersList } from "src/store/Identity/stageUsers-slice";
 import { useAlerts } from "src/hooks/useAlerts";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 // Layouts
 import TitleLayout from "src/components/layouts/TitleLayout";
 import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
@@ -49,12 +50,8 @@ import { useGettingStageUserQuery } from "../../services/rpcUsers";
 import useApiError from "src/hooks/useApiError";
 import GlobalErrors from "src/components/errors/GlobalErrors";
 import ModalErrors from "src/components/errors/ModalErrors";
-// Navigation
-import { useSearchParams } from "react-router-dom";
 
 const StageUsers = () => {
-  const [searchParams, setSearchParams] = useSearchParams();
-
   // Initialize stage users list (Redux)
   const dispatch = useAppDispatch();
 
@@ -69,6 +66,10 @@ const StageUsers = () => {
   // Alerts to show in the UI
   const alerts = useAlerts();
 
+  // URL parameters: page number, page size, search value
+  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+    useListPageSearchParams();
+
   // Retrieve API version from environment data
   const apiVersion = useAppSelector(
     (state) => state.global.environment.api_version
@@ -82,13 +83,6 @@ const StageUsers = () => {
   const modalErrors = useApiError([]);
 
   // Main states - what user can define / what we could use in page URL
-  const [searchValue, setSearchValue] = React.useState(
-    searchParams.get("search") || ""
-  );
-  const [page, setPage] = useState<number>(
-    parseInt(searchParams.get("p") || "1")
-  );
-  const [perPage, setPerPage] = useState<number>(10);
   const [totalCount, setUsersTotalCount] = useState<number>(0);
   const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
@@ -158,27 +152,6 @@ const StageUsers = () => {
       );
     }
   }, [userDataResponse]);
-
-  // Handle URLs with pagination and search values
-  React.useEffect(() => {
-    let searchParamsNew = {};
-
-    if (page > 1) {
-      searchParamsNew = {
-        ...searchParamsNew,
-        p: page.toString(),
-      };
-    }
-
-    if (searchValue !== "") {
-      searchParamsNew = {
-        ...searchParamsNew,
-        search: searchValue,
-      };
-    }
-
-    setSearchParams(searchParamsNew, { replace: true });
-  }, [page, searchValue]);
 
   // Refresh button handling
   const refreshUsersData = () => {


### PR DESCRIPTION
The custom hook `useListPageSearchParams` can provide a better way to manage the URL parameters in the User pages (Active, Stage, and Preserve). 

The current solution is not is not optimal as it requires setting each of the parameters and the general `useEffect` hook to track any change done in those, hence it must be replaced by the custom hook instead.