### PR TITLE
Fix: `page` parameter is not shown when refreshing any 'Is a member of` tab section

### DIFF
--- a/src/components/MemberOf/MemberOfHbacRules.tsx
+++ b/src/components/MemberOf/MemberOfHbacRules.tsx
@@ -91,11 +91,6 @@ const MemberOfHbacRules = (props: MemberOfHbacRulesProps) => {
     version: API_VERSION_BACKUP,
   });
 
-  // Reset page on direction change
-  React.useEffect(() => {
-    setPage(1);
-  }, [membershipDirection]);
-
   // Refresh HBAC rules
   React.useEffect(() => {
     const hbacRulesNames = getHbacRulesNameToLoad();

--- a/src/components/MemberOf/MemberOfHostGroups.tsx
+++ b/src/components/MemberOf/MemberOfHostGroups.tsx
@@ -90,11 +90,6 @@ const MemberOfHostGroups = (props: MemberOfHostGroupsProps) => {
     version: API_VERSION_BACKUP,
   });
 
-  // Reset page on direction change
-  React.useEffect(() => {
-    setPage(1);
-  }, [membershipDirection]);
-
   // Refresh host groups
   React.useEffect(() => {
     const hostGroupsNames = getHostGroupsNameToLoad();

--- a/src/components/MemberOf/MemberOfNetgroups.tsx
+++ b/src/components/MemberOf/MemberOfNetgroups.tsx
@@ -93,11 +93,6 @@ const memberOfNetgroups = (props: MemberOfNetroupsProps) => {
     version: API_VERSION_BACKUP,
   });
 
-  // Reset page on direction change
-  React.useEffect(() => {
-    setPage(1);
-  }, [membershipDirection]);
-
   // Refresh netgroups
   React.useEffect(() => {
     const netgroupsNames = getNetgroupsNameToLoad();

--- a/src/components/MemberOf/MemberOfRoles.tsx
+++ b/src/components/MemberOf/MemberOfRoles.tsx
@@ -93,11 +93,6 @@ const MemberOfRoles = (props: MemberOfRolesProps) => {
     version: API_VERSION_BACKUP,
   });
 
-  // Reset page on direction change
-  useEffect(() => {
-    setPage(1);
-  }, [membershipDirection]);
-
   // Refresh roles
   useEffect(() => {
     const rolesNames = getRolesNameToLoad();

--- a/src/components/MemberOf/MemberOfSudoRules.tsx
+++ b/src/components/MemberOf/MemberOfSudoRules.tsx
@@ -91,11 +91,6 @@ const MemberOfSudoRules = (props: MemberOfSudoRulesProps) => {
     version: API_VERSION_BACKUP,
   });
 
-  // Reset page on direction change
-  React.useEffect(() => {
-    setPage(1);
-  }, [membershipDirection]);
-
   // Refresh Sudo rules
   React.useEffect(() => {
     const sudoRulesNames = getSudoRulesNameToLoad();

--- a/src/components/MemberOf/MemberOfUserGroups.tsx
+++ b/src/components/MemberOf/MemberOfUserGroups.tsx
@@ -88,11 +88,6 @@ const MemberOfUserGroups = (props: MemberOfUserGroupsProps) => {
     version: API_VERSION_BACKUP,
   });
 
-  // Reset page on direction change
-  React.useEffect(() => {
-    setPage(1);
-  }, [membershipDirection]);
-
   // Refresh user groups
   React.useEffect(() => {
     const userGroupsNames = getUserGroupsNameToLoad();

--- a/src/pages/Hosts/HostsMemberOf.tsx
+++ b/src/pages/Hosts/HostsMemberOf.tsx
@@ -109,7 +109,6 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
 
   React.useEffect(() => {
     setActiveTabKey(props.tabSection);
-    navigate("/hosts/" + props.host.fqdn + "/" + props.tabSection);
   }, [props.tabSection]);
 
   // Render component


### PR DESCRIPTION
When any tab content of the 'Is a member of' section (e.g. 'User groups', 'Roles, etc.) that is set with any parameters option is refreshed, the `page` parameter is not properly set and tends to dissapear even when is larger than 2.

Example:
When refreshing the following page `hosts/server.ipa.demo/memberof_hostgroup?size=10&page=2` , the result will be `hosts/server.ipa.demo/memberof_hostgroup?size=10`.

This is because the following `useEffect` hook is setting the page to 1 every time the `membershipDirection` changes (that would happen on any refresh as well):

```ts
// Reset page on direction change
React.useEffect(() => {
  setPage(1);
}, [membershipDirection]);
```

This can be solved by removing these lines from all the components that correspond to the 'Is a member of' tab sections.

Fixes: https://github.com/freeipa/freeipa-webui/issues/435