### PR TITLE
Add Contextual help links panel in the Active users' main page

### DIFF
--- a/src/assets/documentation/documentation-links.json
+++ b/src/assets/documentation/documentation-links.json
@@ -1,0 +1,28 @@
+{
+  "active-users": [
+    {
+      "name": "User life cycle",
+      "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_idm_users_groups_hosts_and_access_control_rules/managing-user-accounts-using-the-idm-web-ui_managing-users-groups-hosts#user-life-cycle_managing-user-accounts-using-the-idm-web-ui"
+    },
+    {
+      "name": "Adding users in the Web UI",
+      "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_idm_users_groups_hosts_and_access_control_rules/managing-user-accounts-using-the-idm-web-ui_managing-users-groups-hosts#adding-users-in-the-web-ui_managing-user-accounts-using-the-idm-web-ui"
+    },
+    {
+      "name": "Disabling user accounts in the Web UI",
+      "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_idm_users_groups_hosts_and_access_control_rules/managing-user-accounts-using-the-idm-web-ui_managing-users-groups-hosts#disabling-user-accounts-in-the-web-ui_managing-user-accounts-using-the-idm-web-ui"
+    },
+    {
+      "name": "Enabling user accounts in the Web UI",
+      "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_idm_users_groups_hosts_and_access_control_rules/managing-user-accounts-using-the-idm-web-ui_managing-users-groups-hosts#enabling-user-accounts-in-the-web-ui_managing-user-accounts-using-the-idm-web-ui"
+    },
+    {
+      "name": "Deleting users in the IdM Web UI",
+      "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_idm_users_groups_hosts_and_access_control_rules/managing-user-accounts-using-the-idm-web-ui_managing-users-groups-hosts#deleting-users-in-the-idm-web-ui_managing-user-accounts-using-the-idm-web-ui"
+    },
+    {
+      "name": "Rebuilding automatic membership",
+      "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/managing_idm_users_groups_hosts_and_access_control_rules/index#applying-automember-rules-to-existing-entries-using-idm-web-ui_automating-group-membership-using-idm-web-ui"
+    }
+  ]
+}

--- a/src/components/ContextualHelpPanel/ContextualHelpPanel.tsx
+++ b/src/components/ContextualHelpPanel/ContextualHelpPanel.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+// PatternFly
+import {
+  Drawer,
+  DrawerActions,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerContentBody,
+  DrawerHead,
+  DrawerPanelBody,
+  DrawerPanelContent,
+  List,
+  ListItem,
+} from "@patternfly/react-core";
+// JSON
+import DocumentationLinks from "src/assets/documentation/documentation-links.json";
+// Icons
+import ExternalLinkAltIcon from "@patternfly/react-icons/dist/esm/icons/external-link-alt-icon";
+// Components
+import TextLayout from "../layouts/TextLayout";
+
+export interface DocLink {
+  name: string;
+  url: string;
+}
+
+interface ContextualHelpPanelProps {
+  fromPage: string;
+  isExpanded: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+const ContextualHelpPanel = (props: ContextualHelpPanelProps) => {
+  // URLs from JSON
+  const [urlList, setUrlList] = React.useState<DocLink[]>([]);
+
+  React.useEffect(() => {
+    const urlList: DocLink[] = [];
+    switch (props.fromPage) {
+      case "active-users":
+        DocumentationLinks["active-users"].map((entry) => {
+          urlList.push({
+            name: entry.name,
+            url: entry.url,
+          });
+        });
+        setUrlList(urlList);
+        break;
+      // TODO: Add rest of the cases for the links data (based on key)
+      default:
+        setUrlList([]);
+        break;
+    }
+  }, []);
+
+  const drawerRef = React.useRef<HTMLDivElement>(null);
+
+  const onExpand = () => {
+    drawerRef.current && drawerRef.current.focus();
+  };
+
+  const listOfDocLinks = urlList.map((linkEntry, idx) => {
+    return (
+      <ListItem key={"link-" + idx} icon={<ExternalLinkAltIcon />}>
+        <a href={linkEntry.url} target="_blank" rel="noreferrer">
+          {linkEntry.name}
+        </a>
+      </ListItem>
+    );
+  });
+
+  const panelContent = (
+    <DrawerPanelContent>
+      <DrawerHead id="contextual-help-panel-header">
+        <span tabIndex={props.isExpanded ? 0 : -1} ref={drawerRef}>
+          <TextLayout component="h2">Links</TextLayout>
+        </span>
+        <DrawerActions>
+          <DrawerCloseButton onClick={props.onClose} />
+        </DrawerActions>
+        <DrawerPanelBody id="contextual-help-panel-body">
+          <List isPlain>{listOfDocLinks}</List>
+        </DrawerPanelBody>
+      </DrawerHead>
+    </DrawerPanelContent>
+  );
+
+  return (
+    <Drawer
+      isExpanded={props.isExpanded}
+      onExpand={onExpand}
+      id="contextual-help-panel"
+    >
+      <DrawerContent panelContent={panelContent}>
+        <DrawerContentBody>{props.children}</DrawerContentBody>
+      </DrawerContent>
+    </Drawer>
+  );
+};
+
+export default ContextualHelpPanel;

--- a/src/components/UsersSections/UserSettings.tsx
+++ b/src/components/UsersSections/UserSettings.tsx
@@ -3,15 +3,12 @@ import React, { useState } from "react";
 import {
   JumpLinks,
   JumpLinksItem,
-  TextVariants,
   Flex,
   Sidebar,
   SidebarPanel,
   SidebarContent,
   DropdownItem,
 } from "@patternfly/react-core";
-// Icons
-import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
 // Data types
 import {
   Metadata,
@@ -440,16 +437,7 @@ const UserSettings = (props: PropsToUserSettings) => {
       <alerts.ManagedAlerts />
       <Sidebar isPanelRight>
         <SidebarPanel variant="sticky">
-          <HelpTextWithIconLayout
-            textComponent={TextVariants.p}
-            textClassName="pf-v5-u-mb-md"
-            subTextComponent={TextVariants.a}
-            subTextIsVisitedLink={true}
-            textContent="Help"
-            icon={
-              <OutlinedQuestionCircleIcon className="pf-v5-u-primary-color-100 pf-v5-u-mr-sm" />
-            }
-          />
+          <HelpTextWithIconLayout textContent="Help" />
           <JumpLinks
             isVertical
             label="Jump to section"

--- a/src/components/layouts/HelpTextWithIconLayout.tsx
+++ b/src/components/layouts/HelpTextWithIconLayout.tsx
@@ -1,74 +1,24 @@
 import React from "react";
-import { TextContent, Text } from "@patternfly/react-core";
+// PatternFly
+import { Button } from "@patternfly/react-core";
+// Icons
+import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
 
 interface PropsToHelpTextLayout {
-  // TextContent
-  textContentClassName?: string;
-  // Text 1
-  textComponent:
-    | "h1"
-    | "h2"
-    | "h3"
-    | "h4"
-    | "h5"
-    | "h6"
-    | "p"
-    | "a"
-    | "small"
-    | "blockquote"
-    | "pre";
-  textClassName?: string;
-  textIsVisitedLink?: boolean | undefined;
-  textLinkUrl?: string | undefined;
-  textOuiaId?: number | string;
-  textOuiaSafe?: boolean;
-  // Text 2
-  subTextComponent:
-    | "h1"
-    | "h2"
-    | "h3"
-    | "h4"
-    | "h5"
-    | "h6"
-    | "p"
-    | "a"
-    | "small"
-    | "blockquote"
-    | "pre";
-  subTextClassName?: string;
-  subTextIsVisitedLink?: boolean | undefined;
-  subTextLinkUrl?: string | undefined;
-  subTextOuiaId?: number | string;
-  subTextOuiaSafe?: boolean;
-  // Children
   textContent: string;
-  icon: JSX.Element;
+  icon?: JSX.Element;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
 }
 
 const HelpTextWithIconLayout = (props: PropsToHelpTextLayout) => {
   return (
-    <TextContent>
-      <Text
-        component={props.textComponent}
-        className={props.textClassName}
-        isVisitedLink={props.textIsVisitedLink}
-        href={props.textLinkUrl}
-        ouiaId={props.textOuiaId}
-        ouiaSafe={props.textOuiaSafe}
-      >
-        {props.icon}
-        <Text
-          component={props.subTextComponent}
-          className={props.subTextClassName}
-          isVisitedLink={props.subTextIsVisitedLink}
-          href={props.subTextLinkUrl}
-          ouiaId={props.subTextOuiaId}
-          ouiaSafe={props.subTextOuiaSafe}
-        >
-          {props.textContent}
-        </Text>
-      </Text>
-    </TextContent>
+    <Button
+      variant="link"
+      icon={props.icon || <OutlinedQuestionCircleIcon />}
+      onClick={props.onClick}
+    >
+      {props.textContent}
+    </Button>
   );
 };
 

--- a/src/components/layouts/SidebarLayout.tsx
+++ b/src/components/layouts/SidebarLayout.tsx
@@ -6,11 +6,8 @@ import {
   Sidebar,
   SidebarContent,
   SidebarPanel,
-  TextVariants,
 } from "@patternfly/react-core";
 import HelpTextWithIconLayout from "./HelpTextWithIconLayout";
-// Icons
-import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
 
 interface SidebarLayoutProps {
   itemNames: string[];
@@ -28,16 +25,7 @@ const SidebarLayout = (props: SidebarLayoutProps) => {
     <>
       <Sidebar isPanelRight>
         <SidebarPanel variant="sticky">
-          <HelpTextWithIconLayout
-            textComponent={TextVariants.p}
-            textClassName="pf-v5-u-mb-md"
-            subTextComponent={TextVariants.a}
-            subTextIsVisitedLink={true}
-            textContent="Help"
-            icon={
-              <OutlinedQuestionCircleIcon className="pf-v5-u-primary-color-100 pf-v5-u-mr-sm" />
-            }
-          />
+          <HelpTextWithIconLayout textContent="Help" />
           <JumpLinks
             isVertical
             label="Jump to section"

--- a/src/pages/ActiveUsers/ActiveUsers.tsx
+++ b/src/pages/ActiveUsers/ActiveUsers.tsx
@@ -33,6 +33,7 @@ import UsersTable from "../../components/tables/UsersTable";
 // Components
 import PaginationLayout from "../../components/layouts/PaginationLayout";
 import BulkSelectorPrep from "src/components/BulkSelectorPrep";
+import ContextualHelpPanel from "src/components/ContextualHelpPanel/ContextualHelpPanel";
 // Modals
 import AddUser from "src/components/modals/UserModals/AddUser";
 import DeleteUsers from "src/components/modals/UserModals/DeleteUsers";
@@ -595,6 +596,18 @@ const ActiveUsers = () => {
     submitSearchValue,
   };
 
+  // Contextual links panel
+  const [isContextualPanelExpanded, setIsContextualPanelExpanded] =
+    React.useState(false);
+
+  const onOpenContextualPanel = () => {
+    setIsContextualPanelExpanded(!isContextualPanelExpanded);
+  };
+
+  const onCloseContextualPanel = () => {
+    setIsContextualPanelExpanded(false);
+  };
+
   // List of Toolbar items
   const toolbarItems: ToolbarItem[] = [
     {
@@ -700,7 +713,12 @@ const ActiveUsers = () => {
     },
     {
       key: 10,
-      element: <HelpTextWithIconLayout textContent="Help" />,
+      element: (
+        <HelpTextWithIconLayout
+          textContent="Help"
+          onClick={onOpenContextualPanel}
+        />
+      ),
     },
     {
       key: 11,
@@ -718,94 +736,100 @@ const ActiveUsers = () => {
 
   // Render 'Active users'
   return (
-    <Page>
-      <alerts.ManagedAlerts />
-      <PageSection variant={PageSectionVariants.light}>
-        <TitleLayout
-          id="active users title"
-          headingLevel="h1"
-          text="Active Users"
+    <ContextualHelpPanel
+      fromPage="active-users"
+      isExpanded={isContextualPanelExpanded}
+      onClose={onCloseContextualPanel}
+    >
+      <Page>
+        <alerts.ManagedAlerts />
+        <PageSection variant={PageSectionVariants.light}>
+          <TitleLayout
+            id="active users title"
+            headingLevel="h1"
+            text="Active Users"
+          />
+        </PageSection>
+        <PageSection
+          variant={PageSectionVariants.light}
+          isFilled={false}
+          className="pf-v5-u-m-lg pf-v5-u-pb-md pf-v5-u-pl-0 pf-v5-u-pr-0"
+        >
+          <ToolbarLayout
+            className="pf-v5-u-pt-0 pf-v5-u-pl-lg pf-v5-u-pr-md"
+            contentClassName="pf-v5-u-p-0"
+            toolbarItems={toolbarItems}
+          />
+          <div style={{ height: `calc(100vh - 352.2px)` }}>
+            <OuterScrollContainer>
+              <InnerScrollContainer>
+                {batchError !== undefined && batchError ? (
+                  <GlobalErrors errors={globalErrors.getAll()} />
+                ) : (
+                  <UsersTable
+                    shownElementsList={activeUsersList}
+                    from="active-users"
+                    showTableRows={showTableRows}
+                    usersData={usersTableData}
+                    buttonsData={usersTableButtonsData}
+                    paginationData={selectedPerPageData}
+                    searchValue={searchValue}
+                  />
+                )}
+              </InnerScrollContainer>
+            </OuterScrollContainer>
+          </div>
+          <PaginationLayout
+            list={activeUsersList}
+            paginationData={paginationData}
+            variant={PaginationVariant.bottom}
+            widgetId="pagination-options-menu-bottom"
+            className="pf-v5-u-pb-0 pf-v5-u-pr-md"
+          />
+        </PageSection>
+        <AddUser
+          show={showAddModal}
+          from="active-users"
+          handleModalToggle={onAddModalToggle}
+          onOpenAddModal={onAddClickHandler}
+          onCloseAddModal={onCloseAddModal}
+          onRefresh={refreshUsersData}
         />
-      </PageSection>
-      <PageSection
-        variant={PageSectionVariants.light}
-        isFilled={false}
-        className="pf-v5-u-m-lg pf-v5-u-pb-md pf-v5-u-pl-0 pf-v5-u-pr-0"
-      >
-        <ToolbarLayout
-          className="pf-v5-u-pt-0 pf-v5-u-pl-lg pf-v5-u-pr-md"
-          contentClassName="pf-v5-u-p-0"
-          toolbarItems={toolbarItems}
+        <DeleteUsers
+          show={showDeleteModal}
+          from="active-users"
+          handleModalToggle={onDeleteModalToggle}
+          selectedUsersData={selectedUsersData}
+          buttonsData={deleteUsersButtonsData}
+          onRefresh={refreshUsersData}
+          onCloseDeleteModal={onCloseDeleteModal}
+          onOpenDeleteModal={onOpenDeleteModal}
         />
-        <div style={{ height: `calc(100vh - 352.2px)` }}>
-          <OuterScrollContainer>
-            <InnerScrollContainer>
-              {batchError !== undefined && batchError ? (
-                <GlobalErrors errors={globalErrors.getAll()} />
-              ) : (
-                <UsersTable
-                  shownElementsList={activeUsersList}
-                  from="active-users"
-                  showTableRows={showTableRows}
-                  usersData={usersTableData}
-                  buttonsData={usersTableButtonsData}
-                  paginationData={selectedPerPageData}
-                  searchValue={searchValue}
-                />
-              )}
-            </InnerScrollContainer>
-          </OuterScrollContainer>
-        </div>
-        <PaginationLayout
-          list={activeUsersList}
-          paginationData={paginationData}
-          variant={PaginationVariant.bottom}
-          widgetId="pagination-options-menu-bottom"
-          className="pf-v5-u-pb-0 pf-v5-u-pr-md"
+        <DisableEnableUsers
+          show={showEnableDisableModal}
+          from="active-users"
+          handleModalToggle={onEnableDisableModalToggle}
+          optionSelected={enableDisableOptionSelected}
+          selectedUsersData={selectedUsersData}
+          buttonsData={disableEnableButtonsData}
+          onRefresh={refreshUsersData}
         />
-      </PageSection>
-      <AddUser
-        show={showAddModal}
-        from="active-users"
-        handleModalToggle={onAddModalToggle}
-        onOpenAddModal={onAddClickHandler}
-        onCloseAddModal={onCloseAddModal}
-        onRefresh={refreshUsersData}
-      />
-      <DeleteUsers
-        show={showDeleteModal}
-        from="active-users"
-        handleModalToggle={onDeleteModalToggle}
-        selectedUsersData={selectedUsersData}
-        buttonsData={deleteUsersButtonsData}
-        onRefresh={refreshUsersData}
-        onCloseDeleteModal={onCloseDeleteModal}
-        onOpenDeleteModal={onOpenDeleteModal}
-      />
-      <DisableEnableUsers
-        show={showEnableDisableModal}
-        from="active-users"
-        handleModalToggle={onEnableDisableModalToggle}
-        optionSelected={enableDisableOptionSelected}
-        selectedUsersData={selectedUsersData}
-        buttonsData={disableEnableButtonsData}
-        onRefresh={refreshUsersData}
-      />
-      <ModalErrors errors={modalErrors.getAll()} />
-      {isMembershipModalOpen && (
-        <ModalWithFormLayout
-          variantType="medium"
-          modalPosition="top"
-          offPosition="76px"
-          title="Confirmation"
-          formId="rebuild-auto-membership-modal"
-          fields={confirmationQuestion}
-          show={isMembershipModalOpen}
-          onClose={() => setIsMembershipModalOpen(!isMembershipModalOpen)}
-          actions={membershipModalActions}
-        />
-      )}
-    </Page>
+        <ModalErrors errors={modalErrors.getAll()} />
+        {isMembershipModalOpen && (
+          <ModalWithFormLayout
+            variantType="medium"
+            modalPosition="top"
+            offPosition="76px"
+            title="Confirmation"
+            formId="rebuild-auto-membership-modal"
+            fields={confirmationQuestion}
+            show={isMembershipModalOpen}
+            onClose={() => setIsMembershipModalOpen(!isMembershipModalOpen)}
+            actions={membershipModalActions}
+          />
+        )}
+      </Page>
+    </ContextualHelpPanel>
   );
 };
 

--- a/src/pages/ActiveUsers/ActiveUsers.tsx
+++ b/src/pages/ActiveUsers/ActiveUsers.tsx
@@ -4,7 +4,6 @@ import {
   Page,
   PageSection,
   PageSectionVariants,
-  TextVariants,
   PaginationVariant,
   Button,
   DropdownItem,
@@ -14,8 +13,6 @@ import {
   InnerScrollContainer,
   OuterScrollContainer,
 } from "@patternfly/react-table";
-// Icons
-import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
 // Data types
 import { User } from "src/utils/datatypes/globalDataTypes";
 import { ToolbarItem } from "src/components/layouts/ToolbarLayout";
@@ -703,17 +700,7 @@ const ActiveUsers = () => {
     },
     {
       key: 10,
-      element: (
-        <HelpTextWithIconLayout
-          textComponent={TextVariants.p}
-          subTextComponent={TextVariants.a}
-          subTextIsVisitedLink={true}
-          textContent="Help"
-          icon={
-            <OutlinedQuestionCircleIcon className="pf-v5-u-primary-color-100 pf-v5-u-mr-sm" />
-          }
-        />
-      ),
+      element: <HelpTextWithIconLayout textContent="Help" />,
     },
     {
       key: 11,

--- a/src/pages/Configuration/Configuration.tsx
+++ b/src/pages/Configuration/Configuration.tsx
@@ -10,12 +10,9 @@ import {
   Sidebar,
   SidebarPanel,
   SidebarContent,
-  TextVariants,
 } from "@patternfly/react-core";
 // Redux
 import { useAppSelector } from "src/store/hooks";
-// Icons
-import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
 // Layouts
 import TitleLayout from "src/components/layouts/TitleLayout";
 import SecondaryButton from "src/components/layouts/SecondaryButton";
@@ -251,16 +248,7 @@ const Configuration = () => {
         >
           <Sidebar isPanelRight>
             <SidebarPanel variant="sticky">
-              <HelpTextWithIconLayout
-                textComponent={TextVariants.p}
-                textClassName="pf-v5-u-mb-md"
-                subTextComponent={TextVariants.a}
-                subTextIsVisitedLink={true}
-                textContent="Help"
-                icon={
-                  <OutlinedQuestionCircleIcon className="pf-v5-u-primary-color-100 pf-v5-u-mr-sm" />
-                }
-              />
+              <HelpTextWithIconLayout textContent="Help" />
               <JumpLinks
                 isVertical
                 label="Jump to section"

--- a/src/pages/HBACRules/HBACRules.tsx
+++ b/src/pages/HBACRules/HBACRules.tsx
@@ -4,7 +4,6 @@ import {
   Page,
   PageSection,
   PageSectionVariants,
-  TextVariants,
   PaginationVariant,
 } from "@patternfly/react-core";
 // PatternFly table
@@ -12,8 +11,6 @@ import {
   InnerScrollContainer,
   OuterScrollContainer,
 } from "@patternfly/react-table";
-// Icons
-import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
 // Data types
 import { HBACRule } from "src/utils/datatypes/globalDataTypes";
 import { ToolbarItem } from "src/components/layouts/ToolbarLayout";
@@ -554,17 +551,7 @@ const HBACRules = () => {
     },
     {
       key: 10,
-      element: (
-        <HelpTextWithIconLayout
-          textComponent={TextVariants.p}
-          subTextComponent={TextVariants.a}
-          subTextIsVisitedLink={true}
-          textContent="Help"
-          icon={
-            <OutlinedQuestionCircleIcon className="pf-v5-u-primary-color-100 pf-v5-u-mr-sm" />
-          }
-        />
-      ),
+      element: <HelpTextWithIconLayout textContent="Help" />,
     },
     {
       key: 11,

--- a/src/pages/HBACRules/HBACRulesSettings.tsx
+++ b/src/pages/HBACRules/HBACRulesSettings.tsx
@@ -219,10 +219,6 @@ const HBACRulesSettings = (props: PropsToSettings) => {
       <Sidebar isPanelRight>
         <SidebarPanel variant="sticky">
           <HelpTextWithIconLayout
-            textComponent={TextVariants.p}
-            textClassName="pf-v5-u-mb-md"
-            subTextComponent={TextVariants.a}
-            subTextIsVisitedLink={true}
             textContent="Help"
             icon={
               <OutlinedQuestionCircleIcon className="pf-v5-u-primary-color-100 pf-v5-u-mr-sm" />

--- a/src/pages/HBACServiceGroups/HBACServiceGroups.tsx
+++ b/src/pages/HBACServiceGroups/HBACServiceGroups.tsx
@@ -4,7 +4,6 @@ import {
   Page,
   PageSection,
   PageSectionVariants,
-  TextVariants,
   PaginationVariant,
 } from "@patternfly/react-core";
 // PatternFly table
@@ -12,8 +11,6 @@ import {
   InnerScrollContainer,
   OuterScrollContainer,
 } from "@patternfly/react-table";
-// Icons
-import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
 // Data types
 import { HBACServiceGroup } from "src/utils/datatypes/globalDataTypes";
 import { ToolbarItem } from "src/components/layouts/ToolbarLayout";
@@ -485,17 +482,7 @@ const HBACServiceGroups = () => {
     },
     {
       key: 7,
-      element: (
-        <HelpTextWithIconLayout
-          textComponent={TextVariants.p}
-          subTextComponent={TextVariants.a}
-          subTextIsVisitedLink={true}
-          textContent="Help"
-          icon={
-            <OutlinedQuestionCircleIcon className="pf-v5-u-primary-color-100 pf-v5-u-mr-sm" />
-          }
-        />
-      ),
+      element: <HelpTextWithIconLayout textContent="Help" />,
     },
     {
       key: 8,

--- a/src/pages/HBACServices/HBACServices.tsx
+++ b/src/pages/HBACServices/HBACServices.tsx
@@ -4,7 +4,6 @@ import {
   Page,
   PageSection,
   PageSectionVariants,
-  TextVariants,
   PaginationVariant,
 } from "@patternfly/react-core";
 // PatternFly table
@@ -12,8 +11,6 @@ import {
   InnerScrollContainer,
   OuterScrollContainer,
 } from "@patternfly/react-table";
-// Icons
-import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
 // Data types
 import { HBACService } from "src/utils/datatypes/globalDataTypes";
 import { ToolbarItem } from "src/components/layouts/ToolbarLayout";
@@ -481,17 +478,7 @@ const HBACServices = () => {
     },
     {
       key: 7,
-      element: (
-        <HelpTextWithIconLayout
-          textComponent={TextVariants.p}
-          subTextComponent={TextVariants.a}
-          subTextIsVisitedLink={true}
-          textContent="Help"
-          icon={
-            <OutlinedQuestionCircleIcon className="pf-v5-u-primary-color-100 pf-v5-u-mr-sm" />
-          }
-        />
-      ),
+      element: <HelpTextWithIconLayout textContent="Help" />,
     },
     {
       key: 8,

--- a/src/pages/HostGroups/HostGroups.tsx
+++ b/src/pages/HostGroups/HostGroups.tsx
@@ -5,7 +5,6 @@ import {
   PageSection,
   PageSectionVariants,
   PaginationVariant,
-  TextVariants,
 } from "@patternfly/react-core";
 import {
   InnerScrollContainer,
@@ -44,8 +43,6 @@ import { SerializedError } from "@reduxjs/toolkit";
 import useApiError from "src/hooks/useApiError";
 import GlobalErrors from "src/components/errors/GlobalErrors";
 import ModalErrors from "src/components/errors/ModalErrors";
-// Icons
-import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
 // RPC client
 import { GenericPayload, useSearchEntriesMutation } from "../../services/rpc";
 import { useGettingHostGroupsQuery } from "../../services/rpcHostGroups";
@@ -486,17 +483,7 @@ const HostGroups = () => {
     },
     {
       key: 7,
-      element: (
-        <HelpTextWithIconLayout
-          textComponent={TextVariants.p}
-          subTextComponent={TextVariants.a}
-          subTextIsVisitedLink={true}
-          textContent="Help"
-          icon={
-            <OutlinedQuestionCircleIcon className="pf-v5-u-primary-color-100 pf-v5-u-mr-sm" />
-          }
-        />
-      ),
+      element: <HelpTextWithIconLayout textContent="Help" />,
     },
     {
       key: 8,

--- a/src/pages/Hosts/Hosts.tsx
+++ b/src/pages/Hosts/Hosts.tsx
@@ -7,7 +7,6 @@ import {
   PageSection,
   PageSectionVariants,
   PaginationVariant,
-  TextVariants,
 } from "@patternfly/react-core";
 import {
   InnerScrollContainer,
@@ -49,8 +48,6 @@ import { SerializedError } from "@reduxjs/toolkit";
 import useApiError from "src/hooks/useApiError";
 import GlobalErrors from "src/components/errors/GlobalErrors";
 import ModalErrors from "src/components/errors/ModalErrors";
-// Icons
-import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
 // RPC client
 import { GenericPayload, useSearchEntriesMutation } from "../../services/rpc";
 import {
@@ -650,17 +647,7 @@ const Hosts = () => {
     },
     {
       key: 8,
-      element: (
-        <HelpTextWithIconLayout
-          textComponent={TextVariants.p}
-          subTextComponent={TextVariants.a}
-          subTextIsVisitedLink={true}
-          textContent="Help"
-          icon={
-            <OutlinedQuestionCircleIcon className="pf-v5-u-primary-color-100 pf-v5-u-mr-sm" />
-          }
-        />
-      ),
+      element: <HelpTextWithIconLayout textContent="Help" />,
     },
     {
       key: 9,

--- a/src/pages/Hosts/HostsSettings.tsx
+++ b/src/pages/Hosts/HostsSettings.tsx
@@ -9,10 +9,7 @@ import {
   Sidebar,
   SidebarContent,
   SidebarPanel,
-  TextVariants,
 } from "@patternfly/react-core";
-// Icons
-import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
 // Data types
 import { Host, Metadata } from "src/utils/datatypes/globalDataTypes";
 // Hooks
@@ -365,16 +362,7 @@ const HostsSettings = (props: PropsToHostsSettings) => {
       <alerts.ManagedAlerts />
       <Sidebar isPanelRight>
         <SidebarPanel variant="sticky">
-          <HelpTextWithIconLayout
-            textComponent={TextVariants.p}
-            textClassName="pf-v5-u-mb-md"
-            subTextComponent={TextVariants.a}
-            subTextIsVisitedLink={true}
-            textContent="Help"
-            icon={
-              <OutlinedQuestionCircleIcon className="pf-v5-u-primary-color-100 pf-v5-u-mr-sm" />
-            }
-          />
+          <HelpTextWithIconLayout textContent="Help" />
           <JumpLinks
             isVertical
             label="Jump to section"

--- a/src/pages/IDViews/IDViews.tsx
+++ b/src/pages/IDViews/IDViews.tsx
@@ -6,7 +6,6 @@ import {
   PageSection,
   PageSectionVariants,
   PaginationVariant,
-  TextVariants,
 } from "@patternfly/react-core";
 import {
   InnerScrollContainer,
@@ -46,8 +45,6 @@ import { SerializedError } from "@reduxjs/toolkit";
 import useApiError from "src/hooks/useApiError";
 import GlobalErrors from "src/components/errors/GlobalErrors";
 import ModalErrors from "src/components/errors/ModalErrors";
-// Icons
-import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
 // RPC client
 import {
   ErrorResult,
@@ -609,17 +606,7 @@ const IDViews = () => {
     },
     {
       key: 8,
-      element: (
-        <HelpTextWithIconLayout
-          textComponent={TextVariants.p}
-          subTextComponent={TextVariants.a}
-          subTextIsVisitedLink={true}
-          textContent="Help"
-          icon={
-            <OutlinedQuestionCircleIcon className="pf-v5-u-primary-color-100 pf-v5-u-mr-sm" />
-          }
-        />
-      ),
+      element: <HelpTextWithIconLayout textContent="Help" />,
     },
     {
       key: 9,

--- a/src/pages/IDViews/IDViewsAppliedTo.tsx
+++ b/src/pages/IDViews/IDViewsAppliedTo.tsx
@@ -12,7 +12,6 @@ import {
   PageSectionVariants,
   PaginationVariant,
   SearchInput,
-  TextVariants,
 } from "@patternfly/react-core";
 import {
   InnerScrollContainer,
@@ -41,8 +40,6 @@ import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 // Errors
 import useApiError from "src/hooks/useApiError";
 import ModalErrors from "src/components/errors/ModalErrors";
-// Icons
-import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
 // RPC client
 import { ErrorResult } from "../../services/rpc";
 import {
@@ -609,17 +606,7 @@ const IDViewsAppliedTo = (props: AppliesToProps) => {
     },
     {
       key: 7,
-      element: (
-        <HelpTextWithIconLayout
-          textComponent={TextVariants.p}
-          subTextComponent={TextVariants.a}
-          subTextIsVisitedLink={true}
-          textContent="Help"
-          icon={
-            <OutlinedQuestionCircleIcon className="pf-v5-u-primary-color-100 pf-v5-u-mr-sm" />
-          }
-        />
-      ),
+      element: <HelpTextWithIconLayout textContent="Help" />,
     },
     {
       key: 8,

--- a/src/pages/Netgroups/Netgroups.tsx
+++ b/src/pages/Netgroups/Netgroups.tsx
@@ -5,7 +5,6 @@ import {
   PageSection,
   PageSectionVariants,
   PaginationVariant,
-  TextVariants,
 } from "@patternfly/react-core";
 import {
   InnerScrollContainer,
@@ -44,8 +43,6 @@ import { SerializedError } from "@reduxjs/toolkit";
 import useApiError from "src/hooks/useApiError";
 import GlobalErrors from "src/components/errors/GlobalErrors";
 import ModalErrors from "src/components/errors/ModalErrors";
-// Icons
-import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
 // RPC client
 import { GenericPayload, useSearchEntriesMutation } from "../../services/rpc";
 import { useGettingNetgroupsQuery } from "../../services/rpcNetgroups";
@@ -476,17 +473,7 @@ const Netgroups = () => {
     },
     {
       key: 7,
-      element: (
-        <HelpTextWithIconLayout
-          textComponent={TextVariants.p}
-          subTextComponent={TextVariants.a}
-          subTextIsVisitedLink={true}
-          textContent="Help"
-          icon={
-            <OutlinedQuestionCircleIcon className="pf-v5-u-primary-color-100 pf-v5-u-mr-sm" />
-          }
-        />
-      ),
+      element: <HelpTextWithIconLayout textContent="Help" />,
     },
     {
       key: 8,

--- a/src/pages/PreservedUsers/PreservedUsers.tsx
+++ b/src/pages/PreservedUsers/PreservedUsers.tsx
@@ -5,15 +5,12 @@ import {
   PaginationVariant,
   PageSection,
   PageSectionVariants,
-  TextVariants,
 } from "@patternfly/react-core";
 // PatternFly table
 import {
   InnerScrollContainer,
   OuterScrollContainer,
 } from "@patternfly/react-table";
-// Icons
-import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
 // Data types
 import { User } from "src/utils/datatypes/globalDataTypes";
 import { ToolbarItem } from "src/components/layouts/ToolbarLayout";
@@ -500,17 +497,7 @@ const PreservedUsers = () => {
     },
     {
       key: 8,
-      element: (
-        <HelpTextWithIconLayout
-          textComponent={TextVariants.p}
-          subTextComponent={TextVariants.a}
-          subTextIsVisitedLink={true}
-          textContent="Help"
-          icon={
-            <OutlinedQuestionCircleIcon className="pf-v5-u-primary-color-100 pf-v5-u-mr-sm" />
-          }
-        />
-      ),
+      element: <HelpTextWithIconLayout textContent="Help" />,
     },
     {
       key: 9,

--- a/src/pages/Services/Services.tsx
+++ b/src/pages/Services/Services.tsx
@@ -5,7 +5,6 @@ import {
   PageSection,
   PageSectionVariants,
   PaginationVariant,
-  TextVariants,
 } from "@patternfly/react-core";
 import {
   InnerScrollContainer,
@@ -31,8 +30,6 @@ import { updateServicesList } from "../../store/Identity/services-slice";
 import { Host, Service } from "../../utils/datatypes/globalDataTypes";
 // Utils
 import { API_VERSION_BACKUP, isServiceSelectable } from "../../utils/utils";
-// Icons
-import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
 // Modals
 import AddService from "../../components/modals/AddService";
 import DeleteServices from "../../components/modals/DeleteServices";
@@ -512,17 +509,7 @@ const Services = () => {
     },
     {
       key: 7,
-      element: (
-        <HelpTextWithIconLayout
-          textComponent={TextVariants.p}
-          subTextComponent={TextVariants.a}
-          subTextIsVisitedLink={true}
-          textContent="Help"
-          icon={
-            <OutlinedQuestionCircleIcon className="pf-v5-u-primary-color-100 pf-v5-u-mr-sm" />
-          }
-        />
-      ),
+      element: <HelpTextWithIconLayout textContent="Help" />,
     },
     {
       key: 8,

--- a/src/pages/Services/ServicesSettings.tsx
+++ b/src/pages/Services/ServicesSettings.tsx
@@ -9,10 +9,7 @@ import {
   Sidebar,
   SidebarContent,
   SidebarPanel,
-  TextVariants,
 } from "@patternfly/react-core";
-// Icons
-import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
 // Data types
 import { Metadata, Service } from "src/utils/datatypes/globalDataTypes";
 // Modals
@@ -266,16 +263,7 @@ const ServicesSettings = (props: PropsToServicesSettings) => {
       <alerts.ManagedAlerts />
       <Sidebar isPanelRight className="pf-v5-u-mt-lg">
         <SidebarPanel variant="sticky">
-          <HelpTextWithIconLayout
-            textComponent={TextVariants.p}
-            textClassName="pf-v5-u-mb-md"
-            subTextComponent={TextVariants.a}
-            subTextIsVisitedLink={true}
-            textContent="Help"
-            icon={
-              <OutlinedQuestionCircleIcon className="pf-v5-u-primary-color-100 pf-v5-u-mr-sm" />
-            }
-          />
+          <HelpTextWithIconLayout textContent="Help" />
           <JumpLinks
             isVertical
             label="Jump to section"

--- a/src/pages/StageUsers/StageUsers.tsx
+++ b/src/pages/StageUsers/StageUsers.tsx
@@ -4,7 +4,6 @@ import {
   Page,
   PageSection,
   PageSectionVariants,
-  TextVariants,
   PaginationVariant,
 } from "@patternfly/react-core";
 // PatternFly table
@@ -12,8 +11,6 @@ import {
   InnerScrollContainer,
   OuterScrollContainer,
 } from "@patternfly/react-table";
-// Icons
-import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
 // Data types
 import { User } from "src/utils/datatypes/globalDataTypes";
 import { ToolbarItem } from "src/components/layouts/ToolbarLayout";
@@ -504,17 +501,7 @@ const StageUsers = () => {
     },
     {
       key: 8,
-      element: (
-        <HelpTextWithIconLayout
-          textComponent={TextVariants.p}
-          subTextComponent={TextVariants.a}
-          subTextIsVisitedLink={true}
-          textContent="Help"
-          icon={
-            <OutlinedQuestionCircleIcon className="pf-v5-u-primary-color-100 pf-v5-u-mr-sm" />
-          }
-        />
-      ),
+      element: <HelpTextWithIconLayout textContent="Help" />,
     },
     {
       key: 9,

--- a/src/pages/SudoCmdGroups/SudoCmdGroups.tsx
+++ b/src/pages/SudoCmdGroups/SudoCmdGroups.tsx
@@ -4,7 +4,6 @@ import {
   Page,
   PageSection,
   PageSectionVariants,
-  TextVariants,
   PaginationVariant,
 } from "@patternfly/react-core";
 // PatternFly table
@@ -12,8 +11,6 @@ import {
   InnerScrollContainer,
   OuterScrollContainer,
 } from "@patternfly/react-table";
-// Icons
-import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
 // Data types
 import { SudoCmdGroup } from "src/utils/datatypes/globalDataTypes";
 import { ToolbarItem } from "src/components/layouts/ToolbarLayout";
@@ -474,17 +471,7 @@ const SudoCmds = () => {
     },
     {
       key: 7,
-      element: (
-        <HelpTextWithIconLayout
-          textComponent={TextVariants.p}
-          subTextComponent={TextVariants.a}
-          subTextIsVisitedLink={true}
-          textContent="Help"
-          icon={
-            <OutlinedQuestionCircleIcon className="pf-v5-u-primary-color-100 pf-v5-u-mr-sm" />
-          }
-        />
-      ),
+      element: <HelpTextWithIconLayout textContent="Help" />,
     },
     {
       key: 8,

--- a/src/pages/SudoCmds/SudoCmds.tsx
+++ b/src/pages/SudoCmds/SudoCmds.tsx
@@ -4,7 +4,6 @@ import {
   Page,
   PageSection,
   PageSectionVariants,
-  TextVariants,
   PaginationVariant,
 } from "@patternfly/react-core";
 // PatternFly table
@@ -12,8 +11,6 @@ import {
   InnerScrollContainer,
   OuterScrollContainer,
 } from "@patternfly/react-table";
-// Icons
-import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
 // Data types
 import { SudoCmd } from "src/utils/datatypes/globalDataTypes";
 import { ToolbarItem } from "src/components/layouts/ToolbarLayout";
@@ -475,17 +472,7 @@ const SudoCmds = () => {
     },
     {
       key: 7,
-      element: (
-        <HelpTextWithIconLayout
-          textComponent={TextVariants.p}
-          subTextComponent={TextVariants.a}
-          subTextIsVisitedLink={true}
-          textContent="Help"
-          icon={
-            <OutlinedQuestionCircleIcon className="pf-v5-u-primary-color-100 pf-v5-u-mr-sm" />
-          }
-        />
-      ),
+      element: <HelpTextWithIconLayout textContent="Help" />,
     },
     {
       key: 8,

--- a/src/pages/SudoRules/SudoRules.tsx
+++ b/src/pages/SudoRules/SudoRules.tsx
@@ -4,7 +4,6 @@ import {
   Page,
   PageSection,
   PageSectionVariants,
-  TextVariants,
   PaginationVariant,
 } from "@patternfly/react-core";
 // PatternFly table
@@ -12,8 +11,6 @@ import {
   InnerScrollContainer,
   OuterScrollContainer,
 } from "@patternfly/react-table";
-// Icons
-import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
 // Data types
 import { SudoRule } from "src/utils/datatypes/globalDataTypes";
 import { ToolbarItem } from "src/components/layouts/ToolbarLayout";
@@ -554,17 +551,7 @@ const SudoRules = () => {
     },
     {
       key: 10,
-      element: (
-        <HelpTextWithIconLayout
-          textComponent={TextVariants.p}
-          subTextComponent={TextVariants.a}
-          subTextIsVisitedLink={true}
-          textContent="Help"
-          icon={
-            <OutlinedQuestionCircleIcon className="pf-v5-u-primary-color-100 pf-v5-u-mr-sm" />
-          }
-        />
-      ),
+      element: <HelpTextWithIconLayout textContent="Help" />,
     },
     {
       key: 11,

--- a/src/pages/UserGroups/UserGroups.tsx
+++ b/src/pages/UserGroups/UserGroups.tsx
@@ -5,7 +5,6 @@ import {
   PageSection,
   PageSectionVariants,
   PaginationVariant,
-  TextVariants,
 } from "@patternfly/react-core";
 import {
   InnerScrollContainer,
@@ -44,8 +43,6 @@ import { SerializedError } from "@reduxjs/toolkit";
 import useApiError from "src/hooks/useApiError";
 import GlobalErrors from "src/components/errors/GlobalErrors";
 import ModalErrors from "src/components/errors/ModalErrors";
-// Icons
-import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
 // RPC client
 import { GenericPayload, useSearchEntriesMutation } from "../../services/rpc";
 import { useGettingGroupsQuery } from "../../services/rpcUserGroups";
@@ -475,17 +472,7 @@ const UserGroups = () => {
     },
     {
       key: 7,
-      element: (
-        <HelpTextWithIconLayout
-          textComponent={TextVariants.p}
-          subTextComponent={TextVariants.a}
-          subTextIsVisitedLink={true}
-          textContent="Help"
-          icon={
-            <OutlinedQuestionCircleIcon className="pf-v5-u-primary-color-100 pf-v5-u-mr-sm" />
-          }
-        />
-      ),
+      element: <HelpTextWithIconLayout textContent="Help" />,
     },
     {
       key: 8,


### PR DESCRIPTION
The contextual help links panel should be implemented using the Drawer component from PatternFly[[1](https://v5-archive.patternfly.org/components/drawer)] and added into the Active users page. This should be toggled by clicking the 'Help' button located in the main page.

First, the `HelpTextWithIcon` component has been improved and adapted to use buttons components instead of `TextContent`, thus allowing better readability and less props needed. Then, a JSON file has been created to hold all the documentation links (as a single-source of truth) that will be consumed by the `ContextualHelpPanel` component.

[1] - https://v5-archive.patternfly.org/components/drawer