### PR TITLE
Add contextual help panel in 'Services' > 'Settings' page

### DIFF
--- a/src/assets/documentation/documentation-links.json
+++ b/src/assets/documentation/documentation-links.json
@@ -188,5 +188,19 @@
       "name": "The IdM services",
       "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/accessing_identity_management_services/viewing-starting-and-stopping-the-ipa-server_accessing-idm-services#the-idm-services_start-stop-ipa"
     }
+  ],
+  "services-settings": [
+    {
+      "name": "Kerberos authentication indicators",
+      "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_idm_users_groups_hosts_and_access_control_rules/managing-kerberos-ticket-policies_managing-users-groups-hosts#kerberos-authentication-indicators_managing-kerberos-ticket-policies"
+    },
+    {
+      "name": "Enforcing authentication indicators for an IdM service",
+      "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_idm_users_groups_hosts_and_access_control_rules/managing-kerberos-ticket-policies_managing-users-groups-hosts#enforcing-authentication-indicators-for-an-idm-service_managing-kerberos-ticket-policies"
+    },
+    {
+      "name": "Associating authentication indicators with an IdM service using IdM Web UI",
+      "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_idm_users_groups_hosts_and_access_control_rules/managing-kerberos-ticket-policies_managing-users-groups-hosts#associating-authentication-indicators-with-an-idm-service-using-idm-web-ui_enforcing-authentication-indicators-for-an-idm-service"
+    }
   ]
 }

--- a/src/pages/Services/ServicesSettings.tsx
+++ b/src/pages/Services/ServicesSettings.tsx
@@ -55,6 +55,8 @@ interface PropsToServicesSettings {
   modifiedValues: () => Partial<Service>;
   onResetValues: () => void;
   certData: Record<string, unknown>;
+  changeFromPage: (from: string) => void;
+  onOpenContextualPanel: () => void;
 }
 
 const ServicesSettings = (props: PropsToServicesSettings) => {
@@ -64,6 +66,11 @@ const ServicesSettings = (props: PropsToServicesSettings) => {
   // API call: Save the Service
   const [saveService] = useSaveServiceMutation();
   const [executeUnprovision] = useUnprovisionServiceMutation();
+
+  // Update page to show correct links info in Contextual panel
+  React.useEffect(() => {
+    props.changeFromPage("service-settings");
+  }, [props.changeFromPage]);
 
   // Kebab
   const [isKebabOpen, setIsKebabOpen] = useState(false);
@@ -263,7 +270,10 @@ const ServicesSettings = (props: PropsToServicesSettings) => {
       <alerts.ManagedAlerts />
       <Sidebar isPanelRight className="pf-v5-u-mt-lg">
         <SidebarPanel variant="sticky">
-          <HelpTextWithIconLayout textContent="Help" />
+          <HelpTextWithIconLayout
+            textContent="Help"
+            onClick={props.onOpenContextualPanel}
+          />
           <JumpLinks
             isVertical
             label="Jump to section"

--- a/src/pages/Services/ServicesTabs.tsx
+++ b/src/pages/Services/ServicesTabs.tsx
@@ -16,6 +16,7 @@ import ServicesManagedBy from "./ServicesManagedBy";
 import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
 import TitleLayout from "src/components/layouts/TitleLayout";
 import { partialServiceToService } from "src/utils/serviceUtils";
+import ContextualHelpPanel from "src/components/ContextualHelpPanel/ContextualHelpPanel";
 // Hooks
 import { useAlerts } from "../../hooks/useAlerts";
 // Hooks
@@ -42,6 +43,29 @@ const ServicesTabs = ({ section }) => {
   const [breadcrumbItems, setBreadcrumbItems] = React.useState<
     BreadCrumbItem[]
   >([]);
+
+  // Contextual links panel
+  const [fromPageSelected, setFromPageSelected] =
+    React.useState("services-settings");
+  const [isContextualPanelExpanded, setIsContextualPanelExpanded] =
+    React.useState(false);
+
+  const changeFromPage = (fromPage: string) => {
+    setFromPageSelected(fromPage);
+  };
+
+  const onOpenContextualPanel = () => {
+    setIsContextualPanelExpanded(!isContextualPanelExpanded);
+  };
+
+  const onCloseContextualPanel = () => {
+    setIsContextualPanelExpanded(false);
+  };
+
+  // - Close links panel when tab section is changed
+  React.useEffect(() => {
+    setIsContextualPanelExpanded(false);
+  }, [section]);
 
   // Data loaded from DB
   const serviceSettingsData = useServiceSettings(decodedId as string);
@@ -114,63 +138,74 @@ const ServicesTabs = ({ section }) => {
 
   return (
     <>
-      <alerts.ManagedAlerts />
-      <PageSection variant={PageSectionVariants.light} className="pf-v5-u-pr-0">
-        <BreadCrumb
-          className="pf-v5-u-mb-md"
-          breadcrumbItems={breadcrumbItems}
-        />
-        <TitleLayout
-          id={service.krbcanonicalname}
-          preText="Service:"
-          text={service.krbcanonicalname}
-          headingLevel="h1"
-        />
-      </PageSection>
-      <PageSection type="tabs" variant={PageSectionVariants.light} isFilled>
-        <Tabs
-          activeKey={activeTabKey}
-          onSelect={handleTabClick}
-          variant="light300"
-          isBox
-          className="pf-v5-u-ml-lg"
-          mountOnEnter
-          unmountOnExit
+      <ContextualHelpPanel
+        fromPage={fromPageSelected}
+        isExpanded={isContextualPanelExpanded}
+        onClose={onCloseContextualPanel}
+      >
+        <alerts.ManagedAlerts />
+        <PageSection
+          variant={PageSectionVariants.light}
+          className="pf-v5-u-pr-0"
         >
-          <Tab
-            eventKey={"settings"}
-            name="details"
-            title={<TabTitleText>Settings</TabTitleText>}
+          <BreadCrumb
+            className="pf-v5-u-mb-md"
+            breadcrumbItems={breadcrumbItems}
+          />
+          <TitleLayout
+            id={service.krbcanonicalname}
+            preText="Service:"
+            text={service.krbcanonicalname}
+            headingLevel="h1"
+          />
+        </PageSection>
+        <PageSection type="tabs" variant={PageSectionVariants.light} isFilled>
+          <Tabs
+            activeKey={activeTabKey}
+            onSelect={handleTabClick}
+            variant="light300"
+            isBox
+            className="pf-v5-u-ml-lg"
+            mountOnEnter
+            unmountOnExit
           >
-            <ServicesSettings
-              service={service}
-              originalService={serviceSettingsData.originalService}
-              metadata={serviceSettingsData.metadata}
-              onServiceChange={serviceSettingsData.setService}
-              isDataLoading={serviceSettingsData.isLoading}
-              onRefresh={serviceSettingsData.refetch}
-              isModified={serviceSettingsData.modified}
-              onResetValues={serviceSettingsData.resetValues}
-              modifiedValues={serviceSettingsData.modifiedValues}
-              certData={certificates}
-            />
-          </Tab>
-          <Tab
-            eventKey={"memberof"}
-            name="details"
-            title={<TabTitleText>Is a member of</TabTitleText>}
-          >
-            <ServicesMemberOf service={service} tabSection={section} />
-          </Tab>
-          <Tab
-            eventKey={"managedby"}
-            name="details"
-            title={<TabTitleText>Is managed by</TabTitleText>}
-          >
-            <ServicesManagedBy service={service} />
-          </Tab>
-        </Tabs>
-      </PageSection>
+            <Tab
+              eventKey={"settings"}
+              name="details"
+              title={<TabTitleText>Settings</TabTitleText>}
+            >
+              <ServicesSettings
+                service={service}
+                originalService={serviceSettingsData.originalService}
+                metadata={serviceSettingsData.metadata}
+                onServiceChange={serviceSettingsData.setService}
+                isDataLoading={serviceSettingsData.isLoading}
+                onRefresh={serviceSettingsData.refetch}
+                isModified={serviceSettingsData.modified}
+                onResetValues={serviceSettingsData.resetValues}
+                modifiedValues={serviceSettingsData.modifiedValues}
+                certData={certificates}
+                changeFromPage={changeFromPage}
+                onOpenContextualPanel={onOpenContextualPanel}
+              />
+            </Tab>
+            <Tab
+              eventKey={"memberof"}
+              name="details"
+              title={<TabTitleText>Is a member of</TabTitleText>}
+            >
+              <ServicesMemberOf service={service} tabSection={section} />
+            </Tab>
+            <Tab
+              eventKey={"managedby"}
+              name="details"
+              title={<TabTitleText>Is managed by</TabTitleText>}
+            >
+              <ServicesManagedBy service={service} />
+            </Tab>
+          </Tabs>
+        </PageSection>
+      </ContextualHelpPanel>
     </>
   );
 };

--- a/tests/features/contextual_help_panel.feature
+++ b/tests/features/contextual_help_panel.feature
@@ -93,3 +93,13 @@ Feature: Contextual help links panel
     Given I should see contextual help panel
     When I click on close button in the panel
     Then I should not see contextual help panel
+
+  # - Services > Settings page
+  Scenario: Open and close the contextual help links panel on 'services-settings' main page
+    Given I am on "services-settings" page
+    When I click on "Help" button
+    Then I should see contextual help panel
+    And I should see a title "Links" in the panel
+    * I should see a list of links
+    When I click on close button in the panel
+    Then I should not see contextual help panel

--- a/tests/features/sudo_rules_settings.feature
+++ b/tests/features/sudo_rules_settings.feature
@@ -117,6 +117,7 @@ Feature: Sudo rules - Settings page
     * I type in the field "Host name" text "my-temp-server"
     * in the modal dialog I click on "Add" button
     * I should see "success" alert with text "New host added"
+    Then I close the alert
     Then I should see partial "my-temp-server" entry in the data table
 
   Scenario: Add a new host from the 'Sudo rules' page
@@ -150,6 +151,7 @@ Feature: Sudo rules - Settings page
     * I type in the field "Group name" text "a_host_group"
     When in the modal dialog I click on "Add" button
     * I should see "success" alert with text "New host group added"
+    Then I close the alert
     Then I should see "a_host_group" entry in the data table
 
   Scenario: Add a new host group
@@ -320,7 +322,8 @@ Feature: Sudo rules - Settings page
     And I should see "admin" entry in the data table
 
   Scenario: Remove runAs user from table
-    Given I should see "admin" entry in the data table
+    Given I am on the "sudo-rules" > "sudoRule1" Settings page
+    Given I should see "admin" entry in the data table with ID "keytab-user-table"
     When I select "admin" entry with no link in the data table
     And I click on "Delete" button
     And the "admin" element should be in the dialog table with id "remove-users-table"
@@ -343,7 +346,7 @@ Feature: Sudo rules - Settings page
     And I should see "admins" entry in the data table
 
   Scenario: Remove group of runAs users from table
-    Given I should see "admins" entry in the data table
+    Given I should see "admins" entry in the data table with ID "keytab-group-table"
     When I select "admins" entry with no link in the data table
     And I click on "Delete" button
     And the "admins" element should be in the dialog table with id "remove-groups-table"
@@ -354,6 +357,7 @@ Feature: Sudo rules - Settings page
 
   # - RunAs Groups
   Scenario: Add a new runAs group
+    Given I am on the "sudo-rules" > "sudoRule1" Settings page
     When I click on ID "add-runas-group-group" button
     Then I see a modal with title text "Add RunAs groups into sudo rule sudoRule1"
     And I click on the arrow icon to perform search
@@ -365,6 +369,7 @@ Feature: Sudo rules - Settings page
     And I should see "admins" entry in the data table with ID "keytab-group-table"
 
   Scenario: Remove runAs group from table
+    Given I am on the "sudo-rules" > "sudoRule1" Settings page
     Given I should see "admins" entry in the data table with ID "keytab-group-table"
     When I select "admins" entry with no link in the data table
     And I click on "Delete" button
@@ -375,6 +380,7 @@ Feature: Sudo rules - Settings page
     And I should not see "admins" entry in the data table with ID "keytab-group-table"
 
   Scenario: Change runAs user and group categories
+    Given I am on the "sudo-rules" > "sudoRule1" Settings page
     When I click on the "Anyone" option under ID "ipasudorunasusercategory" toggle group
     When I click on the "Any Group" option under ID "ipasudorunasgroupcategory" toggle group
     And I click on "Save" button
@@ -394,6 +400,7 @@ Feature: Sudo rules - Settings page
     * I should see partial "my-temp-server" entry in the data table
     When in the modal dialog I click on "Delete" button
     * I should see "success" alert with text "Hosts removed"
+    Then I close the alert
     Then I should not see "my-temp-server" entry in the data table
 
   # - Host group
@@ -406,6 +413,7 @@ Feature: Sudo rules - Settings page
     * I should see "a_host_group" entry in the data table
     When in the modal dialog I click on "Delete" button
     * I should see "success" alert with text "Host groups removed"
+    Then I close the alert
     Then I should not see "a_host_group" entry in the data table
 
   # - Sudo command
@@ -444,6 +452,7 @@ Feature: Sudo rules - Settings page
     * I should see "sudoRule1" entry in the data table
     * in the modal dialog I click on "Delete" button
     * I should see "success" alert with text "Sudo rules removed"
+    Then I close the alert
     Then I should not see "sudoRule1" entry in the data table
 
 


### PR DESCRIPTION
The Context Help Links Panel needs to be implemented in Services > 'Settings' page to provide help links according to the shown page.

This PR depends on this one to be merged: https://github.com/freeipa/freeipa-webui/pull/619