### PR TITLE
WA: Downgrade runner version

### DIFF
--- a/.github/workflows/gating.yml
+++ b/.github/workflows/gating.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   audit-and-build:
     name: Audit and build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container:
       image: fedora:latest
 
@@ -57,7 +57,7 @@ jobs:
   unit-tests:
     name: Unit tests
     needs: audit-and-build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
 
@@ -75,7 +75,7 @@ jobs:
   integration-tests:
     name: Integration tests
     needs: audit-and-build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Due to changes in Ubuntu 20240915.1.0, which are breaking Vagrant
launch, downgrade the runner to Ubuntu 20.04, which is known to work.
    
Signed-off-by: Michal Polovka <mpolovka@redhat.com>
