### PR TITLE
Fix: Not rely on error messages when user is not logged out

### DIFF
--- a/src/login/LoginMainPage.tsx
+++ b/src/login/LoginMainPage.tsx
@@ -152,6 +152,8 @@ const LoginMainPage = () => {
   };
 
   // Analyze the error reason
+  // - A modal will be shown if the error should be shown in the same page
+  // - Otherwise, the error will be sent to the redirected page (e.g., reset password)
   const analyzeErrorReason = (reason: string | null) => {
     let returnMessage = "";
     switch (reason) {
@@ -237,7 +239,7 @@ const LoginMainPage = () => {
 
           if (msg) {
             navigate("/reset-password/" + username, {
-              state: username,
+              state: { username, msg },
             });
           }
         } else {

--- a/src/login/ResetPasswordPage.tsx
+++ b/src/login/ResetPasswordPage.tsx
@@ -34,7 +34,15 @@ import { useLocation, useNavigate } from "react-router-dom";
 const ResetPasswordPage = () => {
   // Get user Id
   const location = useLocation();
-  const uid = location.state as string;
+  const uid = location.state.username as string;
+  const msg = location.state.msg as string;
+
+  // Show error message from login page when the page is loaded the first time
+  React.useEffect(() => {
+    if (msg) {
+      alerts.addAlert("reset-password-error", msg, "danger");
+    }
+  }, []);
 
   // Redux
   const dispatch = useAppDispatch();

--- a/src/pages/ActiveUsers/ActiveUsers.tsx
+++ b/src/pages/ActiveUsers/ActiveUsers.tsx
@@ -96,9 +96,6 @@ const ActiveUsers = () => {
   const [totalCount, setUsersTotalCount] = useState<number>(0);
   const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
-  // Button disabled due to error
-  const [isDisabledDueError, setIsDisabledDueError] = useState<boolean>(false);
-
   // Page indexes
   const firstUserIdx = (page - 1) * perPage;
   const lastUserIdx = page * perPage;
@@ -125,7 +122,6 @@ const ActiveUsers = () => {
       // Reset selected users on refresh
       setUsersTotalCount(0);
       globalErrors.clear();
-      setIsDisabledDueError(false);
       return;
     }
 
@@ -159,12 +155,9 @@ const ActiveUsers = () => {
       userDataResponse.isError &&
       userDataResponse.error !== undefined
     ) {
-      setIsDisabledDueError(true);
-      globalErrors.addError(
-        batchError,
-        "Error when loading data",
-        "error-batch-users"
-      );
+      // This normally happens when the user is not authorized to view the data
+      // So instead of adding an error, refresh page
+      window.location.reload();
     }
   }, [userDataResponse]);
 
@@ -664,7 +657,7 @@ const ActiveUsers = () => {
       element: (
         <SecondaryButton
           onClickHandler={onAddClickHandler}
-          isDisabled={!showTableRows || isDisabledDueError}
+          isDisabled={!showTableRows}
         >
           Add
         </SecondaryButton>

--- a/src/pages/HBACRules/HBACRules.tsx
+++ b/src/pages/HBACRules/HBACRules.tsx
@@ -79,9 +79,6 @@ const HBACRules = () => {
   const [totalCount, setRulesTotalCount] = useState<number>(0);
   const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
-  // Button disabled due to error
-  const [isDisabledDueError, setIsDisabledDueError] = useState<boolean>(false);
-
   // Page indexes
   const firstUserIdx = (page - 1) * perPage;
   const lastUserIdx = page * perPage;
@@ -108,7 +105,6 @@ const HBACRules = () => {
       // Reset selected users on refresh
       setRulesTotalCount(0);
       globalErrors.clear();
-      setIsDisabledDueError(false);
       return;
     }
 
@@ -140,12 +136,9 @@ const HBACRules = () => {
       rulesDataResponse.isError &&
       rulesDataResponse.error !== undefined
     ) {
-      setIsDisabledDueError(true);
-      globalErrors.addError(
-        batchError,
-        "Error when loading data",
-        "error-batch-hbacrules"
-      );
+      // This normally happens when the user is not authorized to view the data
+      // So instead of adding an error, refresh page
+      window.location.reload();
     }
   }, [rulesDataResponse]);
 
@@ -527,7 +520,7 @@ const HBACRules = () => {
       element: (
         <SecondaryButton
           onClickHandler={onAddClickHandler}
-          isDisabled={!showTableRows || isDisabledDueError}
+          isDisabled={!showTableRows}
         >
           Add
         </SecondaryButton>

--- a/src/pages/HBACServiceGroups/HBACServiceGroups.tsx
+++ b/src/pages/HBACServiceGroups/HBACServiceGroups.tsx
@@ -81,9 +81,6 @@ const HBACServiceGroups = () => {
   const [totalCount, setServicesTotalCount] = useState<number>(0);
   const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
-  // Button disabled due to error
-  const [isDisabledDueError, setIsDisabledDueError] = useState<boolean>(false);
-
   // Page indexes
   const firstIdx = (page - 1) * perPage;
   const lastIdx = page * perPage;
@@ -109,7 +106,6 @@ const HBACServiceGroups = () => {
       setShowTableRows(false);
       setServicesTotalCount(0);
       globalErrors.clear();
-      setIsDisabledDueError(false);
       return;
     }
 
@@ -141,12 +137,9 @@ const HBACServiceGroups = () => {
       servicesDataResponse.isError &&
       servicesDataResponse.error !== undefined
     ) {
-      setIsDisabledDueError(true);
-      globalErrors.addError(
-        batchError,
-        "Error when loading data",
-        "error-batch-hbacservicegroup"
-      );
+      // This normally happens when the user is not authorized to view the data
+      // So instead of adding an error, refresh page
+      window.location.reload();
     }
   }, [servicesDataResponse]);
 
@@ -480,7 +473,7 @@ const HBACServiceGroups = () => {
       element: (
         <SecondaryButton
           onClickHandler={onAddClickHandler}
-          isDisabled={!showTableRows || isDisabledDueError}
+          isDisabled={!showTableRows}
         >
           Add
         </SecondaryButton>

--- a/src/pages/HBACServices/HBACServices.tsx
+++ b/src/pages/HBACServices/HBACServices.tsx
@@ -78,9 +78,6 @@ const HBACServices = () => {
   const [totalCount, setServicesTotalCount] = useState<number>(0);
   const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
-  // Button disabled due to error
-  const [isDisabledDueError, setIsDisabledDueError] = useState<boolean>(false);
-
   // Page indexes
   const firstIdx = (page - 1) * perPage;
   const lastIdx = page * perPage;
@@ -107,7 +104,6 @@ const HBACServices = () => {
       // Reset selected users on refresh
       setServicesTotalCount(0);
       globalErrors.clear();
-      setIsDisabledDueError(false);
       return;
     }
 
@@ -139,12 +135,9 @@ const HBACServices = () => {
       servicesDataResponse.isError &&
       servicesDataResponse.error !== undefined
     ) {
-      setIsDisabledDueError(true);
-      globalErrors.addError(
-        batchError,
-        "Error when loading data",
-        "error-batch-hbacservices"
-      );
+      // This normally happens when the user is not authorized to view the data
+      // So instead of adding an error, refresh page
+      window.location.reload();
     }
   }, [servicesDataResponse]);
 
@@ -476,7 +469,7 @@ const HBACServices = () => {
       element: (
         <SecondaryButton
           onClickHandler={onAddClickHandler}
-          isDisabled={!showTableRows || isDisabledDueError}
+          isDisabled={!showTableRows}
         >
           Add
         </SecondaryButton>

--- a/src/pages/HostGroups/HostGroups.tsx
+++ b/src/pages/HostGroups/HostGroups.tsx
@@ -177,12 +177,15 @@ const HostGroups = () => {
       groupDataResponse.isError &&
       groupDataResponse.error !== undefined
     ) {
-      setIsDisabledDueError(true);
-      globalErrors.addError(
-        batchError,
-        "Error when loading data",
-        "error-batch-groups"
-      );
+      // This normally happens when the user is not authorized to view the data
+      // So instead of adding an error, refresh page
+      window.location.reload();
+      // setIsDisabledDueError(true);
+      // globalErrors.addError(
+      //   batchError,
+      //   "Error when loading data. Please refresh page",
+      //   "error-batch-groups"
+      // );
     }
   }, [groupDataResponse]);
 

--- a/src/pages/Hosts/Hosts.tsx
+++ b/src/pages/Hosts/Hosts.tsx
@@ -190,12 +190,9 @@ const Hosts = () => {
       hostDataResponse.isError &&
       hostDataResponse.error !== undefined
     ) {
-      setIsDisabledDueError(true);
-      globalErrors.addError(
-        batchError,
-        "Error when loading data",
-        "error-batch-hosts"
-      );
+      // This normally happens when the user is not authorized to view the data
+      // So instead of adding an error, refresh page
+      window.location.reload();
     }
   }, [hostDataResponse]);
 

--- a/src/pages/IDViews/IDViews.tsx
+++ b/src/pages/IDViews/IDViews.tsx
@@ -126,9 +126,6 @@ const IDViews = () => {
     setViewsList(newShownViewsList);
   };
 
-  // Button disabled due to error
-  const [isDisabledDueError, setIsDisabledDueError] = useState<boolean>(false);
-
   // Page indexes
   const firstIdx = (page - 1) * perPage;
   const lastIdx = page * perPage;
@@ -155,7 +152,6 @@ const IDViews = () => {
       // Reset selected ID views on refresh
       setViewsTotalCount(0);
       globalErrors.clear();
-      setIsDisabledDueError(false);
       return;
     }
 
@@ -186,12 +182,9 @@ const IDViews = () => {
       viewsDataResponse.isError &&
       viewsDataResponse.error !== undefined
     ) {
-      setIsDisabledDueError(true);
-      globalErrors.addError(
-        batchError,
-        "Error when loading data",
-        "error-batch-views"
-      );
+      // This normally happens when the user is not authorized to view the data
+      // So instead of adding an error, refresh page
+      window.location.reload();
     }
   }, [viewsDataResponse]);
 
@@ -588,7 +581,7 @@ const IDViews = () => {
       element: (
         <SecondaryButton
           onClickHandler={onAddClickHandler}
-          isDisabled={!showTableRows || isDisabledDueError}
+          isDisabled={!showTableRows}
         >
           Add
         </SecondaryButton>

--- a/src/pages/Netgroups/Netgroups.tsx
+++ b/src/pages/Netgroups/Netgroups.tsx
@@ -115,9 +115,6 @@ const Netgroups = () => {
     setGroupsList(newShownGroupsList);
   };
 
-  // Button disabled due to error
-  const [isDisabledDueError, setIsDisabledDueError] = useState<boolean>(false);
-
   // Page indexes
   const firstIdx = (page - 1) * perPage;
   const lastIdx = page * perPage;
@@ -144,7 +141,6 @@ const Netgroups = () => {
       // Reset selected user groups on refresh
       setGroupsTotalCount(0);
       globalErrors.clear();
-      setIsDisabledDueError(false);
       return;
     }
 
@@ -177,12 +173,9 @@ const Netgroups = () => {
       groupDataResponse.isError &&
       groupDataResponse.error !== undefined
     ) {
-      setIsDisabledDueError(true);
-      globalErrors.addError(
-        batchError,
-        "Error when loading data",
-        "error-batch-groups"
-      );
+      // This normally happens when the user is not authorized to view the data
+      // So instead of adding an error, refresh page
+      window.location.reload();
     }
   }, [groupDataResponse]);
 
@@ -471,7 +464,7 @@ const Netgroups = () => {
       element: (
         <SecondaryButton
           onClickHandler={onAddClickHandler}
-          isDisabled={!showTableRows || isDisabledDueError}
+          isDisabled={!showTableRows}
         >
           Add
         </SecondaryButton>

--- a/src/pages/PreservedUsers/PreservedUsers.tsx
+++ b/src/pages/PreservedUsers/PreservedUsers.tsx
@@ -144,11 +144,9 @@ const PreservedUsers = () => {
       userDataResponse.isError &&
       userDataResponse.error !== undefined
     ) {
-      globalErrors.addError(
-        batchError,
-        "Error when loading data",
-        "error-batch-users"
-      );
+      // This normally happens when the user is not authorized to view the data
+      // So instead of adding an error, refresh page
+      window.location.reload();
     }
   }, [userDataResponse]);
 

--- a/src/pages/Services/Services.tsx
+++ b/src/pages/Services/Services.tsx
@@ -246,9 +246,6 @@ const Services = () => {
   // - Selectable checkboxes on table
   const selectableServicesTable = servicesList.filter(isServiceSelectable); // elements per Table
 
-  // Button disabled due to error
-  const [isDisabledDueError, setIsDisabledDueError] = useState<boolean>(false);
-
   const updateSelectedServices = (services: Service[], isSelected: boolean) => {
     let newSelectedServices: Service[] = [];
     if (isSelected) {
@@ -319,7 +316,6 @@ const Services = () => {
       // Reset selected users on refresh
       setServicesTotalCount(0);
       globalErrors.clear();
-      setIsDisabledDueError(false);
       return;
     }
 
@@ -352,12 +348,9 @@ const Services = () => {
       servicesDataResponse.isError &&
       servicesDataResponse.error !== undefined
     ) {
-      setIsDisabledDueError(true);
-      globalErrors.addError(
-        batchError,
-        "Error when loading data",
-        "error-batch-hosts"
-      );
+      // This normally happens when the user is not authorized to view the data
+      // So instead of adding an error, refresh page
+      window.location.reload();
     }
   }, [servicesDataResponse]);
 
@@ -506,7 +499,7 @@ const Services = () => {
       key: 5,
       element: (
         <SecondaryButton
-          isDisabled={!showTableRows || isDisabledDueError}
+          isDisabled={!showTableRows}
           onClickHandler={onAddClickHandler}
         >
           Add

--- a/src/pages/StageUsers/StageUsers.tsx
+++ b/src/pages/StageUsers/StageUsers.tsx
@@ -145,11 +145,9 @@ const StageUsers = () => {
       userDataResponse.isError &&
       userDataResponse.error !== undefined
     ) {
-      globalErrors.addError(
-        batchError,
-        "Error when loading data",
-        "error-batch-users"
-      );
+      // This normally happens when the user is not authorized to view the data
+      // So instead of adding an error, refresh page
+      window.location.reload();
     }
   }, [userDataResponse]);
 

--- a/src/pages/SudoCmdGroups/SudoCmdGroups.tsx
+++ b/src/pages/SudoCmdGroups/SudoCmdGroups.tsx
@@ -78,9 +78,6 @@ const SudoCmds = () => {
   const [totalCount, setCmdGroupsTotalCount] = useState<number>(0);
   const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
-  // Button disabled due to error
-  const [isDisabledDueError, setIsDisabledDueError] = useState<boolean>(false);
-
   // Page indexes
   const firstIdx = (page - 1) * perPage;
   const lastIdx = page * perPage;
@@ -107,7 +104,6 @@ const SudoCmds = () => {
       // Reset selected entries on refresh
       setCmdGroupsTotalCount(0);
       globalErrors.clear();
-      setIsDisabledDueError(false);
       return;
     }
 
@@ -139,12 +135,9 @@ const SudoCmds = () => {
       cmdGroupsDataResponse.isError &&
       cmdGroupsDataResponse.error !== undefined
     ) {
-      setIsDisabledDueError(true);
-      globalErrors.addError(
-        batchError,
-        "Error when loading data",
-        "error-batch-sudo-cmd-groups"
-      );
+      // This normally happens when the user is not authorized to view the data
+      // So instead of adding an error, refresh page
+      window.location.reload();
     }
   }, [cmdGroupsDataResponse]);
 
@@ -469,7 +462,7 @@ const SudoCmds = () => {
       element: (
         <SecondaryButton
           onClickHandler={onAddClickHandler}
-          isDisabled={!showTableRows || isDisabledDueError}
+          isDisabled={!showTableRows}
         >
           Add
         </SecondaryButton>

--- a/src/pages/SudoCmds/SudoCmds.tsx
+++ b/src/pages/SudoCmds/SudoCmds.tsx
@@ -78,9 +78,6 @@ const SudoCmds = () => {
   const [totalCount, setCmdsTotalCount] = useState<number>(0);
   const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
-  // Button disabled due to error
-  const [isDisabledDueError, setIsDisabledDueError] = useState<boolean>(false);
-
   // Page indexes
   const firstIdx = (page - 1) * perPage;
   const lastIdx = page * perPage;
@@ -107,7 +104,6 @@ const SudoCmds = () => {
       // Reset selected entries on refresh
       setCmdsTotalCount(0);
       globalErrors.clear();
-      setIsDisabledDueError(false);
       return;
     }
 
@@ -139,12 +135,9 @@ const SudoCmds = () => {
       cmdsDataResponse.isError &&
       cmdsDataResponse.error !== undefined
     ) {
-      setIsDisabledDueError(true);
-      globalErrors.addError(
-        batchError,
-        "Error when loading data",
-        "error-batch-sudo-cmds"
-      );
+      // This normally happens when the user is not authorized to view the data
+      // So instead of adding an error, refresh page
+      window.location.reload();
     }
   }, [cmdsDataResponse]);
 
@@ -470,7 +463,7 @@ const SudoCmds = () => {
       element: (
         <SecondaryButton
           onClickHandler={onAddClickHandler}
-          isDisabled={!showTableRows || isDisabledDueError}
+          isDisabled={!showTableRows}
         >
           Add
         </SecondaryButton>

--- a/src/pages/SudoRules/SudoRules.tsx
+++ b/src/pages/SudoRules/SudoRules.tsx
@@ -85,9 +85,6 @@ const SudoRules = () => {
   const [totalCount, setRulesTotalCount] = useState<number>(0);
   const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
-  // Button disabled due to error
-  const [isDisabledDueError, setIsDisabledDueError] = useState<boolean>(false);
-
   // Page indexes
   const firstIdx = (page - 1) * perPage;
   const lastIdx = page * perPage;
@@ -114,7 +111,6 @@ const SudoRules = () => {
       // Reset selected users on refresh
       setRulesTotalCount(0);
       globalErrors.clear();
-      setIsDisabledDueError(false);
       return;
     }
 
@@ -146,12 +142,9 @@ const SudoRules = () => {
       rulesDataResponse.isError &&
       rulesDataResponse.error !== undefined
     ) {
-      setIsDisabledDueError(true);
-      globalErrors.addError(
-        batchError,
-        "Error when loading data",
-        "error-batch-sudorules"
-      );
+      // This normally happens when the user is not authorized to view the data
+      // So instead of adding an error, refresh page
+      window.location.reload();
     }
   }, [rulesDataResponse]);
 
@@ -527,7 +520,7 @@ const SudoRules = () => {
       element: (
         <SecondaryButton
           onClickHandler={onAddClickHandler}
-          isDisabled={!showTableRows || isDisabledDueError}
+          isDisabled={!showTableRows}
         >
           Add
         </SecondaryButton>

--- a/src/pages/UserGroups/UserGroups.tsx
+++ b/src/pages/UserGroups/UserGroups.tsx
@@ -115,9 +115,6 @@ const UserGroups = () => {
     setGroupsList(newShownGroupsList);
   };
 
-  // Button disabled due to error
-  const [isDisabledDueError, setIsDisabledDueError] = useState<boolean>(false);
-
   // Page indexes
   const firstIdx = (page - 1) * perPage;
   const lastIdx = page * perPage;
@@ -144,7 +141,6 @@ const UserGroups = () => {
       // Reset selected user groups on refresh
       setGroupsTotalCount(0);
       globalErrors.clear();
-      setIsDisabledDueError(false);
       return;
     }
 
@@ -177,12 +173,9 @@ const UserGroups = () => {
       groupDataResponse.isError &&
       groupDataResponse.error !== undefined
     ) {
-      setIsDisabledDueError(true);
-      globalErrors.addError(
-        batchError,
-        "Error when loading data",
-        "error-batch-groups"
-      );
+      // This normally happens when the user is not authorized to view the data
+      // So instead of adding an error, refresh page
+      window.location.reload();
     }
   }, [groupDataResponse]);
 
@@ -470,7 +463,7 @@ const UserGroups = () => {
       element: (
         <SecondaryButton
           onClickHandler={onAddClickHandler}
-          isDisabled={!showTableRows || isDisabledDueError}
+          isDisabled={!showTableRows}
         >
           Add
         </SecondaryButton>


### PR DESCRIPTION
Login-related error messages mechanism can be improved: when a logged-in user is not logged anymore (because session ended), there is no way to know that there is no session active. 

In the past this was handled by showing an error message in the pages' content, but this is not a good approach. Instead, it will be nice to redirect the user to the login page (by refreshing the current page) when a user is trying to move to another page.