### PR TITLE
[User groups][Members] Implement the 'User groups' tab section

### DIFF
--- a/src/components/Members/MemberTable.tsx
+++ b/src/components/Members/MemberTable.tsx
@@ -2,7 +2,7 @@ import React from "react";
 // PatternFly
 import { Table, Tr, Th, Td, Thead, Tbody } from "@patternfly/react-table";
 // Data types
-import { User } from "src/utils/datatypes/globalDataTypes";
+import { User, UserGroup } from "src/utils/datatypes/globalDataTypes";
 // Components
 import SkeletonOnTableLayout from "../layouts/Skeleton/SkeletonOnTableLayout";
 import EmptyBodyTable from "../tables/EmptyBodyTable";
@@ -13,7 +13,7 @@ import { CheckIcon } from "@patternfly/react-icons";
 import { MinusIcon } from "@patternfly/react-icons";
 
 export interface MemberOfTableProps {
-  entityList: User[]; // More types can be added here
+  entityList: User[] | UserGroup[]; // More types can be added here
   idKey: string; // Users: uid, Groups: cn, etc.
   columnNamesToShow: string[];
   propertiesToShow: string[]; // Users: uid, givenname, sn, description, etc.
@@ -24,7 +24,7 @@ export interface MemberOfTableProps {
 
 // Body
 const TableBody = (props: {
-  list: User[]; // More types can be added here
+  list: User[] | UserGroup[]; // More types can be added here
   idKey: string; // Users: uid, Groups: cn, etc.
   columnNamesToShow: string[];
   propertiesToShow: string[]; // Users: uid, first, last, description, etc.

--- a/src/components/Members/MembersUserGroups.tsx
+++ b/src/components/Members/MembersUserGroups.tsx
@@ -1,0 +1,382 @@
+import React from "react";
+// PatternFly
+import { Pagination, PaginationVariant } from "@patternfly/react-core";
+// Components
+import MemberOfToolbar from "../MemberOf/MemberOfToolbar";
+import MemberOfAddModal, { AvailableItems } from "../MemberOf/MemberOfAddModal";
+import MemberOfDeleteModal from "../MemberOf/MemberOfDeleteModal";
+import MemberTable from "./MemberTable";
+// Data types
+import { UserGroup } from "src/utils/datatypes/globalDataTypes";
+// Hooks
+import useAlerts from "src/hooks/useAlerts";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
+// Utils
+import { API_VERSION_BACKUP, paginate } from "src/utils/utils";
+// RPC
+import { ErrorResult } from "src/services/rpc";
+import {
+  MemberPayload,
+  useAddAsMemberMutation,
+  useGetGroupInfoByNameQuery,
+  useGettingGroupsQuery,
+  useRemoveAsMemberMutation,
+} from "src/services/rpcUserGroups";
+import { apiToGroup } from "src/utils/groupUtils";
+
+interface PropsToMembersUsergroups {
+  entity: Partial<UserGroup>;
+  id: string;
+  from: string;
+  isDataLoading: boolean;
+  onRefreshData: () => void;
+  member_group: string[];
+  memberindirect_group?: string[];
+  membershipDisabled?: boolean;
+}
+
+const MembersUserGroups = (props: PropsToMembersUsergroups) => {
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
+  const membershipDisabled =
+    props.membershipDisabled === undefined ? false : props.membershipDisabled;
+
+  // Get parameters from URL
+  const {
+    page,
+    setPage,
+    perPage,
+    setPerPage,
+    searchValue,
+    setSearchValue,
+    membershipDirection,
+    setMembershipDirection,
+  } = useListPageSearchParams();
+
+  // Other states
+  const [userGroupsSelected, setUserGroupsSelected] = React.useState<string[]>(
+    []
+  );
+
+  // Loaded userGroups based on paging and member attributes
+  const [userGroups, setUserGroups] = React.useState<UserGroup[]>([]);
+
+  // Choose the correct users based on the membership direction
+  const member_group = props.member_group || [];
+  const memberindirect_group = props.memberindirect_group || [];
+  let userGroupNames =
+    membershipDirection === "direct" ? member_group : memberindirect_group;
+  userGroupNames = [...userGroupNames];
+
+  const getUserGroupsNameToLoad = (): string[] => {
+    let toLoad = [...userGroupNames];
+    toLoad.sort();
+
+    // Filter by search
+    if (searchValue) {
+      toLoad = toLoad.filter((name) =>
+        name.toLowerCase().includes(searchValue.toLowerCase())
+      );
+    }
+
+    // Apply paging
+    toLoad = paginate(toLoad, page, perPage);
+
+    return toLoad;
+  };
+
+  const [userGroupNamesToLoad, setUserGroupNamesToLoad] = React.useState<
+    string[]
+  >(getUserGroupsNameToLoad());
+
+  // Load user groups
+  const fullUserGroupsQuery = useGetGroupInfoByNameQuery({
+    groupNamesList: userGroupNamesToLoad,
+    no_members: true,
+    version: API_VERSION_BACKUP,
+  });
+
+  // Refresh user groups
+  React.useEffect(() => {
+    const userGroupsNames = getUserGroupsNameToLoad();
+    setUserGroupNamesToLoad(userGroupsNames);
+  }, [props.entity, membershipDirection, searchValue, page, perPage]);
+
+  React.useEffect(() => {
+    if (userGroupNamesToLoad.length > 0) {
+      fullUserGroupsQuery.refetch();
+    }
+  }, [userGroupNamesToLoad]);
+
+  // Update user groups
+  React.useEffect(() => {
+    if (fullUserGroupsQuery.data && !fullUserGroupsQuery.isFetching) {
+      setUserGroups(fullUserGroupsQuery.data);
+    }
+  }, [fullUserGroupsQuery.data, fullUserGroupsQuery.isFetching]);
+
+  // Get type of the entity to show as text
+  const getEntityType = () => {
+    if (props.from === "user-groups") {
+      return "user group";
+    } else {
+      // Return 'group' as default
+      return "group";
+    }
+  };
+
+  // Computed "states"
+  const someItemSelected = userGroupsSelected.length > 0;
+  const showTableRows = userGroups.length > 0;
+  const entityType = getEntityType();
+  const userGroupColumnNames = ["Group name", "GID", "Description"];
+  const userGroupProperties = ["cn", "gidnumber", "description"];
+
+  // Dialogs and actions
+  const [showAddModal, setShowAddModal] = React.useState(false);
+  const [showDeleteModal, setShowDeleteModal] = React.useState(false);
+
+  // Buttons functionality
+  const isRefreshButtonEnabled =
+    !fullUserGroupsQuery.isFetching && !props.isDataLoading;
+  const isDeleteEnabled =
+    someItemSelected && membershipDirection !== "indirect";
+  const isAddButtonEnabled =
+    membershipDirection !== "indirect" && isRefreshButtonEnabled;
+
+  // Add new member to 'UserGroup'
+  // API calls
+  const [addMemberToUserGroups] = useAddAsMemberMutation();
+  const [removeMembersFromUserGroups] = useRemoveAsMemberMutation();
+  const [adderSearchValue, setAdderSearchValue] = React.useState("");
+  const [availableUserGroups, setAvailableUserGroups] = React.useState<
+    UserGroup[]
+  >([]);
+  const [availableItems, setAvailableItems] = React.useState<AvailableItems[]>(
+    []
+  );
+
+  // Load available user groups, delay the search for opening the modal
+  const userGroupsQuery = useGettingGroupsQuery({
+    search: adderSearchValue,
+    apiVersion: API_VERSION_BACKUP,
+    sizelimit: 100,
+    startIdx: 0,
+    stopIdx: 100,
+  });
+
+  // Trigger available user groups search
+  React.useEffect(() => {
+    if (showAddModal) {
+      userGroupsQuery.refetch();
+    }
+  }, [showAddModal, adderSearchValue, props.entity]);
+
+  // Update available user groups
+  React.useEffect(() => {
+    if (userGroupsQuery.data && !userGroupsQuery.isFetching) {
+      // transform data to user groups
+      const count = userGroupsQuery.data.result.count;
+      const results = userGroupsQuery.data.result.results;
+      let items: AvailableItems[] = [];
+      const avalUserGroups: UserGroup[] = [];
+      for (let i = 0; i < count; i++) {
+        const userGroup = apiToGroup(results[i].result);
+        avalUserGroups.push(userGroup);
+        items.push({
+          key: userGroup.cn,
+          title: userGroup.cn,
+        });
+      }
+      items = items.filter((item) => !member_group.includes(item.key));
+
+      setAvailableUserGroups(avalUserGroups);
+      setAvailableItems(items);
+    }
+  }, [userGroupsQuery.data, userGroupsQuery.isFetching]);
+
+  // Add
+  const onAddUserGroup = (items: AvailableItems[]) => {
+    const newUserGroupNames = items.map((item) => item.key);
+    if (props.id === undefined || newUserGroupNames.length == 0) {
+      return;
+    }
+
+    const payload = {
+      userGroup: props.id,
+      entityType: "group",
+      idsToAdd: newUserGroupNames,
+    } as MemberPayload;
+
+    addMemberToUserGroups(payload).then((response) => {
+      if ("data" in response) {
+        if (response.data.result) {
+          // Set alert: success
+          alerts.addAlert(
+            "add-member-success",
+            "Assigned new user groups to " + entityType + " " + props.id,
+            "success"
+          );
+          // Update displayed users before they are updated via refresh
+          const newUserGroups = userGroups.concat(
+            availableUserGroups.filter((userGroup) =>
+              newUserGroupNames.includes(userGroup.cn)
+            )
+          );
+          setUserGroups(newUserGroups);
+
+          // Refresh data
+          props.onRefreshData();
+          // Close modal
+          setShowAddModal(false);
+        } else if (response.data.error) {
+          // Set alert: error
+          const errorMessage = response.data.error as unknown as ErrorResult;
+          alerts.addAlert("add-member-error", errorMessage.message, "danger");
+        }
+      }
+    });
+  };
+
+  // Delete
+  const onDeleteUserGroups = () => {
+    const payload = {
+      userGroup: props.id,
+      entityType: "group",
+      idsToAdd: userGroupsSelected,
+    } as MemberPayload;
+
+    removeMembersFromUserGroups(payload).then((response) => {
+      if ("data" in response) {
+        if (response.data.result) {
+          // Set alert: success
+          alerts.addAlert(
+            "remove-usersgroups-success",
+            "Removed user groups from " + entityType + " '" + props.id + "'",
+            "success"
+          );
+          // Update displayed user groups
+          const newUserGroups = userGroups.filter(
+            (userGroup) => !userGroupsSelected.includes(userGroup.cn)
+          );
+          setUserGroups(newUserGroups);
+          // Update data
+          setUserGroupsSelected([]);
+          // Close modal
+          setShowDeleteModal(false);
+          // Refresh
+          props.onRefreshData();
+          // Back to page 1
+          setPage(1);
+        } else if (response.data.error) {
+          // Set alert: error
+          const errorMessage = response.data.error as unknown as ErrorResult;
+          alerts.addAlert(
+            "remove-usergroups-error",
+            errorMessage.message,
+            "danger"
+          );
+        }
+      }
+    });
+  };
+
+  return (
+    <>
+      <alerts.ManagedAlerts />
+      {membershipDisabled ? (
+        <MemberOfToolbar
+          searchText={searchValue}
+          onSearchTextChange={setSearchValue}
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          onSearch={() => {}}
+          refreshButtonEnabled={isRefreshButtonEnabled}
+          onRefreshButtonClick={props.onRefreshData}
+          deleteButtonEnabled={isDeleteEnabled}
+          onDeleteButtonClick={() => setShowDeleteModal(true)}
+          addButtonEnabled={isAddButtonEnabled}
+          onAddButtonClick={() => setShowAddModal(true)}
+          helpIconEnabled={true}
+          totalItems={userGroupNames.length}
+          perPage={perPage}
+          page={page}
+          onPerPageChange={setPerPage}
+          onPageChange={setPage}
+        />
+      ) : (
+        <MemberOfToolbar
+          searchText={searchValue}
+          onSearchTextChange={setSearchValue}
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          onSearch={() => {}}
+          refreshButtonEnabled={isRefreshButtonEnabled}
+          onRefreshButtonClick={props.onRefreshData}
+          deleteButtonEnabled={isDeleteEnabled}
+          onDeleteButtonClick={() => setShowDeleteModal(true)}
+          addButtonEnabled={isAddButtonEnabled}
+          onAddButtonClick={() => setShowAddModal(true)}
+          membershipDirectionEnabled={true}
+          membershipDirection={membershipDirection}
+          onMembershipDirectionChange={setMembershipDirection}
+          helpIconEnabled={true}
+          totalItems={userGroupNames.length}
+          perPage={perPage}
+          page={page}
+          onPerPageChange={setPerPage}
+          onPageChange={setPage}
+        />
+      )}
+      <MemberTable
+        entityList={userGroups}
+        idKey="cn"
+        columnNamesToShow={userGroupColumnNames}
+        propertiesToShow={userGroupProperties}
+        checkedItems={userGroupsSelected}
+        onCheckItemsChange={setUserGroupsSelected}
+        showTableRows={showTableRows}
+      />
+      <Pagination
+        className="pf-v5-u-pb-0 pf-v5-u-pr-md"
+        itemCount={userGroupNames.length}
+        widgetId="pagination-options-menu-bottom"
+        perPage={perPage}
+        page={page}
+        variant={PaginationVariant.bottom}
+        onSetPage={(_e, page) => setPage(page)}
+        onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+      />
+      {showAddModal && (
+        <MemberOfAddModal
+          showModal={showAddModal}
+          onCloseModal={() => setShowAddModal(false)}
+          availableItems={availableItems}
+          onAdd={onAddUserGroup}
+          onSearchTextChange={setAdderSearchValue}
+          title={"Assign User groups to " + entityType + " " + props.id}
+          ariaLabel={"Add " + entityType + " of user groups modal"}
+        />
+      )}
+      {showDeleteModal && someItemSelected && (
+        <MemberOfDeleteModal
+          showModal={showDeleteModal}
+          onCloseModal={() => setShowDeleteModal(false)}
+          title={"Delete " + entityType + " from User groups"}
+          onDelete={onDeleteUserGroups}
+        >
+          <MemberTable
+            entityList={availableUserGroups.filter((userGroup) =>
+              userGroupsSelected.includes(userGroup.cn)
+            )}
+            idKey="cn"
+            columnNamesToShow={userGroupColumnNames}
+            propertiesToShow={userGroupProperties}
+            showTableRows
+          />
+        </MemberOfDeleteModal>
+      )}
+    </>
+  );
+};
+
+export default MembersUserGroups;

--- a/src/components/Members/MembersUsers.tsx
+++ b/src/components/Members/MembersUsers.tsx
@@ -22,8 +22,8 @@ import {
 } from "src/services/rpcUsers";
 import {
   MemberPayload,
-  useAddToUsersAsMemberMutation,
-  useRemoveFromUsersAsMemberMutation,
+  useAddAsMemberMutation,
+  useRemoveAsMemberMutation,
 } from "src/services/rpcUserGroups";
 
 interface PropsToMembersUsers {
@@ -164,8 +164,8 @@ const MembersUsers = (props: PropsToMembersUsers) => {
 
   // Add new member to 'User'
   // API calls
-  const [addMemberToUser] = useAddToUsersAsMemberMutation();
-  const [removeMembersFromUsers] = useRemoveFromUsersAsMemberMutation();
+  const [addMemberToUser] = useAddAsMemberMutation();
+  const [removeMembersFromUsers] = useRemoveAsMemberMutation();
   const [adderSearchValue, setAdderSearchValue] = React.useState("");
   const [availableUsers, setAvailableUsers] = React.useState<User[]>([]);
   const [availableItems, setAvailableItems] = React.useState<AvailableItems[]>(
@@ -221,7 +221,7 @@ const MembersUsers = (props: PropsToMembersUsers) => {
     const payload = {
       userGroup: props.id,
       entityType: "user",
-      userIds: newUserNames,
+      idsToAdd: newUserNames,
     } as MemberPayload;
 
     addMemberToUser(payload).then((response) => {
@@ -257,7 +257,7 @@ const MembersUsers = (props: PropsToMembersUsers) => {
     const payload = {
       userGroup: props.id,
       entityType: "user",
-      userIds: usersSelected,
+      idsToAdd: usersSelected,
     } as MemberPayload;
 
     removeMembersFromUsers(payload).then((response) => {

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -130,6 +130,10 @@ export const AppRoutes = (): React.ReactElement => (
           path="member_user"
           element={<UserGroupsTabs section="member_user" />}
         />
+        <Route
+          path="member_group"
+          element={<UserGroupsTabs section="member_group" />}
+        />
       </Route>
     </Route>
     <Route path="host-groups">

--- a/src/pages/UserGroups/UserGroupsMembers.tsx
+++ b/src/pages/UserGroups/UserGroupsMembers.tsx
@@ -18,6 +18,7 @@ import useUpdateRoute from "src/hooks/useUpdateRoute";
 // RPC
 import { useGetGroupByIdQuery } from "src/services/rpcUserGroups";
 import MembersUsers from "src/components/Members/MembersUsers";
+import MembersUserGroups from "src/components/Members/MembersUserGroups";
 // 'Is a member of' sections
 
 interface PropsToUserGroupsMembers {
@@ -56,10 +57,19 @@ const UserGroupsMembers = (props: PropsToUserGroupsMembers) => {
     }
   }, [userGroup]);
 
+  // 'User Groups' length to show in tab badge
+  const [userGroupsLength, setUserGroupsLength] = React.useState(0);
+
+  React.useEffect(() => {
+    if (userGroup && userGroup.member_group) {
+      setUserGroupsLength(userGroup.member_group.length);
+    }
+  }, [userGroup]);
+
   // TODO: Add the rest of the tab lengths here
 
   // Tab
-  const [activeTabKey, setActiveTabKey] = useState("member_user");
+  const [activeTabKey, setActiveTabKey] = useState(props.tabSection);
 
   const handleTabClick = (
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
@@ -106,6 +116,27 @@ const UserGroupsMembers = (props: PropsToUserGroupsMembers) => {
               isDataLoading={userGroupQuery.isFetching}
               onRefreshData={onRefreshUserGroupData}
               member_user={userGroup.member_user || []}
+            />
+          </Tab>
+          <Tab
+            eventKey={"member_group"}
+            name="member_group"
+            title={
+              <TabTitleText>
+                User Groups{" "}
+                <Badge key={1} isRead>
+                  {userGroupsLength}
+                </Badge>
+              </TabTitleText>
+            }
+          >
+            <MembersUserGroups
+              entity={userGroup}
+              id={userGroup.cn as string}
+              from="user-groups"
+              isDataLoading={userGroupQuery.isFetching}
+              onRefreshData={onRefreshUserGroupData}
+              member_group={userGroup.member_group || []}
             />
           </Tab>
         </Tabs>

--- a/src/pages/UserGroups/UserGroupsTabs.tsx
+++ b/src/pages/UserGroups/UserGroupsTabs.tsx
@@ -28,7 +28,6 @@ import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
 
 // eslint-disable-next-line react/prop-types
 const UserGroupsTabs = ({ section }) => {
-  // Get location (React Router DOM) and get state data
   const { cn } = useParams();
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
@@ -42,9 +41,10 @@ const UserGroupsTabs = ({ section }) => {
     tabIndex: number | string
   ) => {
     setActiveTabKey(tabIndex as string);
+
     if (tabIndex === "settings") {
       navigate("/user-groups/" + cn);
-    } else if (tabIndex === "member_user") {
+    } else if (tabIndex === "member") {
       navigate("/user-groups/" + cn + "/member_user");
     } else if (tabIndex === "memberof") {
       navigate("/user-groups/" + cn + "/memberof_usergroup");
@@ -79,7 +79,14 @@ const UserGroupsTabs = ({ section }) => {
     if (!section) {
       navigate(URL_PREFIX + "/user-groups/" + cn);
     }
-    setActiveTabKey(section);
+    // Infer the general tab key from the section name
+    const sect = section as string;
+    if (sect.startsWith("member_")) {
+      setActiveTabKey("member");
+    } else {
+      setActiveTabKey(section);
+    }
+    // TODO: Check more routes here
   }, [section]);
 
   if (
@@ -135,7 +142,7 @@ const UserGroupsTabs = ({ section }) => {
             />
           </Tab>
           <Tab
-            eventKey={"member_user"}
+            eventKey={"member"}
             name={"members-details"}
             title={<TabTitleText>Members</TabTitleText>}
           >

--- a/src/services/rpcUserGroups.ts
+++ b/src/services/rpcUserGroups.ts
@@ -62,7 +62,7 @@ export type GroupFullData = {
 
 export interface MemberPayload {
   userGroup: string;
-  userIds: string[];
+  idsToAdd: string[];
   entityType: string;
 }
 
@@ -327,17 +327,17 @@ const extendedApi = api.injectEndpoints({
      * Given a list of user IDs, add them as members to a group
      * @param {MemberPayload} - Payload with user IDs and options
      */
-    addToUsersAsMember: build.mutation<FindRPCResponse, MemberPayload>({
+    addAsMember: build.mutation<FindRPCResponse, MemberPayload>({
       query: (payload) => {
         const userGroup = payload.userGroup;
-        const userIds = payload.userIds;
+        const idsToAdd = payload.idsToAdd;
         const memberType = payload.entityType;
 
         return getCommand({
           method: "group_add_member",
           params: [
             [userGroup],
-            { all: true, [memberType]: userIds, version: API_VERSION_BACKUP },
+            { all: true, [memberType]: idsToAdd, version: API_VERSION_BACKUP },
           ],
         });
       },
@@ -346,17 +346,17 @@ const extendedApi = api.injectEndpoints({
      * Remove a user group from some user members
      * @param {MemberPayload} - Payload with user IDs and options
      */
-    removeFromUsersAsMember: build.mutation<FindRPCResponse, MemberPayload>({
+    removeAsMember: build.mutation<FindRPCResponse, MemberPayload>({
       query: (payload) => {
         const userGroup = payload.userGroup;
-        const userIds = payload.userIds;
+        const idsToAdd = payload.idsToAdd;
         const memberType = payload.entityType;
 
         return getCommand({
           method: "group_remove_member",
           params: [
             [userGroup],
-            { all: true, [memberType]: userIds, version: API_VERSION_BACKUP },
+            { all: true, [memberType]: idsToAdd, version: API_VERSION_BACKUP },
           ],
         });
       },
@@ -384,6 +384,6 @@ export const {
   useConvertGroupExternalMutation,
   useConvertGroupPOSIXMutation,
   useGetGroupByIdQuery,
-  useAddToUsersAsMemberMutation,
-  useRemoveFromUsersAsMemberMutation,
+  useAddAsMemberMutation,
+  useRemoveAsMemberMutation,
 } = extendedApi;


### PR DESCRIPTION
The 'User groups' tab should show the user groups associated as member.

The solution also adapts the `addToUsersAsMember` and `removeFromUsersAsMember` endpoints to receive a generic function name and some parameters.