### PR TITLE
[User groups][Members] Implement 'Users' tab section

### DIFF
--- a/src/components/Members/MemberTable.tsx
+++ b/src/components/Members/MemberTable.tsx
@@ -1,0 +1,164 @@
+import React from "react";
+// PatternFly
+import { Table, Tr, Th, Td, Thead, Tbody } from "@patternfly/react-table";
+// Data types
+import { User } from "src/utils/datatypes/globalDataTypes";
+// Components
+import SkeletonOnTableLayout from "../layouts/Skeleton/SkeletonOnTableLayout";
+import EmptyBodyTable from "../tables/EmptyBodyTable";
+// Utils
+import { parseEmptyString } from "src/utils/utils";
+// Icons
+import { CheckIcon } from "@patternfly/react-icons";
+import { MinusIcon } from "@patternfly/react-icons";
+
+export interface MemberOfTableProps {
+  entityList: User[]; // More types can be added here
+  idKey: string; // Users: uid, Groups: cn, etc.
+  columnNamesToShow: string[];
+  propertiesToShow: string[]; // Users: uid, givenname, sn, description, etc.
+  checkedItems?: string[];
+  onCheckItemsChange?: (checkedItems: string[]) => void;
+  showTableRows: boolean;
+}
+
+// Body
+const TableBody = (props: {
+  list: User[]; // More types can be added here
+  idKey: string; // Users: uid, Groups: cn, etc.
+  columnNamesToShow: string[];
+  propertiesToShow: string[]; // Users: uid, first, last, description, etc.
+  showCheckboxColumn: boolean;
+  checkedItems: string[];
+  onCheckboxChange: (checked: boolean, entityName: string) => void;
+}) => {
+  const { list, idKey, propertiesToShow } = props;
+  return (
+    <>
+      {list.map((item, index) => (
+        <Tr key={index}>
+          {props.showCheckboxColumn && (
+            <Td
+              select={{
+                rowIndex: index,
+                onSelect: (_e, isSelected) =>
+                  props.onCheckboxChange(isSelected, item[idKey]),
+                isSelected: props.checkedItems.includes(item[idKey]),
+              }}
+            />
+          )}
+          {propertiesToShow.map((propertyName, index) => {
+            // Handle special cases: 'nsaccountlock' is a boolean
+            if (propertyName === "nsaccountlock") {
+              if (item[propertyName]) {
+                return (
+                  <Td key={index}>
+                    <MinusIcon /> {" Disabled"}
+                  </Td>
+                );
+              } else {
+                return (
+                  <Td key={index}>
+                    <CheckIcon /> {" Enabled"}
+                  </Td>
+                );
+              }
+            } else {
+              // Rest of the cases
+              return (
+                <Td key={index}>{parseEmptyString(item[propertyName])}</Td>
+              );
+            }
+          })}
+        </Tr>
+      ))}
+    </>
+  );
+};
+
+// Define skeleton
+const skeleton = (
+  <SkeletonOnTableLayout
+    rows={4}
+    colSpan={3}
+    screenreaderText={"Loading table rows"}
+  />
+);
+
+export default function MemberOfTable(props: MemberOfTableProps) {
+  const { entityList } = props;
+
+  if (!entityList || entityList.length <= 0) {
+    // Return empty placeholder
+    return (
+      <Table
+        aria-label="member of table"
+        name="cn"
+        variant="compact"
+        borders
+        className={"pf-v5-u-mt-md"}
+        id="member-of-table"
+        isStickyHeader
+      >
+        <Tbody>
+          <EmptyBodyTable />
+        </Tbody>
+      </Table>
+    );
+  }
+
+  const showCheckboxColumn = props.onCheckItemsChange !== undefined;
+
+  const onCheckboxChange = (checked: boolean, item: string) => {
+    const originalItems = props.checkedItems || [];
+    let newItems: string[] = [];
+    if (checked) {
+      newItems = [...originalItems, item];
+    } else {
+      newItems = originalItems.filter((name) => name !== item);
+    }
+    if (props.onCheckItemsChange) {
+      props.onCheckItemsChange(newItems);
+    }
+  };
+
+  return (
+    <Table
+      aria-label="member of table"
+      name="cn"
+      variant="compact"
+      borders
+      className={"pf-v5-u-mt-md"}
+      id="member-of-table"
+      isStickyHeader
+    >
+      <Thead>
+        <Tr>
+          {props.onCheckItemsChange && <Th />}
+          {props.columnNamesToShow.map((columnName, index) => (
+            <Th key={index} modifier="wrap">
+              {columnName}
+            </Th>
+          ))}
+        </Tr>
+      </Thead>
+      <Tbody>
+        {!props.showTableRows ? (
+          skeleton
+        ) : entityList.length === 0 ? (
+          <EmptyBodyTable />
+        ) : (
+          <TableBody
+            list={entityList}
+            idKey={props.idKey}
+            columnNamesToShow={props.columnNamesToShow}
+            propertiesToShow={props.propertiesToShow}
+            showCheckboxColumn={showCheckboxColumn}
+            onCheckboxChange={onCheckboxChange}
+            checkedItems={props.checkedItems || []}
+          />
+        )}
+      </Tbody>
+    </Table>
+  );
+}

--- a/src/components/Members/MembersUsers.tsx
+++ b/src/components/Members/MembersUsers.tsx
@@ -1,0 +1,391 @@
+import React from "react";
+// PatternFly
+import { Pagination, PaginationVariant } from "@patternfly/react-core";
+// Components
+import MemberOfToolbar from "../MemberOf/MemberOfToolbar";
+import MemberOfAddModal, { AvailableItems } from "../MemberOf/MemberOfAddModal";
+import MemberOfDeleteModal from "../MemberOf/MemberOfDeleteModal";
+import MemberTable from "./MemberTable";
+// Data types
+import { User, UserGroup } from "src/utils/datatypes/globalDataTypes";
+// Hooks
+import useAlerts from "src/hooks/useAlerts";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
+// Utils
+import { API_VERSION_BACKUP, paginate } from "src/utils/utils";
+import { apiToUser } from "src/utils/userUtils";
+// RPC
+import { ErrorResult } from "src/services/rpc";
+import {
+  useGetUsersInfoByUidQuery,
+  useGettingActiveUserQuery,
+} from "src/services/rpcUsers";
+import {
+  MemberPayload,
+  useAddToUsersAsMemberMutation,
+  useRemoveFromUsersAsMemberMutation,
+} from "src/services/rpcUserGroups";
+
+interface PropsToMembersUsers {
+  entity: Partial<UserGroup>;
+  id: string;
+  from: string;
+  isDataLoading: boolean;
+  onRefreshData: () => void;
+  member_user: string[];
+  memberindirect_user?: string[];
+  membershipDisabled?: boolean;
+}
+
+const MembersUsers = (props: PropsToMembersUsers) => {
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
+  const membershipDisabled =
+    props.membershipDisabled === undefined ? false : props.membershipDisabled;
+
+  // Get parameters from URL
+  const {
+    page,
+    setPage,
+    perPage,
+    setPerPage,
+    searchValue,
+    setSearchValue,
+    membershipDirection,
+    setMembershipDirection,
+  } = useListPageSearchParams();
+
+  // Other states
+  const [usersSelected, setUsersSelected] = React.useState<string[]>([]);
+
+  // Loaded users based on paging and member attributes
+  const [users, setUsers] = React.useState<User[]>([]);
+
+  // Choose the correct users based on the membership direction
+  const member_user = props.member_user || [];
+  const memberindirect_user = props.memberindirect_user || [];
+  let userNames =
+    membershipDirection === "direct" ? member_user : memberindirect_user;
+  userNames = [...userNames];
+
+  const getUsersNameToLoad = (): string[] => {
+    let toLoad = [...userNames];
+    toLoad.sort();
+
+    // Filter by search
+    if (searchValue) {
+      toLoad = toLoad.filter((name) =>
+        name.toLowerCase().includes(searchValue.toLowerCase())
+      );
+    }
+
+    // Apply paging
+    toLoad = paginate(toLoad, page, perPage);
+
+    return toLoad;
+  };
+
+  const [userNamesToLoad, setUserNamesToLoad] = React.useState<string[]>(
+    getUsersNameToLoad()
+  );
+
+  // Load users
+  const fullUsersQuery = useGetUsersInfoByUidQuery({
+    uidsList: userNamesToLoad,
+    noMembers: true,
+  });
+
+  // Refresh users
+  React.useEffect(() => {
+    const usersNames = getUsersNameToLoad();
+    setUserNamesToLoad(usersNames);
+  }, [props.entity, membershipDirection, searchValue, page, perPage]);
+
+  React.useEffect(() => {
+    if (userNamesToLoad.length > 0) {
+      fullUsersQuery.refetch();
+    }
+  }, [userNamesToLoad]);
+
+  // Update users
+  React.useEffect(() => {
+    if (fullUsersQuery.data && !fullUsersQuery.isFetching) {
+      setUsers(fullUsersQuery.data);
+    }
+  }, [fullUsersQuery.data, fullUsersQuery.isFetching]);
+
+  // Get type of the entity to show as text
+  const getEntityType = () => {
+    if (props.from === "user-groups") {
+      return "user group";
+    } else {
+      // Return 'group' as default
+      return "group";
+    }
+  };
+
+  // Computed "states"
+  const someItemSelected = usersSelected.length > 0;
+  const showTableRows = users.length > 0;
+  const entityType = getEntityType();
+  const userColumnNames = [
+    "User login",
+    "First name",
+    "Last name",
+    "Status",
+    "UID",
+    "Email address",
+    "Telephone number",
+    "Job title",
+  ];
+  const userProperties = [
+    "uid",
+    "givenname",
+    "sn",
+    "nsaccountlock",
+    "uidnumber",
+    "mail",
+    "telephonenumber",
+    "title",
+  ];
+
+  // Dialogs and actions
+  const [showAddModal, setShowAddModal] = React.useState(false);
+  const [showDeleteModal, setShowDeleteModal] = React.useState(false);
+
+  // Buttons functionality
+  const isRefreshButtonEnabled =
+    !fullUsersQuery.isFetching && !props.isDataLoading;
+  const isDeleteEnabled =
+    someItemSelected && membershipDirection !== "indirect";
+  const isAddButtonEnabled =
+    membershipDirection !== "indirect" && isRefreshButtonEnabled;
+
+  // Add new member to 'User'
+  // API calls
+  const [addMemberToUser] = useAddToUsersAsMemberMutation();
+  const [removeMembersFromUsers] = useRemoveFromUsersAsMemberMutation();
+  const [adderSearchValue, setAdderSearchValue] = React.useState("");
+  const [availableUsers, setAvailableUsers] = React.useState<User[]>([]);
+  const [availableItems, setAvailableItems] = React.useState<AvailableItems[]>(
+    []
+  );
+
+  // Load available users, delay the search for opening the modal
+  const usersQuery = useGettingActiveUserQuery({
+    search: adderSearchValue,
+    apiVersion: API_VERSION_BACKUP,
+    sizelimit: 100,
+    startIdx: 0,
+    stopIdx: 100,
+  });
+
+  // Trigger available users search
+  React.useEffect(() => {
+    if (showAddModal) {
+      usersQuery.refetch();
+    }
+  }, [showAddModal, adderSearchValue, props.entity]);
+
+  // Update available users
+  React.useEffect(() => {
+    if (usersQuery.data && !usersQuery.isFetching) {
+      // transform data to users
+      const count = usersQuery.data.result.count;
+      const results = usersQuery.data.result.results;
+      let items: AvailableItems[] = [];
+      const avalUsers: User[] = [];
+      for (let i = 0; i < count; i++) {
+        const user = apiToUser(results[i].result);
+        avalUsers.push(user);
+        items.push({
+          key: user.uid,
+          title: user.uid,
+        });
+      }
+      items = items.filter((item) => !member_user.includes(item.key));
+
+      setAvailableUsers(avalUsers);
+      setAvailableItems(items);
+    }
+  }, [usersQuery.data, usersQuery.isFetching]);
+
+  // Add
+  const onAddUser = (items: AvailableItems[]) => {
+    const newUserNames = items.map((item) => item.key);
+    if (props.id === undefined || newUserNames.length == 0) {
+      return;
+    }
+
+    const payload = {
+      userGroup: props.id,
+      entityType: "user",
+      userIds: newUserNames,
+    } as MemberPayload;
+
+    addMemberToUser(payload).then((response) => {
+      if ("data" in response) {
+        if (response.data.result) {
+          // Set alert: success
+          alerts.addAlert(
+            "add-member-success",
+            "Assigned new users to " + entityType + " " + props.id,
+            "success"
+          );
+          // Update displayed users before they are updated via refresh
+          const newUsers = users.concat(
+            availableUsers.filter((user) => newUserNames.includes(user.uid))
+          );
+          setUsers(newUsers);
+
+          // Refresh data
+          props.onRefreshData();
+          // Close modal
+          setShowAddModal(false);
+        } else if (response.data.error) {
+          // Set alert: error
+          const errorMessage = response.data.error as unknown as ErrorResult;
+          alerts.addAlert("add-member-error", errorMessage.message, "danger");
+        }
+      }
+    });
+  };
+
+  // Delete
+  const onDeleteUser = () => {
+    const payload = {
+      userGroup: props.id,
+      entityType: "user",
+      userIds: usersSelected,
+    } as MemberPayload;
+
+    removeMembersFromUsers(payload).then((response) => {
+      if ("data" in response) {
+        if (response.data.result) {
+          // Set alert: success
+          alerts.addAlert(
+            "remove-users-success",
+            "Removed users from " + entityType + " '" + props.id + "'",
+            "success"
+          );
+          // Update displayed users
+          const newUsers = users.filter(
+            (user) => !usersSelected.includes(user.uid)
+          );
+          setUsers(newUsers);
+          // Update data
+          setUsersSelected([]);
+          // Close modal
+          setShowDeleteModal(false);
+          // Refresh
+          props.onRefreshData();
+          // Back to page 1
+          setPage(1);
+        } else if (response.data.error) {
+          // Set alert: error
+          const errorMessage = response.data.error as unknown as ErrorResult;
+          alerts.addAlert("remove-users-error", errorMessage.message, "danger");
+        }
+      }
+    });
+  };
+
+  return (
+    <>
+      <alerts.ManagedAlerts />
+      {membershipDisabled ? (
+        <MemberOfToolbar
+          searchText={searchValue}
+          onSearchTextChange={setSearchValue}
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          onSearch={() => {}}
+          refreshButtonEnabled={isRefreshButtonEnabled}
+          onRefreshButtonClick={props.onRefreshData}
+          deleteButtonEnabled={isDeleteEnabled}
+          onDeleteButtonClick={() => setShowDeleteModal(true)}
+          addButtonEnabled={isAddButtonEnabled}
+          onAddButtonClick={() => setShowAddModal(true)}
+          helpIconEnabled={true}
+          totalItems={userNames.length}
+          perPage={perPage}
+          page={page}
+          onPerPageChange={setPerPage}
+          onPageChange={setPage}
+        />
+      ) : (
+        <MemberOfToolbar
+          searchText={searchValue}
+          onSearchTextChange={setSearchValue}
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          onSearch={() => {}}
+          refreshButtonEnabled={isRefreshButtonEnabled}
+          onRefreshButtonClick={props.onRefreshData}
+          deleteButtonEnabled={isDeleteEnabled}
+          onDeleteButtonClick={() => setShowDeleteModal(true)}
+          addButtonEnabled={isAddButtonEnabled}
+          onAddButtonClick={() => setShowAddModal(true)}
+          membershipDirectionEnabled={true}
+          membershipDirection={membershipDirection}
+          onMembershipDirectionChange={setMembershipDirection}
+          helpIconEnabled={true}
+          totalItems={userNames.length}
+          perPage={perPage}
+          page={page}
+          onPerPageChange={setPerPage}
+          onPageChange={setPage}
+        />
+      )}
+      <MemberTable
+        entityList={users}
+        idKey="uid"
+        columnNamesToShow={userColumnNames}
+        propertiesToShow={userProperties}
+        checkedItems={usersSelected}
+        onCheckItemsChange={setUsersSelected}
+        showTableRows={showTableRows}
+      />
+      <Pagination
+        className="pf-v5-u-pb-0 pf-v5-u-pr-md"
+        itemCount={userNames.length}
+        widgetId="pagination-options-menu-bottom"
+        perPage={perPage}
+        page={page}
+        variant={PaginationVariant.bottom}
+        onSetPage={(_e, page) => setPage(page)}
+        onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+      />
+      {showAddModal && (
+        <MemberOfAddModal
+          showModal={showAddModal}
+          onCloseModal={() => setShowAddModal(false)}
+          availableItems={availableItems}
+          onAdd={onAddUser}
+          onSearchTextChange={setAdderSearchValue}
+          title={"Assign users to " + entityType + " " + props.id}
+          ariaLabel={"Add " + entityType + " of user modal"}
+        />
+      )}
+      {showDeleteModal && someItemSelected && (
+        <MemberOfDeleteModal
+          showModal={showDeleteModal}
+          onCloseModal={() => setShowDeleteModal(false)}
+          title={"Delete " + entityType + " from Users"}
+          onDelete={onDeleteUser}
+        >
+          <MemberTable
+            entityList={availableUsers.filter((user) =>
+              usersSelected.includes(user.uid)
+            )}
+            idKey="uid"
+            columnNamesToShow={userColumnNames}
+            propertiesToShow={userProperties}
+            showTableRows
+          />
+        </MemberOfDeleteModal>
+      )}
+    </>
+  );
+};
+
+export default MembersUsers;

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -126,6 +126,10 @@ export const AppRoutes = (): React.ReactElement => (
       <Route path="" element={<UserGroups />} />
       <Route path=":cn">
         <Route path="" element={<UserGroupsTabs section="settings" />} />
+        <Route
+          path="member_user"
+          element={<UserGroupsTabs section="member_user" />}
+        />
       </Route>
     </Route>
     <Route path="host-groups">

--- a/src/pages/Services/ServicesSettings.tsx
+++ b/src/pages/Services/ServicesSettings.tsx
@@ -18,7 +18,7 @@ import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/o
 // Data types
 import { Metadata, Service } from "src/utils/datatypes/globalDataTypes";
 // Modals
-import DeletionConfirmationModal from "src/components/modals/DeletionConfirmationModal";
+import ConfirmationModal from "src/components/modals/ConfirmationModal";
 import IssueNewCertificate from "src/components/modals/IssueNewCertificate";
 // Layouts
 import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
@@ -376,7 +376,7 @@ const ServicesSettings = (props: PropsToServicesSettings) => {
         className={"pf-v5-u-p-md pf-v5-u-ml-lg pf-v5-u-mr-lg"}
         toolbarItems={toolbarFields}
       />
-      <DeletionConfirmationModal
+      <ConfirmationModal
         title={"Unprovision service"}
         isOpen={isUnprovisionModalOpen}
         onClose={onCloseUnprovisionModal}

--- a/src/pages/UserGroups/UserGroupsMembers.tsx
+++ b/src/pages/UserGroups/UserGroupsMembers.tsx
@@ -1,0 +1,117 @@
+import React, { useState } from "react";
+// PatternFly
+import {
+  Badge,
+  Page,
+  PageSection,
+  PageSectionVariants,
+  Tab,
+  Tabs,
+  TabTitleText,
+} from "@patternfly/react-core";
+// Data types
+import { UserGroup } from "src/utils/datatypes/globalDataTypes";
+// Navigation
+import { useNavigate } from "react-router-dom";
+// Hooks
+import useUpdateRoute from "src/hooks/useUpdateRoute";
+// RPC
+import { useGetGroupByIdQuery } from "src/services/rpcUserGroups";
+import MembersUsers from "src/components/Members/MembersUsers";
+// 'Is a member of' sections
+
+interface PropsToUserGroupsMembers {
+  userGroup: UserGroup;
+  tabSection: string;
+}
+
+const UserGroupsMembers = (props: PropsToUserGroupsMembers) => {
+  const navigate = useNavigate();
+
+  // User groups' full data
+  const userGroupQuery = useGetGroupByIdQuery(props.userGroup.cn);
+  const userGroupData = userGroupQuery.data || {};
+
+  const [userGroup, setUserGroup] = useState<Partial<UserGroup>>({});
+
+  React.useEffect(() => {
+    if (!userGroupQuery.isFetching && userGroupData) {
+      setUserGroup({ ...userGroupData });
+    }
+  }, [userGroupData, userGroupQuery.isFetching]);
+
+  const onRefreshUserGroupData = () => {
+    userGroupQuery.refetch();
+  };
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  useUpdateRoute({ pathname: "user-groups", noBreadcrumb: true });
+
+  // 'Users' length to show in tab badge
+  const [usersLength, setUsersLength] = React.useState(0);
+
+  React.useEffect(() => {
+    if (userGroup && userGroup.member_user) {
+      setUsersLength(userGroup.member_user.length);
+    }
+  }, [userGroup]);
+
+  // TODO: Add the rest of the tab lengths here
+
+  // Tab
+  const [activeTabKey, setActiveTabKey] = useState("member_user");
+
+  const handleTabClick = (
+    _event: React.MouseEvent<HTMLElement, MouseEvent>,
+    tabIndex: number | string
+  ) => {
+    setActiveTabKey(tabIndex as string);
+    navigate("/user-groups/" + props.userGroup.cn + "/" + tabIndex);
+  };
+
+  React.useEffect(() => {
+    setActiveTabKey(props.tabSection);
+  }, [props.tabSection]);
+
+  return (
+    <Page>
+      <PageSection
+        variant={PageSectionVariants.light}
+        isFilled={false}
+        className="pf-v5-u-m-lg"
+      >
+        <Tabs
+          activeKey={activeTabKey}
+          onSelect={handleTabClick}
+          isBox={false}
+          mountOnEnter
+          unmountOnExit
+        >
+          <Tab
+            eventKey={"member_user"}
+            name="member_user"
+            title={
+              <TabTitleText>
+                Users{" "}
+                <Badge key={0} isRead>
+                  {usersLength}
+                </Badge>
+              </TabTitleText>
+            }
+          >
+            <MembersUsers
+              entity={userGroup}
+              id={userGroup.cn as string}
+              from="user-groups"
+              isDataLoading={userGroupQuery.isFetching}
+              onRefreshData={onRefreshUserGroupData}
+              member_user={userGroup.member_user || []}
+            />
+          </Tab>
+        </Tabs>
+      </PageSection>
+    </Page>
+  );
+};
+
+export default UserGroupsMembers;

--- a/src/pages/UserGroups/UserGroupsTabs.tsx
+++ b/src/pages/UserGroups/UserGroupsTabs.tsx
@@ -17,6 +17,7 @@ import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
 // Components
 import UserGroupsSettings from "./UserGroupsSettings";
 import { partialGroupToGroup } from "src/utils/groupUtils";
+import UserGroupsMembers from "./UserGroupsMembers";
 // Hooks
 import { useUserGroupSettings } from "src/hooks/useUserGroupSettingsData";
 import DataSpinner from "src/components/layouts/DataSpinner";
@@ -43,6 +44,8 @@ const UserGroupsTabs = ({ section }) => {
     setActiveTabKey(tabIndex as string);
     if (tabIndex === "settings") {
       navigate("/user-groups/" + cn);
+    } else if (tabIndex === "member_user") {
+      navigate("/user-groups/" + cn + "/member_user");
     } else if (tabIndex === "memberof") {
       navigate("/user-groups/" + cn + "/memberof_usergroup");
     } else if (tabIndex === "managedby") {
@@ -130,6 +133,14 @@ const UserGroupsTabs = ({ section }) => {
               modifiedValues={userGroupSettingsData.modifiedValues}
               pwPolicyData={userGroupSettingsData.pwPolicyData}
             />
+          </Tab>
+          <Tab
+            eventKey={"member_user"}
+            name={"members-details"}
+            title={<TabTitleText>Members</TabTitleText>}
+          >
+            <PageSection className="pf-v5-u-pb-0"></PageSection>
+            <UserGroupsMembers userGroup={usergroup} tabSection={section} />
           </Tab>
           <Tab
             eventKey={"memberof"}

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -147,6 +147,16 @@ export interface UserGroup {
   dn: string;
   member: string[];
   objectclass: string[];
+  // Member
+  member_user: string[];
+  memberindirect_user: string[];
+  member_group: string[];
+  memberindirect_group: string[];
+  member_service: string[];
+  memberindirect_service: string[];
+  member_external: string[];
+  member_idoverrideuser: string[];
+  memberindirect_idoverrideuser: string[];
 }
 
 export interface NetgroupOld {

--- a/src/utils/groupUtils.tsx
+++ b/src/utils/groupUtils.tsx
@@ -41,6 +41,15 @@ export function createEmptyGroup(): UserGroup {
     dn: "",
     objectclass: [],
     member: [],
+    member_user: [],
+    memberindirect_user: [],
+    member_group: [],
+    memberindirect_group: [],
+    member_service: [],
+    memberindirect_service: [],
+    member_external: [],
+    member_idoverrideuser: [],
+    memberindirect_idoverrideuser: [],
   };
 
   return group;


### PR DESCRIPTION
The 'User groups' > 'Members' section should contain the available members related to a given user group (this is not the same as the 'Is a member of' section elements). At the same time, its first tab 'Users' should have the functionality to assign any user, this includes:
- Refresh, add and delete functionality
- Show direct and indirect members
- Search input functionality
- Pagination
- URL parameters