### PR TITLE
Add integration test for contextual panel

### DIFF
--- a/tests/features/contextual_help_panel.feature
+++ b/tests/features/contextual_help_panel.feature
@@ -1,0 +1,22 @@
+Feature: Contextual help links panel
+  Check the contextual help links panel
+
+  Background:
+    Given I am logged in as "Administrator"
+
+  # Active users page
+  Scenario: Open the contextual help links panel on 'active-users' main page
+    Given I am on "active-users" page
+    When I click on "Help" button
+    Then I should see contextual help panel
+    And I should see a title "Links" in the panel
+    * I should see a list of links
+
+  Scenario: Close the contextual help links panel on 'Active users' main page
+    Given I am on "active-users" page
+    Given I should see contextual help panel
+    When I click on close button in the panel
+    Then I should not see contextual help panel
+
+
+

--- a/tests/features/steps/contextual_help_panel.ts
+++ b/tests/features/steps/contextual_help_panel.ts
@@ -1,0 +1,28 @@
+import { When, Then, Given } from "@badeball/cypress-cucumber-preprocessor";
+
+Given("I click the help button", () => {
+  cy.get("button").contains("Help").click();
+});
+
+Then("I should see contextual help panel", () => {
+  cy.get("div[class='pf-v5-c-drawer__panel'").should("be.visible");
+});
+
+Then("I should see a title {string} in the panel", (title: string) => {
+  cy.get("div[class='pf-v5-c-drawer__head'")
+    .find("h2")
+    .contains(title)
+    .should("be.visible");
+});
+
+Then("I should see a list of links", () => {
+  cy.get("ul").should("be.visible");
+});
+
+When("I click on close button in the panel", () => {
+  cy.get("button[aria-label='Close drawer panel']").click();
+});
+
+Then("I should not see contextual help panel", () => {
+  cy.get("div[class='pf-v5-c-drawer__panel']").should("be.hidden");
+});


### PR DESCRIPTION
The integration test should check the interactions made on the Contextual help links panel in the pages where it has been implemented (active users' main page so far).