### PR TITLE
[Doc] How to authenticate via Certificates and Kerberos

### DIFF
--- a/doc/designs/index.rst
+++ b/doc/designs/index.rst
@@ -6,3 +6,4 @@ FreeIPA WebUI documentation
 
    webui-communication-layer.md
    login-via-certificates.md
+   login-via-kerberos.md

--- a/doc/designs/index.rst
+++ b/doc/designs/index.rst
@@ -5,3 +5,4 @@ FreeIPA WebUI documentation
    :maxdepth: 1
 
    webui-communication-layer.md
+   login-via-certificates.md

--- a/doc/designs/login-via-certificates.md
+++ b/doc/designs/login-via-certificates.md
@@ -1,0 +1,74 @@
+# Authentication via Certificates
+
+## Introduction
+
+The certificate authentication method takes as argument the username to perform the api call to the `/ipa/session/login_x509` endpoint after clicking the `Login using certificate` button.
+
+## Steps to configure
+
+This has been extracted from the [official RHEL documentation](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/configuring_and_managing_identity_management/dc-web-ui-auth_configuring-and-managing-idm#requesting-and-exporting-a-user-certificate_dc-web-ui-auth). Please refer to it for troubleshooting.
+
+[**Inside the vagrant VM**] Create a ticket to configure the IDM server and generate the script to generate certs.
+
+```
+>> kinit admin
+>> ipa-advise config-server-for-smart-card-auth > server_certificate_script.sh
+>> chmod +x server_certificate_script.sh
+>> ./server_certificate_script.sh /etc/ipa/ca.crt
+```
+
+Log in into FreeIPA, create a new user (e.g. Mary Shelley, aka. `mshelley`), and generate a certificate for her from the Vagrant VM as super user.
+
+```
+>> sudo su -
+>> mkdir certdb/
+>> certutil -N -d certdb/
+>> cd certdb/
+>> certutil -R -d ./certdb/ -a -g 4096 -n mshelley -s "CN=mshelley,O=DOM-IPA.DEMO" > certificate_request.csr
+>> ipa cert-request certificate_request.csr --principal=mshelley@DOM-IPA.DEMO --profile-id=IECUserRoles --certificate-out=mshelley.pem
+>> certutil -A -d ./certdb/ -n mshelley -t "P,," -i /root/mshelley.pem
+```
+
+Check that the generated certificate is not orphan:
+
+```
+>> certutil -K -d ./certdb/
+```
+
+Generate .p12 file based on generated .pem, move it to a public folder and change the permissions (that would allow to tranfer it via `scp`):
+
+```
+>> pk12util -d <absolute-path-to-folder>/certdb -o /root/certdb/mshelley.p12 -n mshelley
+>> mkdir /home/vagrant/certs
+>> cp /root/certdb/mshelley.p12 /home/vagrant/certs
+>> chmod 666 /home/vagrant/certs/mshelley.p12
+```
+
+Now, the `.p12` certificate can be exported to **your local**:
+
+```
+# In our local, go to the folder where the vagrantFile sits (inside the WebUI project)
+>> vagrant ssh-config > config.txt
+>> scp -F config.txt default:/home/vagrant/certs/mshelley.p12 ~/Downloads
+```
+
+At this point, the `.p12` file should be in your local.
+
+Now the [certificate](https://server.ipa.demo/ipa/config/ca.crt) ([alternative link](https://ipa.demo1.freeipa.org/ipa/config/ca.crt)) for the `DOM.IPA.DEMO` realm should be downloaded as described in the [Browser kerberos setup](https://server.ipa.demo/ipa/config/ssbrowser.html) ([alternative link](https://ipa.demo1.freeipa.org/ipa/config/ssbrowser.html)) page. For this example, we will use the steps described for Firefox browser.
+
+To add both certificates to **Firefox browser**:
+
+- Go to `Settings` > `Privacy and Security` > `View certificates`
+- Add the realm certificate (`DOM-IPA.DEMO`) in the `Authorities` label
+- Add the user certificate (`mshelley`) under `Your certificates`. Write the same password you used when it was created
+
+As a final step, you must enable the post-handshake auth parameter:
+
+- Write in Firefox: `about:config`
+- Search: `security.tls.enable_post_handshake_auth`
+- Enable it to `true`
+- Restart Firefox
+
+## Try certificate authentication in the modern WebUI
+
+To test the certificate authentication, go to the [modern WebUI login page](https://server.ipa.demo/ipa/modern_ui/login), write the username `mshelley` and click `Login using Certificate`.

--- a/doc/designs/login-via-kerberos.md
+++ b/doc/designs/login-via-kerberos.md
@@ -1,0 +1,121 @@
+The Kerberos authentication should be performed by taking the already-configured kerberos credentials (via `kinit`) and authenticate through the `/ipa/session/login_kerberos` endpoint.
+
+### How to reproduce
+
+It is assumed that no ticket is created, no browser has been opened yet, and there is a vagrant machine up and running containing the modern WebUI (see `README` file instructions).
+
+[From local] Destroy all kerberos keys:
+
+```
+>> kdestroy -A
+```
+
+To be able to test the results in local, we need to modify the `resolved` file and add the IP of our already created vagrant VM. Add the following lines in the `/etc/systemd/resolved.conf` file:
+
+```
+[Resolve]
+...
+DNS=<ip-of-the-vagrant-vm>
+```
+
+Save the changes and restart the service.
+
+```
+>> sudo systemctl restart systemd-resolved.service
+```
+
+Create a ticket against admin + the webui realm
+
+```
+>> kinit admin@DOM-IPA.DEMO
+```
+
+You can check if the ticket was successfully create it by executing `klist -A`. Alternatively, you can also create the ticket while debugging by executing `KRB5_TRACE=/dev/stdout kinit admin@DOM-IPA.DEMO`.
+
+These steps should be enough to test the authentication via Kerberos:
+
+- Open a new tab on any browser (recommended: Firefox or Chrome)
+- Navigate to the `/login` page
+- Follow the instructions mentioned in the `Browser Kerberos setup` link (or `/ipa/config/ssbrowser.html`)([link from the FreeIPA demo](https://ipa.demo1.freeipa.org/ipa/config/ssbrowser.html)) for your specific browser
+  - NOTE: No need to add any certificate, so you can skip those specific steps
+- Close the browser and open it again to apply the changes (that includes ALL tabs from that browser)
+- Go to the `/login` page and click the `Login` button (without entering any user + pwd). You should be authenticated now.
+
+If this doesn't work, try the steps described in 'Plan B'.
+
+### Plan B
+
+This approach assumes that we want to configure the Kerberos authentication in a server with a different name (e.g., `<my-webui-local-instance>.ipa.demo`). This can be configured via the WebUI or CLI commands
+
+#### Option 1: WebUI
+
+Create the zone for `dom-ipa.demo`
+
+- Access the WebUI with our credentials
+- Go to `Network services` > `DNS` > `DNS zones`
+- Create a new zone called `dom-ipa.demo.` (the final `.` is important!)
+- Access the settings page of the already-created zone
+- Create new records (you can use the same values from e.g. `dom-server.ipa.demo` as a reference):
+  - `_kerberos` (`TXT` and `URI` types)
+  - `_kerberos._tcp` (if it doesn't exist)
+- Save the changes
+- At the end, it should look like something similar to this:
+  ![image](https://github.com/user-attachments/assets/10c04be4-04a3-44a6-9b61-1da0884790fd)
+  **Disclaimer:** The image show more values defined, but there might be not necessary in this case
+
+#### Option 2: CLI
+
+Execute the following commands to generate the zone:
+
+- Access vagrant machine: `vagrant ssh`
+- Create a ticket: `kinit`
+- Create DNS zone: `ipa dnszone_add mynewzone.ipa.demo.`
+- Create the records:
+  - `ipa dnsrecord_add somezone.ipa.demo. --uri-priority=0 --uri-weight=100 --uri-target=krb5srv:m:tcp:server.ipa.demo`
+    - Record name: `_kerberos`
+  - `ipa dnsrecord_add somezone.ipa.demo. --uri-priority=0 --uri-weight=100 --uri-target=krb5srv:m:udp:server.ipa.demo`
+    - Record name: `_kerberos`
+  - `ipa dnsrecord_add somezone.ipa.demo. --txt-data=DOM-IPA.DEMO`
+    - Record name: `_kerberos`
+  - `ipa dnsrecord_add somezone --srv-priority=0 --srv-weight=100 --srv-port=88 --srv-target=server.ipa.demo`
+    - Record name: `_kerberos._tcp`
+  - `ipa dnsrecord_add somezone --srv-priority=0 --srv-weight=100 --srv-port=88 --srv-target=server.ipa.demo`
+    - Record name: `_kerberos._udp`
+
+Modify the kerberos configuration file to be able to create tickets for the `DOM-IPA.DEMO` realm
+
+- `sudo vim /etc/krb5.conf.d/ipa.demo`
+- Add the following settings:
+
+```
+[libdefaults]
+default_realm = DOM-IPA.DEMO
+
+[realms]
+DOM-IPA.DEMO = {
+   default_domain = ipa.demo
+}
+```
+
+- Save the changes
+
+Check if there is a krb ticket and print the version numbers
+
+```
+>> kvno HTTP/server.ipa.demo
+```
+
+Open a Google chrome window while adding the `ipa.demo` server to the whitelist
+
+- Be sure to close any chrome tab that could've been opened before executing this
+- This will work for normal tabs (not incognito)
+
+```
+>> google-chrome --auth-server-whitelist="*.ipa.demo"
+```
+
+If there is a kerberos ticket, this should automatically log in to the WebUI
+
+### NOTE
+
+This solution is not able to log out from the WebUi as long as there is a Kerberos ticket. The same thing happens to the current WebUI when the page is refreshed from the `/login` page. Not sure if this is an expected behavior.


### PR DESCRIPTION
The documents describe the steps to follow on how to setup and be able to authenticate to the modern WebUI via Certificates and Kerberos.