### PR TITLE
[Services] Implement 'Is a member of' section

### DIFF
--- a/src/components/MemberOf/MemberOfRoles.tsx
+++ b/src/components/MemberOf/MemberOfRoles.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 // PatternFly
 import { Pagination, PaginationVariant } from "@patternfly/react-core";
 // Data types
-import { User, Role, Host } from "src/utils/datatypes/globalDataTypes";
+import { User, Role, Host, Service } from "src/utils/datatypes/globalDataTypes";
 // Components
 import MemberOfToolbar from "./MemberOfToolbar";
 import MemberOfTableRoles from "./MemberOfTableRoles";
@@ -24,11 +24,13 @@ import { API_VERSION_BACKUP, paginate } from "src/utils/utils";
 import { apiToRole } from "src/utils/rolesUtils";
 
 interface MemberOfRolesProps {
-  entity: Partial<User> | Partial<Host>;
+  entity: Partial<User> | Partial<Host> | Partial<Service>;
   id: string;
   from: string;
   isDataLoading: boolean;
   onRefreshData: () => void;
+  memberof_role: string[];
+  memberofindirect_role?: string[];
 }
 const MemberOfRoles = (props: MemberOfRolesProps) => {
   // Alerts to show in the UI
@@ -52,8 +54,8 @@ const MemberOfRoles = (props: MemberOfRolesProps) => {
   const [roles, setRoles] = React.useState<Role[]>([]);
 
   // Choose the correct roles based on the membership direction
-  const memberof_role = props.entity.memberof_role || [];
-  const memberofindirect_role = props.entity.memberofindirect_role || [];
+  const memberof_role = props.memberof_role || [];
+  const memberofindirect_role = props.memberofindirect_role || [];
   let roleNames =
     membershipDirection === "direct" ? memberof_role : memberofindirect_role;
   roleNames = [...roleNames];
@@ -116,6 +118,8 @@ const MemberOfRoles = (props: MemberOfRolesProps) => {
       return "user";
     } else if (props.from === "hosts") {
       return "host";
+    } else if (props.from === "services") {
+      return "service";
     } else {
       // Return 'user' as default
       return "user";

--- a/src/pages/ActiveUsers/UserMemberOf.tsx
+++ b/src/pages/ActiveUsers/UserMemberOf.tsx
@@ -200,6 +200,8 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
               from={props.from}
               isDataLoading={userQuery.isFetching}
               onRefreshData={onRefreshUserData}
+              memberof_role={user.memberof_role as string[]}
+              memberofindirect_role={user.memberofindirect_role as string[]}
             />
           </Tab>
           <Tab

--- a/src/pages/Hosts/HostsMemberOf.tsx
+++ b/src/pages/Hosts/HostsMemberOf.tsx
@@ -183,6 +183,8 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
               from={"hosts"}
               isDataLoading={hostQuery.isFetching}
               onRefreshData={onRefreshHostData}
+              memberof_role={host.memberof_role as string[]}
+              memberofindirect_role={host.memberofindirect_role as string[]}
             />
           </Tab>
           <Tab

--- a/src/pages/Services/ServicesMemberOf.tsx
+++ b/src/pages/Services/ServicesMemberOf.tsx
@@ -1,35 +1,30 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 // PatternFly
 import {
   Badge,
   Page,
   PageSection,
   PageSectionVariants,
-  Pagination,
-  PaginationVariant,
   Tab,
   Tabs,
   TabTitleText,
 } from "@patternfly/react-core";
-// Others
-import MemberOfToolbar from "src/components/MemberOf/MemberOfToolbarOld";
-import MemberOfTable from "src/components/MemberOf/MemberOfTable";
+// Components
 import { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
+import MemberOfRoles from "src/components/MemberOf/MemberOfRoles";
 // Data types
-import { RolesOld, Service } from "src/utils/datatypes/globalDataTypes";
+import { Service } from "src/utils/datatypes/globalDataTypes";
 // Redux
-import { useAppDispatch, useAppSelector } from "src/store/hooks";
+import { useAppDispatch } from "src/store/hooks";
 import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
-// Repositories
-import { servicesRolesInitialData } from "src/utils/data/GroupRepositories";
-// Modals
-import MemberOfAddModal from "src/components/MemberOf/MemberOfAddModalOld";
-import MemberOfDeleteModal from "src/components/MemberOf/MemberOfDeleteModalOld";
 // React Router DOM
 import { useNavigate } from "react-router-dom";
+// RPC
+import { useGetServiceByIdQuery } from "src/services/rpcServices";
 
 interface PropsToServicesMemberOf {
   service: Service;
+  tabSection: string;
 }
 
 const ServicesMemberOf = (props: PropsToServicesMemberOf) => {
@@ -57,248 +52,30 @@ const ServicesMemberOf = (props: PropsToServicesMemberOf) => {
     }
   }, [props.service.krbcanonicalname]);
 
-  // Retrieve Roles' list (Redux)
-  let rolesList = useAppSelector((state) => state.roles.roleList);
+  // User's full data
+  const serviceQuery = useGetServiceByIdQuery(props.service.krbcanonicalname);
+  const serviceData = serviceQuery.data || {};
 
-  // Alter the available options list to keep the state of the recently added / removed items
-  const updateRolesList = (newAvOptionsList: unknown[]) => {
-    rolesList = newAvOptionsList as RolesOld[];
+  const [service, setService] = React.useState<Partial<Service>>({});
+
+  React.useEffect(() => {
+    if (!serviceQuery.isFetching && serviceData) {
+      setService({ ...serviceData });
+    }
+  }, [serviceData, serviceQuery.isFetching]);
+
+  const onRefreshServiceData = () => {
+    serviceQuery.refetch();
   };
 
-  // List of default dummy data
-  const [rolesRepository, setRolesRepository] = useState(
-    servicesRolesInitialData
-  );
+  // 'Roles' length to show in tab badge
+  const [rolesLength, setRolesLength] = React.useState(0);
 
-  // Filter (Input search)
-  const [searchValue, setSearchValue] = React.useState("");
-
-  const updateSearchValue = (value: string) => {
-    setSearchValue(value);
-  };
-
-  // Filter functions to compare the available data with the data that
-  //  the service is already member of. This is done to prevent duplicates
-  //  (e.g: adding the same element twice).
-  const filterRolesData = () => {
-    // Roles
-    return rolesList.filter((item) => {
-      return !rolesRepository.some((itm) => {
-        return item.name === itm.name;
-      });
-    });
-  };
-
-  // Available data to be added as member of
-  const rolesFilteredData: RolesOld[] = filterRolesData();
-
-  // Number of items on the list for each repository
-  const [rolesRepoLength, setRolesRepoLength] = useState(
-    rolesRepository.length
-  );
-
-  // Some data is updated when any group list is altered
-  //  - The whole list itself
-  //  - The slice of data to show (considering the pagination)
-  //  - Number of items for a specific list
-  const updateGroupRepository = (groupRepository: RolesOld[]) => {
-    setRolesRepository(groupRepository as RolesOld[]);
-    setShownRolesList(rolesRepository.slice(0, perPage));
-    setRolesRepoLength(rolesRepository.length);
-  };
-
-  // State that determines whether the row tables are displayed nor not
-  // - This helps with the reload state
-  const [showTableRows, setShowTableRows] = useState(false);
-
-  // -- Name of the groups selected on the table (to remove)
-  const [groupsNamesSelected, setGroupsNamesSelected] = useState<string[]>([]);
-
-  const updateGroupsNamesSelected = (groups: string[]) => {
-    setGroupsNamesSelected(groups);
-  };
-
-  // -- 'Delete' button state
-  const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
-    useState<boolean>(true);
-
-  const updateIsDeleteButtonDisabled = (updatedDeleteButton: boolean) => {
-    setIsDeleteButtonDisabled(updatedDeleteButton);
-  };
-
-  // If some entries have been deleted, restore the 'groupsNamesSelected' list
-  const [isDeletion, setIsDeletion] = useState(false);
-
-  const updateIsDeletion = (option: boolean) => {
-    setIsDeletion(option);
-  };
-
-  // -- Tab
-  // 2: 'Roles' (name, description)
-  const [activeTabKey, setActiveTabKey] = useState(2);
-
-  const handleTabClick = (
-    _event: React.MouseEvent<HTMLElement, MouseEvent>,
-    tabIndex: number | string
-  ) => {
-    setActiveTabKey(tabIndex as number);
-  };
-
-  // -- Pagination
-  const [page, setPage] = useState(1);
-  const [perPage, setPerPage] = useState(10);
-
-  // Member groups displayed on the first page
-  const [shownRolesList, setShownRolesList] = useState(
-    rolesRepository.slice(0, perPage)
-  );
-
-  // Update pagination
-  const changeMemberGroupsList = (value: RolesOld[]) => {
-    setShownRolesList(value as RolesOld[]);
-  };
-
-  // Pages setters
-  const onSetPage = (
-    _event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
-    newPage: number,
-    perPage: number | undefined,
-    startIdx: number | undefined,
-    endIdx: number | undefined
-  ) => {
-    setPage(newPage);
-    setShownRolesList(rolesRepository.slice(startIdx, endIdx));
-  };
-
-  const onPerPageSelect = (
-    _event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
-    newPerPage: number,
-    newPage: number,
-    startIdx: number | undefined,
-    endIdx: number | undefined
-  ) => {
-    setPerPage(newPerPage);
-    setShownRolesList(rolesRepository.slice(startIdx, endIdx));
-  };
-
-  // Page setters passed as props
-  const changeSetPage = (
-    newPage: number,
-    perPage: number | undefined,
-    startIdx: number | undefined,
-    endIdx: number | undefined
-  ) => {
-    setPage(newPage);
-    setShownRolesList(rolesRepository.slice(startIdx, endIdx));
-  };
-
-  const changePerPageSelect = (
-    newPerPage: number,
-    newPage: number,
-    startIdx: number | undefined,
-    endIdx: number | undefined
-  ) => {
-    setPerPage(newPerPage);
-    setShownRolesList(rolesRepository.slice(startIdx, endIdx));
-  };
-
-  // -- Modal
-  const [showAddModal, setShowAddModal] = useState(false);
-  const [showDeleteModal, setShowDeleteModal] = useState(false);
-
-  const onClickAddHandler = () => {
-    setShowAddModal(true);
-  };
-  const onModalToggle = () => {
-    setShowAddModal(!showAddModal);
-  };
-
-  const onClickDeleteHandler = () => {
-    setShowDeleteModal(true);
-  };
-
-  const onModalDeleteToggle = () => {
-    setShowDeleteModal(!showDeleteModal);
-  };
-
-  // -- Tab name
-  const [tabName, setTabName] = useState("roles");
-
-  const updateTabName = (name: string) => {
-    setTabName(name);
-  };
-
-  // Reloads the table everytime any of the group lists are updated
-  useEffect(() => {
-    setPage(1);
-    if (showTableRows) setShowTableRows(false);
-    setTimeout(() => {
-      setShownRolesList(rolesRepository.slice(0, perPage));
-      setRolesRepoLength(rolesRepository.length);
-      setShowTableRows(true);
-    }, 1000);
-  }, [rolesRepository]);
-
-  // Data wrappers
-  // - MemberOfToolbar
-  const toolbarPageData = {
-    page,
-    changeSetPage,
-    perPage,
-    changePerPageSelect,
-  };
-
-  const toolbarButtonData = {
-    onClickAddHandler,
-    onClickDeleteHandler,
-    isDeleteButtonDisabled,
-  };
-
-  const toolbarSettersData = {
-    changeMemberGroupsList,
-    changeTabName: updateTabName,
-  };
-
-  // - MemberOfTable
-  const tableButtonData = {
-    isDeletion,
-    updateIsDeletion,
-    changeIsDeleteButtonDisabled: updateIsDeleteButtonDisabled,
-  };
-
-  // - MemberOfAddModal
-  const addModalData = {
-    showModal: showAddModal,
-    handleModalToggle: onModalToggle,
-  };
-
-  const tabData = {
-    tabName,
-    userName: props.service.krbcanonicalname,
-  };
-
-  // - MemberOfDeleteModal
-  const deleteModalData = {
-    showModal: showDeleteModal,
-    handleModalToggle: onModalDeleteToggle,
-  };
-
-  const deleteButtonData = {
-    changeIsDeleteButtonDisabled: updateIsDeleteButtonDisabled,
-    updateIsDeletion,
-  };
-
-  const deleteTabData = {
-    tabName,
-    activeTabKey,
-  };
-
-  // - 'MemberOfToolbar' > 'SearchInputLayout'
-  // SearchInputLayout
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-  };
+  React.useEffect(() => {
+    if (service && service.memberof_role) {
+      setRolesLength(service.memberof_role.length);
+    }
+  }, [service]);
 
   // Render component
   return (
@@ -308,73 +85,30 @@ const ServicesMemberOf = (props: PropsToServicesMemberOf) => {
         isFilled={false}
         className="pf-v5-u-m-lg"
       >
-        <Tabs activeKey={activeTabKey} onSelect={handleTabClick} isBox={false}>
+        <Tabs activeKey={0} isBox={false} mountOnEnter unmountOnExit>
           <Tab
-            eventKey={2}
+            eventKey={0}
             name="memberof_role"
             title={
               <TabTitleText>
                 Roles{" "}
-                <Badge key={2} isRead>
-                  {rolesRepoLength}
+                <Badge key={0} isRead>
+                  {rolesLength}
                 </Badge>
               </TabTitleText>
             }
           >
-            <MemberOfToolbar
-              pageRepo={rolesRepository}
-              shownItems={shownRolesList}
-              toolbar="roles"
-              settersData={toolbarSettersData}
-              pageData={toolbarPageData}
-              buttonData={toolbarButtonData}
-              searchValueData={searchValueData}
-            />
-            <MemberOfTable
-              group={shownRolesList}
-              tableName={"Roles"}
-              activeTabKey={activeTabKey}
-              changeSelectedGroups={updateGroupsNamesSelected}
-              buttonData={tableButtonData}
-              showTableRows={showTableRows}
-              searchValue={searchValue}
-              fullGroupList={rolesRepository}
+            <MemberOfRoles
+              entity={service}
+              id={service.krbcanonicalname as string}
+              from={"services"}
+              isDataLoading={serviceQuery.isFetching}
+              onRefreshData={onRefreshServiceData}
+              memberof_role={service.memberof_role as string[]}
             />
           </Tab>
         </Tabs>
-        <Pagination
-          className="pf-v5-u-pb-0 pf-v5-u-pr-md"
-          itemCount={rolesRepository.length}
-          widgetId="pagination-options-menu-bottom"
-          perPage={perPage}
-          page={page}
-          variant={PaginationVariant.bottom}
-          onSetPage={onSetPage}
-          onPerPageSelect={onPerPageSelect}
-        />
       </PageSection>
-      <>
-        {showAddModal && (
-          <MemberOfAddModal
-            modalData={addModalData}
-            availableData={rolesFilteredData}
-            groupRepository={rolesRepository}
-            updateGroupRepository={updateGroupRepository}
-            updateAvOptionsList={updateRolesList}
-            tabData={tabData}
-          />
-        )}
-        {showDeleteModal && groupsNamesSelected.length !== 0 && (
-          <MemberOfDeleteModal
-            modalData={deleteModalData}
-            tabData={deleteTabData}
-            groupNamesToDelete={groupsNamesSelected}
-            groupRepository={rolesRepository}
-            updateGroupRepository={updateGroupRepository}
-            buttonData={deleteButtonData}
-          />
-        )}
-      </>
     </Page>
   );
 };

--- a/src/pages/Services/ServicesTabs.tsx
+++ b/src/pages/Services/ServicesTabs.tsx
@@ -152,7 +152,7 @@ const ServicesTabs = ({ section }) => {
             title={<TabTitleText>Is a member of</TabTitleText>}
           >
             <PageSection className="pf-v5-u-pb-0"></PageSection>
-            <ServicesMemberOf service={service} />
+            <ServicesMemberOf service={service} tabSection={section} />
           </Tab>
           <Tab
             eventKey={"managedby"}

--- a/src/services/rpcServices.ts
+++ b/src/services/rpcServices.ts
@@ -148,6 +148,16 @@ const extendedApi = api.injectEndpoints({
         });
       },
     }),
+    getServiceById: build.query<Service, string>({
+      query: (serviceId) => {
+        return getCommand({
+          method: "service_show",
+          params: [[serviceId], { version: API_VERSION_BACKUP }],
+        });
+      },
+      transformResponse: (response: FindRPCResponse): Service =>
+        apiToService(response.result.result),
+    }),
   }),
   overrideExisting: false,
 });
@@ -164,4 +174,5 @@ export const {
   useSaveServiceMutation,
   useAddServicePrincipalAliasMutation,
   useRemoveServicePrincipalAliasMutation,
+  useGetServiceByIdQuery,
 } = extendedApi;

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -281,6 +281,7 @@ export interface Service {
   sshpublickey: string[];
   usercertificate: string[];
   ipakrbauthzdata: string[]; // pac_type: MS-PAC, PAD, NONE
+  memberof_role: string[];
   managedby_host: string[];
   ipakrbrequirespreauth: boolean;
   ipakrbokasdelegate: boolean;

--- a/src/utils/serviceUtils.tsx
+++ b/src/utils/serviceUtils.tsx
@@ -74,6 +74,7 @@ export function createEmptyService(): Service {
     sshpublickey: [],
     usercertificate: [],
     ipakrbauthzdata: [],
+    memberof_role: [],
     managedby_host: [],
     ipakrbrequirespreauth: false,
     ipakrbokasdelegate: false,


### PR DESCRIPTION
The Services > 'Is a member of' section should be adapted and manage the list of roles associated to a specific service. 

As the `MemberOfRoles` component can accept three different types of entities (i.e., Users, Hosts, and Services), its `memberof_role` and `memberofindirect_role` variables can differ among them. For example, a service doesn't have a `memberofindirect_role` parameter.

That is why those variables should be passed to `MemberOfRole` as props to be managed from the component itself. At the same time, some preparation to hold the new 'Service' entity have been done.

This PR depends on this one to be merged: https://github.com/freeipa/freeipa-webui/pull/436