### PR TITLE
Fix: incorrect fields shown in reset password forms

### DIFF
--- a/src/components/modals/UserModals/ResetPassword.tsx
+++ b/src/components/modals/UserModals/ResetPassword.tsx
@@ -34,7 +34,7 @@ const ResetPassword = (props: PropsToResetPassword) => {
 
   // Get current logged-in user info
   const loggedInUser = useAppSelector(
-    (state) => state.global.loggedUserInfo.arguments[0]
+    (state) => state.global.loggedUserInfo.arguments
   );
 
   // RPC hooks

--- a/src/store/Global/global-slice.ts
+++ b/src/store/Global/global-slice.ts
@@ -13,7 +13,7 @@ interface GlobalState {
 }
 
 interface LoggedUserInfo {
-  arguments: string;
+  arguments: string | Record<string, unknown>;
   command: string;
   error: Record<string, unknown>;
   object: string;
@@ -51,7 +51,10 @@ const globalSlice = createSlice({
       action: PayloadAction<Record<string, unknown>>
     ) => {
       const newLoggedUserInfo = action.payload;
-      state.loggedUserInfo = { ...state.loggedUserInfo, ...newLoggedUserInfo };
+      state.loggedUserInfo = {
+        ...state.loggedUserInfo,
+        arguments: newLoggedUserInfo,
+      };
     },
     updateEnvironment: (
       state,


### PR DESCRIPTION
The `ResetPassword` component is not showing the right form fields. Those can be different depending on the logged in user wants to reset its own password or from another user.

When a given user wants to reset its own password the following fields should be shown: current password, new password, validate password, and OTP.

If it wants to reset another user password (and has enough permissions to perform the operation) the fields are: new password and verify password.

This was implemented in the past, but the current logged-in user is not being retrieved correctly and needs to be fixed.