### PR TITLE
[Sudo rules][Settings][Who] Provide radio buttons functionality

### DIFF
--- a/src/components/Form/IpaToggleGroup.tsx
+++ b/src/components/Form/IpaToggleGroup.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+// PatternFly
+import { ToggleGroup, ToggleGroupItem } from "@patternfly/react-core";
+// Utils
+import {
+  IPAParamDefinition,
+  getParamProperties,
+  updateIpaObject,
+} from "src/utils/ipaObjectUtils";
+
+/**
+ * This component provides functionality to handle a set of two toggle
+ * groups with idempotent logic (i.e., when one option is selected, the other
+ * is deselected).
+ */
+
+interface ToggleOptions {
+  label: string;
+  value: string;
+}
+
+interface ToggleOptionProps extends IPAParamDefinition {
+  options: ToggleOptions[];
+  optionSelected: string;
+  setOptionSelected: (value: string) => void;
+  className?: string;
+  isCompact?: boolean | false;
+}
+
+const IpaToggleGroup = (props: ToggleOptionProps) => {
+  const { value, required, readOnly } = getParamProperties(props);
+
+  React.useEffect(() => {
+    for (const option of props.options) {
+      if (option.value === value) {
+        props.setOptionSelected(option.label);
+        return;
+      }
+    }
+  }, [props.ipaObject]);
+
+  const handleItemClick = (event) => {
+    const id = event.currentTarget.id;
+    let newValue = value;
+
+    if (props.optionSelected === id) {
+      // No change
+      return;
+    }
+
+    if (props.ipaObject !== undefined && props.onChange !== undefined) {
+      for (const option of props.options) {
+        if (option.label === id) {
+          newValue = option.value;
+          break;
+        }
+      }
+      props.setOptionSelected(id);
+      updateIpaObject(props.ipaObject, props.onChange, newValue, props.name);
+    }
+  };
+
+  return (
+    <ToggleGroup isCompact={props.isCompact} className={props.className}>
+      {props.options.map((option) => (
+        <ToggleGroupItem
+          key={option.label}
+          text={option.label}
+          buttonId={option.label}
+          isSelected={props.optionSelected === option.label}
+          onChange={handleItemClick}
+          isDisabled={readOnly || false}
+          required={required || false}
+        />
+      ))}
+    </ToggleGroup>
+  );
+};
+
+export default IpaToggleGroup;

--- a/src/components/layouts/DualListLayout.tsx
+++ b/src/components/layouts/DualListLayout.tsx
@@ -221,7 +221,7 @@ const DualListTableLayout = (props: PropsToAddModal) => {
     setExternalValue("");
   };
 
-  if (props.addExternalsOption) {
+  if (props.addExternalsOption === true) {
     fields.push({
       id: "form-externals",
       pfComponent: (

--- a/src/components/layouts/SettingsTableLayout.tsx
+++ b/src/components/layouts/SettingsTableLayout.tsx
@@ -30,6 +30,7 @@ export interface PropsToSettingsTableLayout {
   onDeleteModal: () => void;
   isDeleteDisabled?: boolean;
   onAddModal: () => void;
+  isAddDisabled?: boolean;
   onSearchChange: (value: string) => void;
   searchValue: string;
   // pagination
@@ -74,13 +75,14 @@ const SettingsTableLayout = (props: PropsToSettingsTableLayout) => {
             <FlexItem>
               <SecondaryButton
                 classname="pf-v5-u-mr-sm"
-                isDisabled={props.isDeleteDisabled}
+                isDisabled={props.isDeleteDisabled || false}
                 onClickHandler={props.onDeleteModal}
               >
                 Delete
               </SecondaryButton>
               <SecondaryButton
                 classname="pf-v5-u-mr-sm"
+                isDisabled={props.isAddDisabled || false}
                 onClickHandler={props.onAddModal}
               >
                 Add {props.entryType.toLowerCase()}s
@@ -125,7 +127,10 @@ const SettingsTableLayout = (props: PropsToSettingsTableLayout) => {
           />
           <EmptyStateBody>
             <EmptyStateActions>
-              <SecondaryButton onClickHandler={props.onAddModal}>
+              <SecondaryButton
+                onClickHandler={props.onAddModal}
+                isDisabled={props.isAddDisabled || false}
+              >
                 Add {props.entryType.toLowerCase()}s
               </SecondaryButton>
             </EmptyStateActions>

--- a/src/components/tables/KeytabTableWithFilter.tsx
+++ b/src/components/tables/KeytabTableWithFilter.tsx
@@ -37,6 +37,8 @@ interface PropsToKeytabTable {
   onAdd: (newEntries: string[]) => void;
   onDelete: (entriesToDelete: string[]) => void;
   checkboxesDisabled?: boolean;
+  // Add external option
+  externalOption?: boolean;
 }
 
 const KeytabTableWithFilter = (props: PropsToKeytabTable) => {
@@ -132,6 +134,7 @@ const KeytabTableWithFilter = (props: PropsToKeytabTable) => {
 
   // Computed states
   const isDeleteDisabled = selectedEntries.length === 0;
+  const isAddDisabled = props.checkboxesDisabled;
 
   // Entries displayed on the first page
   const updateShownEntriesList = (newShownEntriesList: TableEntry[]) => {
@@ -267,6 +270,7 @@ const KeytabTableWithFilter = (props: PropsToKeytabTable) => {
         onDeleteModal={onChangeDeleteModal}
         isDeleteDisabled={isDeleteDisabled}
         onAddModal={onChangeAddModal}
+        isAddDisabled={isAddDisabled}
         onSearchChange={onSearchChange}
         searchValue={searchValue}
         paginationData={paginationData}
@@ -287,7 +291,7 @@ const KeytabTableWithFilter = (props: PropsToKeytabTable) => {
         spinning={props.isSpinning}
         addBtnName="Add"
         addSpinningBtnName="Adding"
-        addExternalsOption={true}
+        addExternalsOption={props.externalOption || false}
       />
       {/* Delete modal */}
       <MemberOfDeleteModal

--- a/src/services/rpcSudoRules.ts
+++ b/src/services/rpcSudoRules.ts
@@ -314,6 +314,8 @@ const extendedApi = api.injectEndpoints({
     saveSudoRule: build.mutation<FindRPCResponse, Partial<SudoRule>>({
       query: (rule) => {
         const params = {
+          all: true,
+          rights: true,
           version: API_VERSION_BACKUP,
           ...rule,
         };
@@ -381,7 +383,7 @@ const extendedApi = api.injectEndpoints({
     addToSudoRule: build.mutation<BatchResponse, AddRemoveToSudoRulesPayload>({
       query: (payload) => {
         const toId = payload.toId;
-        const type = payload.type; // Shoud be 'user'
+        const type = payload.type; // Shoud be 'user' or 'group'
         const listOfMembers = payload.listOfMembers;
 
         const batchParams: Command[] = [];


### PR DESCRIPTION
The configuration of the 'Anyone' and 'Specified Users and Groups' radio buttons should be implemented to match the following behavior:
- When 'Anyone' radio is selected and 'Save' button is clicked, 'usercategory' parameter should change to "all" and all users and user groups should be removed from the lists.
- When 'Specified ...' radio button is selected, the 'usercategory' should be changed to empty string ("").
  - At this point, the user can either save the changes or add new users / groups and save afterwards.

This PR depend on this one to be merged: https://github.com/freeipa/freeipa-webui/pull/572

Signed-off-by: Carla Martinez <carlmart@redhat.com>