### PR TITLE
Calulate membership count when rendering

### DIFF
--- a/src/pages/ActiveUsers/UserMemberOf.tsx
+++ b/src/pages/ActiveUsers/UserMemberOf.tsx
@@ -63,60 +63,6 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
     userQuery.refetch();
   };
 
-  // 'User groups' length to show in tab badge
-  const [userGroupsLength, setUserGroupLength] = React.useState(0);
-
-  React.useEffect(() => {
-    if (user && user.memberof_group) {
-      setUserGroupLength(user.memberof_group.length);
-    }
-  }, [user]);
-
-  // 'Netgroups' length to show in tab badge
-  const [netgroupsLength, setNetgroupsLength] = React.useState(0);
-
-  React.useEffect(() => {
-    if (user && user.memberof_netgroup) {
-      setNetgroupsLength(user.memberof_netgroup.length);
-    }
-  }, [user]);
-
-  // 'Roles' length to show in tab badge
-  const [rolesLength, setRolesLength] = React.useState(0);
-
-  React.useEffect(() => {
-    if (user && user.memberof_role) {
-      setRolesLength(user.memberof_role.length);
-    }
-  }, [user]);
-
-  // 'HBACRules' length to show in tab badge
-  const [hbacRulesLength, setHbacRulesLength] = React.useState(0);
-
-  React.useEffect(() => {
-    if (user && user.memberof_hbacrule) {
-      setHbacRulesLength(user.memberof_hbacrule.length);
-    }
-  }, [user]);
-
-  // 'Sudo rules' length to show in tab badge
-  const [sudoRulesLength, setSudoRulesLength] = React.useState(0);
-
-  React.useEffect(() => {
-    if (user && user.memberof_sudorule) {
-      setSudoRulesLength(user.memberof_sudorule.length);
-    }
-  }, [user]);
-
-  // 'Subordinate IDs' length to show in tab badge
-  const [subIdsLength, setSubIdsLength] = React.useState(0);
-
-  React.useEffect(() => {
-    if (user && user.memberof_subid) {
-      setSubIdsLength(user.memberof_subid.length);
-    }
-  }, [user]);
-
   // Tab
   const [activeTabKey, setActiveTabKey] = useState("group");
 
@@ -150,7 +96,7 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
               <TabTitleText>
                 User groups{" "}
                 <Badge key={0} isRead>
-                  {userGroupsLength}
+                  {user && user.memberof_group ? user.memberof_group.length : 0}
                 </Badge>
               </TabTitleText>
             }
@@ -169,7 +115,9 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
               <TabTitleText>
                 Netgroups{" "}
                 <Badge key={1} isRead>
-                  {netgroupsLength}
+                  {user && user.memberof_netgroup
+                    ? user.memberof_netgroup.length
+                    : 0}
                 </Badge>
               </TabTitleText>
             }
@@ -189,7 +137,7 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
               <TabTitleText>
                 Roles{" "}
                 <Badge key={2} isRead>
-                  {rolesLength}
+                  {user && user.memberof_role ? user.memberof_role.length : 0}
                 </Badge>
               </TabTitleText>
             }
@@ -211,7 +159,9 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
               <TabTitleText>
                 HBAC rules{" "}
                 <Badge key={3} isRead>
-                  {hbacRulesLength}
+                  {user && user.memberof_hbacrule
+                    ? user.memberof_hbacrule.length
+                    : 0}
                 </Badge>
               </TabTitleText>
             }
@@ -231,7 +181,9 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
               <TabTitleText>
                 Sudo rules{" "}
                 <Badge key={4} isRead>
-                  {sudoRulesLength}
+                  {user && user.memberof_sudorule
+                    ? user.memberof_sudorule.length
+                    : 0}
                 </Badge>
               </TabTitleText>
             }
@@ -251,7 +203,7 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
               <TabTitleText>
                 Subordinate IDs{" "}
                 <Badge key={5} isRead>
-                  {subIdsLength}
+                  {user && user.memberof_subid ? user.memberof_subid.length : 0}
                 </Badge>
               </TabTitleText>
             }

--- a/src/pages/Hosts/HostsManagedBy.tsx
+++ b/src/pages/Hosts/HostsManagedBy.tsx
@@ -35,12 +35,6 @@ const HostsManagedBy = (props: PropsToHostsManagedBy) => {
   const [host, setHost] = useState<Partial<Host>>({});
 
   React.useEffect(() => {
-    if (host && host.managedby_host) {
-      setHostGroupsLength(host.managedby_host.length);
-    }
-  }, [host]);
-
-  React.useEffect(() => {
     if (!hostQuery.isFetching && hostData) {
       setHost({ ...hostData });
     }
@@ -52,9 +46,6 @@ const HostsManagedBy = (props: PropsToHostsManagedBy) => {
 
   // Update current route data to Redux and highlight the current page in the Nav bar
   useUpdateRoute({ pathname: "hosts" });
-
-  // 'Host groups' length to show in tab badge
-  const [hostGroupsLength, setHostGroupsLength] = React.useState(0);
 
   // Render component
   return (
@@ -81,7 +72,7 @@ const HostsManagedBy = (props: PropsToHostsManagedBy) => {
               <TabTitleText>
                 Hosts{" "}
                 <Badge key={0} isRead>
-                  {hostGroupsLength}
+                  {host && host.managedby_host ? host.managedby_host.length : 0}
                 </Badge>
               </TabTitleText>
             }

--- a/src/pages/Hosts/HostsMemberOf.tsx
+++ b/src/pages/Hosts/HostsMemberOf.tsx
@@ -51,51 +51,6 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
   // Update current route data to Redux and highlight the current page in the Nav bar
   useUpdateRoute({ pathname: "hosts", noBreadcrumb: true });
 
-  // 'Host groups' length to show in tab badge
-  const [hostGroupsLength, setHostGroupLength] = React.useState(0);
-
-  React.useEffect(() => {
-    if (host && host.memberof_hostgroup) {
-      setHostGroupLength(host.memberof_hostgroup.length);
-    }
-  }, [host]);
-
-  // 'Netgroups' length to show in tab badge
-  const [netgroupsLength, setNetgroupLength] = React.useState(0);
-
-  React.useEffect(() => {
-    if (host && host.memberof_netgroup) {
-      setNetgroupLength(host.memberof_netgroup.length);
-    }
-  }, [host]);
-
-  // 'Roles' length to show in tab badge
-  const [rolesLength, setRolesLength] = React.useState(0);
-
-  React.useEffect(() => {
-    if (host && host.memberof_role) {
-      setRolesLength(host.memberof_role.length);
-    }
-  }, [host]);
-
-  // 'HBAC rules' length to show in tab badge
-  const [hbacRulesLength, setHbacRulesLength] = React.useState(0);
-
-  React.useEffect(() => {
-    if (host && host.memberof_hbacrule) {
-      setHbacRulesLength(host.memberof_hbacrule.length);
-    }
-  }, [host]);
-
-  // 'Sudo rules' length to show in tab badge
-  const [sudoRulesLength, setSudoRulesLength] = React.useState(0);
-
-  React.useEffect(() => {
-    if (host && host.memberof_sudorule) {
-      setSudoRulesLength(host.memberof_sudorule.length);
-    }
-  }, [host]);
-
   // Tab
   const [activeTabKey, setActiveTabKey] = useState("memberof_hostgroup");
 
@@ -133,7 +88,9 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
               <TabTitleText>
                 Host groups{" "}
                 <Badge key={0} isRead>
-                  {hostGroupsLength}
+                  {host && host.memberof_hostgroup
+                    ? host.memberof_hostgroup.length
+                    : 0}
                 </Badge>
               </TabTitleText>
             }
@@ -151,7 +108,9 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
               <TabTitleText>
                 Netgroups{" "}
                 <Badge key={1} isRead>
-                  {netgroupsLength}
+                  {host && host.memberof_netgroup
+                    ? host.memberof_netgroup.length
+                    : 0}
                 </Badge>
               </TabTitleText>
             }
@@ -171,7 +130,7 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
               <TabTitleText>
                 Roles{" "}
                 <Badge key={2} isRead>
-                  {rolesLength}
+                  {host && host.memberof_role ? host.memberof_role.length : 0}
                 </Badge>
               </TabTitleText>
             }
@@ -193,7 +152,9 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
               <TabTitleText>
                 HBAC rules{" "}
                 <Badge key={3} isRead>
-                  {hbacRulesLength}
+                  {host && host.memberof_hbacrule
+                    ? host.memberof_hbacrule.length
+                    : 0}
                 </Badge>
               </TabTitleText>
             }
@@ -213,7 +174,9 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
               <TabTitleText>
                 Sudo rules{" "}
                 <Badge key={4} isRead>
-                  {sudoRulesLength}
+                  {host && host.memberof_sudorule
+                    ? host.memberof_sudorule.length
+                    : 0}
                 </Badge>
               </TabTitleText>
             }

--- a/src/pages/Services/ServicesManagedBy.tsx
+++ b/src/pages/Services/ServicesManagedBy.tsx
@@ -49,15 +49,6 @@ const ServicesManagedBy = (props: PropsToServicesManagedBy) => {
   // Encoded data to pass to the URL
   const encodedServiceId = encodeURIComponent(props.service.krbcanonicalname);
 
-  // 'Hosts' length to show in tab badge
-  const [hostsLength, setHostsLength] = React.useState(0);
-
-  React.useEffect(() => {
-    if (service && service.managedby_host) {
-      setHostsLength(service.managedby_host.length);
-    }
-  }, [service]);
-
   return (
     <Page>
       <PageSection
@@ -82,7 +73,9 @@ const ServicesManagedBy = (props: PropsToServicesManagedBy) => {
               <TabTitleText>
                 Hosts{" "}
                 <Badge key={0} isRead>
-                  {hostsLength}
+                  {service && service.managedby_host
+                    ? service.managedby_host.length
+                    : 0}
                 </Badge>
               </TabTitleText>
             }

--- a/src/pages/Services/ServicesMemberOf.tsx
+++ b/src/pages/Services/ServicesMemberOf.tsx
@@ -73,15 +73,6 @@ const ServicesMemberOf = (props: PropsToServicesMemberOf) => {
   // Update current route data to Redux and highlight the current page in the Nav bar
   useUpdateRoute({ pathname: "services", noBreadcrumb: true });
 
-  // 'Roles' length to show in tab badge
-  const [rolesLength, setRolesLength] = React.useState(0);
-
-  React.useEffect(() => {
-    if (service && service.memberof_role) {
-      setRolesLength(service.memberof_role.length);
-    }
-  }, [service]);
-
   // Render component
   return (
     <Page>
@@ -98,7 +89,9 @@ const ServicesMemberOf = (props: PropsToServicesMemberOf) => {
               <TabTitleText>
                 Roles{" "}
                 <Badge key={0} isRead>
-                  {rolesLength}
+                  {service && service.memberof_role
+                    ? service.memberof_role.length
+                    : 0}
                 </Badge>
               </TabTitleText>
             }

--- a/src/pages/UserGroups/UserGroupsMemberOf.tsx
+++ b/src/pages/UserGroups/UserGroupsMemberOf.tsx
@@ -51,46 +51,6 @@ const UserGroupsMemberOf = (props: PropsToMemberOf) => {
   // Update current route data to Redux and highlight the current page in the Nav bar
   useUpdateRoute({ pathname: "user-groups", noBreadcrumb: true });
 
-  // 'User groups' length to show in tab badge
-  const [userGroupsLength, setUserGroupLength] = React.useState(0);
-  React.useEffect(() => {
-    if (group && group.memberof_group) {
-      setUserGroupLength(group.memberof_group.length);
-    }
-  }, [group]);
-
-  // 'Netgroups' length to show in tab badge
-  const [netgroupsLength, setNetgroupLength] = React.useState(0);
-  React.useEffect(() => {
-    if (group && group.memberof_netgroup) {
-      setNetgroupLength(group.memberof_netgroup.length);
-    }
-  }, [group]);
-
-  // 'Roles' length to show in tab badge
-  const [rolesLength, setRolesLength] = React.useState(0);
-  React.useEffect(() => {
-    if (group && group.memberof_role) {
-      setRolesLength(group.memberof_role.length);
-    }
-  }, [group]);
-
-  // 'HBAC rules' length to show in tab badge
-  const [hbacRulesLength, setHbacRulesLength] = React.useState(0);
-  React.useEffect(() => {
-    if (group && group.memberof_hbacrule) {
-      setHbacRulesLength(group.memberof_hbacrule.length);
-    }
-  }, [group]);
-
-  // 'Sudo rules' length to show in tab badge
-  const [sudoRulesLength, setSudoRulesLength] = React.useState(0);
-  React.useEffect(() => {
-    if (group && group.memberof_sudorule) {
-      setSudoRulesLength(group.memberof_sudorule.length);
-    }
-  }, [group]);
-
   // Tab
   const [activeTabKey, setActiveTabKey] = useState("memberof_usergroup");
   const handleTabClick = (
@@ -127,7 +87,9 @@ const UserGroupsMemberOf = (props: PropsToMemberOf) => {
               <TabTitleText>
                 User groups{" "}
                 <Badge key={0} isRead>
-                  {userGroupsLength}
+                  {group && group.memberof_group
+                    ? group.memberof_group.length
+                    : 0}
                 </Badge>
               </TabTitleText>
             }
@@ -146,7 +108,9 @@ const UserGroupsMemberOf = (props: PropsToMemberOf) => {
               <TabTitleText>
                 Netgroups{" "}
                 <Badge key={1} isRead>
-                  {netgroupsLength}
+                  {group && group.memberof_netgroup
+                    ? group.memberof_netgroup.length
+                    : 0}
                 </Badge>
               </TabTitleText>
             }
@@ -166,7 +130,9 @@ const UserGroupsMemberOf = (props: PropsToMemberOf) => {
               <TabTitleText>
                 Roles{" "}
                 <Badge key={2} isRead>
-                  {rolesLength}
+                  {group && group.memberof_role
+                    ? group.memberof_role.length
+                    : 0}
                 </Badge>
               </TabTitleText>
             }
@@ -188,7 +154,9 @@ const UserGroupsMemberOf = (props: PropsToMemberOf) => {
               <TabTitleText>
                 HBAC rules{" "}
                 <Badge key={3} isRead>
-                  {hbacRulesLength}
+                  {group && group.memberof_hbacrule
+                    ? group.memberof_hbacrule.length
+                    : 0}
                 </Badge>
               </TabTitleText>
             }
@@ -208,7 +176,9 @@ const UserGroupsMemberOf = (props: PropsToMemberOf) => {
               <TabTitleText>
                 Sudo rules{" "}
                 <Badge key={4} isRead>
-                  {sudoRulesLength}
+                  {group && group.memberof_sudorule
+                    ? group.memberof_sudorule.length
+                    : 0}
                 </Badge>
               </TabTitleText>
             }


### PR DESCRIPTION
The counts for the various memberOf tab badges were set during a state cgange, but in turn triggered a second rending of the page  Just read the existing state objects length when the page is rendered.

Fixes: https://github.com/freeipa/freeipa-webui/issues/511