### PR TITLE
[Services] Implement 'Is managed by' section

### DIFF
--- a/src/pages/Services/ServicesManagedBy.tsx
+++ b/src/pages/Services/ServicesManagedBy.tsx
@@ -1,244 +1,62 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 // PatternFly
 import {
   Badge,
   Page,
   PageSection,
   PageSectionVariants,
-  Pagination,
-  PaginationVariant,
   Tab,
   Tabs,
   TabTitleText,
 } from "@patternfly/react-core";
 // Data type
-import { Host, Service } from "src/utils/datatypes/globalDataTypes";
-// Redux
-import { useAppSelector } from "src/store/hooks";
-// Others
-import ManagedByTable from "src/components/ManagedBy/ManagedByTable";
-import ManagedByToolbar from "src/components/ManagedBy/ManagedByToolbar";
-// Modals
-import ManagedByAddModal from "src/components/ManagedBy/ManagedByAddModal";
-import ManagedByDeleteModal from "src/components/ManagedBy/ManagedByDeleteModal";
+import { Service } from "src/utils/datatypes/globalDataTypes";
+// Components
+import ManagedByHosts from "src/components/ManagedBy/ManagedByHosts";
+// Hooks
+import useUpdateRoute from "src/hooks/useUpdateRoute";
+// RPC
+import { useGetServiceByIdQuery } from "src/services/rpcServices";
+// Navigation
+import { useNavigate } from "react-router-dom";
 
 interface PropsToServicesManagedBy {
   service: Service;
 }
 
 const ServicesManagedBy = (props: PropsToServicesManagedBy) => {
-  // Retrieve available hosts data from Redux
-  let availableHostsData = useAppSelector((state) => state.hosts.hostsList);
+  const navigate = useNavigate();
 
-  // Alter the available options list to keep the state of the recently added / removed items
-  const updateAvailableHostsList = (newAvOptionsList: unknown[]) => {
-    availableHostsData = newAvOptionsList as Host[];
+  // Service full data
+  const serviceQuery = useGetServiceByIdQuery(props.service.krbcanonicalname);
+  const serviceData = serviceQuery.data || {};
+
+  const [service, setService] = React.useState<Partial<Service>>({});
+
+  React.useEffect(() => {
+    if (!serviceQuery.isFetching && serviceData) {
+      setService({ ...serviceData });
+    }
+  }, [serviceData, serviceQuery.isFetching]);
+
+  const onRefreshServiceData = () => {
+    serviceQuery.refetch();
   };
 
-  // Retrieve full host information given a host name
-  const getFullHostInformation = (hostNameList: string[]) => {
-    const fullHostList: Host[] = [];
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  useUpdateRoute({ pathname: "services" });
 
-    availableHostsData.map((host) => {
-      hostNameList.map((hostName) => {
-        if (host.fqdn === hostName) {
-          fullHostList.push(host as Host);
-        }
-      });
-    });
+  // Encoded data to pass to the URL
+  const encodedServiceId = encodeURIComponent(props.service.krbcanonicalname);
 
-    return fullHostList;
-  };
+  // 'Hosts' length to show in tab badge
+  const [hostsLength, setHostsLength] = React.useState(0);
 
-  // List is current elements on the list (Dummy data)
-  const [hostsList, setHostsList] = useState<Host[]>(
-    getFullHostInformation([props.service.krbcanonicalname])
-  );
-
-  // Some data is updated when any group list is altered
-  //  - The whole list itself
-  //  - The slice of data to show (considering the pagination)
-  //  - Number of items for a specific list
-  const updateGroupRepository = (newHostsList: Host[]) => {
-    setHostsList(newHostsList);
-    setShownHostsList(hostsList.slice(0, perPage));
-  };
-
-  // Filter functions to compare the available data with the data that
-  //  the host is managed by. This is done to prevent duplicates
-  //  (e.g: adding the same element twice).
-  const filterHostsData = () => {
-    // Host groups
-    return availableHostsData.filter((item) => {
-      return !hostsList.some((itm) => {
-        return item.fqdn === itm.fqdn;
-      });
-    });
-  };
-
-  // Available data to be added as managed by
-  const hostsFilteredData: Host[] = filterHostsData();
-
-  // State that determines whether the row tables are displayed nor not
-  // - This helps with the reload state
-  const [showTableRows, setShowTableRows] = useState(false);
-
-  // -- Pagination
-  const [page, setPage] = useState(1);
-  const [perPage, setPerPage] = useState(10);
-
-  // -- Name of the hosts selected on the table (to remove)
-  const [hostsSelected, setHostsSelected] = useState<string[]>([]);
-
-  const updateHostsSelected = (hosts: string[]) => {
-    setHostsSelected(hosts);
-  };
-
-  // -- 'Delete' button state
-  const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
-    useState<boolean>(true);
-
-  const updateIsDeleteButtonDisabled = (updatedDeleteButton: boolean) => {
-    setIsDeleteButtonDisabled(updatedDeleteButton);
-  };
-
-  // If some entries have been deleted, restore the 'groupsNamesSelected' list
-  const [isDeletion, setIsDeletion] = useState(false);
-
-  const updateIsDeletion = (option: boolean) => {
-    setIsDeletion(option);
-  };
-
-  // Member groups displayed on the first page
-  const [shownHostsList, setShownHostsList] = useState(
-    hostsList.slice(0, perPage)
-  );
-
-  const updateShownHostsList = (newShownHostsList: Host[]) => {
-    setShownHostsList(newShownHostsList);
-  };
-
-  // Pages setters (to manage pagination as an event)
-  const onSetPage = (
-    _event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
-    newPage: number,
-    perPage: number | undefined,
-    startIdx: number | undefined,
-    endIdx: number | undefined
-  ) => {
-    setPage(newPage);
-    setShownHostsList(hostsList.slice(startIdx, endIdx));
-  };
-
-  const onPerPageSelect = (
-    _event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
-    newPerPage: number,
-    newPage: number,
-    startIdx: number | undefined,
-    endIdx: number | undefined
-  ) => {
-    setPerPage(newPerPage);
-    setShownHostsList(hostsList.slice(startIdx, endIdx));
-  };
-
-  // Page setters passed as props
-  const changeSetPage = (
-    newPage: number,
-    perPage: number | undefined,
-    startIdx: number | undefined,
-    endIdx: number | undefined
-  ) => {
-    setPage(newPage);
-    setShownHostsList(hostsList.slice(startIdx, endIdx));
-  };
-
-  const changePerPageSelect = (
-    newPerPage: number,
-    newPage: number,
-    startIdx: number | undefined,
-    endIdx: number | undefined
-  ) => {
-    setPerPage(newPerPage);
-    setShownHostsList(hostsList.slice(startIdx, endIdx));
-  };
-
-  // -- Modal
-  const [showAddModal, setShowAddModal] = useState(false);
-  const [showDeleteModal, setShowDeleteModal] = useState(false);
-
-  const onClickAddHandler = () => {
-    setShowAddModal(true);
-  };
-  const onModalToggle = () => {
-    setShowAddModal(!showAddModal);
-  };
-
-  const onClickDeleteHandler = () => {
-    setShowDeleteModal(true);
-  };
-
-  const onModalDeleteToggle = () => {
-    setShowDeleteModal(!showDeleteModal);
-  };
-
-  // Reloads the table everytime any of the group lists are updated
-  useEffect(() => {
-    setPage(1);
-    if (showTableRows) setShowTableRows(false);
-    setTimeout(() => {
-      setShownHostsList(hostsList.slice(0, perPage));
-      setShowTableRows(true);
-    }, 1000);
-  }, [hostsList]);
-
-  // Data wrappers
-  // - ManagedByToolbar
-  const toolbarPageData = {
-    page,
-    changeSetPage,
-    perPage,
-    changePerPageSelect,
-  };
-
-  const toolbarButtonData = {
-    onClickAddHandler,
-    onClickDeleteHandler,
-    isDeleteButtonDisabled,
-  };
-
-  // - ManagedByTable
-  const tableButtonData = {
-    isDeletion,
-    updateIsDeletion,
-    changeIsDeleteButtonDisabled: updateIsDeleteButtonDisabled,
-  };
-
-  // - MemberOfAddModal
-  const addModalData = {
-    showModal: showAddModal,
-    handleModalToggle: onModalToggle,
-  };
-
-  const tabData = {
-    tabName: "Hosts",
-    elementName: props.service.krbcanonicalname,
-  };
-
-  // - MemberOfDeleteModal
-  const deleteModalData = {
-    showModal: showDeleteModal,
-    handleModalToggle: onModalDeleteToggle,
-  };
-
-  const deleteButtonData = {
-    changeIsDeleteButtonDisabled: updateIsDeleteButtonDisabled,
-    updateIsDeletion,
-  };
-
-  const deleteTabData = {
-    tabName: "Hosts",
-    elementName: props.service.krbcanonicalname,
-  };
+  React.useEffect(() => {
+    if (service && service.managedby_host) {
+      setHostsLength(service.managedby_host.length);
+    }
+  }, [service]);
 
   return (
     <Page>
@@ -247,7 +65,16 @@ const ServicesManagedBy = (props: PropsToServicesManagedBy) => {
         isFilled={false}
         className="pf-v5-u-m-lg"
       >
-        <Tabs activeKey={0} isBox={false}>
+        <Tabs
+          activeKey={0}
+          isBox={false}
+          mountOnEnter
+          unmountOnExit
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          onSelect={(_event) => {
+            navigate("/services/" + encodedServiceId + "/managedby_host");
+          }}
+        >
           <Tab
             eventKey={0}
             name="managedby_host"
@@ -255,60 +82,21 @@ const ServicesManagedBy = (props: PropsToServicesManagedBy) => {
               <TabTitleText>
                 Hosts{" "}
                 <Badge key={0} isRead>
-                  {hostsList.length}
+                  {hostsLength}
                 </Badge>
               </TabTitleText>
             }
           >
-            <ManagedByToolbar
-              pageRepo={hostsList}
-              shownItems={shownHostsList}
-              updateShownElementsList={updateShownHostsList}
-              pageData={toolbarPageData}
-              buttonData={toolbarButtonData}
-            />
-            <ManagedByTable
-              list={shownHostsList}
-              tableName={"Hosts"}
-              showTableRows={showTableRows}
-              updateElementsSelected={updateHostsSelected}
-              buttonData={tableButtonData}
+            <ManagedByHosts
+              entity={service}
+              id={service.krbcanonicalname as string}
+              from="service"
+              isDataLoading={serviceQuery.isFetching}
+              onRefreshData={onRefreshServiceData}
             />
           </Tab>
         </Tabs>
-        <Pagination
-          className="pf-v5-u-pb-0 pf-v5-u-pr-md"
-          itemCount={hostsList.length}
-          widgetId="pagination-options-menu-bottom"
-          perPage={perPage}
-          page={page}
-          variant={PaginationVariant.bottom}
-          onSetPage={onSetPage}
-          onPerPageSelect={onPerPageSelect}
-        />
       </PageSection>
-      <>
-        {showAddModal && (
-          <ManagedByAddModal
-            modalData={addModalData}
-            availableData={hostsFilteredData}
-            groupRepository={hostsList}
-            updateGroupRepository={updateGroupRepository}
-            updateAvOptionsList={updateAvailableHostsList}
-            tabData={tabData}
-          />
-        )}
-        {showDeleteModal && hostsSelected.length !== 0 && (
-          <ManagedByDeleteModal
-            modalData={deleteModalData}
-            tabData={deleteTabData}
-            groupNamesToDelete={hostsSelected}
-            groupRepository={hostsList}
-            updateGroupRepository={updateGroupRepository}
-            buttonData={deleteButtonData}
-          />
-        )}
-      </>
     </Page>
   );
 };

--- a/src/services/rpcServices.ts
+++ b/src/services/rpcServices.ts
@@ -14,7 +14,8 @@ import { API_VERSION_BACKUP } from "../utils/utils";
 import { Service } from "../utils/datatypes/globalDataTypes";
 
 /**
- * Services-related endpoints: getServicesFullData, addService, removeServices, saveService, addServicePrincipalAlias, removeServicePrincipalAlias
+ * Services-related endpoints: getServicesFullData, addService, removeServices, saveService,
+ * addServicePrincipalAlias, removeServicePrincipalAlias, addServiceHost, removeServiceHost
  *
  * API commands:
  * - service_show: https://freeipa.readthedocs.io/en/latest/api/service_show.html
@@ -23,6 +24,8 @@ import { Service } from "../utils/datatypes/globalDataTypes";
  * - service_mod: https://freeipa.readthedocs.io/en/latest/api/service_mod.html
  * - service_add_principal: https://freeipa.readthedocs.io/en/latest/api/service_add_principal.html
  * - service_remove_principal: https://freeipa.readthedocs.io/en/latest/api/service_remove_principal.html
+ * - service_add_host: https://freeipa.readthedocs.io/en/latest/api/service_add_host.html
+ * - service_remove_host: https://freeipa.readthedocs.io/en/latest/api/service_remove_host.html
  */
 
 export interface ServiceAddPayload {
@@ -35,6 +38,11 @@ export type ServiceFullData = {
   service?: Partial<Service>;
   cert?: Record<string, unknown>;
 };
+
+export interface ServiceAddRemoveHostPayload {
+  serviceId: string;
+  hostsList: string[];
+}
 
 const extendedApi = api.injectEndpoints({
   endpoints: (build) => ({
@@ -158,6 +166,40 @@ const extendedApi = api.injectEndpoints({
       transformResponse: (response: FindRPCResponse): Service =>
         apiToService(response.result.result),
     }),
+    addServiceHost: build.mutation<
+      FindRPCResponse,
+      ServiceAddRemoveHostPayload
+    >({
+      query: (payload) => {
+        const serviceId = payload.serviceId;
+        const hostsList = payload.hostsList;
+
+        return getCommand({
+          method: "service_add_host",
+          params: [
+            [serviceId],
+            { all: true, host: hostsList, version: API_VERSION_BACKUP },
+          ],
+        });
+      },
+    }),
+    removeServiceHost: build.mutation<
+      FindRPCResponse,
+      ServiceAddRemoveHostPayload
+    >({
+      query: (payload) => {
+        const serviceId = payload.serviceId;
+        const hostsList = payload.hostsList;
+
+        return getCommand({
+          method: "service_remove_host",
+          params: [
+            [serviceId],
+            { all: true, host: hostsList, version: API_VERSION_BACKUP },
+          ],
+        });
+      },
+    }),
   }),
   overrideExisting: false,
 });
@@ -175,4 +217,6 @@ export const {
   useAddServicePrincipalAliasMutation,
   useRemoveServicePrincipalAliasMutation,
   useGetServiceByIdQuery,
+  useAddServiceHostMutation,
+  useRemoveServiceHostMutation,
 } = extendedApi;


### PR DESCRIPTION
The Services > 'Is managed by' section needs to be implemented to associate or remove hosts to a given service.

The `ManagedByHosts` component has been adapted to be used in 'Hosts' and 'Services' pages.

This PR depends on this one to be merged: https://github.com/freeipa/freeipa-webui/pull/443