### PR TITLE
Reset password page and functionality

### DIFF
--- a/src/AppLayout.tsx
+++ b/src/AppLayout.tsx
@@ -142,8 +142,6 @@ const AppLayout = ({ children }: { children: React.ReactNode }) => {
       onClick={(event) => {
         event.preventDefault();
         const primaryContentContainer = document.getElementById(pageId);
-        console.log("primaryContentContainer");
-        console.log(primaryContentContainer);
         primaryContentContainer && primaryContentContainer.focus();
       }}
       href={`#${pageId}`}

--- a/src/components/layouts/PasswordInput.tsx
+++ b/src/components/layouts/PasswordInput.tsx
@@ -21,6 +21,8 @@ interface PropsToPasswordInput {
   onClick?: React.MouseEventHandler<HTMLButtonElement> | undefined;
   onRevealHandler: (value: boolean) => void;
   validated?: "success" | "warning" | "error" | "default";
+  isRequired?: boolean;
+  isDisabled?: boolean;
 }
 
 // Note - onChange function should trigger validation check (validated prop)
@@ -37,6 +39,8 @@ const PasswordInput = (props: PropsToPasswordInput) => {
           onFocus={props.onFocus}
           onChange={(_event, value) => props.onChange(value)}
           validated={props.validated}
+          required={props.isRequired || false}
+          isDisabled={props.isDisabled || false}
         />
       </InputGroupItem>
       <InputGroupItem>

--- a/src/login/ResetPasswordPage.tsx
+++ b/src/login/ResetPasswordPage.tsx
@@ -1,0 +1,272 @@
+import React from "react";
+// PatternFly
+import {
+  Form,
+  FormGroup,
+  TextInput,
+  HelperText,
+  HelperTextItem,
+  ActionGroup,
+  Button,
+  LoginPage,
+  ListVariant,
+  ValidatedOptions,
+} from "@patternfly/react-core";
+// Images
+import BrandImg from "src/assets/images/login-screen-logo.png";
+import BackgroundImg from "src/assets/images/login-screen-background.jpg";
+// RPC
+import {
+  MetaResponse,
+  ResetPasswordPayload,
+  useResetPasswordMutation,
+  useUserPasswordLoginMutation,
+} from "src/services/rpcAuth";
+// Redux
+import { useAppDispatch } from "src/store/hooks";
+import { setIsLogin } from "src/store/Global/auth-slice";
+// Hooks
+import useAlerts from "src/hooks/useAlerts";
+// Components
+import PasswordInput from "src/components/layouts/PasswordInput";
+import { useLocation, useNavigate } from "react-router-dom";
+
+const ResetPasswordPage = () => {
+  // Get user Id
+  const location = useLocation();
+  const uid = location.state as string;
+
+  // Redux
+  const dispatch = useAppDispatch();
+
+  // Navigate
+  const navigate = useNavigate();
+
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
+  // API calls
+  const [resetPassword] = useResetPasswordMutation();
+  const [onUserPwdLogin] = useUserPasswordLoginMutation();
+
+  // Main states
+  const [currentPassword, setCurrentPassword] = React.useState<string>("");
+  const [newPassword, setNewPassword] = React.useState<string>("");
+  const [verifyPassword, setVerifyPassword] = React.useState<string>("");
+  const [otp, setOtp] = React.useState<string>("");
+  const [spinning, setBtnSpinning] = React.useState<boolean>(false);
+
+  // Password visibility
+  const [currentPasswordHidden, setCurrentPasswordHidden] =
+    React.useState(true);
+  const [newPasswordHidden, setNewPasswordHidden] = React.useState(true);
+  const [verifyPasswordHidden, setVerifyPasswordHidden] = React.useState(true);
+  const [otpHidden, setOtpHidden] = React.useState(true);
+
+  // Verify passwords
+  const [passwordValidationResult, setPasswordValidationResult] =
+    React.useState({
+      isError: false,
+      message: "",
+      pfError: ValidatedOptions.default,
+    });
+
+  const resetVerifyPassword = () => {
+    setPasswordValidationResult({
+      isError: false,
+      message: "",
+      pfError: ValidatedOptions.default,
+    });
+  };
+  // Checks that the passwords are the same
+  const validatePasswords = () => {
+    if (newPassword !== verifyPassword) {
+      const verifyPassVal = {
+        isError: true,
+        message: "Passwords must match",
+        pfError: ValidatedOptions.error,
+      };
+      setPasswordValidationResult(verifyPassVal);
+      return true; // is error
+    }
+    resetVerifyPassword();
+    return false;
+  };
+
+  // Verify the passwords are the same when we update a password value
+  React.useEffect(() => {
+    validatePasswords();
+  }, [newPassword, verifyPassword]);
+
+  // Reset button should be disabled if some conditions are met
+  const evaluateResetButtonDisabled = () => {
+    if (
+      uid === undefined ||
+      currentPassword === "" ||
+      newPassword === "" ||
+      verifyPassword === ""
+    ) {
+      return true;
+    } else {
+      return false;
+    }
+  };
+
+  const isResetButtonDisabled = evaluateResetButtonDisabled();
+
+  // Login function
+  const onLogin = () => {
+    onUserPwdLogin({ username: uid, password: newPassword }).then(() => {
+      dispatch(setIsLogin({ loggedInUser: uid, error: null }));
+      setBtnSpinning(false);
+      // Assuming sucessful login. Refresh page
+      window.location.reload();
+    });
+  };
+
+  // Clear fields when the reset password operation failed
+  const clearFields = () => {
+    setCurrentPassword("");
+    setNewPassword("");
+    setVerifyPassword("");
+    setOtp("");
+  };
+
+  // Reset password function
+  const onResetPwd = () => {
+    setBtnSpinning(true);
+
+    const resetPwdData: ResetPasswordPayload = {
+      username: uid,
+      oldPassword: currentPassword,
+      newPassword: newPassword,
+    };
+    if (otp !== "") {
+      resetPwdData.otp = otp;
+    }
+
+    resetPassword(resetPwdData).then((response) => {
+      if ("error" in response) {
+        const receivedError = response.error as MetaResponse;
+        const reason = receivedError.response?.headers.get(
+          "x-ipa-pwchange-result"
+        );
+
+        if (reason === "invalid-password") {
+          alerts.addAlert(
+            "reset-password-error",
+            "The password or username you entered is incorrect",
+            "danger"
+          );
+          clearFields();
+          setBtnSpinning(false);
+        } else {
+          // Login with the new credentials
+          onLogin();
+        }
+      }
+    });
+  };
+
+  // Form fields
+  const formFields = (
+    <Form isHorizontal>
+      <FormGroup label="username" fieldId="username">
+        <TextInput
+          id="username"
+          name="username"
+          type="text"
+          value={uid}
+          readOnlyVariant="plain"
+        />
+      </FormGroup>
+      <FormGroup label="Current password" fieldId="currentPassword">
+        <PasswordInput
+          id="form-current-password"
+          name="current_password"
+          value={currentPassword}
+          onChange={setCurrentPassword}
+          onRevealHandler={setCurrentPasswordHidden}
+          passwordHidden={currentPasswordHidden}
+          isDisabled={!uid}
+        />
+      </FormGroup>
+      <FormGroup label="New password" fieldId="newPassword">
+        <PasswordInput
+          id="form-new-password"
+          name="new_password"
+          value={newPassword}
+          onChange={setNewPassword}
+          onRevealHandler={setNewPasswordHidden}
+          passwordHidden={newPasswordHidden}
+          isRequired={true}
+          isDisabled={!uid}
+        />
+      </FormGroup>
+      <FormGroup label="Verify password" fieldId="verifyPassword">
+        <PasswordInput
+          id="form-verify-password"
+          name="verify_password"
+          value={verifyPassword}
+          onChange={setVerifyPassword}
+          onRevealHandler={setVerifyPasswordHidden}
+          passwordHidden={verifyPasswordHidden}
+          isRequired={true}
+          isDisabled={!uid}
+          validated={passwordValidationResult.pfError}
+        />
+        <HelperText>
+          <HelperTextItem variant="error">
+            {passwordValidationResult.message}
+          </HelperTextItem>
+        </HelperText>
+      </FormGroup>
+      <FormGroup label="OTP" fieldId="otp">
+        <PasswordInput
+          id="form-otp"
+          name="otp"
+          value={otp}
+          onChange={setOtp}
+          onRevealHandler={setOtpHidden}
+          passwordHidden={otpHidden}
+          isDisabled={!uid}
+        />
+      </FormGroup>
+      <ActionGroup>
+        <Button variant="link" onClick={() => navigate(-1)}>
+          Cancel
+        </Button>
+        <Button
+          variant="primary"
+          isDisabled={isResetButtonDisabled || spinning}
+          onClick={onResetPwd}
+          isLoading={spinning}
+        >
+          {spinning ? "Resetting and login" : "Reset password and Log in"}
+        </Button>
+      </ActionGroup>
+    </Form>
+  );
+
+  return (
+    <>
+      <alerts.ManagedAlerts />
+      <LoginPage
+        style={{ whiteSpace: "pre-line" }}
+        footerListVariants={ListVariant.inline}
+        brandImgSrc={BrandImg}
+        brandImgAlt="FreeIPA logo"
+        backgroundImgSrc={BackgroundImg}
+        textContent={
+          "OTP (One-Time Password): Leave blank if you are not using OTP tokens for authentication."
+        }
+        loginTitle="Reset password"
+        loginSubtitle="Your password has expired. Please enter a new password"
+      >
+        {formFields}
+      </LoginPage>
+    </>
+  );
+};
+
+export default ResetPasswordPage;

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -45,6 +45,7 @@ import NetgroupsTabs from "src/pages/Netgroups/NetgroupsTabs";
 import HBACServicesTabs from "src/pages/HBACServices/HBACServicesTabs";
 import HBACRulesTabs from "src/pages/HBACRules/HBACRulesTabs";
 import HBACServiceGroupsTabs from "src/pages/HBACServiceGroups/HBACServiceGroupsTabs";
+import ResetPasswordPage from "src/login/ResetPasswordPage";
 
 // Renders routes (React)
 export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
@@ -292,6 +293,9 @@ export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
           ) : (
             <>
               <Route path="login" element={<LoginMainPage />} />
+              <Route path="reset-password">
+                <Route path=":uid" element={<ResetPasswordPage />} />
+              </Route>
               <Route path="*" element={<Navigate to={"login"} replace />} />
             </>
           )}

--- a/src/services/rpcAuth.ts
+++ b/src/services/rpcAuth.ts
@@ -18,6 +18,13 @@ export interface UserPasswordPayload {
   password: string;
 }
 
+export interface ResetPasswordPayload {
+  username: string;
+  oldPassword: string;
+  newPassword: string;
+  otp?: string;
+}
+
 export interface ResponseOnLogin {
   error: {
     data: string;
@@ -63,6 +70,7 @@ export interface MetaResponse {
 export const LOGIN_URL = "/ipa/session/login_password";
 export const KERBEROS_URL = "/ipa/session/login_kerberos";
 export const X509_URL = "/ipa/session/login_x509";
+export const RESET_PASSWORD_URL = "/ipa/session/change_password";
 
 // Utils
 export const encodeURIObject = (obj: Record<string, string>) => {
@@ -158,6 +166,40 @@ const extendedApi = api.injectEndpoints({
         return meta as unknown as MetaResponse;
       },
     }),
+    resetPassword: build.mutation<
+      FindRPCResponse | MetaResponse,
+      ResetPasswordPayload
+    >({
+      query: (payload) => {
+        const encodedCredentials = encodeURIObject({
+          user: payload.username,
+          old_password: payload.oldPassword,
+          new_password: payload.newPassword,
+        });
+
+        if (payload.otp) {
+          encodedCredentials.concat("&otp=" + payload.otp);
+        }
+
+        const resetPasswordRequest = {
+          url: RESET_PASSWORD_URL,
+          method: "POST",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+            "Data-Type": "html",
+          },
+          body: encodedCredentials,
+        };
+
+        return resetPasswordRequest;
+      },
+      transformErrorResponse: (
+        response: FetchBaseQueryError,
+        meta: FetchBaseQueryMeta
+      ) => {
+        return meta as unknown as MetaResponse;
+      },
+    }),
   }),
 });
 
@@ -166,4 +208,5 @@ export const {
   useLogoutMutation,
   useKrbLoginMutation,
   useX509LoginMutation,
+  useResetPasswordMutation,
 } = extendedApi;


### PR DESCRIPTION
Resetting password is an operation that should be done after a password of a certain user account has been reset, invalidating its previous one. Then, the administrator should provide to the user the new temporal password to log in and
access the reset password page. After the whole operation, the user account will be automatically logged in to FreeIPA.

The current solution manages any error during the reset password and login operations provided by the IPA API  commands. Previous validation of the reset password page fields will be performed as well.

Steps to reproduce:
- Log in as `admin`
- Go to any user settings and reset its password
- Log out and log in again with the username whose password has been reset
- Follow the instructions and provide the old and new password
- Click `Reset password and Log in` to access FreeIPA with the new credentials