### PR TITLE
[User groups][Members] Implement the 'External' tab section

### DIFF
--- a/src/components/Members/MemberTable.tsx
+++ b/src/components/Members/MemberTable.tsx
@@ -13,8 +13,8 @@ import { CheckIcon } from "@patternfly/react-icons";
 import { MinusIcon } from "@patternfly/react-icons";
 
 export interface MemberOfTableProps {
-  entityList: User[] | UserGroup[] | Service[]; // More types can be added here
-  idKey: string; // Users: uid, Groups: cn, etc.
+  entityList: User[] | UserGroup[] | Service[] | string[]; // More types can be added here
+  idKey?: string; // Users: uid, Groups: cn, etc. If not provided, the entity itself (a single string) will be used
   columnNamesToShow: string[];
   propertiesToShow: string[]; // Users: uid, givenname, sn, description, etc.
   checkedItems?: string[];
@@ -24,8 +24,8 @@ export interface MemberOfTableProps {
 
 // Body
 const TableBody = (props: {
-  list: User[] | UserGroup[] | Service[]; // More types can be added here
-  idKey: string; // Users: uid, Groups: cn, etc.
+  list: User[] | UserGroup[] | Service[] | string[]; // More types can be added here
+  idKey?: string; // Users: uid, Groups: cn, etc.
   columnNamesToShow: string[];
   propertiesToShow: string[]; // Users: uid, first, last, description, etc.
   showCheckboxColumn: boolean;
@@ -38,14 +38,27 @@ const TableBody = (props: {
       {list.map((item, index) => (
         <Tr key={index}>
           {props.showCheckboxColumn && (
-            <Td
-              select={{
-                rowIndex: index,
-                onSelect: (_e, isSelected) =>
-                  props.onCheckboxChange(isSelected, item[idKey]),
-                isSelected: props.checkedItems.includes(item[idKey]),
-              }}
-            />
+            <>
+              {idKey ? (
+                <Td
+                  select={{
+                    rowIndex: index,
+                    onSelect: (_e, isSelected) =>
+                      props.onCheckboxChange(isSelected, item[idKey]),
+                    isSelected: props.checkedItems.includes(item[idKey]),
+                  }}
+                />
+              ) : (
+                <Td
+                  select={{
+                    rowIndex: index,
+                    onSelect: (_e, isSelected) =>
+                      props.onCheckboxChange(isSelected, item),
+                    isSelected: props.checkedItems.includes(item),
+                  }}
+                />
+              )}
+            </>
           )}
           {propertiesToShow.map((propertyName, index) => {
             // Handle special cases: 'nsaccountlock' is a boolean

--- a/src/components/Members/MembersExternal.tsx
+++ b/src/components/Members/MembersExternal.tsx
@@ -1,0 +1,288 @@
+import React from "react";
+// PatternFly
+import {
+  Button,
+  Pagination,
+  PaginationVariant,
+  TextInput,
+} from "@patternfly/react-core";
+// Components
+import MemberOfToolbar from "../MemberOf/MemberOfToolbar";
+import { AvailableItems } from "../MemberOf/MemberOfAddModal";
+import MemberOfDeleteModal from "../MemberOf/MemberOfDeleteModal";
+import MemberTable from "./MemberTable";
+// Data types
+import { UserGroup } from "src/utils/datatypes/globalDataTypes";
+// Hooks
+import useAlerts from "src/hooks/useAlerts";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
+// RPC
+import { ErrorResult } from "src/services/rpc";
+
+import {
+  MemberPayload,
+  useAddAsMemberMutation,
+  useRemoveAsMemberMutation,
+} from "src/services/rpcUserGroups";
+import ModalWithFormLayout from "../layouts/ModalWithFormLayout";
+
+interface PropsToMembersExternal {
+  entity: Partial<UserGroup>;
+  id: string;
+  from: string;
+  isDataLoading: boolean;
+  onRefreshData: () => void;
+  member_external: string[];
+  membershipDisabled?: boolean;
+}
+
+const MembersExternal = (props: PropsToMembersExternal) => {
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
+  // Get parameters from URL
+  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+    useListPageSearchParams();
+
+  // Other states
+  const [externalsSelected, setExternalsSelected] = React.useState<string[]>(
+    []
+  );
+
+  // Choose the correct externals based on the membership direction
+  const [externals, setExternals] = React.useState(props.member_external || []);
+  const isExternal =
+    props.entity.objectclass?.includes("ipaexternalgroup") || false;
+
+  // Get type of the entity to show as text
+  const getEntityType = () => {
+    if (props.from === "user-groups") {
+      return "user group";
+    } else {
+      // Return 'group' as default
+      return "group";
+    }
+  };
+
+  // Computed "states"
+  const someItemSelected = externalsSelected.length > 0;
+  const showTableRows = externals.length > 0;
+  const entityType = getEntityType();
+  const externalColumnNames = ["External member"];
+  const externalProperties = externals;
+
+  // Dialogs and actions
+  const [showAddModal, setShowAddModal] = React.useState(false);
+  const [showDeleteModal, setShowDeleteModal] = React.useState(false);
+
+  // Buttons functionality
+  const isRefreshButtonEnabled = !props.isDataLoading;
+  const isDeleteEnabled = someItemSelected;
+  const isAddButtonEnabled = isExternal && isRefreshButtonEnabled;
+
+  // API calls
+  const [addExternalMember] = useAddAsMemberMutation();
+  const [removeExternalMembers] = useRemoveAsMemberMutation();
+
+  // Add
+  const [newMember, setNewMember] = React.useState("");
+
+  // - Fields
+  const fieldsToAddModal = [
+    {
+      id: "New external member",
+      name: "External member",
+      pfComponent: (
+        <TextInput
+          id="new-external-member"
+          name="ipaexternalmember"
+          value={newMember}
+          onChange={(_event, value) => setNewMember(value)}
+          type="text"
+          aria-label="new external member"
+        />
+      ),
+    },
+  ];
+
+  // - Reset value on close modal
+  React.useEffect(() => {
+    if (!showAddModal) {
+      setNewMember("");
+    }
+  }, [showAddModal]);
+
+  // - Actions
+  const actionsToAddModal = [
+    <Button
+      key="add-new-external"
+      variant="secondary"
+      isDisabled={newMember.length === 0}
+      form="new-external-member"
+      onClick={() => onAddExternal([{ key: newMember, title: newMember }])}
+    >
+      Add
+    </Button>,
+    <Button
+      key="cancel-new-external"
+      variant="link"
+      onClick={() => setShowAddModal(false)}
+    >
+      Cancel
+    </Button>,
+  ];
+
+  const onAddExternal = (items: AvailableItems[]) => {
+    const newExternalNames = items.map((item) => item.key);
+    if (props.id === undefined || newExternalNames.length == 0) {
+      return;
+    }
+
+    const payload = {
+      userGroup: props.id,
+      entityType: "ipaexternalmember",
+      idsToAdd: newExternalNames,
+    } as MemberPayload;
+
+    addExternalMember(payload).then((response) => {
+      if ("data" in response) {
+        if (response.data.result) {
+          // Set alert: success
+          alerts.addAlert(
+            "add-member-success",
+            "Assigned new externals to " + entityType + " " + props.id,
+            "success"
+          );
+          // Update displayed externals before they are updated via refresh
+          setExternals(newExternalNames);
+
+          // Refresh data
+          props.onRefreshData();
+          // Close modal
+          setShowAddModal(false);
+        } else if (response.data.error) {
+          // Set alert: error
+          const errorMessage = response.data.error as unknown as ErrorResult;
+          alerts.addAlert("add-member-error", errorMessage.message, "danger");
+        }
+      }
+    });
+  };
+
+  // Delete
+  const onDeleteExternal = () => {
+    const payload = {
+      userGroup: props.id,
+      entityType: "ipaexternalmember",
+      idsToAdd: externalsSelected,
+    } as MemberPayload;
+
+    removeExternalMembers(payload).then((response) => {
+      if ("data" in response) {
+        if (response.data.result) {
+          // Set alert: success
+          alerts.addAlert(
+            "remove-members-success",
+            "Removed members from " + entityType + " '" + props.id + "'",
+            "success"
+          );
+          // Update displayed externals
+          const newExternals = externals.filter(
+            (external) => !externalsSelected.includes(external)
+          );
+          setExternals(newExternals);
+          // Update data
+          setExternalsSelected([]);
+          // Close modal
+          setShowDeleteModal(false);
+          // Refresh
+          props.onRefreshData();
+          // Back to page 1
+          setPage(1);
+        } else if (response.data.error) {
+          // Set alert: error
+          const errorMessage = response.data.error as unknown as ErrorResult;
+          alerts.addAlert(
+            "remove-externals-error",
+            errorMessage.message,
+            "danger"
+          );
+        }
+      }
+    });
+  };
+
+  return (
+    <>
+      <alerts.ManagedAlerts />
+      <MemberOfToolbar
+        searchText={searchValue}
+        onSearchTextChange={setSearchValue}
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        onSearch={() => {}}
+        refreshButtonEnabled={isRefreshButtonEnabled}
+        onRefreshButtonClick={props.onRefreshData}
+        deleteButtonEnabled={isDeleteEnabled}
+        onDeleteButtonClick={() => setShowDeleteModal(true)}
+        addButtonEnabled={isAddButtonEnabled}
+        onAddButtonClick={() => setShowAddModal(true)}
+        helpIconEnabled={true}
+        totalItems={externals.length}
+        perPage={perPage}
+        page={page}
+        onPerPageChange={setPerPage}
+        onPageChange={setPage}
+      />
+      <MemberTable
+        entityList={externals}
+        idKey="krbcanonicalname"
+        columnNamesToShow={externalColumnNames}
+        propertiesToShow={externalProperties}
+        checkedItems={externalsSelected}
+        onCheckItemsChange={setExternalsSelected}
+        showTableRows={showTableRows}
+      />
+      <Pagination
+        className="pf-v5-u-pb-0 pf-v5-u-pr-md"
+        itemCount={externals.length}
+        widgetId="pagination-options-menu-bottom"
+        perPage={perPage}
+        page={page}
+        variant={PaginationVariant.bottom}
+        onSetPage={(_e, page) => setPage(page)}
+        onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+      />
+      {showAddModal && (
+        <ModalWithFormLayout
+          variantType="small"
+          modalPosition="top"
+          title={"Add external member"}
+          formId={props.id}
+          fields={fieldsToAddModal}
+          show={showAddModal}
+          onClose={() => setShowAddModal(false)}
+          actions={actionsToAddModal}
+        />
+      )}
+      {showDeleteModal && someItemSelected && (
+        <MemberOfDeleteModal
+          showModal={showDeleteModal}
+          onCloseModal={() => setShowDeleteModal(false)}
+          title={"Delete " + entityType + " from External"}
+          onDelete={onDeleteExternal}
+        >
+          <MemberTable
+            entityList={externals.filter((external) =>
+              externalsSelected.includes(external)
+            )}
+            columnNamesToShow={externalColumnNames}
+            propertiesToShow={externalProperties}
+            showTableRows
+          />
+        </MemberOfDeleteModal>
+      )}
+    </>
+  );
+};
+
+export default MembersExternal;

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -155,6 +155,10 @@ export const AppRoutes = ({
                   path="member_service"
                   element={<UserGroupsTabs section="member_service" />}
                 />
+                <Route
+                  path="member_external"
+                  element={<UserGroupsTabs section="member_external" />}
+                />
               </Route>
             </Route>
             <Route path="host-groups">

--- a/src/pages/UserGroups/UserGroupsMembers.tsx
+++ b/src/pages/UserGroups/UserGroupsMembers.tsx
@@ -21,6 +21,7 @@ import { useGetGroupByIdQuery } from "src/services/rpcUserGroups";
 import MembersUsers from "src/components/Members/MembersUsers";
 import MembersUserGroups from "src/components/Members/MembersUserGroups";
 import MembersServices from "src/components/Members/MembersServices";
+import MembersExternal from "src/components/Members/MembersExternal";
 
 interface PropsToUserGroupsMembers {
   userGroup: UserGroup;
@@ -73,6 +74,15 @@ const UserGroupsMembers = (props: PropsToUserGroupsMembers) => {
   React.useEffect(() => {
     if (userGroup && userGroup.member_service) {
       setServicesLength(userGroup.member_service.length);
+    }
+  }, [userGroup]);
+
+  // 'Externals' length to show in tab badge
+  const [externalsLength, setExternalsLength] = React.useState(0);
+
+  React.useEffect(() => {
+    if (userGroup && userGroup.member_external) {
+      setExternalsLength(userGroup.member_external.length);
     }
   }, [userGroup]);
 
@@ -168,6 +178,27 @@ const UserGroupsMembers = (props: PropsToUserGroupsMembers) => {
               isDataLoading={userGroupQuery.isFetching}
               onRefreshData={onRefreshUserGroupData}
               member_service={userGroup.member_service || []}
+            />
+          </Tab>
+          <Tab
+            eventKey={"member_external"}
+            name="member_external"
+            title={
+              <TabTitleText>
+                External{" "}
+                <Badge key={3} isRead>
+                  {externalsLength}
+                </Badge>
+              </TabTitleText>
+            }
+          >
+            <MembersExternal
+              entity={userGroup}
+              id={userGroup.cn as string}
+              from="user-groups"
+              isDataLoading={userGroupQuery.isFetching}
+              onRefreshData={onRefreshUserGroupData}
+              member_external={userGroup.member_external || []}
             />
           </Tab>
         </Tabs>

--- a/src/services/rpcUserGroups.ts
+++ b/src/services/rpcUserGroups.ts
@@ -317,7 +317,10 @@ const extendedApi = api.injectEndpoints({
       query: (groupId) => {
         return getCommand({
           method: "group_show",
-          params: [[groupId], { version: API_VERSION_BACKUP }],
+          params: [
+            [groupId],
+            { all: true, rights: true, version: API_VERSION_BACKUP },
+          ],
         });
       },
       transformResponse: (response: FindRPCResponse): UserGroup =>

--- a/src/utils/groupUtils.tsx
+++ b/src/utils/groupUtils.tsx
@@ -8,7 +8,6 @@ const simpleValues = new Set([
   "gidnumber",
   "description",
   "dn",
-  "objectclass",
   "member",
 ]);
 


### PR DESCRIPTION
The 'External' tab should show the external groups  associated as member for a given user group.

Only a user group marked as 'External' should be able to manage (add / delete) external members. Those can also be created via CLI: ` ipa group-add --external groupname`. Then it can have members added to it: `ipa group-add-member groupname --external group-member@trusted.domain`.

This functionality requires to have a Trust configured (e.g., active directory setup via IDM-CI) to create those external
members.

This PR depends on this one to be merged: https://github.com/freeipa/freeipa-webui/pull/477