### PR TITLE
Fix: Dual selector layout is not filtering data

### DIFF
--- a/src/components/layouts/DualListLayout.tsx
+++ b/src/components/layouts/DualListLayout.tsx
@@ -43,6 +43,7 @@ interface PropsToAddModal {
   addSpinningBtnName: string;
   action: (items: string[]) => void;
   tableElementsList: string[];
+  availableOptions?: string[];
   addExternalsOption?: boolean;
 }
 
@@ -59,10 +60,19 @@ const DualListTableLayout = (props: PropsToAddModal) => {
 
   const [availableOptions, setAvailableOptions] = useState<
     string[] | ReactNode[]
-  >([initialList]);
+  >([]);
   const [chosenOptions, setChosenOptions] = useState<string[]>([]);
   const [searchValue, setSearchValue] = React.useState("");
   const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
+
+  // Show available options if they are defined. Otherwise, show the initial list
+  React.useEffect(() => {
+    if (availableOptions === undefined) {
+      setAvailableOptions([initialList]);
+    } else {
+      setAvailableOptions(availableOptions);
+    }
+  }, []);
 
   const updateAvailableOptions = (newList: string[]) => {
     if (newList.length === 0) {
@@ -110,20 +120,25 @@ const DualListTableLayout = (props: PropsToAddModal) => {
   const [retrieveIDs] = useGetIDListMutation({});
   const submitSearchValue = () => {
     setSearchIsDisabled(true);
-    retrieveIDs({
-      searchValue: searchValue,
-      sizeLimit: 200,
-      startIdx: 0,
-      stopIdx: 200,
-      entryType: props.target,
-    } as GenericPayload).then((result) => {
-      if (result && "data" in result) {
-        updateAvailableOptions(result.data.list);
-      } else {
-        updateAvailableOptions([]);
-      }
+    if (props.availableOptions === undefined) {
+      retrieveIDs({
+        searchValue: props.availableOptions || searchValue,
+        sizeLimit: 200,
+        startIdx: 0,
+        stopIdx: 200,
+        entryType: props.target,
+      } as GenericPayload).then((result) => {
+        if (result && "data" in result) {
+          updateAvailableOptions(result.data.list);
+        } else {
+          updateAvailableOptions([]);
+        }
+        setSearchIsDisabled(false);
+      });
+    } else {
+      updateAvailableOptions(props.availableOptions);
       setSearchIsDisabled(false);
-    });
+    }
   };
 
   const updateSearchValue = (value: string) => {


### PR DESCRIPTION
The `KeytabTableWithFilter` component displays, among other things, a `DualListLayout` component, which is using the `DualListSelector` one. This makes possible to provide a list of options to search and/or display in adding modals.

However, this component (`DualListLayout`) is not filtering the available data that it should show in the left side of the selector. Although any duplicate value can't be added twice (and this is managed by the API itself), this must not show
elements that have been already added in the table, so proper filtering of the available data is needed.

This can be checked in, e.g., `Sudo rules` > `Settings` > `Who` section.