### PR TITLE
Login kerberos authentication method

### DIFF
--- a/src/services/rpc.ts
+++ b/src/services/rpc.ts
@@ -165,6 +165,18 @@ export const getCommand = (commandData: Command) => {
   return payloadWithParams;
 };
 
+export const getCommandNoVersion = (commandData: Command) => {
+  const payloadWithParams = {
+    url: "ipa/session/json",
+    method: "POST",
+    body: {
+      method: commandData.method,
+      params: commandData.params,
+    },
+  };
+  return payloadWithParams;
+};
+
 export const getBatchCommand = (commandData: Command[], apiVersion: string) => {
   const payloadBatchParams = {
     url: "ipa/session/json",


### PR DESCRIPTION
The Kerberos authentication should be performed by taking the already-configured kerberos credentials (via `kinit`) and authenticate through the `/ipa/session/login_kerberos` endpoint.

### How to reproduce
It is assumed that no ticket is created, no browser has been opened yet, and there is a vagrant machine up and running containing the modern WebUI  (see `README` file instructions).

[From local] Destroy all kerberos keys:
```
>> kdestroy -A
```
To be able to test the results in local, we need to modify the `resolved` file and add the IP of our already created vagrant VM. Add the following lines in the `/etc/systemd/resolved.conf` file:
```
[Resolve]
...
DNS=<ip-of-the-vagrant-vm>
```
Save the changes and restart the service.
```
>> sudo systemctl restart systemd-resolved.service
```
Create a ticket against admin + the webui realm
```
>> kinit admin@DOM-IPA.DEMO
```
You can check if the ticket was successfully create it by executing `klist -A`. Alternatively, you can also create the ticket while debugging by executing `KRB5_TRACE=/dev/stdout kinit admin@DOM-IPA.DEMO`.

These steps should be enough to test the authentication via Kerberos:
-  Open a new tab on any browser (recommended: Firefox or Chrome)
- Navigate to the `/login` page
- Follow the instructions mentioned in the `Browser Kerberos setup` link (or `/ipa/config/ssbrowser.html`) for your specific browser
  - NOTE: No need to add any certificate, so you can skip those specific steps
- Close the browser and open it again to apply the changes (that includes ALL tabs from that browser)
- Go to the `/login` page and click the `Login` button (without entering any user + pwd). You should be authenticated now.

If this doesn't work, try the steps described in 'Plan B'.

### Plan B
Create the zone for `dom-ipa.demo`
- Access the WebUI with our credentials
- Go to `Network services` > `DNS` > `DNS zones`
- Create a new zone called `dom-ipa.demo.` (the final `.` is important!)
- Access the settings page of the already-created zone
- Create new records (you can use the same values from e.g. `dom-server.ipa.demo` as a reference):
  - `_kerberos` (`TXT` and `URI` types)
  - `_kerberos._tcp` (if it doesn't exist)
- Save the changes

Modify the kerberos configuration file to be able to create tickets for the `DOM-IPA.DEMO` realm
- `sudo vim /etc/krb5.conf`
- Replace the `default_realm` and create the settings:
```
default_realm = DOM-IPA.DEMO
...
DOM-IPA.DEMO = {
   default_domain = ipa.demo
}
```
- Save the changes

Check if there is a krb ticket and print the version numbers
``` 
>> kvno HTTP/server.ipa.demo
```
Open a Google chrome window while adding the `ipa.demo` server to the whitelist
- Be sure to close any chrome tab that could've been opened before executing this
- This will work for normal tabs (not incognito)
```
>> google-chrome --auth-server-whitelist="*.ipa.demo"
```
If there is a kerberos ticket, this should automatically log in to the WebUI

### NOTE 
This solution is not able to log out from the WebUi as long as there is a Kerberos ticket. The same thing happens to the current WebUI when the page is refreshed from the `/login` page. Not sure if this is an expected behavior.