### PR TITLE
Fix breadcrumbs not showing links

### DIFF
--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -92,7 +92,7 @@ const UserSettings = (props: PropsToUserSettings) => {
   const navigate = useNavigate();
 
   // Update current route data to Redux and highlight the current page in the Nav bar
-  useUpdateRoute({ pathname: props.from });
+  useUpdateRoute({ pathname: props.from, noBreadcrumb: true });
 
   // RTK hook: save user (acive/preserved and stage)
   let [saveUser] = useSaveUserMutation();

--- a/src/components/layouts/BreadCrumb.tsx
+++ b/src/components/layouts/BreadCrumb.tsx
@@ -13,13 +13,18 @@ export interface BreadCrumbItem {
 export interface PropsToBreadcrumb {
   className?: string;
   preText?: string;
+  breadcrumbItems?: BreadCrumbItem[];
 }
 
 const BreadCrumb = (props: PropsToBreadcrumb) => {
   const [breadcrumbItems, setBreadcrumbItems] = React.useState<
     BreadCrumbItem[]
   >([]);
-  const pagesVisited = useAppSelector((state) => state.routes.breadCrumbPath);
+
+  // Posibility of retrieving the 'breadcrumbItems' from the props or via Redux
+  const pagesVisited = !props.breadcrumbItems
+    ? useAppSelector((state) => state.routes.breadCrumbPath)
+    : props.breadcrumbItems;
 
   React.useEffect(() => {
     if (pagesVisited) {
@@ -31,17 +36,17 @@ const BreadCrumb = (props: PropsToBreadcrumb) => {
   return (
     <Breadcrumb className={props.className}>
       {breadcrumbItems.map((page, idx) =>
-        idx === breadcrumbItems.length - 1 ? (
-          <BreadcrumbItem key={idx} isActive={page.isActive || false}>
-            {props.preText && props.preText + " "}
-            {page.name}
-          </BreadcrumbItem>
-        ) : (
+        idx === 0 ? (
           <BreadcrumbItem
             key={idx}
             to={page.url}
             isActive={page.isActive || false}
           >
+            {page.name}
+          </BreadcrumbItem>
+        ) : (
+          <BreadcrumbItem key={idx} isActive={page.isActive || false}>
+            {props.preText && props.preText + " "}
             {page.name}
           </BreadcrumbItem>
         )

--- a/src/hooks/useUpdateRoute.tsx
+++ b/src/hooks/useUpdateRoute.tsx
@@ -22,7 +22,15 @@ import { useAppDispatch } from "src/store/hooks";
  * @returns {loadedGroup, breadCrumbPath, browserTitle}
  */
 
-export const useUpdateRoute = ({ pathname }) => {
+interface UpdateRouteProps {
+  pathname: string;
+  noBreadcrumb?: boolean;
+}
+
+export const useUpdateRoute = ({
+  pathname,
+  noBreadcrumb,
+}: UpdateRouteProps) => {
   const dispatch = useAppDispatch();
 
   const [loadedGroup, setLoadedGroup] = React.useState<string[]>([]);
@@ -53,10 +61,12 @@ export const useUpdateRoute = ({ pathname }) => {
     }
 
     // Get breadcrumb data based on current path
-    const loadedBreadCrumb = getBreadCrumbByPath(pathname);
-    if (loadedBreadCrumb.length > 0) {
-      setBreadCrumbPath(loadedBreadCrumb);
-      dispatch(updateBreadCrumbPath(loadedBreadCrumb));
+    if (noBreadcrumb === undefined || !noBreadcrumb) {
+      const loadedBreadCrumb = getBreadCrumbByPath(pathname);
+      if (loadedBreadCrumb.length > 0) {
+        setBreadCrumbPath(loadedBreadCrumb);
+        dispatch(updateBreadCrumbPath(loadedBreadCrumb));
+      }
     }
 
     // Get browser title based on current path

--- a/src/pages/ActiveUsers/ActiveUsersTabs.tsx
+++ b/src/pages/ActiveUsers/ActiveUsersTabs.tsx
@@ -29,12 +29,18 @@ import { useAppDispatch } from "src/store/hooks";
 import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
 // Utils
 import { partialUserToUser } from "src/utils/userUtils";
+// Navigation
+import { URL_PREFIX } from "src/navigation/NavRoutes";
 
 // eslint-disable-next-line react/prop-types
 const ActiveUsersTabs = ({ memberof }) => {
   const { uid } = useParams();
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
+
+  const [breadcrumbItems, setBreadcrumbItems] = React.useState<
+    BreadCrumbItem[]
+  >([]);
 
   React.useEffect(() => {
     if (!uid) {
@@ -45,14 +51,15 @@ const ActiveUsersTabs = ({ memberof }) => {
       const currentPath: BreadCrumbItem[] = [
         {
           name: "Active users",
-          url: "../active-users",
+          url: URL_PREFIX + "/active-users",
         },
         {
           name: uid,
-          url: "../active-users/" + uid,
+          url: URL_PREFIX + "/active-users/" + uid,
           isActive: true,
         },
       ];
+      setBreadcrumbItems(currentPath);
       dispatch(updateBreadCrumbPath(currentPath));
     }
   }, [uid]);
@@ -79,7 +86,11 @@ const ActiveUsersTabs = ({ memberof }) => {
   return (
     <Page>
       <PageSection variant={PageSectionVariants.light} className="pf-v5-u-pr-0">
-        <BreadCrumb className="pf-v5-u-mb-md" preText="User login:" />
+        <BreadCrumb
+          className="pf-v5-u-mb-md"
+          preText="User login:"
+          breadcrumbItems={breadcrumbItems}
+        />
         <TextContent>
           <Title headingLevel="h1">
             <Text

--- a/src/pages/ActiveUsers/UserMemberOf.tsx
+++ b/src/pages/ActiveUsers/UserMemberOf.tsx
@@ -23,10 +23,6 @@ import { useGetUserByUidQuery } from "src/services/rpcUsers";
 import { convertToString } from "src/utils/ipaObjectUtils";
 // Navigation
 import { useNavigate } from "react-router-dom";
-import { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
-// Redux
-import { useAppDispatch } from "src/store/hooks";
-import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
 // Hooks
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 
@@ -38,32 +34,17 @@ interface PropsToUserMemberOf {
 
 const UserMemberOf = (props: PropsToUserMemberOf) => {
   const navigate = useNavigate();
-  const dispatch = useAppDispatch();
 
   // Update breadcrumb route
   React.useEffect(() => {
     if (!props.user.uid) {
       // Redirect to the main page
       navigate("/" + props.from);
-    } else {
-      const currentPath: BreadCrumbItem[] = [
-        {
-          name:
-            props.from[0].toUpperCase() + props.from.slice(1).replace("-", " "),
-          url: "../../" + props.from,
-        },
-        {
-          name: props.user.uid,
-          url: "../../" + props.from + "/" + props.user.uid,
-          isActive: true,
-        },
-      ];
-      dispatch(updateBreadCrumbPath(currentPath));
     }
   }, [props.user.uid]);
 
   // Update current route data to Redux and highlight the current page in the Nav bar
-  useUpdateRoute({ pathname: props.from });
+  useUpdateRoute({ pathname: props.from, noBreadcrumb: true });
 
   // User's full data
   const userQuery = useGetUserByUidQuery(convertToString(props.user.uid));

--- a/src/pages/Hosts/HostsMemberOf.tsx
+++ b/src/pages/Hosts/HostsMemberOf.tsx
@@ -9,13 +9,8 @@ import {
   Tabs,
   TabTitleText,
 } from "@patternfly/react-core";
-// Components
-import { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
 // Data types
 import { Host } from "src/utils/datatypes/globalDataTypes";
-// Redux
-import { useAppDispatch } from "src/store/hooks";
-import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
 // Navigation
 import { useNavigate } from "react-router-dom";
 // Hooks
@@ -36,28 +31,6 @@ interface PropsToHostsMemberOf {
 
 const HostsMemberOf = (props: PropsToHostsMemberOf) => {
   const navigate = useNavigate();
-  const dispatch = useAppDispatch();
-
-  // Update breadcrumb route
-  React.useEffect(() => {
-    if (!props.host.fqdn) {
-      // Redirect to the main page
-      navigate("/hosts");
-    } else {
-      const currentPath: BreadCrumbItem[] = [
-        {
-          name: "Hosts",
-          url: "../../hosts",
-        },
-        {
-          name: props.host.fqdn,
-          url: "../../hosts/" + props.host.fqdn,
-          isActive: true,
-        },
-      ];
-      dispatch(updateBreadCrumbPath(currentPath));
-    }
-  }, [props.host.fqdn]);
 
   // Host's full data
   const hostQuery = useGetHostByIdQuery(props.host.fqdn);
@@ -76,7 +49,7 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
   };
 
   // Update current route data to Redux and highlight the current page in the Nav bar
-  useUpdateRoute({ pathname: "hosts" });
+  useUpdateRoute({ pathname: "hosts", noBreadcrumb: true });
 
   // 'Host groups' length to show in tab badge
   const [hostGroupsLength, setHostGroupLength] = React.useState(0);

--- a/src/pages/Hosts/HostsTabs.tsx
+++ b/src/pages/Hosts/HostsTabs.tsx
@@ -26,12 +26,18 @@ import { useHostSettings } from "src/hooks/useHostSettingsData";
 import { useAppDispatch } from "src/store/hooks";
 import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
 import { partialHostToHost } from "src/utils/hostUtils";
+// Navigation
+import { URL_PREFIX } from "src/navigation/NavRoutes";
 
 // eslint-disable-next-line react/prop-types
 const HostsTabs = ({ section }) => {
   const { fqdn } = useParams();
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
+
+  const [breadcrumbItems, setBreadcrumbItems] = React.useState<
+    BreadCrumbItem[]
+  >([]);
 
   const [hostId, setHostId] = useState("");
 
@@ -59,21 +65,22 @@ const HostsTabs = ({ section }) => {
   React.useEffect(() => {
     if (!fqdn) {
       // Redirect to the main page
-      navigate("/hosts");
+      navigate(URL_PREFIX + "/hosts");
     } else {
       setHostId(fqdn);
       // Update breadcrumb route
       const currentPath: BreadCrumbItem[] = [
         {
           name: "Hosts",
-          url: "../hosts",
+          url: URL_PREFIX + "/hosts",
         },
         {
           name: fqdn,
-          url: "../hosts/" + fqdn,
+          url: URL_PREFIX + "/hosts/" + fqdn,
           isActive: true,
         },
       ];
+      setBreadcrumbItems(currentPath);
       dispatch(updateBreadCrumbPath(currentPath));
     }
   }, [fqdn]);
@@ -81,7 +88,7 @@ const HostsTabs = ({ section }) => {
   // Redirect to the settings page if the section is not defined
   React.useEffect(() => {
     if (!section) {
-      navigate("/hosts/" + hostId);
+      navigate(URL_PREFIX + "/hosts/" + hostId);
     }
 
     // Case: any of the 'member of' sections is clicked
@@ -99,7 +106,11 @@ const HostsTabs = ({ section }) => {
   return (
     <Page>
       <PageSection variant={PageSectionVariants.light} className="pf-v5-u-pr-0">
-        <BreadCrumb className="pf-v5-u-mb-md" preText="Host:" />
+        <BreadCrumb
+          className="pf-v5-u-mb-md"
+          preText="Host:"
+          breadcrumbItems={breadcrumbItems}
+        />
         <TitleLayout id={hostId} text={hostId} headingLevel="h1" />
       </PageSection>
       <PageSection type="tabs" variant={PageSectionVariants.light} isFilled>

--- a/src/pages/PreservedUsers/PreservedUsersTabs.tsx
+++ b/src/pages/PreservedUsers/PreservedUsersTabs.tsx
@@ -22,6 +22,8 @@ import { useUserSettings } from "src/hooks/useUserSettingsData";
 // Redux
 import { useAppDispatch } from "src/store/hooks";
 import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
+// Navigation
+import { URL_PREFIX } from "src/navigation/NavRoutes";
 
 const PreservedUsersTabs = () => {
   // Get location (React Router DOM) and get state data
@@ -29,23 +31,28 @@ const PreservedUsersTabs = () => {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
 
+  const [breadcrumbItems, setBreadcrumbItems] = React.useState<
+    BreadCrumbItem[]
+  >([]);
+
   React.useEffect(() => {
     if (!uid) {
       // Redirect to the preserved users page
-      navigate("/preserved-users");
+      navigate(URL_PREFIX + "/preserved-users");
     } else {
       // Update breadcrumb route
       const currentPath: BreadCrumbItem[] = [
         {
           name: "Preserved users",
-          url: "../preserved-users",
+          url: URL_PREFIX + "/preserved-users",
         },
         {
           name: uid,
-          url: "../preserved-users/" + uid,
+          url: URL_PREFIX + "/preserved-users/" + uid,
           isActive: true,
         },
       ];
+      setBreadcrumbItems(currentPath);
       dispatch(updateBreadCrumbPath(currentPath));
     }
   }, [uid]);
@@ -70,7 +77,11 @@ const PreservedUsersTabs = () => {
   return (
     <Page>
       <PageSection variant={PageSectionVariants.light} className="pf-v5-u-pr-0">
-        <BreadCrumb className="pf-v5-u-mb-md" preText="User login:" />
+        <BreadCrumb
+          className="pf-v5-u-mb-md"
+          preText="User login:"
+          breadcrumbItems={breadcrumbItems}
+        />
         <TextContent>
           <Title headingLevel="h1">
             <Text>{uid}</Text>

--- a/src/pages/Services/ServicesTabs.tsx
+++ b/src/pages/Services/ServicesTabs.tsx
@@ -25,6 +25,8 @@ import { useServiceSettings } from "src/hooks/useServiceSettingsData";
 import { useAppDispatch } from "src/store/hooks";
 import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
 import DataSpinner from "src/components/layouts/DataSpinner";
+// Navigation
+import { URL_PREFIX } from "src/navigation/NavRoutes";
 
 // eslint-disable-next-line react/prop-types
 const ServicesTabs = ({ section }) => {
@@ -32,6 +34,10 @@ const ServicesTabs = ({ section }) => {
   const encodedId = encodeURIComponent(id as string);
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
+
+  const [breadcrumbItems, setBreadcrumbItems] = React.useState<
+    BreadCrumbItem[]
+  >([]);
 
   const [serviceId, setServiceId] = useState("");
 
@@ -69,14 +75,15 @@ const ServicesTabs = ({ section }) => {
       const currentPath: BreadCrumbItem[] = [
         {
           name: "Services",
-          url: "../services",
+          url: URL_PREFIX + "/services",
         },
         {
           name: id,
-          url: "../services/" + encodeURIComponent(id as string),
+          url: URL_PREFIX + "/services/" + encodeURIComponent(id as string),
           isActive: true,
         },
       ];
+      setBreadcrumbItems(currentPath);
       dispatch(updateBreadCrumbPath(currentPath));
     }
   }, [id]);
@@ -98,7 +105,11 @@ const ServicesTabs = ({ section }) => {
     <Page>
       <alerts.ManagedAlerts />
       <PageSection variant={PageSectionVariants.light} className="pf-v5-u-pr-0">
-        <BreadCrumb className="pf-v5-u-mb-md" />
+        <BreadCrumb
+          className="pf-v5-u-mb-md"
+          preText="Service:"
+          breadcrumbItems={breadcrumbItems}
+        />
         <TitleLayout
           id={service.krbcanonicalname}
           text={service.krbcanonicalname}

--- a/src/pages/StageUsers/StageUsersTabs.tsx
+++ b/src/pages/StageUsers/StageUsersTabs.tsx
@@ -22,29 +22,36 @@ import { useStageUserSettings } from "src/hooks/useUserSettingsData";
 // Redux
 import { useAppDispatch } from "src/store/hooks";
 import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
+// Navigation
+import { URL_PREFIX } from "src/navigation/NavRoutes";
 
 const StageUsersTabs = () => {
   const { uid } = useParams();
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
 
+  const [breadcrumbItems, setBreadcrumbItems] = React.useState<
+    BreadCrumbItem[]
+  >([]);
+
   React.useEffect(() => {
     if (!uid) {
       // Redirect to the stage users page
-      navigate("stage-users");
+      navigate(URL_PREFIX + "stage-users");
     } else {
       // Update breadcrumb route
       const currentPath: BreadCrumbItem[] = [
         {
           name: "Stage users",
-          url: "../stage-users",
+          url: URL_PREFIX + "/stage-users",
         },
         {
           name: uid,
-          url: "../stage-users/" + uid,
+          url: URL_PREFIX + "/stage-users/" + uid,
           isActive: true,
         },
       ];
+      setBreadcrumbItems(currentPath);
       dispatch(updateBreadCrumbPath(currentPath));
     }
   }, [uid]);
@@ -69,7 +76,11 @@ const StageUsersTabs = () => {
   return (
     <Page>
       <PageSection variant={PageSectionVariants.light} className="pf-v5-u-pr-0">
-        <BreadCrumb className="pf-v5-u-mb-md" preText="User login:" />
+        <BreadCrumb
+          className="pf-v5-u-mb-md"
+          preText="User login:"
+          breadcrumbItems={breadcrumbItems}
+        />
         <TextContent>
           <Title headingLevel="h1">
             <Text>{uid}</Text>


### PR DESCRIPTION
The breadcrumbs are not showing the links correctly when accessing to any sub-page (`Settings`, `Is a member of`, and `Is managed by`).

This problem is due to some factors:
- The breadcrumbs are being set via Redux.
- At some point when accessing the settings page, the breadcrumb links are updated by the `useUpdateRoute` custom hook. This overrides the already-set breadcrumb links.

Solution:
- Fix the `BreadCrumb` component to show the link of the first element and removing the `isActive` parameter
(not needed).
- Modify the `BreadCrumb` component to get the links via Redux or props (`breadcrumbItems`) to provide some
flexibility.
- Modify the `useUpdateRoute` hook to accept an optional parameter `noBreadcrumb` (boolean) thus preventing any modification of the breadcrumb links.
- Adapt the aforementioned solutions to the pages and subpages.