### PR TITLE
Fix: Redirect to 'NotFound' if page doesn't exist

### DIFF
--- a/src/pages/ActiveUsers/ActiveUsersTabs.tsx
+++ b/src/pages/ActiveUsers/ActiveUsersTabs.tsx
@@ -31,6 +31,7 @@ import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
 import { partialUserToUser } from "src/utils/userUtils";
 // Navigation
 import { URL_PREFIX } from "src/navigation/NavRoutes";
+import { NotFound } from "src/components/errors/PageErrors";
 
 // eslint-disable-next-line react/prop-types
 const ActiveUsersTabs = ({ memberof }) => {
@@ -78,6 +79,14 @@ const ActiveUsersTabs = ({ memberof }) => {
 
   if (userSettingsData.isLoading || !userSettingsData.user) {
     return <DataSpinner />;
+  }
+
+  // Show the 'NotFound' page if the user is not found
+  if (
+    !userSettingsData.isLoading &&
+    Object.keys(userSettingsData.user).length === 0
+  ) {
+    return <NotFound />;
   }
 
   const disabled = userSettingsData.user.nsaccountlock;

--- a/src/pages/HostGroups/HostGroupsTabs.tsx
+++ b/src/pages/HostGroups/HostGroupsTabs.tsx
@@ -18,6 +18,7 @@ import { HostGroup } from "src/utils/datatypes/globalDataTypes";
 // Hooks
 import { useHostGroupSettings } from "src/hooks/useHostGroupSettingsData";
 import DataSpinner from "src/components/layouts/DataSpinner";
+import { NotFound } from "src/components/errors/PageErrors";
 
 const HostGroupsTabs = () => {
   // Get location (React Router DOM) and get state data
@@ -49,6 +50,14 @@ const HostGroupsTabs = () => {
     hostGroupSettingsData.hostGroup.cn === undefined
   ) {
     return <DataSpinner />;
+  }
+
+  // Show the 'NotFound' page if the hostGroup is not found
+  if (
+    !hostGroupSettingsData.isLoading &&
+    Object.keys(hostGroupSettingsData.hostGroup).length === 0
+  ) {
+    return <NotFound />;
   }
 
   return (

--- a/src/pages/Hosts/HostsTabs.tsx
+++ b/src/pages/Hosts/HostsTabs.tsx
@@ -28,6 +28,7 @@ import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
 import { partialHostToHost } from "src/utils/hostUtils";
 // Navigation
 import { URL_PREFIX } from "src/navigation/NavRoutes";
+import { NotFound } from "src/components/errors/PageErrors";
 
 // eslint-disable-next-line react/prop-types
 const HostsTabs = ({ section }) => {
@@ -99,6 +100,14 @@ const HostsTabs = ({ section }) => {
 
   if (hostSettingsData.isLoading || !hostSettingsData.host) {
     return <DataSpinner />;
+  }
+
+  // Show the 'NotFound' page if the host is not found
+  if (
+    !hostSettingsData.isLoading &&
+    Object.keys(hostSettingsData.host).length === 0
+  ) {
+    return <NotFound />;
   }
 
   const host = hostSettingsData.host;

--- a/src/pages/Netgroups/NetgroupsTabs.tsx
+++ b/src/pages/Netgroups/NetgroupsTabs.tsx
@@ -18,6 +18,7 @@ import { Netgroup } from "src/utils/datatypes/globalDataTypes";
 // Hooks
 import { useNetgroupSettings } from "src/hooks/useNetgroupSettingsData";
 import DataSpinner from "src/components/layouts/DataSpinner";
+import { NotFound } from "src/components/errors/PageErrors";
 
 const NetgroupsTabs = () => {
   // Get location (React Router DOM) and get state data
@@ -49,6 +50,14 @@ const NetgroupsTabs = () => {
     netgroupSettingsData.netgroup.cn === undefined
   ) {
     return <DataSpinner />;
+  }
+
+  // Show the 'NotFound' page if the netgroup is not found
+  if (
+    !netgroupSettingsData.isLoading &&
+    Object.keys(netgroupSettingsData.netgroup).length === 0
+  ) {
+    return <NotFound />;
   }
 
   return (

--- a/src/pages/PreservedUsers/PreservedUsersTabs.tsx
+++ b/src/pages/PreservedUsers/PreservedUsersTabs.tsx
@@ -24,6 +24,7 @@ import { useAppDispatch } from "src/store/hooks";
 import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
 // Navigation
 import { URL_PREFIX } from "src/navigation/NavRoutes";
+import { NotFound } from "src/components/errors/PageErrors";
 
 const PreservedUsersTabs = () => {
   // Get location (React Router DOM) and get state data
@@ -72,6 +73,14 @@ const PreservedUsersTabs = () => {
 
   if (userSettingsData.isLoading) {
     return <DataSpinner />;
+  }
+
+  // Show the 'NotFound' page if the user is not found
+  if (
+    !userSettingsData.isLoading &&
+    Object.keys(userSettingsData.user).length === 0
+  ) {
+    return <NotFound />;
   }
 
   return (

--- a/src/pages/Services/ServicesTabs.tsx
+++ b/src/pages/Services/ServicesTabs.tsx
@@ -27,6 +27,7 @@ import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
 import DataSpinner from "src/components/layouts/DataSpinner";
 // Navigation
 import { URL_PREFIX } from "src/navigation/NavRoutes";
+import { NotFound } from "src/components/errors/PageErrors";
 
 // eslint-disable-next-line react/prop-types
 const ServicesTabs = ({ section }) => {
@@ -98,6 +99,14 @@ const ServicesTabs = ({ section }) => {
 
   if (serviceSettingsData.isLoading || !serviceSettingsData.service) {
     return <DataSpinner />;
+  }
+
+  // Show the 'NotFound' page if the service is not found
+  if (
+    !serviceSettingsData.isLoading &&
+    Object.keys(serviceSettingsData.service).length === 0
+  ) {
+    return <NotFound />;
   }
 
   const service = partialServiceToService(serviceSettingsData.service);

--- a/src/pages/StageUsers/StageUsersTabs.tsx
+++ b/src/pages/StageUsers/StageUsersTabs.tsx
@@ -24,6 +24,7 @@ import { useAppDispatch } from "src/store/hooks";
 import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
 // Navigation
 import { URL_PREFIX } from "src/navigation/NavRoutes";
+import { NotFound } from "src/components/errors/PageErrors";
 
 const StageUsersTabs = () => {
   const { uid } = useParams();
@@ -71,6 +72,14 @@ const StageUsersTabs = () => {
 
   if (userSettingsData.isLoading) {
     return <DataSpinner />;
+  }
+
+  // Show the 'NotFound' page if the user is not found
+  if (
+    !userSettingsData.isLoading &&
+    Object.keys(userSettingsData.user).length === 0
+  ) {
+    return <NotFound />;
   }
 
   return (

--- a/src/pages/UserGroups/UserGroupsTabs.tsx
+++ b/src/pages/UserGroups/UserGroupsTabs.tsx
@@ -21,6 +21,7 @@ import { partialGroupToGroup } from "src/utils/groupUtils";
 import { useUserGroupSettings } from "src/hooks/useUserGroupSettingsData";
 import DataSpinner from "src/components/layouts/DataSpinner";
 import { useAlerts } from "../../hooks/useAlerts";
+import { NotFound } from "src/components/errors/PageErrors";
 // Redux
 import { useAppDispatch } from "src/store/hooks";
 import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
@@ -90,6 +91,14 @@ const UserGroupsTabs = ({ section }) => {
   }
 
   const usergroup = partialGroupToGroup(userGroupSettingsData.userGroup);
+
+  // Show the 'NotFound' page if the userGroup is not found
+  if (
+    !userGroupSettingsData.isLoading &&
+    Object.keys(userGroupSettingsData.userGroup).length === 0
+  ) {
+    return <NotFound />;
+  }
 
   return (
     <Page>


### PR DESCRIPTION
Some non-existing pages are not redirected to the 404 error page (`NotFound` component) and shows a page with empty data. This is affecting all section pages.

This is because the specific ID for that data type is not being checked whether exists or not. This has been solved by adding the following code to check that once the data is retrieved (example for the 'Active users` page):

```ts
// Show the 'NotFound' page if the user is not found
if (
  !userSettingsData.isLoading &&
  Object.keys(userSettingsData.user).length === 0
) {
  return <NotFound />;
}
```
Fixes: https://github.com/freeipa/freeipa-webui/issues/456
Signed-off-by: Carla Martinez <carlmart@redhat.com>