### PR TITLE
[Sudo rules][Settings][Who] Fix spaces on Alerts

### DIFF
--- a/src/components/SudoRuleSections/SudoRulesWho.tsx
+++ b/src/components/SudoRuleSections/SudoRulesWho.tsx
@@ -112,7 +112,7 @@ const SudoRulesWho = (props: PropsToSudoRulesWho) => {
               // Set alert: success
               alerts.addAlert(
                 "add-who-user-external-success",
-                "Added new item(s)' to" + props.rule.cn + "'",
+                "Added new item(s) to '" + props.rule.cn + "'",
                 "success"
               );
               // Refresh page
@@ -224,7 +224,7 @@ const SudoRulesWho = (props: PropsToSudoRulesWho) => {
             // Set alert: success
             alerts.addAlert(
               "add-who-group-external-success",
-              "Added new item(s)' to" + props.rule.cn + "'",
+              "Added new item(s) to '" + props.rule.cn + "'",
               "success"
             );
             // Refresh page


### PR DESCRIPTION
The Alerts of the Sudo rules > 'Settings' > 'Who' section need to have an extra space to show the text.