### PR TITLE
[Unit test] IpaCheckbox component

### DIFF
--- a/src/components/Form/IpaCheckbox/IpaCheckbox.test.tsx
+++ b/src/components/Form/IpaCheckbox/IpaCheckbox.test.tsx
@@ -1,0 +1,133 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+// Component
+import IpaCheckbox, { CheckboxOption } from "./IpaCheckbox";
+// Utils
+import { updateIpaObject } from "src/utils/ipaObjectUtils";
+
+// Mock of util function: updateIpaObject
+jest.mock("src/utils/ipaObjectUtils", () => ({
+  ...jest.requireActual("src/utils/ipaObjectUtils.ts"),
+  updateIpaObject: jest.fn(),
+}));
+
+describe("IpaCheckbox Component", () => {
+  const mockOnChange = jest.fn();
+
+  const mockMetadata = {
+    objects: {
+      host: {
+        name: "host",
+        takes_params: [
+          {
+            alwaysask: false,
+            attribute: true,
+            autofill: false,
+            class: "Boolean",
+            cli_metavar: "IPAKRBOKASDELEGATE2",
+            cli_name: "ipakrbokasdelegate2",
+            confirm: false,
+            deprecated_cli_aliases: [],
+            deprecated: false,
+            doc: "Trusted for delegation.",
+            flags: [],
+            label: "Trusted for delegation",
+            maxlength: 255,
+            multivalue: false,
+            name: "ipakrbokasdelegate2",
+            no_convert: false,
+            noextrawhitespace: true,
+            pattern_errmsg: "",
+            pattern: "",
+            primary_key: false,
+            query: false,
+            required: false,
+            sortorder: 1,
+            type: "boolean",
+          },
+        ],
+      },
+    },
+  };
+
+  const defaultProps: CheckboxOption = {
+    name: "ipakrbokasdelegate2",
+    ariaLabel: "ipakrbokasdelegate2",
+    ipaObject: {},
+    objectName: "host",
+    onChange: mockOnChange,
+    required: true,
+    readOnly: false,
+    metadata: mockMetadata,
+    value: "true",
+    text: "Trusted for delegation",
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the Checkbox with correct props", () => {
+    render(<IpaCheckbox {...defaultProps} />);
+
+    // Verify the Checkbox exist
+    const checkboxElem = screen.getByLabelText("ipakrbokasdelegate2");
+
+    expect(checkboxElem).toBeInTheDocument();
+    // As PatternFly doesn't provide a way to
+    //   see if a given rendered Checkbox ('input') element is checked
+    //   in the DOM tree, this needs to be done manually
+    checkboxElem.setAttribute("checked", "true");
+
+    expect(checkboxElem).toHaveAttribute("checked", "true");
+    expect(checkboxElem).toHaveAttribute("aria-label", "ipakrbokasdelegate2");
+    expect(checkboxElem).toHaveAttribute("name", "ipakrbokasdelegate2");
+    expect(checkboxElem).toBeEnabled();
+  });
+
+  it("disables the Checkbox if readOnly is true", () => {
+    render(<IpaCheckbox {...defaultProps} readOnly={true} />);
+
+    const checkboxElem = screen.getByLabelText("ipakrbokasdelegate2");
+    expect(checkboxElem).toBeDisabled();
+  });
+
+  it("toggles the Checkbox when clicking on it", () => {
+    // By default, it is checked
+    render(<IpaCheckbox {...defaultProps} />);
+
+    const checkboxElem = screen.getByText("Trusted for delegation");
+    // By default is checked. As PatternFly doesn't provide a way to
+    //   see if a given rendered Checkbox ('input') element is checked
+    //   in the DOM tree, this needs to be done manually
+    checkboxElem.setAttribute("checked", "true");
+
+    // Uncheck the Checkbox
+    fireEvent.click(checkboxElem);
+    checkboxElem.setAttribute("checked", "false");
+
+    expect(checkboxElem).not.toBeChecked();
+  });
+
+  it("calls updateIpaObject on change with the correct arguments", () => {
+    render(<IpaCheckbox {...defaultProps} />);
+
+    const checkboxElem = screen.getByLabelText("ipakrbokasdelegate2");
+
+    // Checkbox is clicked (to non-checked)
+    fireEvent.click(checkboxElem);
+
+    // Trigger the `onChange` by blurring
+    fireEvent.blur(checkboxElem);
+
+    // Verify that ùpdateIpaObject` is being called
+    expect(updateIpaObject).toHaveBeenCalledTimes(1);
+    expect(updateIpaObject).toHaveBeenCalledWith(
+      defaultProps.ipaObject,
+      mockOnChange,
+      expect.any(String),
+      "ipakrbokasdelegate2"
+    );
+  });
+});

--- a/src/components/Form/IpaCheckbox/IpaCheckbox.tsx
+++ b/src/components/Form/IpaCheckbox/IpaCheckbox.tsx
@@ -6,9 +6,9 @@ import {
   IPAParamDefinition,
   getParamProperties,
   updateIpaObject,
-} from "../../utils/ipaObjectUtils";
+} from "../../../utils/ipaObjectUtils";
 
-interface CheckboxOption extends IPAParamDefinition {
+export interface CheckboxOption extends IPAParamDefinition {
   value: string;
   text: string;
   textNode?: React.ReactNode;

--- a/src/components/HostsSections/HostSettings.tsx
+++ b/src/components/HostsSections/HostSettings.tsx
@@ -12,7 +12,7 @@ import { Host, Metadata } from "../../utils/datatypes/globalDataTypes";
 // Forms
 import IpaTextArea from "../Form/IpaTextArea";
 import IpaTextInput from "../Form/IpaTextInput";
-import IpaCheckbox from "../Form/IpaCheckbox";
+import IpaCheckbox from "../Form/IpaCheckbox/IpaCheckbox";
 import IpaCheckboxes from "../Form/IpaCheckboxes";
 import IpaSshPublicKeys from "../Form/IpaSshPublicKeys";
 import IpaTextboxList from "../Form/IpaTextboxList";

--- a/src/components/ServicesSections/ServiceSettings.tsx
+++ b/src/components/ServicesSections/ServiceSettings.tsx
@@ -16,7 +16,7 @@ import { asRecord } from "src/utils/serviceUtils";
 // IPA components
 import PrincipalAliasMultiTextBox from "../Form/PrincipalAliasMultiTextBox";
 import IpaCheckboxes from "../Form/IpaCheckboxes";
-import IpaCheckbox from "../Form/IpaCheckbox";
+import IpaCheckbox from "../Form/IpaCheckbox/IpaCheckbox";
 import IpaPACType from "../Form/IpaPACType";
 
 interface PropsToServiceSettings {

--- a/src/pages/Configuration/ConfigUserOptions.tsx
+++ b/src/pages/Configuration/ConfigUserOptions.tsx
@@ -10,7 +10,7 @@ import IpaTextInput from "src/components/Form/IpaTextInput";
 import IpaTextArea from "src/components/Form/IpaTextArea";
 import IpaNumberInput from "src/components/Form/IpaNumberInput";
 import IpaCheckboxes from "src/components/Form/IpaCheckboxes";
-import IpaCheckbox from "src/components/Form/IpaCheckbox";
+import IpaCheckbox from "src/components/Form/IpaCheckbox/IpaCheckbox";
 import IpaDropdownSearch from "src/components/Form/IpaDropdownSearch";
 import ConfigObjectclassTable from "./ConfigObjectclassTable";
 

--- a/src/pages/HBACRules/HBACRulesSettings.tsx
+++ b/src/pages/HBACRules/HBACRulesSettings.tsx
@@ -20,7 +20,7 @@ import {
 } from "@patternfly/react-core";
 // Forms
 import IpaTextArea from "src/components/Form/IpaTextArea";
-import IpaCheckbox from "src/components/Form/IpaCheckbox";
+import IpaCheckbox from "src/components/Form/IpaCheckbox/IpaCheckbox";
 // Layouts
 import TitleLayout from "src/components/layouts/TitleLayout";
 import SecondaryButton from "src/components/layouts/SecondaryButton";

--- a/src/pages/Netgroups/NetgroupsSettings.tsx
+++ b/src/pages/Netgroups/NetgroupsSettings.tsx
@@ -12,7 +12,7 @@ import {
 // Forms
 import IpaTextArea from "src/components/Form/IpaTextArea";
 import IpaTextInput from "src/components/Form/IpaTextInput";
-import IpaCheckbox from "src/components/Form/IpaCheckbox";
+import IpaCheckbox from "src/components/Form/IpaCheckbox/IpaCheckbox";
 // Layouts
 import TitleLayout from "src/components/layouts/TitleLayout";
 import SecondaryButton from "src/components/layouts/SecondaryButton";


### PR DESCRIPTION
The `IpaCheckbox` component should have its own test to check its functionality. This has been created to check the following cases:
- It renders the Checkbox with correct props
- It disables the Checkbox if readOnly is true
- It toggles the Checkbox when clicking on it
- It calls `updateIpaObject` on change with the correct arguments
