### PR TITLE
[Tests] Fix Groups integration tests

### DIFF
--- a/tests/features/hostgroup_settings.feature
+++ b/tests/features/hostgroup_settings.feature
@@ -1,0 +1,41 @@
+Feature: Host group settings manipulation
+  Modify a host group settings
+
+  Background:
+    Given I am logged in as "Administrator"
+    Given I am on "host-groups" page
+
+  Scenario: Add a new host group
+    When I click on "Add" button
+    * I type in the field "Group name" text "my_host_group"
+    When in the modal dialog I click on "Add" button
+    * I should see "success" alert with text "New host group added"
+    Then I should see "my_host_group" entry in the data table
+
+  Scenario: Set Description
+    Given I am on "host-groups" page
+    When I click on "my_host_group" entry in the data table
+    Then I click in the field "Description"
+    * I type in the textarea "Description" text "my_host_group description here"
+    Then I click on "Save" button
+    * I should see "success" alert with text "Host group modified"
+    Then Then I should see "my_host_group description here" in the textarea "description"
+
+  Scenario: Revert data
+    Then I click in the field "Description"
+    * I type in the textarea "Description" text "Modifying the description"
+    Then I click on "Revert" button
+    * I should see "success" alert with text "Host group data reverted"
+    Then Then I should see "my_host_group description here" in the textarea "description"
+
+  # Cleanup
+  Scenario: Cleanup: Delete the host group
+    When I click on the breadcrump link "Host groups"
+    Then I should see "my_host_group" entry in the data table
+    Then I select entry "my_host_group" in the data table
+    When I click on "Delete" button
+    * I see "Remove host groups" modal
+    * I should see "my_host_group" entry in the data table
+    When in the modal dialog I click on "Delete" button
+    * I should see "success" alert with text "Host groups removed"
+    Then I should not see "my_host_group" entry in the data table

--- a/tests/features/netgroup_members.feature
+++ b/tests/features/netgroup_members.feature
@@ -115,42 +115,52 @@ Feature: Netgroup members
   #
   # Test "Host" members
   #
+  #Prep: Add a new host
+  Scenario: Prep: Add a host
+    Given I am on "hosts" page
+    When I click on "Add" button
+    * I type in the field "Host name" text "my-new-server"
+    * in the modal dialog I click on "Add" button
+    * I should see "success" alert with text "New host added"
+    Then I should see partial "my-new-server" entry in the data table
   Scenario: Add a Host member into the netgroup
+    Given I am on "netgroups" page
+    Given I click on "mynetgroup" entry in the data table
+    Given I click on "Members" page tab
     Given I click on "Hosts" page tab
-    Given I am on "mynetgroup" group > Members > "Hosts" section
     Then I should see the "host" tab count is "0"
     When I click on "Add" button located in the toolbar
     Then I should see the dialog with title "Assign hosts to netgroup: mynetgroup"
-    When I move user "server.ipa.demo" from the available list and move it to the chosen options
+    When I move user "my-new-server" from the available list and move it to the chosen options
     And in the modal dialog I click on "Add" button
     * I should see "success" alert with text "Assigned new hosts to netgroup 'mynetgroup'"
     * I close the alert
-    Then I should see "server.ipa.demo" entry in the data table
+    Then I should see "my-new-server.dom-server.ipa.demo" entry in the data table
     Then I should see the "host" tab count is "1"
 
   Scenario: Search for a host
-    When I type "server.ipa.demo" in the search field
-    Then I should see the "server.ipa.demo" text in the search input field
+    When I type "my-new-server" in the search field
+    Then I should see the "my-new-server" text in the search input field
     When I click on the arrow icon to perform search
-    Then I should see "server.ipa.demo" entry in the data table
+    Then I should see "my-new-server.dom-server.ipa.demo" entry in the data table
     * I click on the X icon to clear the search field
     When I type "notthere" in the search field
     Then I should see the "notthere" text in the search input field
     When I click on the arrow icon to perform search
-    Then I should not see "server.ipa.demo" entry in the data table
+    Then I should not see "my-new-server" entry in the data table
     Then I click on the X icon to clear the search field
     Then I click on the arrow icon to perform search
-    Then I should see "server.ipa.demo" entry in the data table
+    Then I should see "my-new-server.dom-server.ipa.demo" entry in the data table
 
   Scenario: Remove host member
-    When I select partial entry "server.ipa.demo" in the data table
+    When I select partial entry "my-new-server" in the data table
     And I click on "Delete" button located in the toolbar
     Then I should see the dialog with title "Delete hosts from netgroup: mynetgroup"
-    And the "server.ipa.demo" element should be in the dialog table
+    And the "my-new-server" element should be in the dialog table
     When in the modal dialog I click on "Delete" button
     Then I should see "success" alert with text "Removed hosts from netgroup 'mynetgroup'"
     * I close the alert
-    And I should not see the element "server.ipa.demo" in the table
+    And I should not see the element "my-new-server" in the table
     Then I should see the "host" tab count is "0"
 
   #
@@ -263,4 +273,14 @@ Feature: Netgroup members
     * I should see "mynetgroup2" entry in the data table
     When in the modal dialog I click on "Delete" button
     * I should see "success" alert with text "Netgroups removed"
+
+  Scenario: Cleanup - remove the test host
+    Given I am on "hosts" page
+    Then I select partial entry "my-new-server" in the data table
+    When I click on "Delete" button
+    * I see "Remove hosts" modal
+    * I should see partial "my-new-server" entry in the data table
+    When in the modal dialog I click on "Delete" button
+    * I should see "success" alert with text "Hosts removed"
+    Then I should not see "my-new-server" entry in the data table
 

--- a/tests/features/netgroup_settings_handling.feature
+++ b/tests/features/netgroup_settings_handling.feature
@@ -18,7 +18,17 @@ Feature: Netgroup settings manipulation
     Then I should see "netgroup1" entry in the data table
     Then I should see "netgroup2" entry in the data table
 
+  # Prep: Add a host that will be added to the netgroup's host category
+  Scenario: Add a host
+    Given I am on "hosts" page
+    When I click on "Add" button
+    * I type in the field "Host name" text "my-server"
+    * in the modal dialog I click on "Add" button
+    * I should see "success" alert with text "New host added"
+    Then I should see partial "my-server" entry in the data table
+
   Scenario: Set Description
+    Given I am on "netgroups" page
     When I click on "netgroup1" entry in the data table
     * I type in the textarea "description" text "test"
     Then I click on "Save" button
@@ -48,6 +58,17 @@ Feature: Netgroup settings manipulation
     * I close the alert
     Then I should see "admin" entry in the data table
 
+  Scenario: Remove user from User category
+    When I click on "Users" page tab
+    Then I should see "admin" entry in the data table
+    * I select entry "admin" in the data table
+    * I click on "Delete" button
+    * I should see "admin" entry in the data table
+    When in the modal dialog I click on "Delete" button
+    * I should see "success" alert with text "Removed user from netgroup"
+    * I close the alert
+    Then I should not see "admin" entry in the data table
+
   Scenario: Add group to User category
     When I click on "Groups" page tab
     Then I click on "Add groups" button
@@ -60,16 +81,40 @@ Feature: Netgroup settings manipulation
     * I close the alert
     Then I should see "admins" entry in the data table
 
+  Scenario: Remove group from User category
+    When I click on "Groups" page tab
+    Then I should see "admins" entry in the data table
+    * I select entry "admins" in the data table
+    * I click on "Delete" button
+    * I should see "admins" entry in the data table
+    When in the modal dialog I click on "Delete" button
+    * I should see "success" alert with text "Removed group from netgroup"
+    * I close the alert
+    Then I should not see "admins" entry in the data table
+
   Scenario: Add host to Host category
     When I click on "Hosts" page tab
     Then I click on "Add hosts" button
     * I see "Add hosts to netgroup" modal
     * I click on the arrow icon to perform search
-    Then I click on the first dual list item
+    Then I click on the dual list item "my-server.dom-server.ipa.demo"
     * I click on the dual list add selected button
     * in the modal dialog I click on "Add" button
     Then I should see "success" alert with text "Added host to netgroup"
     * I close the alert
+    # When I scroll up
+    Then I should see "my-server.dom-server.ipa.demo" entry in the data table
+
+  Scenario: Remove host from Host category
+    When I click on "Hosts" page tab
+    Then I should see "my-server.dom-server.ipa.demo" entry in the data table
+    * I select entry "my-server.dom-server.ipa.demo" in the data table
+    * I click on "Delete" button
+    * I should see "my-server.dom-server.ipa.demo" entry in the data table
+    When in the modal dialog I click on "Delete" button
+    * I should see "success" alert with text "Removed host from netgroup"
+    * I close the alert
+    Then I should not see "my-server.dom-server.ipa.demo" entry in the data table
 
   Scenario: Add hostgroup to Host category
     When I click on "Host groups" page tab
@@ -83,6 +128,17 @@ Feature: Netgroup settings manipulation
     * I close the alert
     Then I should see "ipaservers" entry in the data table
 
+  Scenario: Remove hostgroup from Host category
+    When I click on "Host groups" page tab
+    Then I should see "ipaservers" entry in the data table
+    * I select entry "ipaservers" in the data table
+    * I click on "Delete" button
+    * I should see "ipaservers" entry in the data table
+    When in the modal dialog I click on "Delete" button
+    * I should see "success" alert with text "Removed hostgroup from netgroup"
+    * I close the alert
+    Then I should not see "ipaservers" entry in the data table
+
   Scenario: Add external host to Host category
     When I click on "External host" page tab
     Then I click on "Add external hosts" button
@@ -94,9 +150,43 @@ Feature: Netgroup settings manipulation
     When I scroll down
     Then I should see "test.test.test" entry in the data table
 
+  Scenario: Remove external host from Host category
+    When I click on "External host" page tab
+    Then I should see "test.test.test" entry in the data table
+    * I select entry "test.test.test" in the data table
+    * I click on "Delete" button
+    * I should see "test.test.test" entry in the data table
+    When in the modal dialog I click on "Delete" button
+    * I should see "success" alert with text "Removed externalHost from netgroup"
+    * I close the alert
+    Then I should not see "test.test.test" entry in the data table
+
   Scenario: Set User category to allow all users
     # When enabling "Allow anyone" all members need to be removed otherwise
     # the update fails
+    # Add user to User category (again)
+    When I click on "Users" page tab
+    Then I click on "Add users" button
+    * I see "Add users to netgroup" modal
+    * I click on the arrow icon to perform search
+    Then I click on the dual list item "admin"
+    * I click on the dual list add selected button
+    * in the modal dialog I click on "Add" button
+    Then I should see "success" alert with text "Added user to netgroup"
+    * I close the alert
+    Then I should see "admin" entry in the data table
+    # Add group to User category (again)
+    When I click on "Groups" page tab
+    Then I click on "Add groups" button
+    * I see "Add groups to netgroup" modal
+    * I click on the arrow icon to perform search
+    Then I click on the dual list item "admins"
+    * I click on the dual list add selected button
+    * in the modal dialog I click on "Add" button
+    Then I should see "success" alert with text "Added group to netgroup"
+    * I close the alert
+    Then I should see "admins" entry in the data table
+    # Set user category to allow all
     When I scroll up
     * I click on "Allow anyone" checkbox
     Then I click on "Save" button
@@ -111,6 +201,30 @@ Feature: Netgroup settings manipulation
 
   Scenario: Set Host category to allow all hosts
     # This is the same test as above but for the host category
+    # Add host to Host category (again)
+    When I click on "Hosts" page tab
+    Then I click on "Add hosts" button
+    * I see "Add hosts to netgroup" modal
+    * I click on the arrow icon to perform search
+    Then I click on the dual list item "my-server.dom-server.ipa.demo"
+    * I click on the dual list add selected button
+    * in the modal dialog I click on "Add" button
+    Then I should see "success" alert with text "Added host to netgroup"
+    * I close the alert
+    # When I scroll up
+    Then I should see "my-server.dom-server.ipa.demo" entry in the data table
+    # Add hostgroup to Host category (again)
+    When I click on "Host groups" page tab
+    Then I click on "Add host groups" button
+    * I see "Add Host groups to netgroup" modal
+    Then I click on the arrow icon to perform search
+    Then I click on the dual list item "ipaservers"
+    * I click on the dual list add selected button
+    * in the modal dialog I click on "Add" button
+    Then I should see "success" alert with text "Added hostgroup to netgroup"
+    * I close the alert
+    Then I should see "ipaservers" entry in the data table
+    # Set Host category to allow all
     When I scroll down
     * I click on "Allow any host" checkbox
     Then I click on "Save" button
@@ -119,7 +233,7 @@ Feature: Netgroup settings manipulation
     When I scroll down
     Then I click on "Allow any host" checkbox
     When I click on "Hosts" page tab
-    Then I should not see "server.ipa.demo" entry in the data table
+    Then I should not see "my-server.dom-server.ipa.demo" entry in the data table
     When I click on "Host groups" page tab
     Then I should not see "ipaservers" entry in the data table
     When I click on "External hosts" page tab
@@ -136,4 +250,15 @@ Feature: Netgroup settings manipulation
     * I should see "netgroup2" entry in the data table
     When in the modal dialog I click on "Delete" button
     * I should see "success" alert with text "Netgroups removed"
+
+  # Cleanup
+  Scenario: Cleanup: Remove host
+    Given I am on "hosts" page
+    Then I select partial entry "my-server" in the data table
+    When I click on "Delete" button
+    * I see "Remove hosts" modal
+    * I should see partial "my-server" entry in the data table
+    When in the modal dialog I click on "Delete" button
+    * I should see "success" alert with text "Hosts removed"
+    Then I should not see "my-server" entry in the data table
 

--- a/tests/features/steps/common.ts
+++ b/tests/features/steps/common.ts
@@ -428,6 +428,15 @@ Then(
   }
 );
 
+Then(
+  "I should see an empty readonly text input field with ID {string}",
+  (id: string) => {
+    cy.get("input[id=" + id + "]")
+      .invoke("prop", "value")
+      .should("be.empty");
+  }
+);
+
 When(
   "I type in the field with ID {string} the text {string}",
   (id: string, content: string) => {

--- a/tests/features/steps/common.ts
+++ b/tests/features/steps/common.ts
@@ -149,14 +149,16 @@ When(
 When(
   "I type in the textarea {string} text {string}",
   (name: string, value: string) => {
-    cy.get('textarea[name="' + name + '"').type(value, { delay: 0 });
+    cy.get('textarea[name="' + name.toLowerCase() + '"').type(value, {
+      delay: 0,
+    });
   }
 );
 
 When(
   "Then I should see {string} in the textarea {string}",
   (value: string, name: string) => {
-    cy.get('textarea[name="' + name + '"').contains(value);
+    cy.get('textarea[name="' + name.toLowerCase() + '"').contains(value);
   }
 );
 

--- a/tests/features/usergroup_is_member_of.feature
+++ b/tests/features/usergroup_is_member_of.feature
@@ -2,9 +2,6 @@ Feature: Usergroup is a member of
   Work with usergroup Is a member of section and its operations in all the available tabs
 
   # TODO: Add pending tests for:
-  #          - 'Sudo rules'
-  #          - Elements to add match with the ones available (in other pages)
-  #          - Membership
   #          - Pagination functionality (with more elements in the table)
 
   Background:

--- a/tests/features/usergroup_settings_handling.feature
+++ b/tests/features/usergroup_settings_handling.feature
@@ -38,6 +38,18 @@ Feature: User group settings manipulation
     * I should see a non-empty readonly text input field with ID "gid"
     * I click on the breadcrump link "User groups"
 
+  Scenario: Convert group to external group
+    Given I am on "user-groups" page
+    When I click on "group2" entry in the data table
+    Given I should see a new empty text input field with ID "gid"
+    When I click on the settings kebab menu and select "Change to external group"
+    * I see "Change group type" modal
+    * I click on "Change Group" button
+    Then I should see "success" alert with text "User group changed to external group"
+    Then I should see "External" in readonly text input field with ID "group-type"
+    * I should see an empty readonly text input field with ID "gid"
+    * I click on the breadcrump link "User groups"
+
   Scenario: Delete the groups for cleanup
     Given I am on "user-groups" page
     Then I should see "group1" entry in the data table


### PR DESCRIPTION
The integration tests for the 'Groups' section (`User groups' , `Host groups`, and `Netgroups`) have been reviewed and the following enhancements have been made to ensure that all use-cases are covered:
- Add new scenario in User groups: `Convert group to external group`
- Adda full test for Host group > 'Settings' page
- Add tests to check removals on users and hosts categories
- Specify host to add in Members table