### PR TITLE
Fix: Apache regex configuration

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -65,9 +65,9 @@ Vagrant.configure("2") do |config|
       Satisfy Any
       Require all granted
       RewriteEngine On
-      RewriteRule ^(.*)/js/(.*)\.(js|map)$ js/$2.$3 [L]
-      RewriteRule ^(.*)/public/images/(.*)$ public/images/$2 [L]
-      RewriteRule ^(.*)/(.*)\.(css|ico|woff2)$ $2.$3 [L]
+      RewriteRule ^(.*)/js/(.*)\\\\.(js|map)$ js/\\$2.\\$3 [L]
+      RewriteRule ^(.*)/public/images/(.*)$ public/images/\\$2 [L]
+      RewriteRule ^(.*)/(.*)\\\\.(css|ico|woff2)$ \\$2.\\$3 [L]
       RewriteCond %{REQUEST_FILENAME} !-f
       RewriteRule ^ index.html [QSA,L]
     </Directory>


### PR DESCRIPTION
This change allow to escape the configuration
passing through ruby interpreter and the shell
script interpreter to get finally the
configuration we expect for the regular expression.