### PR TITLE
[Host groups][Is a member of] Implement the 'Host groups' tab section

### DIFF
--- a/src/components/MemberOf/MemberOfHostGroups.tsx
+++ b/src/components/MemberOf/MemberOfHostGroups.tsx
@@ -25,9 +25,11 @@ import { API_VERSION_BACKUP, paginate } from "src/utils/utils";
 import { apiToHostGroup } from "src/utils/hostGroupUtils";
 
 interface MemberOfHostGroupsProps {
-  host: Partial<Host>;
-  isHostDataLoading: boolean;
-  onRefreshHostData: () => void;
+  entity: Partial<Host> | Partial<HostGroup>;
+  id: string;
+  from: string;
+  isDataLoading: boolean;
+  onRefreshData: () => void;
   setDirection: (direction: MembershipDirection) => void;
   direction: MembershipDirection;
 }
@@ -58,9 +60,9 @@ const MemberOfHostGroups = (props: MemberOfHostGroupsProps) => {
   const [hostGroups, setHostGroups] = React.useState<HostGroup[]>([]);
 
   // Choose the correct Host groups based on the membership direction
-  const memberof_hostgroup = props.host.memberof_hostgroup || [];
+  const memberof_hostgroup = props.entity.memberof_hostgroup || [];
   const memberofindirect_hostgroup =
-    props.host.memberofindirect_hostgroup || [];
+    props.entity.memberofindirect_hostgroup || [];
   let hostGroupNames =
     membershipDirection === "direct"
       ? memberof_hostgroup
@@ -103,7 +105,7 @@ const MemberOfHostGroups = (props: MemberOfHostGroupsProps) => {
     const hostGroupsNames = getHostGroupsNameToLoad();
     setHostGroupNamesToLoad(hostGroupsNames);
     props.setDirection(membershipDirection);
-  }, [props.host, membershipDirection, searchValue, page, perPage]);
+  }, [props.entity, membershipDirection, searchValue, page, perPage]);
 
   React.useEffect(() => {
     if (hostGroupNamesToLoad.length > 0) {
@@ -113,7 +115,7 @@ const MemberOfHostGroups = (props: MemberOfHostGroupsProps) => {
 
   React.useEffect(() => {
     setMembershipDirection(props.direction);
-  }, [props.host]);
+  }, [props.entity]);
 
   // Update host groups
   React.useEffect(() => {
@@ -122,8 +124,21 @@ const MemberOfHostGroups = (props: MemberOfHostGroupsProps) => {
     }
   }, [fullHostGroupsQuery.data, fullHostGroupsQuery.isFetching]);
 
+  // Get type of the entity to show as text
+  const getEntityType = () => {
+    if (props.from === "hosts") {
+      return "host";
+    } else if (props.from === "host-groups") {
+      return "hostgroup";
+    } else {
+      // Return 'user' as default
+      return "host";
+    }
+  };
+
   // Computed "states"
   const showTableRows = hostGroups.length > 0;
+  const entityType = getEntityType();
 
   // Dialogs and actions
   const [showAddModal, setShowAddModal] = React.useState(false);
@@ -132,7 +147,7 @@ const MemberOfHostGroups = (props: MemberOfHostGroupsProps) => {
 
   // Buttons functionality
   const isRefreshButtonEnabled =
-    !fullHostGroupsQuery.isFetching && !props.isHostDataLoading;
+    !fullHostGroupsQuery.isFetching && !props.isDataLoading;
   const isAddButtonEnabled =
     membershipDirection !== "indirect" && isRefreshButtonEnabled;
 
@@ -162,7 +177,7 @@ const MemberOfHostGroups = (props: MemberOfHostGroupsProps) => {
     if (showAddModal) {
       hostGroupsQuery.refetch();
     }
-  }, [showAddModal, adderSearchValue, props.host]);
+  }, [showAddModal, adderSearchValue, props.entity]);
 
   // Update available Host groups
   React.useEffect(() => {
@@ -180,7 +195,10 @@ const MemberOfHostGroups = (props: MemberOfHostGroupsProps) => {
           title: userGroup.cn,
         });
       }
-      items = items.filter((item) => !memberof_hostgroup.includes(item.key));
+      items = items.filter(
+        (item) =>
+          !memberof_hostgroup.includes(item.key) && item.key !== props.id
+      );
 
       setAvailableHostGroups(avalHostGroups);
       setAvailableItems(items);
@@ -189,25 +207,24 @@ const MemberOfHostGroups = (props: MemberOfHostGroupsProps) => {
 
   // - Add
   const onAddHostGroup = (items: AvailableItems[]) => {
-    const fqdn = props.host.fqdn;
-    const newHostGroupNames = items.map((item) => item.key);
-    if (fqdn === undefined || newHostGroupNames.length == 0) {
+    const newRoleNames = items.map((item) => item.key);
+    if (props.id === undefined || newRoleNames.length == 0) {
       return;
     }
 
     setSpinning(true);
-    addMemberToHostGroups([fqdn, "host", newHostGroupNames]).then(
+    addMemberToHostGroups([props.id, entityType, newRoleNames]).then(
       (response) => {
         if ("data" in response) {
           if (response.data.result) {
             // Set alert: success
             alerts.addAlert(
               "add-member-success",
-              `Assigned '${fqdn}' to host groups`,
+              `Assigned item(s) to host groups`,
               "success"
             );
             // Refresh data
-            props.onRefreshHostData();
+            props.onRefreshData();
             // Close modal
             setShowAddModal(false);
           } else if (response.data.error) {
@@ -223,42 +240,40 @@ const MemberOfHostGroups = (props: MemberOfHostGroupsProps) => {
 
   // - Delete
   const onDeleteHostGroup = () => {
-    if (props.host.fqdn) {
-      setSpinning(true);
-      removeMembersFromHostGroups([
-        props.host.fqdn,
-        "host",
-        hostGroupsSelected,
-      ]).then((response) => {
-        if ("data" in response) {
-          if (response.data.result) {
-            // Set alert: success
-            alerts.addAlert(
-              "remove-host-groups-success",
-              `Removed '${props.host.fqdn}' from host groups`,
-              "success"
-            );
-            // Refresh
-            props.onRefreshHostData();
-            // Reset delete button
-            setHostGroupsSelected([]);
-            // Close modal
-            setShowDeleteModal(false);
-            // Return to first page
-            setPage(1);
-          } else if (response.data.error) {
-            // Set alert: error
-            const errorMessage = response.data.error as unknown as ErrorResult;
-            alerts.addAlert(
-              "remove-host-groups-error",
-              errorMessage.message,
-              "danger"
-            );
-          }
+    setSpinning(true);
+    removeMembersFromHostGroups([
+      props.id,
+      entityType,
+      hostGroupsSelected,
+    ]).then((response) => {
+      if ("data" in response) {
+        if (response.data.result) {
+          // Set alert: success
+          alerts.addAlert(
+            "remove-host-groups-success",
+            `Removed item(s) from host groups`,
+            "success"
+          );
+          // Refresh
+          props.onRefreshData();
+          // Reset delete button
+          setHostGroupsSelected([]);
+          // Close modal
+          setShowDeleteModal(false);
+          // Back to page 1
+          setPage(1);
+        } else if (response.data.error) {
+          // Set alert: error
+          const errorMessage = response.data.error as unknown as ErrorResult;
+          alerts.addAlert(
+            "remove-host-groups-error",
+            errorMessage.message,
+            "danger"
+          );
         }
-        setSpinning(false);
-      });
-    }
+      }
+      setSpinning(false);
+    });
   };
 
   return (
@@ -270,7 +285,7 @@ const MemberOfHostGroups = (props: MemberOfHostGroupsProps) => {
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         onSearch={() => {}}
         refreshButtonEnabled={isRefreshButtonEnabled}
-        onRefreshButtonClick={props.onRefreshHostData}
+        onRefreshButtonClick={props.onRefreshData}
         deleteButtonEnabled={
           membershipDirection === "direct"
             ? hostGroupsSelected.length > 0
@@ -325,14 +340,14 @@ const MemberOfHostGroups = (props: MemberOfHostGroupsProps) => {
         availableItems={availableItems}
         onAdd={onAddHostGroup}
         onSearchTextChange={setAdderSearchValue}
-        title={`Add '${props.host.fqdn}' into host groups`}
+        title={`Add '${props.id}' into host groups`}
         ariaLabel="Add host of host group modal"
         spinning={spinning}
       />
       <MemberOfDeleteModal
         showModal={showDeleteModal}
         onCloseModal={() => setShowDeleteModal(false)}
-        title={`Remove '${props.host.fqdn}' from host groups`}
+        title={`Remove '${props.id}' from host groups`}
         onDelete={onDeleteHostGroup}
         spinning={spinning}
       >

--- a/src/components/modals/AddHostGroup.tsx
+++ b/src/components/modals/AddHostGroup.tsx
@@ -265,7 +265,7 @@ const AddHostGroup = (props: PropsToAddGroup) => {
       name="add"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
       onClickHandler={addGroupHandler}
-      form="modal-form"
+      form="modal-form-add-hostgroup"
       spinnerAriaValueText="Adding"
       spinnerAriaLabel="Adding"
       isLoading={addSpinning}
@@ -277,7 +277,7 @@ const AddHostGroup = (props: PropsToAddGroup) => {
       name="add_and_add_another"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
       onClickHandler={addAndAddAnotherHandler}
-      form="modal-form"
+      form="modal-form-add-another-hostgroup"
       spinnerAriaValueText="Adding again"
       spinnerAriaLabel="Adding again"
       isLoading={addAgainSpinning}

--- a/src/pages/HostGroups/HostGroupsMemberOf.tsx
+++ b/src/pages/HostGroups/HostGroupsMemberOf.tsx
@@ -1,0 +1,129 @@
+import React from "react";
+// PatternFly
+import { Badge, Tab, Tabs, TabTitleText } from "@patternfly/react-core";
+// Data types
+import { HostGroup } from "src/utils/datatypes/globalDataTypes";
+// Navigation
+import { useNavigate } from "react-router-dom";
+// Layout
+import TabLayout from "src/components/layouts/TabLayout";
+// Hooks
+import useUpdateRoute from "src/hooks/useUpdateRoute";
+// RPC
+import { useGetHostGroupByIdQuery } from "src/services/rpcHostGroups";
+// Components
+import { MembershipDirection } from "src/components/MemberOf/MemberOfToolbar";
+// 'Is a member of' sections
+import MemberOfHostGroups from "src/components/MemberOf/MemberOfHostGroups";
+
+interface PropsToMemberOf {
+  hostGroup: HostGroup;
+  tabSection: string;
+}
+
+const HostGroupsMemberOf = (props: PropsToMemberOf) => {
+  const navigate = useNavigate();
+
+  // Host group's full data
+  const hostgroupQuery = useGetHostGroupByIdQuery(props.hostGroup.cn); // useGetHostGroupsFullDataQuery(props.hostGroup.cn);
+  const hostgroupData = hostgroupQuery.data || {};
+
+  const [hostgroup, setHostgroup] = React.useState<Partial<HostGroup>>({});
+
+  React.useEffect(() => {
+    if (!hostgroupQuery.isFetching && hostgroupData) {
+      setHostgroup((prevState) => ({ ...prevState, ...hostgroupData }));
+    }
+  }, [hostgroupData, hostgroupQuery.isFetching]);
+
+  const onRefreshData = () => {
+    hostgroupQuery.refetch();
+  };
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  useUpdateRoute({ pathname: "host-groups", noBreadcrumb: true });
+
+  // Tab
+  const [activeTabKey, setActiveTabKey] = React.useState("memberof_hostgroup");
+  const handleTabClick = (
+    _event: React.MouseEvent<HTMLElement, MouseEvent>,
+    tabIndex: number | string
+  ) => {
+    setActiveTabKey(tabIndex as string);
+    navigate("/host-groups/" + props.hostGroup.cn + "/" + tabIndex);
+  };
+
+  React.useEffect(() => {
+    setActiveTabKey(props.tabSection);
+  }, [props.tabSection]);
+
+  const [hostgroupCount, setHostgroupCount] = React.useState(0);
+  const [hostgroupDirection, setHostgroupDirection] = React.useState(
+    "direct" as MembershipDirection
+  );
+
+  const updateHostgroupDirection = (direction: MembershipDirection) => {
+    if (direction === "direct") {
+      setHostgroupCount(
+        hostgroup && hostgroup.memberof_hostgroup
+          ? hostgroup.memberof_hostgroup.length
+          : 0
+      );
+    } else {
+      setHostgroupCount(
+        hostgroup && hostgroup.memberofindirect_hostgroup
+          ? hostgroup.memberofindirect_hostgroup.length
+          : 0
+      );
+    }
+    setHostgroupDirection(direction);
+  };
+
+  React.useEffect(() => {
+    if (hostgroupDirection === "direct") {
+      setHostgroupCount(
+        hostgroup && hostgroup.memberof_hostgroup
+          ? hostgroup.memberof_hostgroup.length
+          : 0
+      );
+    }
+  }, [hostgroup]);
+
+  // Render component
+  return (
+    <TabLayout id="memberof">
+      <Tabs
+        activeKey={activeTabKey}
+        onSelect={handleTabClick}
+        isBox={false}
+        mountOnEnter
+        unmountOnExit
+      >
+        <Tab
+          eventKey={"memberof_hostgroup"}
+          name="memberof_hostgroup"
+          title={
+            <TabTitleText>
+              Host groups{" "}
+              <Badge key={0} isRead>
+                {hostgroupCount}
+              </Badge>
+            </TabTitleText>
+          }
+        >
+          <MemberOfHostGroups
+            entity={hostgroup}
+            id={hostgroup.cn as string}
+            from="host-groups"
+            isDataLoading={hostgroupQuery.isFetching}
+            onRefreshData={onRefreshData}
+            setDirection={updateHostgroupDirection}
+            direction={hostgroupDirection}
+          />
+        </Tab>
+      </Tabs>
+    </TabLayout>
+  );
+};
+
+export default HostGroupsMemberOf;

--- a/src/pages/HostGroups/HostGroupsTabs.tsx
+++ b/src/pages/HostGroups/HostGroupsTabs.tsx
@@ -24,6 +24,7 @@ import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
 import { NotFound } from "src/components/errors/PageErrors";
 import HostGroupsSettings from "./HostGroupsSettings";
 import HostGroupsMembers from "./HostGroupsMembers";
+import HostGroupsMemberOf from "./HostGroupsMemberOf";
 
 // eslint-disable-next-line react/prop-types
 const HostGroupsTabs = ({ section }) => {
@@ -50,7 +51,7 @@ const HostGroupsTabs = ({ section }) => {
     } else if (tabIndex === "member") {
       navigate("/host-groups/" + cn + "/member_host");
     } else if (tabIndex === "memberof") {
-      // navigate("/host-groups/" + cn + "/memberof_hostgroup");
+      navigate("/host-groups/" + cn + "/memberof_hostgroup");
     } else if (tabIndex === "managedby") {
       // navigate("/host-groups/" + cn + "/managedby_hostgroup");
     }
@@ -164,7 +165,9 @@ const HostGroupsTabs = ({ section }) => {
             eventKey={"memberof"}
             name="memberof-details"
             title={<TabTitleText>Is a member of</TabTitleText>}
-          ></Tab>
+          >
+            <HostGroupsMemberOf hostGroup={hostgroup} tabSection={section} />
+          </Tab>
           <Tab
             eventKey={"managedby"}
             name="managedby-details"

--- a/src/pages/Hosts/HostsMemberOf.tsx
+++ b/src/pages/Hosts/HostsMemberOf.tsx
@@ -229,9 +229,11 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
           }
         >
           <MemberOfHostGroups
-            host={host}
-            isHostDataLoading={hostQuery.isFetching}
-            onRefreshHostData={onRefreshHostData}
+            entity={host}
+            id={host.fqdn as string}
+            from="hosts"
+            isDataLoading={hostQuery.isFetching}
+            onRefreshData={onRefreshHostData}
             setDirection={updateGroupDirection}
             direction={groupDirection}
           />

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -321,6 +321,14 @@ export interface HostGroup {
   member_hostgroup: string[];
   memberindirect_host: string[];
   memberindirect_hostgroup: string[];
+  memberof_hostgroup: string[];
+  memberof_netgroup: string[];
+  memberof_hbacrule: string[];
+  memberof_sudorule: string[];
+  memberofindirect_hostgroup: string[];
+  memberofindirect_netgroup: string[];
+  memberofindirect_hbacrule: string[];
+  memberofindirect_sudorule: string[];
 }
 
 export interface Service {

--- a/src/utils/hostGroupUtils.tsx
+++ b/src/utils/hostGroupUtils.tsx
@@ -36,6 +36,14 @@ export function createEmptyGroup(): HostGroup {
     member_hostgroup: [],
     memberindirect_host: [],
     memberindirect_hostgroup: [],
+    memberof_hostgroup: [],
+    memberof_netgroup: [],
+    memberof_hbacrule: [],
+    memberof_sudorule: [],
+    memberofindirect_hostgroup: [],
+    memberofindirect_netgroup: [],
+    memberofindirect_hbacrule: [],
+    memberofindirect_sudorule: [],
   };
 
   return group;

--- a/tests/features/hostgroup_memberof.feature
+++ b/tests/features/hostgroup_memberof.feature
@@ -1,0 +1,77 @@
+Feature: Hostgroup is a member of
+  Work with hostgroup Is a member of section and its operations in all the available tabs
+
+  # TODO: Add pending tests for tab sections:
+  #          - 'Netgroups'
+  #          - 'HBAC rules'
+  #          - 'Sudo rules'
+
+  Background:
+    Given I am logged in as "Administrator"
+    Given I am on "host-groups" page
+
+  Scenario: Add a new hostgroup
+    When I click on "Add" button
+    * I type in the field "Group name" text "a_hostgroup"
+    Then TextInput "modal-form-add-hostgroup" should be enabled
+    When in the modal dialog I click on "Add" button
+    * I should see "success" alert with text "New host group added"
+    * I close the alert
+    Then I should see "a_hostgroup" entry in the data table
+
+  Scenario: Add another new hostgroup
+    When I click on "Add" button
+    * I type in the field "Group name" text "a_hostgroup_2"
+    Then TextInput "modal-form-add-hostgroup" should be enabled
+    When in the modal dialog I click on "Add" button
+    * I should see "success" alert with text "New host group added"
+    * I close the alert
+    Then I should see "a_hostgroup_2" entry in the data table
+
+  # Test hostgroup members
+  Scenario: Add a hostgroup member into the new host group
+    Given I click on "a_hostgroup" entry in the data table
+    Given I click on the Is a member of section
+    Given I am on "a_hostgroup" user > Is a member of > "Host groups" section
+    When I click on "Add" button located in the toolbar
+    Then I should see the dialog with title "Add 'a_hostgroup' into host groups"
+    When I move user "a_hostgroup_2" from the available list and move it to the chosen options
+    And in the modal dialog I click on "Add" button
+    * I should see "success" alert with text "Assigned item(s) to host groups"
+    * I close the alert
+    Then I should see the element "editors" in the table
+
+  Scenario: Search for a host group
+    When I type "a_hostgroup_2" in the search field
+    Then I should see the "a_hostgroup_2" text in the search input field
+    When I click on the arrow icon to perform search
+    Then I should see the element "a_hostgroup_2" in the table
+    * I click on the X icon to clear the search field
+
+  Scenario: Delete a hostgroup member from the host group
+    When I select entry "a_hostgroup_2" in the data table
+    And I click on "Delete" button located in the toolbar
+    Then I should see the dialog with title "Remove 'a_hostgroup_2' from host groups"
+    And the "a_hostgroup_2" element should be in the dialog table
+    When in the modal dialog I click on "Delete" button
+    Then I should see "success" alert with text "Removed item(s) from host groups"
+    * I close the alert
+    And I should not see the element "a_hostgroup_2" in the table
+
+  # Cleanup
+  Scenario: Delete the groups and rules (clean up)
+    When I click on the breadcrump link "Host groups"
+    Then I should see "a_hostgroup" entry in the data table
+    * I should see "a_hostgroup_2" entry in the data table
+    And I select entry "a_hostgroup" in the data table
+    * I select entry "a_hostgroup_2" in the data table
+    When I click on "Delete" button
+    * I see "Remove host groups" modal
+    * I should see "a_hostgroup" entry in the data table
+    * I should see "a_hostgroup_2" entry in the data table
+    When in the modal dialog I click on "Delete" button
+    * I should see "success" alert with text "Host groups removed"
+    * I close the alert
+    Then I should not see "a_hostgroup" entry in the data table
+    * I should not see "a_hostgroup_2" entry in the data table
+


### PR DESCRIPTION
The 'Host groups' > 'Is a member of' > 'Host groups' tab section should be implemented as well as its action buttons functionality.

The 'Add' and 'Delete' modals of the `MemberOfHostGroups` has been adapted to be more data-agnostic. Hence, the `hostMemberOf` component has been also adapted to use the new parameters.