### PR TITLE
Issue 447 - Improve empty table handling

### DIFF
--- a/src/components/layouts/SettingsTableLayout.tsx
+++ b/src/components/layouts/SettingsTableLayout.tsx
@@ -1,6 +1,11 @@
 import React from "react";
 // PatternFly
 import {
+  EmptyState,
+  EmptyStateActions,
+  EmptyStateBody,
+  EmptyStateHeader,
+  EmptyStateVariant,
   Flex,
   FlexItem,
   PaginationVariant,
@@ -65,32 +70,34 @@ const SettingsTableLayout = (props: PropsToSettingsTableLayout) => {
             />
           )}
         </FlexItem>
-        <FlexItem>
-          <SecondaryButton
-            classname="pf-v5-u-mr-sm"
-            isDisabled={props.isDeleteDisabled}
-            onClickHandler={props.onDeleteModal}
-          >
-            Delete
-          </SecondaryButton>
-          <SecondaryButton
-            classname="pf-v5-u-mr-sm"
-            onClickHandler={props.onAddModal}
-          >
-            Add {props.entryType}
-          </SecondaryButton>
-        </FlexItem>
-        <FlexItem align={{ default: "alignRight" }}>
-          {props.paginationData.totalCount > 0 && (
-            <PaginationLayout
-              list={props.list}
-              paginationData={props.paginationData}
-              widgetId="pagination-options-menu-bottom"
-              className="pf-v5-u-pb-0 pf-v5-u-pr-md"
-              perPageSize="sm"
-            />
-          )}
-        </FlexItem>
+        {props.paginationData.totalCount > 0 && (
+          <>
+            <FlexItem>
+              <SecondaryButton
+                classname="pf-v5-u-mr-sm"
+                isDisabled={props.isDeleteDisabled}
+                onClickHandler={props.onDeleteModal}
+              >
+                Delete
+              </SecondaryButton>
+              <SecondaryButton
+                classname="pf-v5-u-mr-sm"
+                onClickHandler={props.onAddModal}
+              >
+                Add {props.entryType}
+              </SecondaryButton>
+            </FlexItem>
+            <FlexItem align={{ default: "alignRight" }}>
+              <PaginationLayout
+                list={props.list}
+                paginationData={props.paginationData}
+                widgetId="pagination-options-menu-bottom"
+                className="pf-v5-u-pb-0 pf-v5-u-pr-md"
+                perPageSize="sm"
+              />
+            </FlexItem>
+          </>
+        )}
       </Flex>
       {props.paginationData.totalCount > 0 ? (
         <>
@@ -115,7 +122,24 @@ const SettingsTableLayout = (props: PropsToSettingsTableLayout) => {
           />
         </>
       ) : (
-        <div className="pf-v5-u-mb-lg" />
+        <EmptyState variant={EmptyStateVariant.xs}>
+          <EmptyStateHeader
+            titleText={
+              "No " +
+              props.entryType +
+              "s" +
+              (props.entryCount > 0 ? " found" : "")
+            }
+            headingLevel="h6"
+          />
+          <EmptyStateBody>
+            <EmptyStateActions>
+              <SecondaryButton onClickHandler={props.onAddModal}>
+                Add {props.entryType}
+              </SecondaryButton>
+            </EmptyStateActions>
+          </EmptyStateBody>
+        </EmptyState>
       )}
     </>
   );

--- a/src/components/layouts/TableLayout.tsx
+++ b/src/components/layouts/TableLayout.tsx
@@ -5,6 +5,7 @@ import {
   Thead,
 } from "@patternfly/react-table";
 import React from "react";
+import EmptyBodyTable from "../tables/EmptyBodyTable";
 
 export interface PropsToTable {
   ariaLabel: string;
@@ -19,6 +20,11 @@ export interface PropsToTable {
 }
 
 const TableLayout = (props: PropsToTable) => {
+  let body = props.tableBody;
+  if (Array.isArray(props.tableBody) && props.tableBody.length === 0) {
+    body = <EmptyBodyTable />;
+  }
+
   return (
     <Table
       aria-label={props.ariaLabel}
@@ -30,7 +36,7 @@ const TableLayout = (props: PropsToTable) => {
       isStickyHeader={props.isStickyHeader}
     >
       <Thead>{props.tableHeader}</Thead>
-      <Tbody>{props.tableBody}</Tbody>
+      <Tbody>{body}</Tbody>
     </Table>
   );
 };

--- a/src/components/tables/EmptyBodyTable.tsx
+++ b/src/components/tables/EmptyBodyTable.tsx
@@ -31,11 +31,13 @@ const EmptyBodyTable = (props: EmptyBodyTableProps) => {
               headingLevel="h2"
             />
             <EmptyStateBody>Clear all filters and try again.</EmptyStateBody>
-            <EmptyStateFooter>
-              <Button variant="link" onClick={props.onClickFilter}>
-                Clear all filters
-              </Button>
-            </EmptyStateFooter>
+            {props.onClickFilter && (
+              <EmptyStateFooter>
+                <Button variant="link" onClick={props.onClickFilter}>
+                  Clear all filters
+                </Button>
+              </EmptyStateFooter>
+            )}
           </EmptyState>
         </Bullseye>
       </Td>


### PR DESCRIPTION
For the keytab tables display a simple message and a custom Add button. 

For TableLayout automatically add a emptyBodyTable component 

For EmptyTableBody do not display the button to clear all the filters if a function was not provided

Fixes: https://github.com/freeipa/freeipa-webui/issues/447