### PR TITLE
Automember > 'User group rules' main page

### DIFF
--- a/src/components/BulkSelectorPrep.tsx
+++ b/src/components/BulkSelectorPrep.tsx
@@ -25,6 +25,7 @@ import {
   SudoRule,
   User,
   UserGroup,
+  AutomemberEntry,
 } from "src/utils/datatypes/globalDataTypes";
 // Layouts
 import BulkSelectorLayout from "src/components/layouts/BulkSelectorLayout";
@@ -42,7 +43,8 @@ type EntryDataTypes =
   | SudoCmdGroup
   | SudoRule
   | User
-  | UserGroup;
+  | UserGroup
+  | AutomemberEntry;
 
 interface EntryData {
   selected: EntryDataTypes[];

--- a/src/components/TypeAheadSelect.tsx
+++ b/src/components/TypeAheadSelect.tsx
@@ -1,0 +1,278 @@
+import React from "react";
+// PatternFly
+import {
+  MenuToggle,
+  MenuToggleElement,
+  Select,
+  SelectList,
+  SelectOption,
+  SelectOptionProps,
+  TextInputGroup,
+  TextInputGroupMain,
+  TextInputGroupUtilities,
+} from "@patternfly/react-core";
+
+interface PropsToTypeAheadSelect {
+  id: string;
+  options: SelectOptionProps[];
+  selected: string;
+  onSelectedChange: (selected: string) => void;
+  placeholder?: string;
+}
+
+const TypeAheadSelect = (props: PropsToTypeAheadSelect) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [inputValue, setInputValue] = React.useState<string>(props.selected);
+  const [filterValue, setFilterValue] = React.useState<string>("");
+  const [selectOptions, setSelectOptions] = React.useState<SelectOptionProps[]>(
+    props.options
+  );
+  const [focusedItemIndex, setFocusedItemIndex] = React.useState<number | null>(
+    null
+  );
+  const [activeItemId, setActiveItemId] = React.useState<string | null>(null);
+  const textInputRef = React.useRef<HTMLInputElement>();
+
+  const NO_RESULTS = "no results";
+
+  // Keep options updated when the options prop changes
+  React.useEffect(() => {
+    setSelectOptions(props.options);
+  }, [props.options]);
+
+  React.useEffect(() => {
+    let newSelectOptions: SelectOptionProps[] = props.options;
+
+    // Filter menu items based on the text input value when one exists
+    if (filterValue) {
+      newSelectOptions = props.options.filter((menuItem) =>
+        String(menuItem.children)
+          .toLowerCase()
+          .includes(filterValue.toLowerCase())
+      );
+
+      // When no options are found after filtering, display 'No results found'
+      if (!newSelectOptions.length) {
+        newSelectOptions = [
+          {
+            isAriaDisabled: true,
+            children: `No results found for "${filterValue}"`,
+            value: NO_RESULTS,
+          },
+        ];
+      }
+
+      // Open the menu when the input value changes and the new value is not empty
+      if (!isOpen) {
+        setIsOpen(true);
+      }
+    }
+
+    setSelectOptions(newSelectOptions);
+  }, [filterValue]);
+
+  const createItemId = (value: string) =>
+    `select-typeahead-${value.replace(" ", "-")}`;
+
+  const setActiveAndFocusedItem = (itemIndex: number) => {
+    setFocusedItemIndex(itemIndex);
+    const focusedItem = selectOptions[itemIndex];
+    setActiveItemId(createItemId(focusedItem.value));
+  };
+
+  const resetActiveAndFocusedItem = () => {
+    setFocusedItemIndex(null);
+    setActiveItemId(null);
+  };
+
+  const closeMenu = () => {
+    setIsOpen(false);
+    resetActiveAndFocusedItem();
+  };
+
+  const onInputClick = () => {
+    if (!isOpen) {
+      setIsOpen(true);
+    } else if (!inputValue) {
+      closeMenu();
+    }
+  };
+
+  const selectOption = (value: string | number, content: string | number) => {
+    setInputValue(String(content));
+    setFilterValue("");
+    props.onSelectedChange(String(value));
+
+    closeMenu();
+  };
+
+  const onSelect = (
+    _event: React.MouseEvent<Element, MouseEvent> | undefined,
+    value: string | number | undefined
+  ) => {
+    if (value && value !== NO_RESULTS) {
+      const optionText = selectOptions.find(
+        (option) => option.value === value
+      )?.children;
+      selectOption(value, optionText as string);
+    }
+  };
+
+  const onTextInputChange = (
+    _event: React.FormEvent<HTMLInputElement>,
+    value: string
+  ) => {
+    setInputValue(value);
+    setFilterValue(value);
+
+    resetActiveAndFocusedItem();
+
+    if (value !== props.selected) {
+      props.onSelectedChange("");
+    }
+  };
+
+  const handleMenuArrowKeys = (key: string) => {
+    let indexToFocus = 0;
+
+    if (!isOpen) {
+      setIsOpen(true);
+    }
+
+    if (selectOptions.every((option) => option.isDisabled)) {
+      return;
+    }
+
+    if (key === "ArrowUp") {
+      // When no index is set or at the first index, focus to the last, otherwise decrement focus index
+      if (focusedItemIndex === null || focusedItemIndex === 0) {
+        indexToFocus = selectOptions.length - 1;
+      } else {
+        indexToFocus = focusedItemIndex - 1;
+      }
+
+      // Skip disabled options
+      while (selectOptions[indexToFocus].isDisabled) {
+        indexToFocus--;
+        if (indexToFocus === -1) {
+          indexToFocus = selectOptions.length - 1;
+        }
+      }
+    }
+
+    if (key === "ArrowDown") {
+      // When no index is set or at the last index, focus to the first, otherwise increment focus index
+      if (
+        focusedItemIndex === null ||
+        focusedItemIndex === selectOptions.length - 1
+      ) {
+        indexToFocus = 0;
+      } else {
+        indexToFocus = focusedItemIndex + 1;
+      }
+
+      // Skip disabled options
+      while (selectOptions[indexToFocus].isDisabled) {
+        indexToFocus++;
+        if (indexToFocus === selectOptions.length) {
+          indexToFocus = 0;
+        }
+      }
+    }
+
+    setActiveAndFocusedItem(indexToFocus);
+  };
+
+  const onInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    const focusedItem =
+      focusedItemIndex !== null ? selectOptions[focusedItemIndex] : null;
+
+    switch (event.key) {
+      case "Enter":
+        if (
+          isOpen &&
+          focusedItem &&
+          focusedItem.value !== NO_RESULTS &&
+          !focusedItem.isAriaDisabled
+        ) {
+          selectOption(focusedItem.value, focusedItem.children as string);
+        }
+
+        if (!isOpen) {
+          setIsOpen(true);
+        }
+
+        break;
+      case "ArrowUp":
+      case "ArrowDown":
+        event.preventDefault();
+        handleMenuArrowKeys(event.key);
+        break;
+    }
+  };
+
+  const onToggleClick = () => {
+    setIsOpen(!isOpen);
+    textInputRef?.current?.focus();
+  };
+
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      ref={toggleRef}
+      variant="typeahead"
+      aria-label="Typeahead menu toggle"
+      onClick={onToggleClick}
+      isExpanded={isOpen}
+      isFullWidth
+    >
+      <TextInputGroup isPlain>
+        <TextInputGroupMain
+          value={inputValue}
+          onClick={onInputClick}
+          onChange={onTextInputChange}
+          onKeyDown={onInputKeyDown}
+          id="typeahead-select-input"
+          autoComplete="off"
+          innerRef={textInputRef}
+          placeholder={props.placeholder || ""}
+          {...(activeItemId && { "aria-activedescendant": activeItemId })}
+          role="combobox"
+          isExpanded={isOpen}
+          aria-controls="select-typeahead-listbox"
+        />
+
+        <TextInputGroupUtilities
+          {...(!inputValue ? { style: { display: "none" } } : {})}
+        ></TextInputGroupUtilities>
+      </TextInputGroup>
+    </MenuToggle>
+  );
+
+  return (
+    <Select
+      id={props.id + "-typeahead-select"}
+      isOpen={isOpen}
+      selected={props.selected}
+      onSelect={onSelect}
+      onOpenChange={(isOpen) => {
+        !isOpen && closeMenu();
+      }}
+      toggle={toggle}
+    >
+      <SelectList id={props.id + "select-typeahead-listbox"}>
+        {selectOptions.map((option, index) => (
+          <SelectOption
+            key={option.value || option.children}
+            isFocused={focusedItemIndex === index}
+            className={option.className}
+            id={createItemId(option.value)}
+            {...option}
+            ref={null}
+          />
+        ))}
+      </SelectList>
+    </Select>
+  );
+};
+
+export default TypeAheadSelect;

--- a/src/hooks/useUserGroupsRules.tsx
+++ b/src/hooks/useUserGroupsRules.tsx
@@ -1,0 +1,125 @@
+import React from "react";
+import { useGetGenericListQuery } from "src/services/rpc";
+// RPC
+import {
+  useDefaultGroupShowQuery,
+  useAutomemberFindBasicInfoQuery,
+} from "src/services/rpcAutomember";
+// Error types
+import { SerializedError } from "@reduxjs/toolkit";
+import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
+// Data types
+import {
+  AutomemberEntry,
+  groupType,
+} from "src/utils/datatypes/globalDataTypes";
+
+type UserGroupsRulesData = {
+  isLoading: boolean;
+  isFetching: boolean;
+  automembersIds: AutomemberEntry[];
+  userGroups: string[];
+  defaultGroup: string;
+  refetch: () => void;
+  errors?: Array<FetchBaseQueryError | SerializedError>;
+};
+
+const useUserGroupsRulesData = (): UserGroupsRulesData => {
+  // States
+  const [userGroups, setUserGroups] = React.useState<string[]>([]);
+  const [automemberIdsList, setAutomemberIdsList] = React.useState<
+    AutomemberEntry[]
+  >([]);
+  const [defaultUserGroup, setDefaultUserGroup] = React.useState<string>("");
+  const [userGroupsGeneralData, setUserGroupsGeneralData] = React.useState<
+    groupType[]
+  >([]);
+  const [error, setError] = React.useState<
+    Array<FetchBaseQueryError | SerializedError>
+  >([]);
+
+  // API call: Get all user groups
+  const userGroupsQuery = useGetGenericListQuery("group");
+  const userGroupsError = userGroupsQuery.error;
+  const userGroupsData =
+    (userGroupsQuery.data?.result.result as unknown as groupType[]) || [];
+  const userGroupsLoading = userGroupsQuery.isLoading;
+
+  React.useEffect(() => {
+    if (userGroupsData && !userGroupsQuery.isFetching) {
+      setUserGroupsGeneralData(userGroupsData);
+      const userGroups: string[] = [];
+      userGroupsData.map((group) => {
+        userGroups.push(group.cn.toString());
+      });
+      setUserGroups(userGroups);
+    }
+  }, [userGroupsData, userGroupsQuery.isFetching]);
+
+  React.useEffect(() => {
+    if (userGroupsError) {
+      const errorsUpdated = [...error];
+      errorsUpdated.push(userGroupsError);
+      setError(errorsUpdated);
+    }
+  }, [userGroupsError]);
+
+  // API call: Get all automembers
+  const automembersQuery = useAutomemberFindBasicInfoQuery("group");
+  const automembersError = automembersQuery.error;
+  const automembersList = automembersQuery.data || [];
+  const automembersLoading = automembersQuery.isLoading;
+
+  React.useEffect(() => {
+    if (automembersList.length > 0 && !automembersQuery.isFetching) {
+      setAutomemberIdsList(automembersList);
+    }
+  }, [automembersList, automembersQuery.isFetching, userGroupsGeneralData]);
+
+  React.useEffect(() => {
+    if (automembersError) {
+      const errorsUpdated = [...error];
+      errorsUpdated.push(automembersError);
+      setError(errorsUpdated);
+    }
+  }, [automembersError]);
+
+  // API call: Get default group for automember
+  const defaultGroupQuery = useDefaultGroupShowQuery("group");
+  const defaultGroupError = defaultGroupQuery.error;
+  const defaultGroup = defaultGroupQuery.data || "";
+  const defaultGroupLoading = defaultGroupQuery.isLoading;
+
+  React.useEffect(() => {
+    if (defaultGroup && !defaultGroupQuery.isFetching) {
+      setDefaultUserGroup(defaultGroup);
+    }
+  }, [defaultGroup, defaultGroupQuery.isFetching]);
+
+  React.useEffect(() => {
+    if (defaultGroupError) {
+      const errorsUpdated = [...error];
+      errorsUpdated.push(defaultGroupError);
+      setError(errorsUpdated);
+    }
+  }, [defaultGroupError]);
+
+  // Return object with all data
+  const userGroupRulesData: UserGroupsRulesData = {
+    isLoading: userGroupsLoading || automembersLoading || defaultGroupLoading,
+    isFetching: userGroupsQuery.isFetching,
+    automembersIds: automemberIdsList,
+    userGroups: userGroups,
+    defaultGroup: defaultUserGroup,
+    refetch: () => {
+      userGroupsQuery.refetch();
+      automembersQuery.refetch();
+      defaultGroupQuery.refetch();
+    },
+    errors: error.length > 0 ? error : undefined,
+  };
+
+  return userGroupRulesData;
+};
+
+export { useUserGroupsRulesData };

--- a/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
+++ b/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
@@ -1,9 +1,528 @@
 import React from "react";
-import { EmptyPage } from "src/components/errors/PageErrors";
+// PatternFly
+import {
+  Page,
+  PageSection,
+  PageSectionVariants,
+  PaginationVariant,
+  SelectOptionProps,
+} from "@patternfly/react-core";
+// PatternFly table
+import {
+  InnerScrollContainer,
+  OuterScrollContainer,
+} from "@patternfly/react-table";
+// Data types
+import { AutomemberEntry } from "src/utils/datatypes/globalDataTypes";
+// Redux
+import { useAppSelector } from "src/store/hooks";
+// Layouts
+import TitleLayout from "src/components/layouts/TitleLayout";
+import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
+import SecondaryButton from "src/components/layouts/SecondaryButton";
+import ToolbarLayout, {
+  ToolbarItem,
+} from "src/components/layouts/ToolbarLayout";
+import SearchInputLayout from "src/components/layouts/SearchInputLayout";
+// Tables
+import MainTable from "./AutomemUserRulesTable";
+// Components
+import PaginationLayout from "../../components/layouts/PaginationLayout";
+import BulkSelectorPrep from "src/components/BulkSelectorPrep";
+import TypeAheadSelect from "src/components/TypeAheadSelect";
+import useApiError from "src/hooks/useApiError";
+import GlobalErrors from "src/components/errors/GlobalErrors";
+// RPC
+import { GenericPayload } from "src/services/rpc";
+import { useSearchUserGroupRulesEntriesMutation } from "src/services/rpcAutomember";
+// Hooks
+import { useAlerts } from "src/hooks/useAlerts";
+import useUpdateRoute from "src/hooks/useUpdateRoute";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
+import { useUserGroupsRulesData } from "src/hooks/useUserGroupsRules";
+// Utils
+import {
+  API_VERSION_BACKUP,
+  isAutomemberUserGroupSelectable,
+} from "src/utils/utils";
+// Errors
+import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
+import { SerializedError } from "@reduxjs/toolkit";
 
 // Automembership user group rules
 const AutoMemUserRules = () => {
-  return <EmptyPage />;
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  const { browserTitle } = useUpdateRoute({
+    pathname: "user-group-rules",
+  });
+
+  // Set the page title to be shown in the browser tab
+  React.useEffect(() => {
+    document.title = browserTitle;
+  }, [browserTitle]);
+
+  // Retrieve API version from environment data
+  const apiVersion = useAppSelector(
+    (state) => state.global.environment.api_version
+  ) as string;
+
+  const NO_SELECTION = "No default group selected";
+
+  const [userGroups, setUserGroups] = React.useState<string[]>([]);
+  const [automemberRules, setAutomemberRules] = React.useState<
+    AutomemberEntry[]
+  >([]);
+  const [defaultGroup, setDefaultGroup] = React.useState<string>(NO_SELECTION);
+  const [errors, setErrors] = React.useState<
+    Array<FetchBaseQueryError | SerializedError>
+  >([]);
+  // Options for the default user group selector
+  const [userGroupsOptions, setUserGroupsOptions] = React.useState<
+    SelectOptionProps[]
+  >([]);
+
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
+  // Handle API calls errors
+  const globalErrors = useApiError([]);
+
+  // URL parameters: page number, page size, search value
+  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+    useListPageSearchParams();
+
+  const [totalCount, setTotalCount] = React.useState<number>(0);
+  const [searchDisabled, setSearchIsDisabled] = React.useState<boolean>(false);
+
+  // Page indexes
+  const firstIdx = (page - 1) * perPage;
+  const lastIdx = page * perPage;
+
+  // API calls via custom hook
+  const userGroupRulesData = useUserGroupsRulesData();
+
+  // Show table rows
+  const [showTableRows, setShowTableRows] = React.useState(
+    !userGroupRulesData.isLoading
+  );
+
+  // Update table rows when the data is loaded
+  React.useEffect(() => {
+    if (showTableRows !== !userGroupRulesData.isLoading) {
+      setShowTableRows(!userGroupRulesData.isLoading);
+    }
+  }, [userGroupRulesData.isLoading]);
+
+  // Main API call
+  React.useEffect(() => {
+    if (userGroupRulesData.isFetching) {
+      setShowTableRows(false);
+    } else {
+      if (userGroupRulesData.errors && userGroupRulesData.errors.length > 0) {
+        setErrors(userGroupRulesData.errors || []);
+      } else {
+        const fullAutomemberIds: AutomemberEntry[] =
+          userGroupRulesData.automembersIds;
+        const totalAutomembersCount = fullAutomemberIds.length;
+        // Paginate data based on first and last indexes
+        const shownPaginatedRulesList: AutomemberEntry[] = [];
+        if (userGroupRulesData.automembersIds.length > 0) {
+          const pagAutomemberIds = fullAutomemberIds.slice(firstIdx, lastIdx);
+          shownPaginatedRulesList.push(...pagAutomemberIds);
+        }
+        // Update lists
+        setUserGroups(userGroupRulesData.userGroups);
+        setAutomemberRules(shownPaginatedRulesList);
+        // If no default group is set, set it as 'No selection'
+        if (defaultGroup === "") {
+          setDefaultGroup(NO_SELECTION);
+        } else {
+          setDefaultGroup(userGroupRulesData.defaultGroup);
+        }
+
+        // Set table count
+        setTotalCount(totalAutomembersCount);
+        // Show table elements
+        setShowTableRows(true);
+      }
+    }
+  }, [
+    userGroupRulesData.userGroups,
+    userGroupRulesData.automembersIds,
+    userGroupRulesData.defaultGroup,
+  ]);
+
+  // Parse user groups to be shown in the default user group selector
+  React.useEffect(() => {
+    if (userGroups.length > 0) {
+      // Add empty entry as an option
+      const groupsToSelector = [
+        {
+          value: NO_SELECTION,
+          children: NO_SELECTION,
+        },
+      ];
+
+      // Add the rest of the data from usergroups
+      const tempGroupsToSelector = userGroups.map((group) => ({
+        value: group,
+        children: group,
+      }));
+      groupsToSelector.push(...tempGroupsToSelector);
+      setUserGroupsOptions(groupsToSelector);
+    }
+  }, [userGroups]);
+
+  // If some entries' status has been updated, unselect selected rows
+  const [isDisableEnableOp, setIsDisableEnableOp] = React.useState(false);
+
+  const updateIsDisableEnableOp = (value: boolean) => {
+    setIsDisableEnableOp(value);
+  };
+
+  // Elements selected (per page)
+  //  - This will help to calculate the remaining elements on a specific page (bulk selector)
+  const [selectedPerPage, setSelectedPerPage] = React.useState<number>(0);
+
+  const updateSelectedPerPage = (selected: number) => {
+    setSelectedPerPage(selected);
+  };
+
+  // Pagination
+  const updatePage = (newPage: number) => {
+    setPage(newPage);
+  };
+
+  const updatePerPage = (newSetPerPage: number) => {
+    setPerPage(newSetPerPage);
+  };
+
+  // Automembers displayed on the first page
+  const updateShownAutomembersList = (
+    newShownAutomembersList: AutomemberEntry[]
+  ) => {
+    setAutomemberRules(newShownAutomembersList);
+  };
+
+  // Update search input valie
+  const updateSearchValue = (value: string) => {
+    setSearchValue(value);
+  };
+
+  const [selectedAutomembers, setSelectedAutomembers] = React.useState<
+    AutomemberEntry[]
+  >([]);
+
+  const clearSelectedRules = () => {
+    const emptyList: AutomemberEntry[] = [];
+    setSelectedAutomembers(emptyList);
+  };
+
+  // Refresh button handling
+  const refreshData = () => {
+    setShowTableRows(false);
+    setTotalCount(0);
+    clearSelectedRules();
+    userGroupRulesData.refetch();
+  };
+
+  const [retrieveAutomembers] = useSearchUserGroupRulesEntriesMutation({});
+
+  // Issue a search using a specific search value
+  const submitSearchValue = () => {
+    setShowTableRows(false);
+    setSearchIsDisabled(true);
+    setTotalCount(0);
+    retrieveAutomembers({
+      searchValue: searchValue,
+      sizeLimit: 0,
+      apiVersion: apiVersion || API_VERSION_BACKUP,
+      startIdx: firstIdx,
+      stopIdx: lastIdx,
+    } as GenericPayload).then((result) => {
+      if ("data" in result) {
+        const automembersListResult = result.data;
+        setTotalCount(result.data.length);
+        setAutomemberRules(automembersListResult);
+        // Show table elements
+        setShowTableRows(true);
+        setSearchIsDisabled(false);
+      }
+    });
+  };
+
+  // Always refetch data when the component is loaded.
+  // This ensures the data is always up-to-date.
+  React.useEffect(() => {
+    userGroupRulesData.refetch();
+  }, [page, perPage]);
+
+  // 'Delete' button state
+  const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
+    React.useState<boolean>(true);
+
+  const updateIsDeleteButtonDisabled = (value: boolean) => {
+    setIsDeleteButtonDisabled(value);
+  };
+
+  const [isDeletion, setIsDeletion] = React.useState(false);
+  const updateIsDeletion = (value: boolean) => {
+    setIsDeletion(value);
+  };
+
+  // Table-related shared functionality
+  // - Selectable checkboxes on table
+  const selectableAutomembersTable = automemberRules.filter(
+    isAutomemberUserGroupSelectable
+  ); // elements per Table
+
+  const updateSelectedAutomembers = (
+    automembers: AutomemberEntry[],
+    isSelected: boolean
+  ) => {
+    let newSelectedAutomembers: AutomemberEntry[] = [];
+    if (isSelected) {
+      newSelectedAutomembers = JSON.parse(JSON.stringify(selectedAutomembers));
+      for (let i = 0; i < automembers.length; i++) {
+        if (
+          selectedAutomembers.find(
+            (selectedRule) =>
+              selectedRule.automemberRule === automembers[i].automemberRule
+          )
+        ) {
+          // Already in the list
+          continue;
+        }
+        // Add rule to list
+        newSelectedAutomembers.push(automembers[i]);
+      }
+    } else {
+      // Remove rule
+      for (let i = 0; i < selectedAutomembers.length; i++) {
+        let found = false;
+        for (let ii = 0; ii < automembers.length; ii++) {
+          if (
+            selectedAutomembers[i].automemberRule ===
+            automembers[ii].automemberRule
+          ) {
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          // Keep this valid selected entry
+          newSelectedAutomembers.push(selectedAutomembers[i]);
+        }
+      }
+    }
+    setSelectedAutomembers(newSelectedAutomembers);
+    setIsDeleteButtonDisabled(newSelectedAutomembers.length === 0);
+  };
+
+  // - Helper method to set the selected entries from the table
+  const setAutomembersSelected = (
+    automember: AutomemberEntry,
+    isSelecting = true
+  ) => {
+    if (isAutomemberUserGroupSelectable(automember)) {
+      updateSelectedAutomembers([automember], isSelecting);
+    }
+  };
+
+  // Data wrappers
+  // TODO: Better separation of concerts
+  // - 'PaginationLayout'
+  const paginationData = {
+    page,
+    perPage,
+    updatePage,
+    updatePerPage,
+    updateSelectedPerPage,
+    updateShownElementsList: updateShownAutomembersList,
+    totalCount,
+  };
+
+  // - 'BulkSelectorPrep'
+  const automembersBulkSelectorData = {
+    selected: selectedAutomembers,
+    updateSelected: updateSelectedAutomembers,
+    selectableTable: selectableAutomembersTable,
+    nameAttr: "automemberRule",
+  };
+
+  const buttonsData = {
+    updateIsDeleteButtonDisabled,
+    updateIsDisableEnableOp,
+  };
+
+  const selectedPerPageData = {
+    selectedPerPage,
+    updateSelectedPerPage,
+  };
+
+  // SearchInputLayout
+  const searchValueData = {
+    searchValue,
+    updateSearchValue,
+    submitSearchValue,
+  };
+
+  // 'Table'
+  const automembersTableData = {
+    isElementSelectable: isAutomemberUserGroupSelectable,
+    selectedElements: selectedAutomembers,
+    selectableElementsTable: selectableAutomembersTable,
+    setElementsSelected: setAutomembersSelected,
+    clearSelectedElements: clearSelectedRules,
+  };
+
+  const automembersTableButtonsData = {
+    updateIsDeleteButtonDisabled,
+    isDeletion,
+    updateIsDeletion,
+    isDisableEnableOp,
+    updateIsDisableEnableOp,
+  };
+
+  // List of Toolbar items
+  const toolbarItems: ToolbarItem[] = [
+    {
+      key: 0,
+      element: (
+        <BulkSelectorPrep
+          list={automemberRules}
+          shownElementsList={automemberRules}
+          elementData={automembersBulkSelectorData}
+          buttonsData={buttonsData}
+          selectedPerPageData={selectedPerPageData}
+        />
+      ),
+    },
+    {
+      key: 1,
+      element: (
+        <SearchInputLayout
+          name="search"
+          ariaLabel="Search rules"
+          placeholder="Search"
+          searchValueData={searchValueData}
+          isDisabled={searchDisabled}
+        />
+      ),
+      toolbarItemVariant: "search-filter",
+      toolbarItemSpacer: { default: "spacerMd" },
+    },
+    {
+      key: 2,
+      element: (
+        <TypeAheadSelect
+          id="user-group"
+          options={userGroupsOptions}
+          selected={defaultGroup}
+          placeholder="Default user group"
+          onSelectedChange={setDefaultGroup}
+        />
+      ),
+    },
+    {
+      key: 3,
+      toolbarItemVariant: "separator",
+    },
+    {
+      key: 4,
+      element: (
+        <SecondaryButton
+          onClickHandler={refreshData}
+          isDisabled={!showTableRows}
+        >
+          Refresh
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 5,
+      element: (
+        <SecondaryButton isDisabled={isDeleteButtonDisabled || !showTableRows}>
+          Delete
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 6,
+      element: (
+        <SecondaryButton isDisabled={!showTableRows}>Add</SecondaryButton>
+      ),
+    },
+    {
+      key: 7,
+      toolbarItemVariant: "separator",
+    },
+    {
+      key: 8,
+      element: <HelpTextWithIconLayout textContent="Help" />,
+    },
+    {
+      key: 9,
+      element: (
+        <PaginationLayout
+          list={automemberRules}
+          paginationData={paginationData}
+          widgetId="pagination-options-menu-top"
+          isCompact={true}
+        />
+      ),
+      toolbarItemAlignment: { default: "alignRight" },
+    },
+  ];
+
+  return (
+    <Page>
+      <alerts.ManagedAlerts />
+      <PageSection variant={PageSectionVariants.light}>
+        <TitleLayout
+          id="Automember user groups title"
+          headingLevel="h1"
+          text="User group rules"
+        />
+      </PageSection>
+      <PageSection
+        variant={PageSectionVariants.light}
+        isFilled={false}
+        className="pf-v5-u-m-lg pf-v5-u-pb-md pf-v5-u-pl-0 pf-v5-u-pr-0"
+      >
+        <ToolbarLayout
+          className="pf-v5-u-pt-0 pf-v5-u-pl-lg pf-v5-u-pr-md"
+          contentClassName="pf-v5-u-p-0"
+          toolbarItems={toolbarItems}
+        />
+        <div style={{ height: `calc(100vh - 352.2px)` }}>
+          <OuterScrollContainer>
+            <InnerScrollContainer>
+              {errors !== undefined && errors.length > 0 ? (
+                <GlobalErrors errors={globalErrors.getAll()} />
+              ) : (
+                <MainTable
+                  shownElementsList={automemberRules}
+                  showTableRows={showTableRows}
+                  elementsData={automembersTableData}
+                  buttonsData={automembersTableButtonsData}
+                  paginationData={selectedPerPageData}
+                  searchValue={searchValue}
+                />
+              )}
+            </InnerScrollContainer>
+          </OuterScrollContainer>
+        </div>
+        <PaginationLayout
+          list={automemberRules}
+          paginationData={paginationData}
+          variant={PaginationVariant.bottom}
+          widgetId="pagination-options-menu-bottom"
+          className="pf-v5-u-pb-0 pf-v5-u-pr-md"
+        />
+      </PageSection>
+    </Page>
+  );
 };
 
 export default AutoMemUserRules;

--- a/src/pages/AutoMemUserRules/AutomemUserRulesTable.tsx
+++ b/src/pages/AutoMemUserRules/AutomemUserRulesTable.tsx
@@ -1,0 +1,233 @@
+import React, { useEffect, useState } from "react";
+// PatternFly
+import { Td, Th, Tr } from "@patternfly/react-table";
+// Tables
+import TableLayout from "../../components/layouts/TableLayout";
+// Layouts
+import SkeletonOnTableLayout from "../../components/layouts/Skeleton/SkeletonOnTableLayout";
+// Data types
+import { AutomemberEntry } from "src/utils/datatypes/globalDataTypes";
+
+interface ElementData {
+  isElementSelectable: (element: AutomemberEntry) => boolean;
+  selectedElements: AutomemberEntry[];
+  selectableElementsTable: AutomemberEntry[];
+  setElementsSelected: (rule: AutomemberEntry, isSelecting?: boolean) => void;
+  clearSelectedElements: () => void;
+}
+
+interface ButtonsData {
+  updateIsDeleteButtonDisabled: (value: boolean) => void;
+  isDeletion: boolean;
+  updateIsDeletion: (value: boolean) => void;
+  updateIsEnableButtonDisabled?: (value: boolean) => void;
+  updateIsDisableButtonDisabled?: (value: boolean) => void;
+  isDisableEnableOp?: boolean;
+  updateIsDisableEnableOp?: (value: boolean) => void;
+}
+
+interface PaginationData {
+  selectedPerPage: number;
+  updateSelectedPerPage: (selected: number) => void;
+}
+
+export interface PropsToTable {
+  shownElementsList: AutomemberEntry[];
+  showTableRows: boolean;
+  elementsData: ElementData;
+  buttonsData: ButtonsData;
+  paginationData: PaginationData;
+  searchValue: string;
+}
+
+const MainTable = (props: PropsToTable) => {
+  // Retrieve elements data from props
+  const shownElementsList = [...props.shownElementsList];
+
+  // Column names
+  const columnNames = {
+    automemberRule: "Automember rule",
+    description: "Description",
+  };
+
+  // When user status is updated, unselect selected rows
+  useEffect(() => {
+    if (props.buttonsData.isDisableEnableOp) {
+      props.elementsData.clearSelectedElements();
+    }
+  }, [props.buttonsData.isDisableEnableOp]);
+
+  const isElementSelected = (element: AutomemberEntry) => {
+    if (
+      props.elementsData.selectedElements.find(
+        (selectedElement) =>
+          selectedElement.automemberRule === element.automemberRule
+      )
+    ) {
+      return true;
+    } else {
+      return false;
+    }
+  };
+
+  // To allow shift+click to select/deselect multiple rows
+  const [recentSelectedRowIndex, setRecentSelectedRowIndex] = useState<
+    number | null
+  >(null);
+  const [shifting, setShifting] = useState(false);
+
+  // On selecting one single row
+  const onSelectElement = (
+    element: AutomemberEntry,
+    rowIndex: number,
+    isSelecting: boolean
+  ) => {
+    // If the element is shift + selecting the checkboxes, then all intermediate checkboxes should be selected
+    if (shifting && recentSelectedRowIndex !== null) {
+      const numberSelected = rowIndex - recentSelectedRowIndex;
+      const intermediateIndexes =
+        numberSelected > 0
+          ? Array.from(
+              new Array(numberSelected + 1),
+              (_x, i) => i + recentSelectedRowIndex
+            )
+          : Array.from(
+              new Array(Math.abs(numberSelected) + 1),
+              (_x, i) => i + rowIndex
+            );
+      intermediateIndexes.forEach((index) =>
+        props.elementsData.setElementsSelected(
+          shownElementsList[index],
+          isSelecting
+        )
+      );
+    } else {
+      props.elementsData.setElementsSelected(element, isSelecting);
+    }
+    setRecentSelectedRowIndex(rowIndex);
+
+    // Resetting 'isDisableEnableOp'
+    props.buttonsData.updateIsDeleteButtonDisabled(false);
+
+    // Update elementSelected array
+    if (isSelecting) {
+      // Increment the elements selected per page (++)
+      props.paginationData.updateSelectedPerPage(
+        props.paginationData.selectedPerPage + 1
+      );
+    } else {
+      // Decrement the elements selected per page (--)
+      props.paginationData.updateSelectedPerPage(
+        props.paginationData.selectedPerPage - 1
+      );
+    }
+  };
+
+  // Reset 'selectedElements array if a delete operation has been done
+  useEffect(() => {
+    if (props.buttonsData.isDeletion) {
+      props.elementsData.clearSelectedElements();
+      props.buttonsData.updateIsDeletion(false);
+    }
+  }, [props.buttonsData.isDeletion]);
+
+  // Enable 'Delete' button (if any element selected)
+  useEffect(() => {
+    if (props.elementsData.selectedElements.length > 0) {
+      props.buttonsData.updateIsDeleteButtonDisabled(false);
+    }
+
+    if (props.elementsData.selectedElements.length === 0) {
+      props.buttonsData.updateIsDeleteButtonDisabled(true);
+    }
+  }, [props.elementsData.selectedElements]);
+
+  // Enable 'Delete' and 'Enable|Disable' option buttons (if any element selected)
+  useEffect(() => {
+    if (props.elementsData.selectedElements.length > 0) {
+      props.buttonsData.updateIsDeleteButtonDisabled(false);
+    }
+
+    if (props.elementsData.selectedElements.length === 0) {
+      props.buttonsData.updateIsDeleteButtonDisabled(true);
+      if (
+        props.buttonsData.updateIsEnableButtonDisabled !== undefined &&
+        props.buttonsData.updateIsDisableButtonDisabled !== undefined
+      ) {
+        props.buttonsData.updateIsDisableButtonDisabled(true);
+        props.buttonsData.updateIsEnableButtonDisabled(true);
+      }
+    }
+  }, [props.elementsData.selectedElements]);
+
+  // Keyboard event
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Shift") {
+        setShifting(true);
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === "Shift") {
+        setShifting(false);
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("keyup", onKeyUp);
+
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("keyup", onKeyUp);
+    };
+  }, []);
+
+  // Defining table header and body from here to avoid passing specific names to the Table Layout
+  const header = (
+    <Tr>
+      <Th modifier="wrap"></Th>
+      <Th modifier="wrap">{columnNames.automemberRule}</Th>
+      <Th modifier="wrap">{columnNames.description}</Th>
+    </Tr>
+  );
+
+  const body = shownElementsList.map((element, rowIndex) => (
+    <Tr key={element.automemberRule} id={element.automemberRule}>
+      <Td
+        dataLabel="checkbox"
+        select={{
+          rowIndex,
+          onSelect: (_event, isSelecting) =>
+            onSelectElement(element, rowIndex, isSelecting),
+          isSelected: isElementSelected(element),
+          isDisabled: !props.elementsData.isElementSelectable(element),
+        }}
+      />
+      <Td dataLabel={columnNames.automemberRule}>{element.automemberRule}</Td>
+      <Td dataLabel={columnNames.description}>{element.description}</Td>
+    </Tr>
+  ));
+
+  const skeleton = (
+    <SkeletonOnTableLayout
+      rows={4}
+      colSpan={9}
+      screenreaderText={"Loading table rows"}
+    />
+  );
+
+  return (
+    <TableLayout
+      ariaLabel={"Automember user groups table"}
+      variant={"compact"}
+      hasBorders={true}
+      classes={"pf-v5-u-mt-md"}
+      tableId={"automember-user-groups-table"}
+      isStickyHeader={true}
+      tableHeader={header}
+      tableBody={!props.showTableRows ? skeleton : body}
+    />
+  );
+};
+
+export default MainTable;

--- a/src/services/rpc.ts
+++ b/src/services/rpc.ts
@@ -16,6 +16,7 @@ import {
   cnType,
   roleType,
   sudoCmdType,
+  automemberType,
 } from "../utils/datatypes/globalDataTypes";
 
 export interface Query {
@@ -148,7 +149,8 @@ export interface GenericPayload {
     | "sudocmdgroup"
     | "idview"
     | "idoverrideuser"
-    | "idoverridegroup";
+    | "idoverridegroup"
+    | "automember";
 }
 
 export interface GetEntriesPayload {
@@ -243,6 +245,7 @@ export const api = createApi({
     "FullConfig",
     "FullOverrideUser",
     "FullOverrideGroup",
+    "FullAutomember",
   ],
   endpoints: (build) => ({
     simpleCommand: build.query<FindRPCResponse, Command | void>({
@@ -552,6 +555,9 @@ export const api = createApi({
         } else if (entryType === "sudorule") {
           method = "sudorule_find";
           show_method = "sudorule_show";
+        } else if (entryType === "automember") {
+          method = "automember_find";
+          show_method = "automember_show";
         }
 
         // Prepare payload
@@ -605,6 +611,12 @@ export const api = createApi({
           ) {
             const groupId = responseData.result.result[i] as cnType;
             const { cn } = groupId;
+            ids.push(cn[0] as string);
+          } else if (entryType === "automember") {
+            const automemberId = responseData.result.result[
+              i
+            ] as automemberType;
+            const { cn } = automemberId;
             ids.push(cn[0] as string);
           }
         }
@@ -734,6 +746,8 @@ export const api = createApi({
           method = "sudocmd_find";
         } else if (entryType === "sudocmdgroup") {
           method = "sudocmdgroup_find";
+        } else if (entryType === "automember") {
+          method = "automember_find";
         } else {
           return {
             error: {
@@ -795,6 +809,12 @@ export const api = createApi({
             const sudoCmd = responseData.result.result[i] as sudoCmdType;
             const { sudocmd } = sudoCmd;
             ids.push(sudocmd[0] as string);
+          } else if (entryType === "automember") {
+            const automemberId = responseData.result.result[
+              i
+            ] as automemberType;
+            const { cn } = automemberId;
+            ids.push(cn[0] as string);
           }
         }
 

--- a/src/services/rpcAutomember.ts
+++ b/src/services/rpcAutomember.ts
@@ -1,0 +1,237 @@
+// RTK Query
+import {
+  api,
+  Command,
+  getCommand,
+  FindRPCResponse,
+  useGettingGenericQuery,
+  GenericPayload,
+} from "./rpc";
+import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
+// Utils
+import { API_VERSION_BACKUP } from "../utils/utils";
+// Data types
+import {
+  Automember,
+  automemberType,
+  groupType,
+  AutomemberEntry,
+} from "src/utils/datatypes/globalDataTypes";
+
+/**
+ * Automember-related endpoints: defaultGroupShow
+ *
+ * API commands:
+ * - automember_default_group_show: https://freeipa.readthedocs.io/en/latest/api/automember_default_group_show.html
+ * - automember_find: https://freeipa.readthedocs.io/en/latest/api/automember_find.html
+ */
+
+export type AutomemberFullData = {
+  automember?: Partial<Automember>;
+};
+
+export interface AutomemberShowPayload {
+  automemberNamesList: string[];
+  no_members: boolean | true;
+  version: string;
+}
+
+const extendedApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    /**
+     * Find automembers
+     * @param string Type of automember to retrieve ("group" or "hostgroup")
+     * @returns List of automember IDs
+     */
+    automemberFind: build.query<string[], string>({
+      query: (automemberType) => {
+        const params = [
+          [],
+          { type: automemberType, version: API_VERSION_BACKUP },
+        ];
+        return getCommand({
+          method: "automember_find",
+          params: params,
+        });
+      },
+      transformResponse: (response: FindRPCResponse): string[] => {
+        const automembersResult = response.result
+          .result as unknown as automemberType[];
+        const automemberIdsList: string[] = [];
+        automembersResult.map((automember) => {
+          automemberIdsList.push(automember.cn.toString());
+        });
+        return automemberIdsList;
+      },
+    }),
+    /**
+     * Find automembers basic information (cn and description) and returns it as 'AutomemberEntry' data type
+     * @param string Type of automember to retrieve ("group" or "hostgroup")
+     * @returns List of automembers ('AutomemberEntry')
+     */
+    automemberFindBasicInfo: build.query<AutomemberEntry[], string>({
+      query: (automemberType) => {
+        const params = [
+          [],
+          { type: automemberType, version: API_VERSION_BACKUP },
+        ];
+        return getCommand({
+          method: "automember_find",
+          params: params,
+        });
+      },
+      transformResponse: (response: FindRPCResponse): AutomemberEntry[] => {
+        const automembersResult = response.result
+          .result as unknown as automemberType[];
+        const automembersList: AutomemberEntry[] = [];
+        automembersResult.map((automember) => {
+          const entryInfo: AutomemberEntry = {
+            automemberRule: automember.cn.toString(),
+            description: automember.description
+              ? automember.description[0]
+              : "",
+          };
+          automembersList.push(entryInfo);
+        });
+        return automembersList;
+      },
+    }),
+    /**
+     * Get default group for automember
+     * @param string Type of automember to retrieve ("group" or "hostgroup")
+     * @returns List of default groups
+     */
+    defaultGroupShow: build.query<string, string>({
+      query: (automemberType) => {
+        const params = [
+          [],
+          { type: automemberType, version: API_VERSION_BACKUP },
+        ];
+        return getCommand({
+          method: "automember_default_group_show",
+          params: params,
+        });
+      },
+      transformResponse: (response: FindRPCResponse): string => {
+        return response.result.result.automemberdefaultgroup as string;
+      },
+    }),
+    /**
+     * Find automembers and groups.
+     * Combines the data to build the 'AutomemberEntry' data type
+     * @param GenericPayload
+     * @returns List of automember entries with 'automemberRule' and 'description'
+     *
+     */
+    searchUserGroupRulesEntries: build.mutation<
+      AutomemberEntry[],
+      GenericPayload
+    >({
+      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
+        const { searchValue, apiVersion, startIdx, stopIdx } = payloadData;
+
+        if (apiVersion === undefined) {
+          return {
+            error: {
+              status: "CUSTOM_ERROR",
+              data: "",
+              error: "API version not available",
+            } as FetchBaseQueryError,
+          };
+        }
+
+        // FETCH AUTOMEMBER IDS DATA
+        // Prepare search parameters
+        const automembersParams = {
+          type: "group",
+          version: apiVersion,
+        };
+
+        // Prepare payload
+        const payloadDataAutomembers: Command = {
+          method: "automember_find",
+          params: [[searchValue], automembersParams],
+        };
+
+        // Make call using 'fetchWithBQ'
+        const getResultAutomember = await fetchWithBQ(
+          getCommand(payloadDataAutomembers)
+        );
+        // Return possible errors
+        if (getResultAutomember.error) {
+          return { error: getResultAutomember.error as FetchBaseQueryError };
+        }
+        // If no error: cast and assign 'ids'
+        const responseDataAutomember =
+          getResultAutomember.data as FindRPCResponse;
+
+        const automemberIds: string[] = [];
+        const automembersItemsCount = responseDataAutomember.result.result
+          .length as number;
+
+        for (let i = startIdx; i < automembersItemsCount && i < stopIdx; i++) {
+          const automemberId = responseDataAutomember.result.result[
+            i
+          ] as automemberType;
+          const { cn } = automemberId;
+          automemberIds.push(cn[0] as string);
+        }
+
+        // FETCH USER GROUPS DATA
+        // Prepare search parameters
+        const groupParams = {
+          version: apiVersion,
+        };
+
+        const payloadDataGroups: Command = {
+          method: "group_find",
+          params: [[searchValue], groupParams],
+        };
+
+        // Make call using 'fetchWithBQ'
+        const getResultGroup = await fetchWithBQ(getCommand(payloadDataGroups));
+        // Return possible errors
+        if (getResultGroup.error) {
+          return { error: getResultGroup.error as FetchBaseQueryError };
+        }
+        // If no error: cast and assign 'ids'
+        const responseDataGroup = getResultGroup.data as FindRPCResponse;
+        const groupsItemsCount = responseDataGroup.result.result
+          .length as number;
+
+        // COMBINE RESULTS AND RETURN
+        const fullAutomemberIdsList: AutomemberEntry[] = [];
+        for (let i = 0; i < groupsItemsCount && i < stopIdx; i++) {
+          for (let j = 0; j < automemberIds.length; j++) {
+            const groupId = responseDataGroup.result.result[i] as groupType;
+            if (groupId.cn[0] === automemberIds[j]) {
+              fullAutomemberIdsList.push({
+                automemberRule: groupId.cn[0] as string,
+                description: groupId.description
+                  ? (groupId.description[0] as string)
+                  : "",
+              });
+            }
+          }
+        }
+
+        // Return results
+        return { data: fullAutomemberIdsList };
+      },
+    }),
+  }),
+  overrideExisting: false,
+});
+
+export const useGettingAutomembersQuery = (payloadData) => {
+  payloadData["objName"] = "automember";
+  payloadData["objAttr"] = "cn";
+  return useGettingGenericQuery(payloadData);
+};
+
+export const {
+  useAutomemberFindQuery,
+  useDefaultGroupShowQuery,
+  useSearchUserGroupRulesEntriesMutation,
+  useAutomemberFindBasicInfoQuery,
+} = extendedApi;

--- a/src/utils/automemberUtils.tsx
+++ b/src/utils/automemberUtils.tsx
@@ -1,0 +1,63 @@
+// Data types
+import { Automember } from "src/utils/datatypes/globalDataTypes";
+// Utils
+import { convertApiObj } from "./ipaObjectUtils";
+
+// Parse the 'textInputField' data into expected data type
+// - TODO: Adapt it to work with many types of data
+export const asRecord = (
+  element: Partial<Automember>,
+  onElementChange: (element: Partial<Automember>) => void
+) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ipaObject = element as Record<string, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function recordOnChange(ipaObject: Record<string, any>) {
+    onElementChange(ipaObject as Automember);
+  }
+
+  return { ipaObject, recordOnChange };
+};
+
+const simpleValues = new Set(["cn", "description", "automemberdefaultgroup"]);
+const dateValues = new Set([]);
+
+export function apiToAutomember(
+  apiRecord: Record<string, unknown>
+): Automember {
+  const converted = convertApiObj(
+    apiRecord,
+    simpleValues,
+    dateValues
+  ) as Partial<Automember>;
+  return partialAutomemberToAutomember(converted) as Automember;
+}
+
+export function partialAutomemberToAutomember(
+  partialSudoRule: Partial<Automember>
+): Automember {
+  return {
+    ...createEmptyAutomember(),
+    ...partialSudoRule,
+  };
+}
+
+// Get empty User object initialized with default values
+export function createEmptyAutomember(): Automember {
+  const automember: Automember = {
+    cn: "",
+    description: "",
+    automemberdefaultgroup: "",
+    automemberinclusiveregex: [],
+    automemberexclusiveregex: [],
+    member: [],
+    no_member: [],
+    in_memberof: [],
+    not_in_memberof: [],
+    memberindirect: [],
+    memberofindirect: [],
+    membermanager: [],
+  };
+
+  return automember;
+}

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -580,6 +580,13 @@ export interface cnType {
   cn: string[];
 }
 
+export interface groupType {
+  dn: string;
+  cn: string[];
+  description: string;
+  gidnumber: string;
+}
+
 export interface fqdnType {
   dn: string;
   fqdn: string[];
@@ -600,6 +607,13 @@ export interface sudoCmdType {
   dn: string;
   sudocmd: string;
   description: string;
+}
+
+export interface automemberType {
+  cn: string;
+  automembertargetgroup: string;
+  dn: string;
+  description?: string;
 }
 
 export interface CertProfile {
@@ -636,3 +650,23 @@ export interface SubId {
 export interface DNSZone {
   idnsname: string;
 }
+
+export interface Automember {
+  cn: string;
+  description: string;
+  automemberdefaultgroup: string;
+  automemberinclusiveregex: string[];
+  automemberexclusiveregex: string[];
+  member: string[];
+  no_member: string[];
+  in_memberof: string[];
+  not_in_memberof: string[];
+  memberindirect: string[];
+  memberofindirect: string[];
+  membermanager: string[];
+}
+
+export type AutomemberEntry = {
+  automemberRule: string;
+  description: string;
+};

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -20,6 +20,7 @@ import {
   SudoRule,
   User,
   UserGroup,
+  AutomemberEntry,
 } from "./datatypes/globalDataTypes";
 // Errors
 import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
@@ -112,6 +113,10 @@ export const isUserOverrideSelectable = (user: IDViewOverrideUser) =>
 // Determine whether a IDViewOverrideGroup is selectable or not
 export const isGroupOverrideSelectable = (user: IDViewOverrideGroup) =>
   user.ipaanchoruuid != "";
+
+// Determine whether a Automember User group is selectable or not
+export const isAutomemberUserGroupSelectable = (automember: AutomemberEntry) =>
+  automember.automemberRule != "";
 
 // Write JSX error messages into 'apiErrorsJsx' array
 export const apiErrorToJsXError = (


### PR DESCRIPTION
The Automember > 'User group rules' main page must show the automember group's data, the associated user groups, and its default group. The current solution just shows the information in table and selector. The action button's functionality will be implemented in another PR. 