### PR TITLE
[Sudo rules][Settings] Implement the 'Who' section

### DIFF
--- a/src/components/SudoRuleSections/SudoRulesWho.tsx
+++ b/src/components/SudoRuleSections/SudoRulesWho.tsx
@@ -1,0 +1,351 @@
+import React from "react";
+// PatternFly
+import {
+  Flex,
+  FlexItem,
+  Label,
+  Radio,
+  Tab,
+  Tabs,
+  TabTitleText,
+} from "@patternfly/react-core";
+// Data types
+import { SudoRule } from "src/utils/datatypes/globalDataTypes";
+// Components
+import KeytabTableWithFilter, {
+  TableEntry,
+} from "../tables/KeytabTableWithFilter";
+// RPC
+import {
+  AddRemoveToSudoRulesResult,
+  AddRemoveToSudoRulesPayload,
+  useAddToSudoRuleMutation,
+  useRemoveFromSudoRuleMutation,
+} from "src/services/rpcSudoRules";
+import { containsAny } from "src/utils/utils";
+import useAlerts from "src/hooks/useAlerts";
+
+interface PropsToSudoRulesWho {
+  rule: Partial<SudoRule>;
+  usersList: TableEntry[]; // memberuser_user + externaluser
+  userGroupsList: TableEntry[]; // memberuser_group
+  onRefresh: () => void;
+}
+
+const SudoRulesWho = (props: PropsToSudoRulesWho) => {
+  const [activeTabKey, setActiveTabKey] = React.useState<string | number>(0);
+
+  const handleTabClick = (
+    event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
+    tabIndex: string | number
+  ) => {
+    setActiveTabKey(tabIndex);
+  };
+
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
+  // API calls
+  const [onAdd] = useAddToSudoRuleMutation();
+  const [onRemove] = useRemoveFromSudoRuleMutation();
+
+  // States
+  const [modalSpinning, setModalSpinning] = React.useState(false);
+  const [usersList, setUsersList] = React.useState<TableEntry[]>(
+    props.usersList
+  );
+  const [userGroupsList, setUserGroupsList] = React.useState<TableEntry[]>(
+    props.userGroupsList
+  );
+
+  React.useEffect(() => {
+    setUsersList(props.usersList);
+  }, [props.usersList]);
+
+  React.useEffect(() => {
+    setUserGroupsList(props.userGroupsList);
+  }, [props.userGroupsList]);
+
+  // on Add new user
+  const onAddNewUser = (newUsers: string[]) => {
+    setModalSpinning(true);
+    const payload: AddRemoveToSudoRulesPayload = {
+      toId: props.rule.cn as string,
+      type: "user",
+      listOfMembers: newUsers,
+    };
+
+    onAdd(payload).then((response) => {
+      if ("data" in response) {
+        const data = response.data;
+        const results = data.result
+          .results as unknown as AddRemoveToSudoRulesResult[];
+        results.forEach((result) => {
+          // Some values can be undefined after addition
+          const usersFromResponse = result.result.memberuser_user || [];
+          const externalsFromResponse = result.result.externaluser || [];
+          if (
+            containsAny(usersFromResponse, newUsers) ||
+            containsAny(externalsFromResponse, newUsers)
+          ) {
+            // Set alert: success
+            alerts.addAlert(
+              "add-who-user-external-success",
+              "Added new item(s)' to" + props.rule.cn + "'",
+              "success"
+            );
+            // Refresh page
+            props.onRefresh();
+          }
+          // Check if any errors
+          if (result.error !== null) {
+            alerts.addAlert(
+              "add-who-user-external-error",
+              "Error: " + result.error,
+              "danger"
+            );
+          }
+        });
+      }
+      setModalSpinning(false);
+    });
+  };
+
+  // on Delete user(s)
+  const onDeleteUsers = (usersToDelete: string[]) => {
+    setModalSpinning(true);
+    const payload: AddRemoveToSudoRulesPayload = {
+      toId: props.rule.cn as string,
+      type: "user",
+      listOfMembers: usersToDelete,
+    };
+
+    onRemove(payload).then((response) => {
+      if ("data" in response) {
+        const data = response.data;
+        const results = data.result as unknown as AddRemoveToSudoRulesResult;
+        if (results) {
+          // Some values can be undefined after deletion
+          const usersFromResponse = results.result.memberuser_user || [];
+          const externalsFromResponse = results.result.externaluser || [];
+          if (
+            !containsAny(usersFromResponse, usersToDelete) ||
+            !containsAny(externalsFromResponse, usersToDelete)
+          ) {
+            // Set alert: success
+            alerts.addAlert(
+              "remove-who-user-external-success",
+              "Removed item(s) from " + props.rule.cn,
+              "success"
+            );
+            // Refresh page
+            props.onRefresh();
+          }
+          // Check if any errors
+          else if (results.error || results.failed.memberuser.user.length > 0) {
+            alerts.addAlert(
+              "remove-who-user-external-error",
+              "Error: " + results.error,
+              "danger"
+            );
+          }
+        }
+      }
+      setModalSpinning(false);
+    });
+  };
+
+  // on Add new group
+  const onAddNewGroup = (newGroups: string[]) => {
+    setModalSpinning(true);
+    const payload: AddRemoveToSudoRulesPayload = {
+      toId: props.rule.cn as string,
+      type: "group",
+      listOfMembers: newGroups,
+    };
+
+    onAdd(payload).then((response) => {
+      if ("data" in response) {
+        const data = response.data;
+        const results = data.result
+          .results as unknown as AddRemoveToSudoRulesResult[];
+        results.forEach((result) => {
+          const groupsFromResponse = result.result.memberuser_group;
+          if (containsAny(groupsFromResponse, newGroups)) {
+            // Set alert: success
+            alerts.addAlert(
+              "add-who-group-external-success",
+              "Added new item(s)' to" + props.rule.cn + "'",
+              "success"
+            );
+            // Refresh page
+            props.onRefresh();
+          }
+          // Check if any errors
+          if (result.error !== null) {
+            alerts.addAlert(
+              "add-who-group-external-error",
+              "Error: " + result.error,
+              "danger"
+            );
+          }
+        });
+      }
+      setModalSpinning(false);
+    });
+  };
+
+  // on Delete group(s)
+  const onDeleteGroups = (groupsToDelete: string[]) => {
+    setModalSpinning(true);
+    const payload: AddRemoveToSudoRulesPayload = {
+      toId: props.rule.cn as string,
+      type: "group",
+      listOfMembers: groupsToDelete,
+    };
+
+    onRemove(payload).then((response) => {
+      if ("data" in response) {
+        const data = response.data;
+        const results = data.result as unknown as AddRemoveToSudoRulesResult;
+        if (results) {
+          const groupsFromResponse = results.result.memberuser_group;
+          if (!containsAny(groupsFromResponse, groupsToDelete)) {
+            // Set alert: success
+            alerts.addAlert(
+              "remove-who-group-external-success",
+              "Removed item(s) from " + props.rule.cn,
+              "success"
+            );
+            // Refresh page
+            props.onRefresh();
+          }
+          // Check if any errors
+          else if (
+            results.error ||
+            results.failed.memberuser.group.length > 0
+          ) {
+            alerts.addAlert(
+              "remove-who-group-external-error",
+              "Error: " + results.error,
+              "danger"
+            );
+          }
+        }
+      }
+      setModalSpinning(false);
+    });
+  };
+
+  // Filter
+  const [anyoneRadio, setAnyoneRadio] = React.useState(false);
+  const [specifiedRadio, setSpecifiedRadio] = React.useState(true);
+
+  React.useEffect(() => {
+    if (anyoneRadio === true) {
+      setSpecifiedRadio(false);
+    }
+  }, [anyoneRadio]);
+
+  React.useEffect(() => {
+    if (specifiedRadio === true) {
+      setAnyoneRadio(false);
+    }
+  }, [specifiedRadio]);
+
+  const filter = (
+    <Flex>
+      <FlexItem>User category the rule applies to: </FlexItem>
+      <FlexItem>
+        <Radio
+          isChecked={anyoneRadio}
+          name="anyone-radio"
+          onChange={(_event, value) => setAnyoneRadio(value)}
+          label="Anyone"
+          id="anyone-radio"
+        />
+      </FlexItem>
+      <FlexItem>
+        <Radio
+          isChecked={specifiedRadio}
+          name="specified-radio"
+          onChange={(_event, value) => setSpecifiedRadio(value)}
+          label="Specified Users and Groups"
+          id="specified-radio"
+        />
+      </FlexItem>
+    </Flex>
+  );
+
+  // Render component
+  return (
+    <>
+      <alerts.ManagedAlerts />
+      {/* Filter: radio options */}
+      {filter}
+      {/* Tabs */}
+      <Tabs
+        activeKey={activeTabKey}
+        onSelect={handleTabClick}
+        aria-label="Tabs for types of entries that can create keytabs"
+      >
+        <Tab
+          key={0}
+          eventKey={0}
+          title={
+            <TabTitleText>
+              Users <Label isCompact>{usersList.length}</Label>
+            </TabTitleText>
+          }
+          aria-label="users in the who section of the sudo rule"
+        >
+          <KeytabTableWithFilter
+            className="pf-v5-u-ml-md pf-v5-u-mt-sm"
+            id={props.rule.cn as string}
+            from="sudo rule"
+            name="memberuser_user"
+            isSpinning={modalSpinning}
+            entityType="user"
+            // Table data
+            operationTitle={"Add user into sudo rule " + props.rule.cn}
+            tableEntryList={usersList}
+            columnNames={["User"]}
+            onRefresh={props.onRefresh}
+            onAdd={onAddNewUser}
+            onDelete={onDeleteUsers}
+            checkboxesDisabled={anyoneRadio}
+          />
+        </Tab>
+        <Tab
+          key={1}
+          eventKey={1}
+          title={
+            <TabTitleText>
+              User groups <Label isCompact>{userGroupsList.length}</Label>
+            </TabTitleText>
+          }
+          aria-label="user groups in the who section of the sudo rule"
+        >
+          <KeytabTableWithFilter
+            className="pf-v5-u-ml-md pf-v5-u-mt-sm"
+            id={props.rule.cn as string}
+            from="sudo rule"
+            name="memberuser_group"
+            isSpinning={modalSpinning}
+            entityType="group"
+            // Table data
+            operationTitle={"Add group into sudo rule " + props.rule.cn}
+            tableEntryList={userGroupsList}
+            columnNames={["Group"]}
+            onRefresh={props.onRefresh}
+            onAdd={onAddNewGroup}
+            onDelete={onDeleteGroups}
+            checkboxesDisabled={anyoneRadio}
+          />
+        </Tab>
+      </Tabs>
+    </>
+  );
+};
+
+export default SudoRulesWho;

--- a/src/components/tables/KeytabTableWithFilter.tsx
+++ b/src/components/tables/KeytabTableWithFilter.tsx
@@ -1,0 +1,320 @@
+import React from "react";
+// PatternFly
+import { Td, Th, Tr } from "@patternfly/react-table";
+// React Router DOM
+import { Link } from "react-router-dom";
+// Layout
+import DualListLayout, {
+  DualListTarget,
+} from "src/components/layouts/DualListLayout";
+// Hooks
+import { useAlerts } from "src/hooks/useAlerts";
+import { usePagination } from "src/hooks/usePagination";
+import useShifting from "src/hooks/useShifting";
+// Components
+import { paginate } from "src/utils/utils";
+import MemberOfDeleteModal from "../MemberOf/MemberOfDeleteModal";
+import DeletedElementsTable from "./DeletedElementsTable";
+import SettingsTableLayout from "../layouts/SettingsTableLayout";
+
+export interface TableEntry {
+  entry: string;
+  showLink: boolean;
+}
+
+interface PropsToKeytabTable {
+  className: string;
+  id: string;
+  from: string;
+  name: string; // Name used in IPA
+  isSpinning: boolean;
+  entityType: DualListTarget; // Name used by the DualSelector and IDs
+  operationTitle: string;
+  // Table data
+  tableEntryList: TableEntry[];
+  columnNames: string[];
+  onRefresh: () => void;
+  onAdd: (newEntries: string[]) => void;
+  onDelete: (entriesToDelete: string[]) => void;
+  checkboxesDisabled?: boolean;
+}
+
+const KeytabTableWithFilter = (props: PropsToKeytabTable) => {
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
+  // URL handling
+  let entryURL = "";
+  if (props.entityType === "user") {
+    entryURL = "/active-users/";
+  } else if (props.entityType === "group") {
+    entryURL = "/user-groups/";
+  } else if (props.entityType === "host") {
+    entryURL = "/hosts/";
+  } else {
+    // Host group
+    entryURL = "/host-groups/";
+  }
+
+  // Checkboxes are disabled when 'checkboxesDisabled' is true
+  const [disabledCheckboxes, setDisabledCheckboxes] = React.useState(
+    props.checkboxesDisabled
+  );
+
+  // - Checkboxes are disabled when 'checkboxesDisabled' is true
+  React.useEffect(() => {
+    setDisabledCheckboxes(props.checkboxesDisabled);
+    if (props.checkboxesDisabled) {
+      setSelectedEntries([]);
+    }
+  }, [props.checkboxesDisabled]);
+
+  // Shown list of elements
+  const [tableEntryList, setTableEntryList] = React.useState<TableEntry[]>(
+    props.tableEntryList
+  );
+  const [tableEntriesFilteredList, setTableEntriesFilteredList] =
+    React.useState<TableEntry[]>(props.tableEntryList);
+
+  // Update 'tableEntryList' when 'props.tableEntryList' changes
+  React.useEffect(() => {
+    setTableEntryList(props.tableEntryList);
+    setTableEntriesFilteredList(props.tableEntryList);
+    setTotalCount(props.tableEntryList.length);
+  }, [props.tableEntryList]);
+
+  // Get pagination data and functions
+  const {
+    page,
+    updatePage,
+    perPage,
+    updatePerPage,
+    firstIdx,
+    setFirstIdx,
+    lastIdx,
+    setLastIdx,
+    totalCount,
+    setTotalCount,
+    updateSelectedPerPage,
+  } = usePagination(tableEntryList, 5);
+
+  const resetEntries = () => {
+    const idList: TableEntry[] = [];
+
+    for (let i = firstIdx; i < tableEntryList.length && i < lastIdx; i++) {
+      idList.push(tableEntryList[i]);
+    }
+    setTableEntriesFilteredList(idList);
+    updatePage(1);
+    setTotalCount(tableEntryList.length);
+  };
+
+  // Page indexes
+  React.useEffect(() => {
+    setFirstIdx((page - 1) * perPage);
+    setLastIdx(page * perPage);
+    setTableEntryList(paginate(tableEntryList, page, perPage));
+    setTotalCount(tableEntryList.length);
+    resetEntries();
+  }, [page, perPage]);
+
+  // Search
+  const [searchValue, setSearchValue] = React.useState<string>("");
+
+  // Selected entries on table
+  const [selectedEntries, setSelectedEntries] = React.useState<string[]>([]);
+
+  // Modal functionality
+  const [showAddModal, setShowAddModal] = React.useState(false);
+  const [showDeleteModal, setShowDeleteModal] = React.useState(false);
+  const onChangeAddModal = () => setShowAddModal(!showAddModal);
+  const onChangeDeleteModal = () => setShowDeleteModal(!showDeleteModal);
+
+  // Computed states
+  const isDeleteDisabled = selectedEntries.length === 0;
+
+  // Entries displayed on the first page
+  const updateShownEntriesList = (newShownEntriesList: TableEntry[]) => {
+    setTableEntriesFilteredList(newShownEntriesList);
+  };
+
+  // on Search change
+  const onSearchChange = (value: string) => {
+    const entryList: TableEntry[] = [];
+
+    setSearchValue(value);
+
+    if (value === "") {
+      // Reset back to original list
+      resetEntries();
+      return;
+    }
+
+    // Filter our current list
+    const firstIdx = (page - 1) * perPage;
+    const lastIdx = page * perPage;
+    let count = 0;
+    for (let i = firstIdx; i < tableEntryList.length && count < lastIdx; i++) {
+      if (tableEntryList[i].entry.toLowerCase().includes(value.toLowerCase())) {
+        entryList.push(tableEntryList[i]);
+        count += 1;
+      }
+    }
+    setTotalCount(entryList.length);
+    setTableEntriesFilteredList(entryList);
+  };
+
+  const paginationData = {
+    page,
+    perPage,
+    updatePage,
+    updatePerPage,
+    updateSelectedPerPage,
+    updateShownElementsList: updateShownEntriesList,
+    totalCount,
+  };
+
+  // - Returns true if all entries are selected and entry list is not empty
+  const areAllEntriesSelected =
+    selectedEntries.length === tableEntryList.length &&
+    tableEntryList.length !== 0;
+
+  // - Returns 'True' if a specific table user has been selected
+  const isEntrySelected = (user: string) => selectedEntries.includes(user);
+
+  // - Select all users
+  const selectAllUsers = (isSelecting = true) => {
+    setSelectedEntries(
+      isSelecting ? tableEntryList.map((elem) => elem.entry) : []
+    );
+  };
+
+  // - On selecting one single row
+  const onSelectRow = useShifting(tableEntryList, setSelectedEntries);
+
+  // Header
+  const tableHeader = (
+    <Tr>
+      <Th
+        select={{
+          onSelect: (_event, isSelecting) => selectAllUsers(isSelecting),
+          isSelected: areAllEntriesSelected,
+          isDisabled:
+            tableEntryList.length === 0 || disabledCheckboxes ? true : false,
+        }}
+      />
+      <Th width={10}>{props.columnNames[0]}</Th>
+    </Tr>
+  );
+
+  // Body
+  const tableBody = tableEntriesFilteredList.map((entry, rowIndex) => (
+    <Tr key={entry.entry} id={entry.entry}>
+      <Td
+        dataLabel="checkbox"
+        select={{
+          rowIndex,
+          onSelect: (_event, isSelecting) =>
+            onSelectRow(entry.entry, rowIndex, isSelecting),
+          isSelected: isEntrySelected(entry.entry),
+          isDisabled: disabledCheckboxes,
+        }}
+      />
+      <Td dataLabel={props.columnNames[0]}>
+        {entry.showLink ? (
+          <Link
+            to={entryURL + entry.entry}
+            state={tableEntriesFilteredList[rowIndex]}
+          >
+            {entry.entry}
+          </Link>
+        ) : (
+          entry.entry
+        )}
+      </Td>
+    </Tr>
+  ));
+
+  // on Add new items
+  const onAddNewItems = (chosenItems) => {
+    props.onAdd(chosenItems);
+  };
+
+  // on Remove items
+  const onRemoveItems = () => {
+    props.onDelete(selectedEntries);
+    setSelectedEntries([]);
+    onChangeDeleteModal();
+  };
+
+  // Entry count
+  const entryCount = tableEntryList.map((entry) => entry.entry).length;
+
+  // Render component
+  return (
+    <div className={props.className}>
+      <alerts.ManagedAlerts />
+      {/* Table */}
+      <SettingsTableLayout
+        ariaLabel={props.entityType + " table in " + props.from + " keytabs"}
+        variant="compact"
+        hasBorders={true}
+        name={props.name}
+        tableId={"keytab-" + props.entityType + "-table"}
+        isStickyHeader={false}
+        tableHeader={tableHeader}
+        tableBody={tableBody}
+        onDeleteModal={onChangeDeleteModal}
+        isDeleteDisabled={isDeleteDisabled}
+        onAddModal={onChangeAddModal}
+        onSearchChange={onSearchChange}
+        searchValue={searchValue}
+        paginationData={paginationData}
+        list={tableEntriesFilteredList}
+        entryCount={entryCount}
+        entryType={props.entityType}
+      />
+      {/* Add modal */}
+      <DualListLayout
+        entry={props.id}
+        target={props.entityType}
+        showModal={showAddModal}
+        onCloseModal={onChangeAddModal}
+        onOpenModal={onChangeAddModal}
+        tableElementsList={tableEntryList.map((element) => element.entry)}
+        action={onAddNewItems}
+        title={props.operationTitle}
+        spinning={props.isSpinning}
+        addBtnName="Add"
+        addSpinningBtnName="Adding"
+        addExternalsOption={true}
+      />
+      {/* Delete modal */}
+      <MemberOfDeleteModal
+        showModal={showDeleteModal}
+        onCloseModal={onChangeDeleteModal}
+        title={
+          "Remove " +
+          props.entityType.toLowerCase() +
+          "s from " +
+          props.from +
+          " '" +
+          props.id +
+          "'"
+        }
+        onDelete={onRemoveItems}
+        spinning={props.isSpinning}
+      >
+        <DeletedElementsTable
+          mode="passing_id"
+          elementsToDelete={selectedEntries}
+          columnNames={props.columnNames}
+          elementType={props.entityType}
+          idAttr="cn"
+        />
+      </MemberOfDeleteModal>
+    </div>
+  );
+};
+
+export default KeytabTableWithFilter;

--- a/src/hooks/usePagination.tsx
+++ b/src/hooks/usePagination.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+
+/**
+ *
+ * @param tableList List of items to be paginated
+ * @param initialPerPage Number of items per page
+ * @returns page, perPage, totalCount, firstIdx, lastIdx, setTotalCount, updateSelectedPerPage, updatePage, updatePerPage
+ */
+export const usePagination = (tableList, initialPerPage) => {
+  const [page, setPage] = React.useState<number>(1);
+  const [perPage, setPerPage] = React.useState<number>(initialPerPage);
+  const [totalCount, setTotalCount] = React.useState<number>(tableList.length);
+
+  const [firstIdx, setFirstIdx] = React.useState<number>((page - 1) * perPage);
+  const [lastIdx, setLastIdx] = React.useState<number>(page * perPage);
+
+  const updateSelectedPerPage = () => {
+    // Nothing to do since we are not using bulk selector comp
+    // TODO: Implement functionality to bulk selector component
+    return;
+  };
+  const updatePage = (newPage: number) => {
+    setPage(newPage);
+  };
+  const updatePerPage = (newSetPerPage: number) => {
+    setPerPage(newSetPerPage);
+  };
+
+  return {
+    page,
+    updatePage,
+    perPage,
+    updatePerPage,
+    firstIdx,
+    setFirstIdx,
+    lastIdx,
+    setLastIdx,
+    totalCount,
+    setTotalCount,
+    updateSelectedPerPage,
+  };
+};

--- a/src/hooks/useShifting.tsx
+++ b/src/hooks/useShifting.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+
+export const useShifting = (
+  tableEntryList,
+  changeRowSelected: (newValue) => void
+) => {
+  const [shifting, setShifting] = React.useState(false);
+  const [recentSelectedRowIndex, setRecentSelectedRowIndex] = React.useState<
+    number | null
+  >(null);
+
+  // - Helper method to set the selected users from the table
+  const setRowSelected = (user: string, isSelecting = true) =>
+    changeRowSelected((prevSelected) => {
+      const otherSelectedUsers = prevSelected.filter((r) => r !== user);
+      return isSelecting ? [...otherSelectedUsers, user] : otherSelectedUsers;
+    });
+
+  // Keyboard event to select rows
+  React.useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Shift") {
+        setShifting(true);
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === "Shift") {
+        setShifting(false);
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("keyup", onKeyUp);
+
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("keyup", onKeyUp);
+    };
+  }, []);
+
+  // - On selecting one single row
+  const onSelectRow = (row: string, rowIndex: number, isSelecting: boolean) => {
+    // If the element is shift + selecting the checkboxes, then all intermediate checkboxes should be selected
+    if (shifting && recentSelectedRowIndex !== null) {
+      const numberSelected = rowIndex - recentSelectedRowIndex;
+      const intermediateIndexes =
+        numberSelected > 0
+          ? Array.from(
+              new Array(numberSelected + 1),
+              (_x, i) => i + recentSelectedRowIndex
+            )
+          : Array.from(
+              new Array(Math.abs(numberSelected) + 1),
+              (_x, i) => i + rowIndex
+            );
+      intermediateIndexes.forEach((index) =>
+        setRowSelected(tableEntryList[index], isSelecting)
+      );
+    } else {
+      setRowSelected(row, isSelecting);
+    }
+    setRecentSelectedRowIndex(rowIndex);
+  };
+
+  return onSelectRow;
+};
+
+export default useShifting;

--- a/src/pages/SudoRules/SudoRulesSettings.tsx
+++ b/src/pages/SudoRules/SudoRulesSettings.tsx
@@ -8,10 +8,10 @@ import useAlerts from "src/hooks/useAlerts";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 // RPC
 import { useSaveSudoRuleMutation } from "src/services/rpcSudoRules";
+import { ErrorResult } from "src/services/rpc";
 // Utils
 import { asRecord } from "src/utils/sudoRulesUtils";
 // Components
-// import ConfirmationModal from "src/components/modals/ConfirmationModal";
 import TitleLayout from "src/components/layouts/TitleLayout";
 import SecondaryButton from "src/components/layouts/SecondaryButton";
 import KebabLayout from "src/components/layouts/KebabLayout";
@@ -19,7 +19,8 @@ import TabLayout from "src/components/layouts/TabLayout";
 import SudoRuleGeneral from "src/components/SudoRuleSections/SudoRuleGeneral";
 import SidebarLayout from "src/components/layouts/SidebarLayout";
 import SudoRuleOptions from "src/components/SudoRuleSections/SudoRuleOptions";
-import { ErrorResult } from "src/services/rpc";
+import SudoRulesWho from "src/components/SudoRuleSections/SudoRulesWho";
+import { TableEntry } from "src/components/tables/KeytabTableWithFilter";
 
 interface PropsToSudoRulesSettings {
   rule: Partial<SudoRule>;
@@ -175,10 +176,38 @@ const SudoRulesSettings = (props: PropsToSudoRulesSettings) => {
   ];
 
   // Sidebar items
-  const itemNames = ["General", "Options"];
+  const itemNames = ["General", "Options", "Who"];
 
   // Options
   const sudoOptions = props.rule.ipasudoopt || [];
+
+  // Who section - Users should also contain external users
+  const [usersAndExternalsList, setUsersAndExternalsList] = React.useState<
+    TableEntry[]
+  >([]);
+  const [usergroupsList, setUsergroupsList] = React.useState<TableEntry[]>([]);
+
+  React.useEffect(() => {
+    // - Users list
+    const usersAndExternalsListTemp: TableEntry[] =
+      props.rule.memberuser_user?.map((entry) => {
+        return { entry: entry, showLink: true };
+      }) || [];
+    // Add externals into 'usersList' without showing link
+    usersAndExternalsListTemp.push(
+      ...((props.rule.externaluser || []).map((entry) => {
+        return { entry: entry, showLink: false };
+      }) || [])
+    );
+    setUsersAndExternalsList(usersAndExternalsListTemp);
+
+    // - User groups list
+    const usergroupsListTemp: TableEntry[] =
+      props.rule.memberuser_group?.map((entry) => {
+        return { entry: entry, showLink: true };
+      }) || [];
+    setUsergroupsList(usergroupsListTemp);
+  }, [props.rule]);
 
   // Render component
   return (
@@ -200,6 +229,20 @@ const SudoRulesSettings = (props: PropsToSudoRulesSettings) => {
           <SudoRuleOptions
             sudoRuleId={props.rule.cn as string}
             options={sudoOptions}
+          />
+        </Flex>
+        {/* Who */}
+        <Flex
+          direction={{ default: "column" }}
+          flex={{ default: "flex_1" }}
+          className="pf-v5-u-mt-lg"
+        >
+          <TitleLayout headingLevel="h2" id="who" text="Who" />
+          <SudoRulesWho
+            rule={props.rule}
+            onRefresh={props.onRefresh}
+            usersList={usersAndExternalsList}
+            userGroupsList={usergroupsList}
           />
         </Flex>
       </SidebarLayout>

--- a/src/services/rpc.ts
+++ b/src/services/rpc.ts
@@ -724,6 +724,8 @@ export const api = createApi({
           method = "hbacsvc_find";
         } else if (entryType === "hbacsvcgroup") {
           method = "hbacsvcgroup_find";
+        } else if (entryType === "sudorule") {
+          method = "sudorule_find";
         } else {
           return {
             error: {

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -255,7 +255,7 @@ export interface SudoRulesOld {
 export interface SudoRule {
   cn: string;
   ipaenabledflag: boolean;
-  externaluser: string;
+  externaluser: string[];
   dn: string;
   description: string;
   sudoorder: string;
@@ -263,6 +263,7 @@ export interface SudoRule {
   hostcategory: string;
   cmdcategory: string;
   memberuser_user: string[];
+  memberuser_group: string[];
   memberhost_host: string[];
   memberhost_hostgroup: string[];
   memberallowcmd_sudocmd: string[];

--- a/src/utils/sudoRulesUtils.tsx
+++ b/src/utils/sudoRulesUtils.tsx
@@ -9,6 +9,16 @@ const simpleValues = new Set([
   "dn",
   "description",
   "sudoorder",
+  "usercategory",
+  "hostcategory",
+  "cmdcategory",
+  "ipasudorunasusercategory",
+  "ipasudorunasgroupcategory",
+  "hostmask",
+  "externalhost",
+  "ipasudorunasextusergroup",
+  "ipasudorunasextgroup",
+  "ipasudorunasextuser",
 ]);
 const dateValues = new Set([]);
 
@@ -38,7 +48,7 @@ export function createEmptySudoRule(): SudoRule {
     dn: "",
     description: "",
     sudoorder: "",
-    externaluser: "",
+    externaluser: [],
     usercategory: "",
     hostcategory: "",
     cmdcategory: "",
@@ -60,6 +70,7 @@ export function createEmptySudoRule(): SudoRule {
     ipasudorunasextusergroup: "",
     ipasudorunasextgroup: "",
     ipasudorunasextuser: "",
+    memberuser_group: [],
   };
 
   return sudoRule;

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -395,3 +395,13 @@ export function paginate<Type>(
   const endIdx = perPage * page;
   return array.slice(startIdx, endIdx);
 }
+
+/**
+ * Check if an array contains any element of another array
+ * @param {unknown[]} array1 List of elements to be checked
+ * @param {unknown[]} array2 List of elements to be checked against
+ * @returns {boolean} True if there is any element in array1 that is also in array2
+ */
+export function containsAny(array1: unknown[], array2: unknown[]): boolean {
+  return array1.some((item) => array2.includes(item));
+}


### PR DESCRIPTION
The 'Who' section allows to create and associate Users (already-defined or externals) and User groups to a given Sudo rule. It is also possible to apply the association to specific users or to anyone.

**Disclaimer:** When selecting the `Anyone` radio, the 'Save'  button is enabled. Once it's clicked, two API calls are called: one to delete the existing users and user groups, and the other to modify the current sudo rule. This functionality requires to re-implement the way the changes are detected by the `ipaObject` and perform the corresponding IPA calls, thus this functionality will not work in this PR and will be implemented in a different one.