### PR TITLE
memberOf - fix issues with direct/indirect memberships

### DIFF
--- a/src/components/MemberOf/MemberOfHbacRules.tsx
+++ b/src/components/MemberOf/MemberOfHbacRules.tsx
@@ -8,6 +8,7 @@ import MemberOfToolbar from "./MemberOfToolbar";
 import MemberOfHbacRulesTable from "./MemberOfTableHbacRules";
 import MemberOfAddModal, { AvailableItems } from "./MemberOfAddModal";
 import MemberOfDeleteModal from "./MemberOfDeleteModal";
+import { MembershipDirection } from "src/components/MemberOf/MemberOfToolbar";
 // Hooks
 import useAlerts from "src/hooks/useAlerts";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
@@ -29,6 +30,8 @@ interface MemberOfHbacRulesProps {
   from: string;
   isDataLoading: boolean;
   onRefreshData: () => void;
+  setDirection: (direction: MembershipDirection) => void;
+  direction: MembershipDirection;
 }
 
 const MemberOfHbacRules = (props: MemberOfHbacRulesProps) => {
@@ -95,6 +98,7 @@ const MemberOfHbacRules = (props: MemberOfHbacRulesProps) => {
   React.useEffect(() => {
     const hbacRulesNames = getHbacRulesNameToLoad();
     setHbacRulesNamesToLoad(hbacRulesNames);
+    props.setDirection(membershipDirection);
   }, [props.entity, membershipDirection, searchValue, page, perPage]);
 
   React.useEffect(() => {
@@ -102,6 +106,10 @@ const MemberOfHbacRules = (props: MemberOfHbacRulesProps) => {
       fullHbacRulesQuery.refetch();
     }
   }, [hbacRulesNamesToLoad]);
+
+  React.useEffect(() => {
+    setMembershipDirection(props.direction);
+  }, [props.entity]);
 
   // Update HBAC rules
   React.useEffect(() => {

--- a/src/components/MemberOf/MemberOfHostGroups.tsx
+++ b/src/components/MemberOf/MemberOfHostGroups.tsx
@@ -8,6 +8,7 @@ import MemberOfToolbar from "./MemberOfToolbar";
 import MemberOfHostGroupsTable from "./MemberOfTableHostGroups";
 import MemberOfAddModal, { AvailableItems } from "./MemberOfAddModal";
 import MemberOfDeleteModal from "./MemberOfDeleteModal";
+import { MembershipDirection } from "src/components/MemberOf/MemberOfToolbar";
 // Hooks
 import useAlerts from "src/hooks/useAlerts";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
@@ -27,6 +28,8 @@ interface MemberOfHostGroupsProps {
   host: Partial<Host>;
   isHostDataLoading: boolean;
   onRefreshHostData: () => void;
+  setDirection: (direction: MembershipDirection) => void;
+  direction: MembershipDirection;
 }
 
 const MemberOfHostGroups = (props: MemberOfHostGroupsProps) => {
@@ -94,6 +97,7 @@ const MemberOfHostGroups = (props: MemberOfHostGroupsProps) => {
   React.useEffect(() => {
     const hostGroupsNames = getHostGroupsNameToLoad();
     setHostGroupNamesToLoad(hostGroupsNames);
+    props.setDirection(membershipDirection);
   }, [props.host, membershipDirection, searchValue, page, perPage]);
 
   React.useEffect(() => {
@@ -101,6 +105,10 @@ const MemberOfHostGroups = (props: MemberOfHostGroupsProps) => {
       fullHostGroupsQuery.refetch();
     }
   }, [hostGroupNamesToLoad]);
+
+  React.useEffect(() => {
+    setMembershipDirection(props.direction);
+  }, [props.host]);
 
   // Update host groups
   React.useEffect(() => {

--- a/src/components/MemberOf/MemberOfNetgroups.tsx
+++ b/src/components/MemberOf/MemberOfNetgroups.tsx
@@ -6,6 +6,7 @@ import { User, Netgroup, Host } from "src/utils/datatypes/globalDataTypes";
 // Components
 import MemberOfToolbar from "./MemberOfToolbar";
 import MemberOfTableNetgroups from "./MemberOfTableNetgroups";
+import { MembershipDirection } from "src/components/MemberOf/MemberOfToolbar";
 // Hooks
 import useAlerts from "src/hooks/useAlerts";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
@@ -30,6 +31,8 @@ interface MemberOfNetroupsProps {
   from: string;
   isDataLoading: boolean;
   onRefreshData: () => void;
+  setDirection: (direction: MembershipDirection) => void;
+  direction: MembershipDirection;
 }
 
 const memberOfNetgroups = (props: MemberOfNetroupsProps) => {
@@ -97,6 +100,7 @@ const memberOfNetgroups = (props: MemberOfNetroupsProps) => {
   React.useEffect(() => {
     const netgroupsNames = getNetgroupsNameToLoad();
     setNetgroupNamesToLoad(netgroupsNames);
+    props.setDirection(membershipDirection);
   }, [props.entity, membershipDirection, searchValue, page, perPage]);
 
   React.useEffect(() => {
@@ -104,6 +108,10 @@ const memberOfNetgroups = (props: MemberOfNetroupsProps) => {
       fullNetgroupsQuery.refetch();
     }
   }, [netgroupNamesToLoad]);
+
+  React.useEffect(() => {
+    setMembershipDirection(props.direction);
+  }, [props.entity]);
 
   // Update netgroups
   React.useEffect(() => {

--- a/src/components/MemberOf/MemberOfRoles.tsx
+++ b/src/components/MemberOf/MemberOfRoles.tsx
@@ -8,6 +8,7 @@ import MemberOfToolbar from "./MemberOfToolbar";
 import MemberOfTableRoles from "./MemberOfTableRoles";
 import MemberOfAddModal, { AvailableItems } from "./MemberOfAddModal";
 import MemberOfDeleteModal from "./MemberOfDeleteModal";
+import { MembershipDirection } from "src/components/MemberOf/MemberOfToolbar";
 // Hooks
 import useAlerts from "src/hooks/useAlerts";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
@@ -32,6 +33,8 @@ interface MemberOfRolesProps {
   memberof_role: string[];
   memberofindirect_role?: string[];
   membershipDisabled?: boolean;
+  setDirection: (direction: MembershipDirection) => void;
+  direction: MembershipDirection;
 }
 const MemberOfRoles = (props: MemberOfRolesProps) => {
   // Alerts to show in the UI
@@ -97,7 +100,12 @@ const MemberOfRoles = (props: MemberOfRolesProps) => {
   useEffect(() => {
     const rolesNames = getRolesNameToLoad();
     setRoleNamesToLoad(rolesNames);
+    props.setDirection(membershipDirection);
   }, [props.entity, membershipDirection, searchValue, page, perPage]);
+
+  React.useEffect(() => {
+    setMembershipDirection(props.direction);
+  }, [props.entity]);
 
   React.useEffect(() => {
     if (roleNamesToLoad.length > 0) {

--- a/src/components/MemberOf/MemberOfSudoRules.tsx
+++ b/src/components/MemberOf/MemberOfSudoRules.tsx
@@ -8,6 +8,7 @@ import MemberOfToolbar from "./MemberOfToolbar";
 import MemberOfTableSudoRules from "./MemberOfTableSudoRules";
 import MemberOfAddModal, { AvailableItems } from "./MemberOfAddModal";
 import MemberOfDeleteModal from "./MemberOfDeleteModal";
+import { MembershipDirection } from "src/components/MemberOf/MemberOfToolbar";
 // Hooks
 import useAlerts from "src/hooks/useAlerts";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
@@ -29,6 +30,8 @@ interface MemberOfSudoRulesProps {
   from: string;
   isDataLoading: boolean;
   onRefreshData: () => void;
+  setDirection: (direction: MembershipDirection) => void;
+  direction: MembershipDirection;
 }
 
 const MemberOfSudoRules = (props: MemberOfSudoRulesProps) => {
@@ -95,6 +98,7 @@ const MemberOfSudoRules = (props: MemberOfSudoRulesProps) => {
   React.useEffect(() => {
     const sudoRulesNames = getSudoRulesNameToLoad();
     setSudoRulesNamesToLoad(sudoRulesNames);
+    props.setDirection(membershipDirection);
   }, [props.entity, membershipDirection, searchValue, page, perPage]);
 
   React.useEffect(() => {
@@ -102,6 +106,10 @@ const MemberOfSudoRules = (props: MemberOfSudoRulesProps) => {
       fullSudoRulesQuery.refetch();
     }
   }, [sudoRulesNamesToLoad]);
+
+  React.useEffect(() => {
+    setMembershipDirection(props.direction);
+  }, [props.entity]);
 
   // Update Sudo rules
   React.useEffect(() => {

--- a/src/components/MemberOf/MemberOfUserGroups.tsx
+++ b/src/components/MemberOf/MemberOfUserGroups.tsx
@@ -11,6 +11,7 @@ import MemberOfDeleteModal from "./MemberOfDeleteModal";
 // Hooks
 import useAlerts from "src/hooks/useAlerts";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
+import { MembershipDirection } from "src/components/MemberOf/MemberOfToolbar";
 // RPC
 import { ErrorResult } from "src/services/rpc";
 import {
@@ -28,6 +29,8 @@ interface MemberOfUserGroupsProps {
   from: string;
   isUserDataLoading: boolean;
   onRefreshUserData: () => void;
+  setDirection: (direction: MembershipDirection) => void;
+  direction: MembershipDirection;
 }
 
 const MemberOfUserGroups = (props: MemberOfUserGroupsProps) => {
@@ -99,7 +102,12 @@ const MemberOfUserGroups = (props: MemberOfUserGroupsProps) => {
   React.useEffect(() => {
     const userGroupsNames = getUserGroupsNameToLoad();
     setUserGroupNamesToLoad(userGroupsNames);
+    props.setDirection(membershipDirection);
   }, [props.entry, membershipDirection, searchValue, page, perPage]);
+
+  React.useEffect(() => {
+    setMembershipDirection(props.direction);
+  }, [props.entry]);
 
   React.useEffect(() => {
     if (userGroupNamesToLoad.length > 0) {

--- a/src/pages/ActiveUsers/UserMemberOf.tsx
+++ b/src/pages/ActiveUsers/UserMemberOf.tsx
@@ -11,6 +11,7 @@ import MemberOfSudoRules from "src/components/MemberOf/MemberOfSudoRules";
 import MemberOfSubIds from "src/components/MemberOf/MemberOfSubIds";
 // Layouts
 import TabLayout from "src/components/layouts/TabLayout";
+import { MembershipDirection } from "src/components/MemberOf/MemberOfToolbar";
 // RPC
 import { useGetUserByUidQuery } from "src/services/rpcUsers";
 // Utils
@@ -64,6 +65,110 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
     setActiveTabKey(props.tab);
   }, [props.tab]);
 
+  const [groupCount, setGroupCount] = React.useState(0);
+  const [netgroupCount, setNetgroupCount] = React.useState(0);
+  const [roleCount, setRoleCount] = React.useState(0);
+  const [hbacCount, setHbacCount] = React.useState(0);
+  const [sudoCount, setSudoCount] = React.useState(0);
+  const [groupDirection, setGroupDirection] = React.useState(
+    "direct" as MembershipDirection
+  );
+  const [netgroupDirection, setNetgroupDirection] = React.useState(
+    "direct" as MembershipDirection
+  );
+  const [roleDirection, setRoleDirection] = React.useState(
+    "direct" as MembershipDirection
+  );
+  const [hbacDirection, setHbacDirection] = React.useState(
+    "direct" as MembershipDirection
+  );
+  const [sudoDirection, setSudoDirection] = React.useState(
+    "direct" as MembershipDirection
+  );
+
+  const updateGroupDirection = (direction: MembershipDirection) => {
+    if (direction === "direct") {
+      setGroupCount(
+        user && user.memberof_group ? user.memberof_group.length : 0
+      );
+    } else {
+      setGroupCount(
+        user && user.memberofindirect_group
+          ? user.memberofindirect_group.length
+          : 0
+      );
+    }
+    setGroupDirection(direction);
+  };
+  const updateNetgroupDirection = (direction: MembershipDirection) => {
+    if (direction === "direct") {
+      setNetgroupCount(
+        user && user.memberof_netgroup ? user.memberof_netgroup.length : 0
+      );
+    } else {
+      setNetgroupCount(
+        user && user.memberofindirect_netgroup
+          ? user.memberofindirect_netgroup.length
+          : 0
+      );
+    }
+    setNetgroupDirection(direction);
+  };
+  const updateRoleDirection = (direction: MembershipDirection) => {
+    if (direction === "direct") {
+      setRoleCount(user && user.memberof_role ? user.memberof_role.length : 0);
+    } else {
+      setRoleCount(
+        user && user.memberofindirect_role
+          ? user.memberofindirect_role.length
+          : 0
+      );
+    }
+    setRoleDirection(direction);
+  };
+  const updateHbacDirection = (direction: MembershipDirection) => {
+    if (direction === "direct") {
+      setHbacCount(
+        user && user.memberof_hbacrule ? user.memberof_hbacrule.length : 0
+      );
+    } else {
+      setHbacCount(
+        user && user.memberofindirect_hbacrule
+          ? user.memberofindirect_hbacrule.length
+          : 0
+      );
+    }
+    setHbacDirection(direction);
+  };
+  const updateSudoDirection = (direction: MembershipDirection) => {
+    if (direction === "direct") {
+      setSudoCount(
+        user && user.memberof_sudorule ? user.memberof_sudorule.length : 0
+      );
+    } else {
+      setSudoCount(
+        user && user.memberofindirect_sudorule
+          ? user.memberofindirect_sudorule.length
+          : 0
+      );
+    }
+    setSudoDirection(direction);
+  };
+
+  React.useEffect(() => {
+    setGroupCount(user && user.memberof_group ? user.memberof_group.length : 0);
+    setNetgroupCount(
+      user && user.memberof_netgroup ? user.memberof_netgroup.length : 0
+    );
+    setRoleCount(user && user.memberof_role ? user.memberof_role.length : 0);
+    setHbacCount(
+      user && user.memberof_hbacrule ? user.memberof_hbacrule.length : 0
+    );
+    setSudoCount(
+      user && user.memberof_sudorule ? user.memberof_sudorule.length : 0
+    );
+  }, [user]);
+
   return (
     <TabLayout id="memberOf">
       <Tabs
@@ -85,7 +190,7 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
             <TabTitleText>
               User groups{" "}
               <Badge key={0} isRead>
-                {user && user.memberof_group ? user.memberof_group.length : 0}
+                {groupCount}
               </Badge>
             </TabTitleText>
           }
@@ -95,6 +200,8 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
             from={props.from}
             isUserDataLoading={userQuery.isFetching}
             onRefreshUserData={onRefreshUserData}
+            setDirection={updateGroupDirection}
+            direction={groupDirection}
           />
         </Tab>
         <Tab
@@ -104,9 +211,7 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
             <TabTitleText>
               Netgroups{" "}
               <Badge key={1} isRead>
-                {user && user.memberof_netgroup
-                  ? user.memberof_netgroup.length
-                  : 0}
+                {netgroupCount}
               </Badge>
             </TabTitleText>
           }
@@ -117,6 +222,8 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
             from={props.from}
             isDataLoading={userQuery.isFetching}
             onRefreshData={onRefreshUserData}
+            setDirection={updateNetgroupDirection}
+            direction={netgroupDirection}
           />
         </Tab>
         <Tab
@@ -126,7 +233,7 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
             <TabTitleText>
               Roles{" "}
               <Badge key={2} isRead>
-                {user && user.memberof_role ? user.memberof_role.length : 0}
+                {roleCount}
               </Badge>
             </TabTitleText>
           }
@@ -139,6 +246,8 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
             onRefreshData={onRefreshUserData}
             memberof_role={user.memberof_role as string[]}
             memberofindirect_role={user.memberofindirect_role as string[]}
+            setDirection={updateRoleDirection}
+            direction={roleDirection}
           />
         </Tab>
         <Tab
@@ -148,9 +257,7 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
             <TabTitleText>
               HBAC rules{" "}
               <Badge key={3} isRead>
-                {user && user.memberof_hbacrule
-                  ? user.memberof_hbacrule.length
-                  : 0}
+                {hbacCount}
               </Badge>
             </TabTitleText>
           }
@@ -161,6 +268,8 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
             from={props.from}
             isDataLoading={userQuery.isFetching}
             onRefreshData={onRefreshUserData}
+            setDirection={updateHbacDirection}
+            direction={hbacDirection}
           />
         </Tab>
         <Tab
@@ -170,9 +279,7 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
             <TabTitleText>
               Sudo rules{" "}
               <Badge key={4} isRead>
-                {user && user.memberof_sudorule
-                  ? user.memberof_sudorule.length
-                  : 0}
+                {sudoCount}
               </Badge>
             </TabTitleText>
           }
@@ -183,6 +290,8 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
             from={props.from}
             isDataLoading={userQuery.isFetching}
             onRefreshData={onRefreshUserData}
+            setDirection={updateSudoDirection}
+            direction={sudoDirection}
           />
         </Tab>
         <Tab

--- a/src/pages/HostGroups/HostGroupsTabs.tsx
+++ b/src/pages/HostGroups/HostGroupsTabs.tsx
@@ -46,9 +46,9 @@ const HostGroupsTabs = ({ section }) => {
     if (tabIndex === "settings") {
       navigate("/host-groups/" + cn);
     } else if (tabIndex === "memberof") {
-      navigate("/host-groups/" + cn + "/memberof_hostgroup");
+      // navigate("/host-groups/" + cn + "/memberof_hostgroup");
     } else if (tabIndex === "managedby") {
-      navigate("/host-groups/" + cn + "/managedby_hostgroup");
+      // navigate("/host-groups/" + cn + "/managedby_hostgroup");
     }
   };
 

--- a/src/pages/Hosts/HostsMemberOf.tsx
+++ b/src/pages/Hosts/HostsMemberOf.tsx
@@ -17,6 +17,7 @@ import MemberOfNetgroups from "src/components/MemberOf/MemberOfNetgroups";
 import MemberOfRoles from "src/components/MemberOf/MemberOfRoles";
 import MemberOfHbacRules from "src/components/MemberOf/MemberOfHbacRules";
 import MemberOfSudoRules from "src/components/MemberOf/MemberOfSudoRules";
+import { MembershipDirection } from "src/components/MemberOf/MemberOfToolbar";
 
 interface PropsToHostsMemberOf {
   host: Host;
@@ -60,6 +61,111 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
     setActiveTabKey(props.tabSection);
   }, [props.tabSection]);
 
+  const [groupCount, setGroupCount] = React.useState(0);
+  const [netgroupCount, setNetgroupCount] = React.useState(0);
+  const [roleCount, setRoleCount] = React.useState(0);
+  const [hbacCount, setHbacCount] = React.useState(0);
+  const [sudoCount, setSudoCount] = React.useState(0);
+  const [groupDirection, setGroupDirection] = React.useState(
+    "direct" as MembershipDirection
+  );
+  const [netgroupDirection, setNetgroupDirection] = React.useState(
+    "direct" as MembershipDirection
+  );
+  const [roleDirection, setRoleDirection] = React.useState(
+    "direct" as MembershipDirection
+  );
+  const [hbacDirection, setHbacDirection] = React.useState(
+    "direct" as MembershipDirection
+  );
+  const [sudoDirection, setSudoDirection] = React.useState(
+    "direct" as MembershipDirection
+  );
+
+  const updateGroupDirection = (direction: MembershipDirection) => {
+    if (direction === "direct") {
+      setGroupCount(
+        host && host.memberof_hostgroup ? host.memberof_hostgroup.length : 0
+      );
+    } else {
+      setGroupCount(
+        host && host.memberofindirect_hostgroup
+          ? host.memberofindirect_hostgroup.length
+          : 0
+      );
+    }
+    setGroupDirection(direction);
+  };
+  const updateNetgroupDirection = (direction: MembershipDirection) => {
+    if (direction === "direct") {
+      setNetgroupCount(
+        host && host.memberof_netgroup ? host.memberof_netgroup.length : 0
+      );
+    } else {
+      setNetgroupCount(
+        host && host.memberofindirect_netgroup
+          ? host.memberofindirect_netgroup.length
+          : 0
+      );
+    }
+    setNetgroupDirection(direction);
+  };
+  const updateRoleDirection = (direction: MembershipDirection) => {
+    if (direction === "direct") {
+      setRoleCount(host && host.memberof_role ? host.memberof_role.length : 0);
+    } else {
+      setRoleCount(
+        host && host.memberofindirect_role
+          ? host.memberofindirect_role.length
+          : 0
+      );
+    }
+    setRoleDirection(direction);
+  };
+  const updateHbacDirection = (direction: MembershipDirection) => {
+    if (direction === "direct") {
+      setHbacCount(
+        host && host.memberof_hbacrule ? host.memberof_hbacrule.length : 0
+      );
+    } else {
+      setHbacCount(
+        host && host.memberofindirect_hbacrule
+          ? host.memberofindirect_hbacrule.length
+          : 0
+      );
+    }
+    setHbacDirection(direction);
+  };
+  const updateSudoDirection = (direction: MembershipDirection) => {
+    if (direction === "direct") {
+      setSudoCount(
+        host && host.memberof_sudorule ? host.memberof_sudorule.length : 0
+      );
+    } else {
+      setSudoCount(
+        host && host.memberofindirect_sudorule
+          ? host.memberofindirect_sudorule.length
+          : 0
+      );
+    }
+    setSudoDirection(direction);
+  };
+  React.useEffect(() => {
+    setGroupCount(
+      host && host.memberof_hostgroup ? host.memberof_hostgroup.length : 0
+    );
+    setRoleCount(host && host.memberof_role ? host.memberof_role.length : 0);
+    setHbacCount(
+      host && host.memberof_hbacrule ? host.memberof_hbacrule.length : 0
+    );
+    setSudoCount(
+      host && host.memberof_sudorule ? host.memberof_sudorule.length : 0
+    );
+    setNetgroupCount(
+      host && host.memberof_netgroup ? host.memberof_netgroup.length : 0
+    );
+  }, [host]);
+
   // Render component
   return (
     <TabLayout id="memberof">
@@ -77,9 +183,7 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
             <TabTitleText>
               Host groups{" "}
               <Badge key={0} isRead>
-                {host && host.memberof_hostgroup
-                  ? host.memberof_hostgroup.length
-                  : 0}
+                {groupCount}
               </Badge>
             </TabTitleText>
           }
@@ -88,6 +192,8 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
             host={host}
             isHostDataLoading={hostQuery.isFetching}
             onRefreshHostData={onRefreshHostData}
+            setDirection={updateGroupDirection}
+            direction={groupDirection}
           />
         </Tab>
         <Tab
@@ -97,9 +203,7 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
             <TabTitleText>
               Netgroups{" "}
               <Badge key={1} isRead>
-                {host && host.memberof_netgroup
-                  ? host.memberof_netgroup.length
-                  : 0}
+                {netgroupCount}
               </Badge>
             </TabTitleText>
           }
@@ -110,6 +214,8 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
             from={"hosts"}
             isDataLoading={hostQuery.isFetching}
             onRefreshData={onRefreshHostData}
+            setDirection={updateNetgroupDirection}
+            direction={netgroupDirection}
           />
         </Tab>
         <Tab
@@ -119,7 +225,7 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
             <TabTitleText>
               Roles{" "}
               <Badge key={2} isRead>
-                {host && host.memberof_role ? host.memberof_role.length : 0}
+                {roleCount}
               </Badge>
             </TabTitleText>
           }
@@ -132,6 +238,8 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
             onRefreshData={onRefreshHostData}
             memberof_role={host.memberof_role as string[]}
             memberofindirect_role={host.memberofindirect_role as string[]}
+            setDirection={updateRoleDirection}
+            direction={roleDirection}
           />
         </Tab>
         <Tab
@@ -141,9 +249,7 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
             <TabTitleText>
               HBAC rules{" "}
               <Badge key={3} isRead>
-                {host && host.memberof_hbacrule
-                  ? host.memberof_hbacrule.length
-                  : 0}
+                {hbacCount}
               </Badge>
             </TabTitleText>
           }
@@ -154,6 +260,8 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
             from={"hosts"}
             isDataLoading={hostQuery.isFetching}
             onRefreshData={onRefreshHostData}
+            setDirection={updateHbacDirection}
+            direction={hbacDirection}
           />
         </Tab>
         <Tab
@@ -163,9 +271,7 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
             <TabTitleText>
               Sudo rules{" "}
               <Badge key={4} isRead>
-                {host && host.memberof_sudorule
-                  ? host.memberof_sudorule.length
-                  : 0}
+                {sudoCount}
               </Badge>
             </TabTitleText>
           }
@@ -176,6 +282,8 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
             from={"hosts"}
             isDataLoading={hostQuery.isFetching}
             onRefreshData={onRefreshHostData}
+            setDirection={updateSudoDirection}
+            direction={sudoDirection}
           />
         </Tab>
       </Tabs>

--- a/src/pages/IDViews/IDViewsTabs.tsx
+++ b/src/pages/IDViews/IDViewsTabs.tsx
@@ -46,9 +46,9 @@ const IDViewsTabs = ({ section }) => {
     if (tabIndex === "settings") {
       navigate("/id-views/" + cn);
     } else if (tabIndex === "overrides") {
-      navigate("/id-views/" + cn + "/overrides_idview");
-    } else if (tabIndex === "appliedto") {
-      navigate("/id-views/" + cn + "/appliedto_idview");
+      // navigate("/id-views/" + cn + "/overrides_idview");
+    } else if (tabIndex === "appliesto") {
+      // navigate("/id-views/" + cn + "/appliesto_idview");
     }
   };
 
@@ -147,8 +147,8 @@ const IDViewsTabs = ({ section }) => {
             title={<TabTitleText>Overrides</TabTitleText>}
           ></Tab>
           <Tab
-            eventKey={"appliesTo"}
-            name="appliesTo-details"
+            eventKey={"appliesto"}
+            name="appliesto-details"
             title={<TabTitleText>Applies to</TabTitleText>}
           ></Tab>
         </Tabs>

--- a/src/pages/Netgroups/NetgroupsTabs.tsx
+++ b/src/pages/Netgroups/NetgroupsTabs.tsx
@@ -44,9 +44,9 @@ const NetgroupsTabs = ({ section }) => {
     if (tabIndex === "settings") {
       navigate("/netgroups/" + cn);
     } else if (tabIndex === "memberof") {
-      navigate("/netgroups/" + cn + "/memberof_netgroup");
-    } else if (tabIndex === "managedby") {
-      navigate("/netgroups/" + cn + "/managedby_netgroup");
+      // navigate("/netgroups/" + cn + "/memberof_netgroup");
+    } else if (tabIndex === "members") {
+      // navigate("/netgroups/" + cn + "/members_netgroup");
     }
   };
 

--- a/src/pages/Services/ServicesMemberOf.tsx
+++ b/src/pages/Services/ServicesMemberOf.tsx
@@ -4,8 +4,9 @@ import { Badge, Tab, Tabs, TabTitleText } from "@patternfly/react-core";
 // Components
 import { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
 import MemberOfRoles from "src/components/MemberOf/MemberOfRoles";
-// LAyouts
+// Layouts
 import TabLayout from "src/components/layouts/TabLayout";
+import { MembershipDirection } from "src/components/MemberOf/MemberOfToolbar";
 // Data types
 import { Service } from "src/utils/datatypes/globalDataTypes";
 // Redux
@@ -93,6 +94,9 @@ const ServicesMemberOf = (props: PropsToServicesMemberOf) => {
             onRefreshData={onRefreshServiceData}
             memberof_role={service.memberof_role as string[]}
             membershipDisabled={true}
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+            setDirection={() => {}}
+            direction={"direct" as MembershipDirection}
           />
         </Tab>
       </Tabs>

--- a/src/pages/UserGroups/UserGroupsMemberOf.tsx
+++ b/src/pages/UserGroups/UserGroupsMemberOf.tsx
@@ -17,6 +17,7 @@ import MemberOfNetgroups from "src/components/MemberOf/MemberOfNetgroups";
 import MemberOfRoles from "src/components/MemberOf/MemberOfRoles";
 import MemberOfHbacRules from "src/components/MemberOf/MemberOfHbacRules";
 import MemberOfSudoRules from "src/components/MemberOf/MemberOfSudoRules";
+import { MembershipDirection } from "src/components/MemberOf/MemberOfToolbar";
 
 interface PropsToMemberOf {
   userGroup: UserGroup;
@@ -59,6 +60,114 @@ const UserGroupsMemberOf = (props: PropsToMemberOf) => {
     setActiveTabKey(props.tabSection);
   }, [props.tabSection]);
 
+  const [groupCount, setGroupCount] = React.useState(0);
+  const [netgroupCount, setNetgroupCount] = React.useState(0);
+  const [roleCount, setRoleCount] = React.useState(0);
+  const [hbacCount, setHbacCount] = React.useState(0);
+  const [sudoCount, setSudoCount] = React.useState(0);
+  const [groupDirection, setGroupDirection] = React.useState(
+    "direct" as MembershipDirection
+  );
+  const [netgroupDirection, setNetgroupDirection] = React.useState(
+    "direct" as MembershipDirection
+  );
+  const [roleDirection, setRoleDirection] = React.useState(
+    "direct" as MembershipDirection
+  );
+  const [hbacDirection, setHbacDirection] = React.useState(
+    "direct" as MembershipDirection
+  );
+  const [sudoDirection, setSudoDirection] = React.useState(
+    "direct" as MembershipDirection
+  );
+
+  const updateGroupDirection = (direction: MembershipDirection) => {
+    if (direction === "direct") {
+      setGroupCount(
+        group && group.memberof_group ? group.memberof_group.length : 0
+      );
+    } else {
+      setGroupCount(
+        group && group.memberofindirect_group
+          ? group.memberofindirect_group.length
+          : 0
+      );
+    }
+    setGroupDirection(direction);
+  };
+  const updateNetgroupDirection = (direction: MembershipDirection) => {
+    if (direction === "direct") {
+      setNetgroupCount(
+        group && group.memberof_netgroup ? group.memberof_netgroup.length : 0
+      );
+    } else {
+      setNetgroupCount(
+        group && group.memberofindirect_netgroup
+          ? group.memberofindirect_netgroup.length
+          : 0
+      );
+    }
+    setNetgroupDirection(direction);
+  };
+  const updateRoleDirection = (direction: MembershipDirection) => {
+    if (direction === "direct") {
+      setRoleCount(
+        group && group.memberof_role ? group.memberof_role.length : 0
+      );
+    } else {
+      setRoleCount(
+        group && group.memberofindirect_role
+          ? group.memberofindirect_role.length
+          : 0
+      );
+    }
+    setRoleDirection(direction);
+  };
+  const updateHbacDirection = (direction: MembershipDirection) => {
+    if (direction === "direct") {
+      setHbacCount(
+        group && group.memberof_hbacrule ? group.memberof_hbacrule.length : 0
+      );
+    } else {
+      setHbacCount(
+        group && group.memberofindirect_hbacrule
+          ? group.memberofindirect_hbacrule.length
+          : 0
+      );
+    }
+    setHbacDirection(direction);
+  };
+  const updateSudoDirection = (direction: MembershipDirection) => {
+    if (direction === "direct") {
+      setSudoCount(
+        group && group.memberof_sudorule ? group.memberof_sudorule.length : 0
+      );
+    } else {
+      setSudoCount(
+        group && group.memberofindirect_sudorule
+          ? group.memberofindirect_sudorule.length
+          : 0
+      );
+    }
+    setSudoDirection(direction);
+  };
+
+  React.useEffect(() => {
+    setGroupCount(
+      group && group.memberof_group ? group.memberof_group.length : 0
+    );
+    setRoleCount(group && group.memberof_role ? group.memberof_role.length : 0);
+    setHbacCount(
+      group && group.memberof_hbacrule ? group.memberof_hbacrule.length : 0
+    );
+    setSudoCount(
+      group && group.memberof_sudorule ? group.memberof_sudorule.length : 0
+    );
+    setNetgroupCount(
+      group && group.memberof_netgroup ? group.memberof_netgroup.length : 0
+    );
+  }, [group]);
+
   // Render component
   return (
     <TabLayout id="memberof">
@@ -76,9 +185,7 @@ const UserGroupsMemberOf = (props: PropsToMemberOf) => {
             <TabTitleText>
               User groups{" "}
               <Badge key={0} isRead>
-                {group && group.memberof_group
-                  ? group.memberof_group.length
-                  : 0}
+                {groupCount}
               </Badge>
             </TabTitleText>
           }
@@ -88,6 +195,8 @@ const UserGroupsMemberOf = (props: PropsToMemberOf) => {
             from="User groups"
             isUserDataLoading={groupQuery.isFetching}
             onRefreshUserData={onRefreshData}
+            setDirection={updateGroupDirection}
+            direction={groupDirection}
           />
         </Tab>
         <Tab
@@ -97,9 +206,7 @@ const UserGroupsMemberOf = (props: PropsToMemberOf) => {
             <TabTitleText>
               Netgroups{" "}
               <Badge key={1} isRead>
-                {group && group.memberof_netgroup
-                  ? group.memberof_netgroup.length
-                  : 0}
+                {netgroupCount}
               </Badge>
             </TabTitleText>
           }
@@ -110,6 +217,8 @@ const UserGroupsMemberOf = (props: PropsToMemberOf) => {
             from={"user-groups"}
             isDataLoading={groupQuery.isFetching}
             onRefreshData={onRefreshData}
+            setDirection={updateNetgroupDirection}
+            direction={netgroupDirection}
           />
         </Tab>
         <Tab
@@ -119,7 +228,7 @@ const UserGroupsMemberOf = (props: PropsToMemberOf) => {
             <TabTitleText>
               Roles{" "}
               <Badge key={2} isRead>
-                {group && group.memberof_role ? group.memberof_role.length : 0}
+                {roleCount}
               </Badge>
             </TabTitleText>
           }
@@ -132,6 +241,8 @@ const UserGroupsMemberOf = (props: PropsToMemberOf) => {
             onRefreshData={onRefreshData}
             memberof_role={group.memberof_role as string[]}
             memberofindirect_role={group.memberofindirect_role as string[]}
+            setDirection={updateRoleDirection}
+            direction={roleDirection}
           />
         </Tab>
         <Tab
@@ -141,9 +252,7 @@ const UserGroupsMemberOf = (props: PropsToMemberOf) => {
             <TabTitleText>
               HBAC rules{" "}
               <Badge key={3} isRead>
-                {group && group.memberof_hbacrule
-                  ? group.memberof_hbacrule.length
-                  : 0}
+                {hbacCount}
               </Badge>
             </TabTitleText>
           }
@@ -154,6 +263,8 @@ const UserGroupsMemberOf = (props: PropsToMemberOf) => {
             from={"user-groups"}
             isDataLoading={groupQuery.isFetching}
             onRefreshData={onRefreshData}
+            setDirection={updateHbacDirection}
+            direction={hbacDirection}
           />
         </Tab>
         <Tab
@@ -163,9 +274,7 @@ const UserGroupsMemberOf = (props: PropsToMemberOf) => {
             <TabTitleText>
               Sudo rules{" "}
               <Badge key={4} isRead>
-                {group && group.memberof_sudorule
-                  ? group.memberof_sudorule.length
-                  : 0}
+                {sudoCount}
               </Badge>
             </TabTitleText>
           }
@@ -176,6 +285,8 @@ const UserGroupsMemberOf = (props: PropsToMemberOf) => {
             from={"user-groups"}
             isDataLoading={groupQuery.isFetching}
             onRefreshData={onRefreshData}
+            setDirection={updateSudoDirection}
+            direction={sudoDirection}
           />
         </Tab>
       </Tabs>

--- a/src/pages/UserGroups/UserGroupsTabs.tsx
+++ b/src/pages/UserGroups/UserGroupsTabs.tsx
@@ -92,6 +92,8 @@ const UserGroupsTabs = ({ section }) => {
       setActiveTabKey("memberof");
     } else if (section_string.startsWith("member_")) {
       setActiveTabKey("member");
+    } else if (section_string.startsWith("managedby")) {
+      // setActiveTabKey("managedby");
     }
   }, [section]);
 


### PR DESCRIPTION
The Tab counters were not being updated when switching between direct/indirect memberships.  Also the membership would always reset to "direct" when switching between tabs.

Now the counts are properly updated, and the membership direction is maintained when switching between tabs

Fixes: https://github.com/freeipa/freeipa-webui/issues/516