### PR TITLE
use only Date in User object and convert to generalized time later

### DIFF
--- a/src/components/Form/DateTimeSelector.tsx
+++ b/src/components/Form/DateTimeSelector.tsx
@@ -43,17 +43,21 @@ const DateTimeSelector = (props: PropsToDateTimeSelector) => {
       const newTimeText = hhMMFormat(props.datetime);
       if (newTimeText !== timeText) {
         setTimeText(newTimeText);
+        setTimeValid(true);
       }
 
       const newDateText = yyyyMMddFormat(props.datetime);
       if (newDateText !== dateText) {
         setDateText(newDateText);
+        setDateValid(true);
       }
     } else if (props.datetime === null) {
       setDateText("");
+      setDateValid(true);
       // the TimePicker component will unfornately reset the time to current
       // time if the time is set to an empty string
-      setTimeText("");
+      setTimeText("00:00");
+      setTimeValid(true);
     }
   }, [props.datetime]);
 
@@ -76,6 +80,7 @@ const DateTimeSelector = (props: PropsToDateTimeSelector) => {
     // The limitation is that revert might not reset the value as the source
     // might still have the original value.
     if (!dateValid || !timeValid) {
+      props.onChange(new Date(NaN));
       return;
     }
 

--- a/src/components/Form/IpaCalendar.tsx
+++ b/src/components/Form/IpaCalendar.tsx
@@ -1,9 +1,6 @@
 import React from "react";
 // Utils
-import {
-  parseFullDateStringToUTCFormat,
-  toGeneralizedTime,
-} from "src/utils/utils";
+import { parseFullDateStringToUTCFormat } from "src/utils/utils";
 import {
   BasicType,
   IPAParamDefinition,
@@ -17,11 +14,6 @@ import DateTimeSelector from "./DateTimeSelector";
 
 export interface DateParam {
   __datetime__: string;
-}
-
-export interface ValueDateTime {
-  valueDate: string;
-  valueTime: string;
 }
 
 export interface ParamPropertiesDateTime {
@@ -61,12 +53,7 @@ const IpaCalendar = (props: IPAParamDefinition) => {
 
   const onDateChange = (date: Date | null) => {
     if (props.ipaObject !== undefined && props.onChange !== undefined) {
-      updateIpaObject(
-        props.ipaObject,
-        props.onChange,
-        toGeneralizedTime(date),
-        props.name
-      );
+      updateIpaObject(props.ipaObject, props.onChange, date, props.name);
     }
   };
 

--- a/src/components/modals/UserModals/StagePreservedUsers.tsx
+++ b/src/components/modals/UserModals/StagePreservedUsers.tsx
@@ -152,7 +152,7 @@ const StagePreservedUsers = (props: PropsToStagePreservedUsers) => {
           } else {
             // Update data from Redux
             props.selectedUsers.map((user) => {
-              dispatch(removePreservedUser(user[0]));
+              dispatch(removePreservedUser(user.uid));
             });
 
             // Reset selected values

--- a/src/hooks/useUserSettingsData.tsx
+++ b/src/hooks/useUserSettingsData.tsx
@@ -20,6 +20,8 @@ import {
   RadiusServer,
   User,
 } from "src/utils/datatypes/globalDataTypes";
+// Utils
+import { getModifiedValues, isObjectModified } from "src/utils/ipaObjectUtils";
 
 type UserSettingsData = {
   isLoading: boolean;
@@ -127,42 +129,16 @@ const useSettingsData = (
     settings.originalUser = {};
   }
 
-  const getModifiedValues = (): Partial<User> => {
-    if (!userFullData || !userFullData.user) {
-      return {};
-    }
-
-    const modifiedValues = {};
-    for (const [key, value] of Object.entries(user)) {
-      if (userFullData.user[key] !== value) {
-        modifiedValues[key] = value;
-      }
-    }
-    return modifiedValues;
+  settings.modifiedValues = (): Partial<User> => {
+    return getModifiedValues(user, userFullData?.user || null);
   };
-  settings.modifiedValues = getModifiedValues;
 
   // Detect any change in 'originalUser' and 'user' objects
   useEffect(() => {
-    if (!userFullData || !userFullData.user) {
-      return;
+    const newModified = isObjectModified(user, userFullData?.user || null);
+    if (newModified !== modified) {
+      setModified(newModified);
     }
-    let modified = false;
-    for (const [key, value] of Object.entries(user)) {
-      if (Array.isArray(value)) {
-        // Using 'JSON.stringify' when comparing arrays (to prevent data type false positives)
-        if (JSON.stringify(userFullData.user[key]) !== JSON.stringify(value)) {
-          modified = true;
-          break;
-        }
-      } else {
-        if (userFullData.user[key] !== value) {
-          modified = true;
-          break;
-        }
-      }
-    }
-    setModified(modified);
   }, [user, userFullData]);
 
   const onResetValues = () => {

--- a/src/services/rpcUsers.ts
+++ b/src/services/rpcUsers.ts
@@ -9,7 +9,7 @@ import {
   FindRPCResponse,
   useGettingGenericQuery,
 } from "./rpc";
-import { apiToUser } from "../utils/userUtils";
+import { apiToUser, userToApi } from "../utils/userUtils";
 import { apiToPwPolicy } from "../utils/pwPolicyUtils";
 import { apiToKrbPolicy } from "../utils/krbPolicyUtils";
 import { API_VERSION_BACKUP } from "../utils/utils";
@@ -186,7 +186,7 @@ const extendedApi = api.injectEndpoints({
       query: (user) => {
         const params = {
           version: API_VERSION_BACKUP,
-          ...user,
+          ...userToApi(user),
         };
 
         delete params["uid"];
@@ -202,7 +202,7 @@ const extendedApi = api.injectEndpoints({
       query: (user) => {
         const params = {
           version: API_VERSION_BACKUP,
-          ...user,
+          ...userToApi(user),
         };
         delete params["uid"];
 

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 export interface User {
+  [key: string]: unknown; // to fulfill Record<string, unknown> type
   // identity
   title: string;
   givenname: string; // required

--- a/src/utils/userUtils.tsx
+++ b/src/utils/userUtils.tsx
@@ -1,7 +1,7 @@
 // Data types
 import { User } from "src/utils/datatypes/globalDataTypes";
 // Utils
-import { convertApiObj } from "src/utils/ipaObjectUtils";
+import { convertApiObj, convertToApiObj } from "src/utils/ipaObjectUtils";
 
 // Parse the 'textInputField' data into expected data type
 // - TODO: Adapt it to work with many types of data
@@ -89,6 +89,10 @@ export function partialUserToUser(partialUser: Partial<User>): User {
     ...createEmptyUser(),
     ...partialUser,
   };
+}
+
+export function userToApi(user: Partial<User>): Record<string, unknown> {
+  return convertToApiObj(user as Record<string, unknown>, dateValues);
 }
 
 // Get empty User object initialized with default values


### PR DESCRIPTION
based on PR: https://github.com/freeipa/freeipa-webui/pull/544 

**refactor: convert Date object to generalized time string in rpc**

Make it possible to work directly with Date object in User properties
and do conversion to generalized time in RPC module.

**fix: use Data object in IpaCalendar**

thus be able to set invalid date from DateTimeSelector and thus enable reset of invalid dates on user settings page.

**fix: type issue in StagePreservedUsers**