### PR TITLE
Add waiting time on loading some pages

### DIFF
--- a/tests/features/steps/common.ts
+++ b/tests/features/steps/common.ts
@@ -4,7 +4,7 @@ import { When, Then, Given } from "@badeball/cypress-cucumber-preprocessor";
 Given("I am on {string} page", (handle: string) => {
   cy.url().then(($url) => {
     if (!$url.includes(handle)) {
-      cy.visit(Cypress.env("base_url") + "/" + handle);
+      cy.visit(Cypress.env("base_url") + "/" + handle, { timeout: 6000 });
     }
   });
 });
@@ -96,7 +96,7 @@ When("I click on {string} page tab", (tabText: string) => {
 
 When("I click on {string} button", function (buttonText: string) {
   const regex = new RegExp("^" + buttonText + "$", "i");
-  cy.get("button").contains(regex).click();
+  cy.get("button", { timeout: 6000 }).contains(regex).click();
 });
 
 When("I click on ID {string} button", function (id: string) {
@@ -242,7 +242,7 @@ When("I select entry {string} in the data table", (name: string) => {
 });
 
 When("I click on {string} entry in the data table", (name: string) => {
-  cy.get("tr[id='" + name + "'] a")
+  cy.get("tr[id='" + name + "'] a", { timeout: 5000 })
     .contains(name)
     .click();
 });

--- a/tests/features/steps/user_handling.ts
+++ b/tests/features/steps/user_handling.ts
@@ -105,7 +105,7 @@ Then("I am on {string} user settings page", (username: string) => {
       cy.get(".pf-v5-c-breadcrumb__item")
         .contains(username)
         .should("be.visible");
-      cy.get("h1>p").contains(username).should("be.visible");
+      cy.get("h1>p", { timeout: 5000 }).contains(username).should("be.visible");
     }
   });
 });


### PR DESCRIPTION
Some pages require some time to allow the data get loaded (e.g., Active users, Hosts, etc.) because some API calls are being done and data is being retrieved and shown.

Due to that, some assertions need to have some waiting time when performing operations that imply a loading time.