### PR TITLE
[Services] Fix URL not being loaded on refresh

### DIFF
--- a/src/pages/Services/ServicesManagedBy.tsx
+++ b/src/pages/Services/ServicesManagedBy.tsx
@@ -44,7 +44,7 @@ const ServicesManagedBy = (props: PropsToServicesManagedBy) => {
   };
 
   // Update current route data to Redux and highlight the current page in the Nav bar
-  useUpdateRoute({ pathname: "services" });
+  useUpdateRoute({ pathname: "services", noBreadcrumb: true });
 
   // Encoded data to pass to the URL
   const encodedServiceId = encodeURIComponent(props.service.krbcanonicalname);

--- a/src/pages/Services/ServicesMemberOf.tsx
+++ b/src/pages/Services/ServicesMemberOf.tsx
@@ -21,6 +21,8 @@ import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
 import { useNavigate } from "react-router-dom";
 // RPC
 import { useGetServiceByIdQuery } from "src/services/rpcServices";
+// Hooks
+import useUpdateRoute from "src/hooks/useUpdateRoute";
 
 interface PropsToServicesMemberOf {
   service: Service;
@@ -67,6 +69,9 @@ const ServicesMemberOf = (props: PropsToServicesMemberOf) => {
   const onRefreshServiceData = () => {
     serviceQuery.refetch();
   };
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  useUpdateRoute({ pathname: "services", noBreadcrumb: true });
 
   // 'Roles' length to show in tab badge
   const [rolesLength, setRolesLength] = React.useState(0);

--- a/src/pages/Services/ServicesSettings.tsx
+++ b/src/pages/Services/ServicesSettings.tsx
@@ -36,6 +36,8 @@ import useApiError from "src/hooks/useApiError";
 import { useSaveServiceMutation } from "src/services/rpcServices";
 import { ErrorResult } from "src/services/rpc";
 import { partialServiceToService } from "src/utils/serviceUtils";
+// Hooks
+import useUpdateRoute from "src/hooks/useUpdateRoute";
 
 interface PropsToServicesSettings {
   service: Partial<Service>;
@@ -78,6 +80,9 @@ const ServicesSettings = (props: PropsToServicesSettings) => {
   ) => {
     setIsKebabOpen(!isKebabOpen);
   };
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  useUpdateRoute({ pathname: "services", noBreadcrumb: true });
 
   // 'Save' handler method
   const onSave = () => {

--- a/src/pages/Services/ServicesTable.tsx
+++ b/src/pages/Services/ServicesTable.tsx
@@ -163,28 +163,31 @@ const ServicesTable = (props: PropsToTable) => {
     </Tr>
   );
 
-  const body = shownServicesList.map((service, rowIndex) => (
-    <Tr key={service.krbcanonicalname[0]} id={service.krbcanonicalname[0]}>
-      <Td
-        dataLabel="checkbox"
-        select={{
-          rowIndex,
-          onSelect: (_event, isSelecting) =>
-            onSelectService(service, rowIndex, isSelecting),
-          isSelected: isServiceSelected(service),
-          isDisabled: !props.servicesData.isServiceSelectable(service),
-        }}
-      />
-      <Td dataLabel={columnNames.principalName}>
-        <Link
-          to={"/services/" + encodeURIComponent(service.krbcanonicalname[0])}
-          state={service}
-        >
-          {service.krbcanonicalname[0]}
-        </Link>
-      </Td>
-    </Tr>
-  ));
+  const body = shownServicesList.map((service, rowIndex) => {
+    const encodedServiceId = encodeURIComponent(
+      encodeURIComponent(service.krbcanonicalname[0])
+    );
+
+    return (
+      <Tr key={service.krbcanonicalname[0]} id={service.krbcanonicalname[0]}>
+        <Td
+          dataLabel="checkbox"
+          select={{
+            rowIndex,
+            onSelect: (_event, isSelecting) =>
+              onSelectService(service, rowIndex, isSelecting),
+            isSelected: isServiceSelected(service),
+            isDisabled: !props.servicesData.isServiceSelectable(service),
+          }}
+        />
+        <Td dataLabel={columnNames.principalName}>
+          <Link to={"/services/" + encodedServiceId} state={service}>
+            {service.krbcanonicalname[0]}
+          </Link>
+        </Td>
+      </Tr>
+    );
+  });
 
   const skeleton = (
     <SkeletonOnTableLayout

--- a/src/pages/Services/ServicesTabs.tsx
+++ b/src/pages/Services/ServicesTabs.tsx
@@ -31,7 +31,11 @@ import { URL_PREFIX } from "src/navigation/NavRoutes";
 // eslint-disable-next-line react/prop-types
 const ServicesTabs = ({ section }) => {
   const { id } = useParams();
-  const encodedId = encodeURIComponent(id as string);
+
+  // As the id is sent by React Router DOM partially decoded, this should be fixed
+  const decodedId = decodeURIComponent(id as string); // original ID
+  const doubleEncodedId = encodeURIComponent(encodeURIComponent(decodedId)); // double encoded ID
+
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
 
@@ -39,10 +43,8 @@ const ServicesTabs = ({ section }) => {
     BreadCrumbItem[]
   >([]);
 
-  const [serviceId, setServiceId] = useState("");
-
   // Data loaded from DB
-  const serviceSettingsData = useServiceSettings(id as string);
+  const serviceSettingsData = useServiceSettings(decodedId as string);
 
   // Alerts to show in the UI
   const alerts = useAlerts();
@@ -54,14 +56,14 @@ const ServicesTabs = ({ section }) => {
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
+    console.log("tabIndex", tabIndex);
     setActiveTabKey(tabIndex as string);
-    id;
     if (tabIndex === "settings") {
-      navigate("/services/" + encodedId);
+      navigate("/services/" + doubleEncodedId);
     } else if (tabIndex === "memberof") {
-      navigate("/services/" + encodedId + "/memberof_role");
+      navigate("/services/" + doubleEncodedId + "/memberof_role");
     } else if (tabIndex === "managedby") {
-      navigate("/services/" + encodedId + "/managedby_host");
+      navigate("/services/" + doubleEncodedId + "/managedby_host");
     }
   };
 
@@ -70,7 +72,6 @@ const ServicesTabs = ({ section }) => {
       // Redirect to the main page
       navigate("/services");
     } else {
-      setServiceId(id);
       // Update breadcrumb route
       const currentPath: BreadCrumbItem[] = [
         {
@@ -78,8 +79,8 @@ const ServicesTabs = ({ section }) => {
           url: URL_PREFIX + "/services",
         },
         {
-          name: id,
-          url: URL_PREFIX + "/services/" + encodeURIComponent(id as string),
+          name: decodedId,
+          url: URL_PREFIX + "/services/" + doubleEncodedId,
           isActive: true,
         },
       ];
@@ -91,8 +92,9 @@ const ServicesTabs = ({ section }) => {
   // Redirect to the settings page if the section is not defined
   React.useEffect(() => {
     if (!section) {
-      navigate("/services/" + serviceId);
+      navigate(URL_PREFIX + "/services/" + doubleEncodedId);
     }
+    setActiveTabKey(section);
   }, [section]);
 
   if (serviceSettingsData.isLoading || !serviceSettingsData.service) {


### PR DESCRIPTION
When accessing any 'Services' subpage (e.g., 'Settings') and hitting refresh from the browser, the page doesn't load and a
404 error message is shown. This is because the server is not processing this URL correctly.

In order to fix that, the URL has been double-encoded so that it can be processed from the subpages. At the same time, some enhancements have been adapted:
- The right side Navbar node is highlighted when the page is loaded from any Services' subsection via `useUpdateRoute` custom hook.
- The right tab section is loaded by setting the right tab key when receiving a `section` name:

```ts
React.useEffect(() => {
  if (!section) {
    navigate(URL_PREFIX + "/services/" + doubleEncodedId);
  }
  setActiveTabKey(section);
 }, [section]);
```

This PR depend on these ones to be merged: https://github.com/freeipa/freeipa-webui/pull/445 and https://github.com/freeipa/freeipa-webui/pull/444