### PR TITLE
Automember > 'User group rules' - Action buttons

### DIFF
--- a/src/components/TypeAheadSelect.tsx
+++ b/src/components/TypeAheadSelect.tsx
@@ -40,6 +40,11 @@ const TypeAheadSelect = (props: PropsToTypeAheadSelect) => {
     setSelectOptions(props.options);
   }, [props.options]);
 
+  // Keep the selected value updated
+  React.useEffect(() => {
+    setInputValue(props.selected);
+  }, [props.selected]);
+
   React.useEffect(() => {
     let newSelectOptions: SelectOptionProps[] = props.options;
 

--- a/src/components/modals/Automember/AddRule.tsx
+++ b/src/components/modals/Automember/AddRule.tsx
@@ -1,0 +1,252 @@
+import React from "react";
+// PatternFly
+import {
+  Button,
+  MenuToggle,
+  MenuToggleElement,
+  Select,
+  SelectOption,
+} from "@patternfly/react-core";
+// Layouts
+import SecondaryButton from "src/components/layouts/SecondaryButton";
+import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
+// Errors
+import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
+import { SerializedError } from "@reduxjs/toolkit";
+// Hooks
+import useAlerts from "src/hooks/useAlerts";
+// RPC
+import {
+  AddPayload,
+  useAddToAutomemberMutation,
+} from "src/services/rpcAutomember";
+import { useGetGenericListQuery } from "src/services/rpc";
+// Data types
+import { groupType } from "src/utils/datatypes/globalDataTypes";
+
+interface PropsToAddRule {
+  show: boolean;
+  handleModalToggle: () => void;
+  onOpenAddModal?: () => void;
+  onCloseAddModal?: () => void;
+  onRefresh?: () => void;
+  groupsAvailableToAdd: string[];
+  ruleType: string;
+}
+
+const AddRule = (props: PropsToAddRule) => {
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
+  // API calls
+  const [addRuleCommand] = useAddToAutomemberMutation();
+
+  // States
+  const [addSpinning, setAddBtnSpinning] = React.useState<boolean>(false);
+  const [addAgainSpinning, setAddAgainBtnSpinning] =
+    React.useState<boolean>(false);
+  const [groupSelected, setGroupSelected] = React.useState("");
+  const [isSelectOpen, setIsSelectOpen] = React.useState(false);
+
+  // Add button is disabled until the user fills the required fields
+  const [buttonDisabled, setButtonDisabled] = React.useState(true);
+
+  React.useEffect(() => {
+    if (groupSelected === "") {
+      setButtonDisabled(true);
+    } else {
+      setButtonDisabled(false);
+    }
+  }, [groupSelected]);
+
+  // Assign groups to selector
+  const groupsQuery = useGetGenericListQuery(props.ruleType);
+  const groupsError = groupsQuery.error;
+  const groupsData =
+    (groupsQuery.data?.result.result as unknown as groupType[]) || [];
+
+  React.useEffect(() => {
+    if (groupsData && !groupsQuery.isFetching) {
+      const groups: string[] = [];
+      groupsData.map((group) => {
+        groups.push(group.cn.toString());
+      });
+    }
+  }, [groupsData, groupsQuery.isFetching]);
+
+  // Set alery on error
+  React.useEffect(() => {
+    if (groupsError) {
+      alerts.addAlert(
+        "retrieve-groups-error",
+        "Error while retrieving groups",
+        "danger"
+      );
+    }
+  }, [groupsError]);
+
+  // Toggle
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={() => setIsSelectOpen(!isSelectOpen)}
+      className="pf-v5-u-w-100"
+    >
+      {groupSelected}
+    </MenuToggle>
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const onSelectGroup = (selection: any) => {
+    setGroupSelected(selection.target.textContent);
+    setIsSelectOpen(false);
+  };
+
+  // List of fields
+  const fields = [
+    {
+      id: "automember",
+      name: "Automember",
+      pfComponent: (
+        <Select
+          id="automember"
+          toggle={toggle}
+          onSelect={onSelectGroup}
+          selected={groupSelected}
+          isOpen={isSelectOpen}
+          aria-labelledby="automember-group-add"
+        >
+          {props.groupsAvailableToAdd.map((option, index) => (
+            <SelectOption key={index} value={option}>
+              {option}
+            </SelectOption>
+          ))}
+        </Select>
+      ),
+    },
+  ];
+
+  const cleanFields = () => {
+    setGroupSelected("");
+    setIsSelectOpen(false);
+    setAddBtnSpinning(false);
+    setAddAgainBtnSpinning(false);
+  };
+
+  // Clean fields and close modal (To prevent data persistence when reopen modal)
+  const cleanAndCloseModal = () => {
+    cleanFields();
+    props.handleModalToggle();
+  };
+
+  // Add
+  const onAdd = () => {
+    const addPayload: AddPayload = {
+      group: groupSelected,
+      type: props.ruleType,
+    };
+
+    setAddBtnSpinning(true);
+    addRuleCommand(addPayload).then((response) => {
+      if ("data" in response) {
+        const data = response.data;
+        const error = data.error as FetchBaseQueryError | SerializedError;
+
+        if (error) {
+          alerts.addAlert("add-rule-error", error, "danger");
+        } else {
+          // Set alert: success
+          alerts.addAlert(
+            "add-rule-success",
+            "Entry successfully added",
+            "success"
+          );
+          setAddBtnSpinning(true);
+
+          // Refresh table content
+          if (props.onRefresh !== undefined) props.onRefresh();
+          // Clean and close modal
+          cleanAndCloseModal();
+        }
+      }
+    });
+  };
+
+  // Add and add another
+  const onAddAndAddAnother = () => {
+    const addPayload: AddPayload = {
+      group: groupSelected,
+      type: "group",
+    };
+
+    setAddAgainBtnSpinning(true);
+    addRuleCommand(addPayload).then((response) => {
+      if ("data" in response) {
+        const data = response.data;
+        const error = data.error as FetchBaseQueryError | SerializedError;
+
+        if (error) {
+          alerts.addAlert("add-rule-error", error, "danger");
+        } else {
+          // Set alert: success
+          alerts.addAlert(
+            "add-rule-success",
+            "Entry successfully added",
+            "success"
+          );
+          setAddAgainBtnSpinning(false);
+
+          // Clean fields and refresh table
+          cleanFields();
+          props.onRefresh && props.onRefresh();
+        }
+      }
+    });
+  };
+
+  const modalActions = [
+    <SecondaryButton
+      key="add"
+      onClickHandler={onAdd}
+      isLoading={addSpinning}
+      spinnerAriaValueText="Adding"
+      spinnerAriaLabel="Adding"
+      isDisabled={buttonDisabled}
+    >
+      Add
+    </SecondaryButton>,
+    <SecondaryButton
+      key="add-another"
+      onClickHandler={onAddAndAddAnother}
+      isLoading={addAgainSpinning}
+      spinnerAriaValueText="Adding"
+      spinnerAriaLabel="Adding"
+      isDisabled={buttonDisabled}
+    >
+      Add and add another
+    </SecondaryButton>,
+    <Button key="cancel-new-rule" variant="link" onClick={cleanAndCloseModal}>
+      Cancel
+    </Button>,
+  ];
+
+  // Render component
+  return (
+    <>
+      <alerts.ManagedAlerts />
+      <ModalWithFormLayout
+        variantType="small"
+        modalPosition="top"
+        offPosition="76px"
+        title="Add rule"
+        formId="add-rule-modal"
+        fields={fields}
+        show={props.show}
+        onClose={cleanAndCloseModal}
+        actions={modalActions}
+      />
+    </>
+  );
+};
+
+export default AddRule;

--- a/src/components/modals/Automember/DeleteRule.tsx
+++ b/src/components/modals/Automember/DeleteRule.tsx
@@ -1,0 +1,167 @@
+import React from "react";
+// PatternFly
+import {
+  TextContent,
+  Text,
+  TextVariants,
+  Button,
+} from "@patternfly/react-core";
+// Layouts
+import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
+// Tables
+import DeletedElementsTable from "src/components/tables/DeletedElementsTable";
+// Hooks
+import useAlerts from "src/hooks/useAlerts";
+import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
+import { SerializedError } from "@reduxjs/toolkit";
+// Data types
+import { AutomemberEntry } from "src/utils/datatypes/globalDataTypes";
+// RPC
+import {
+  RemovePayload,
+  useDeleteFromAutomemberMutation,
+} from "src/services/rpcAutomember";
+
+interface ButtonsData {
+  updateIsDeleteButtonDisabled: (value: boolean) => void;
+  updateIsDeletion: (value: boolean) => void;
+}
+
+interface SelectedData {
+  selectedItems: AutomemberEntry[];
+  clearSelected: () => void;
+}
+
+interface PropsToDeleteRule {
+  show: boolean;
+  handleModalToggle: () => void;
+  selectedData: SelectedData;
+  buttonsData: ButtonsData;
+  onRefresh?: () => void;
+  ruleType: string;
+}
+
+const DeleteRule = (props: PropsToDeleteRule) => {
+  // Alerts
+  const alerts = useAlerts();
+
+  // RPC
+  const [deleteRuleCommand] = useDeleteFromAutomemberMutation();
+
+  // Define the column names that will be displayed on the confirmation table.
+  const deleteColumnNames = ["Automember rule", "Description"];
+
+  // States
+  const [spinning, setBtnSpinning] = React.useState<boolean>(false);
+
+  // Computed data
+  const rulesToDelete = props.selectedData.selectedItems.map((idRule) => {
+    return idRule.automemberRule;
+  });
+
+  // List of fields
+  const fields = [
+    {
+      id: "question-text",
+      pfComponent: (
+        <TextContent>
+          <Text component={TextVariants.p}>
+            Are you sure you want to remove the selected rules?
+          </Text>
+        </TextContent>
+      ),
+    },
+    {
+      id: "deleted-rules-table",
+      pfComponent: (
+        <DeletedElementsTable
+          mode="passing_id"
+          elementsToDelete={rulesToDelete}
+          columnNames={deleteColumnNames}
+          elementType="rule"
+          idAttr="automemberRule"
+        />
+      ),
+    },
+  ];
+
+  // Close modal
+  const closeModal = () => {
+    props.handleModalToggle();
+  };
+
+  // Delete
+  const onDelete = () => {
+    setBtnSpinning(true);
+
+    const deletePayload: RemovePayload = {
+      groups: rulesToDelete,
+      type: props.ruleType,
+    };
+
+    deleteRuleCommand(deletePayload).then((response) => {
+      if ("data" in response) {
+        const data = response.data;
+        const error = data.error as FetchBaseQueryError | SerializedError;
+
+        if (error) {
+          alerts.addAlert("delete-rule-error", error, "danger");
+        } else {
+          // Set alert: success
+          alerts.addAlert(
+            "delete-rule-success",
+            "The selected rules have been removed successfully",
+            "success"
+          );
+          setBtnSpinning(false);
+
+          // Refresh data
+          if (props.onRefresh !== undefined) {
+            props.onRefresh();
+          }
+
+          // Close modal
+          closeModal();
+        }
+      }
+    });
+  };
+
+  // Set the Modal and Action buttons for 'Delete' option
+  const modalActionsDelete: JSX.Element[] = [
+    <Button
+      key="delete-rules"
+      variant="danger"
+      onClick={onDelete}
+      form="delete-rules-modal"
+      spinnerAriaValueText="Deleting"
+      spinnerAriaLabel="Deleting"
+      isLoading={spinning}
+      isDisabled={spinning}
+    >
+      {spinning ? "Deleting" : "Delete"}
+    </Button>,
+    <Button key="cancel-delete-rules" variant="link" onClick={closeModal}>
+      Cancel
+    </Button>,
+  ];
+
+  return (
+    <>
+      <alerts.ManagedAlerts />
+      <ModalWithFormLayout
+        variantType="medium"
+        modalPosition="top"
+        offPosition="76px"
+        title="Remove auto membership rules"
+        formId="remove-rules-modal"
+        fields={fields}
+        show={props.show}
+        onClose={closeModal}
+        actions={modalActionsDelete}
+      />
+    </>
+  );
+};
+
+export default DeleteRule;

--- a/src/hooks/useUserGroupsRules.tsx
+++ b/src/hooks/useUserGroupsRules.tsx
@@ -71,7 +71,7 @@ const useUserGroupsRulesData = (): UserGroupsRulesData => {
   const automembersLoading = automembersQuery.isLoading;
 
   React.useEffect(() => {
-    if (automembersList.length > 0 && !automembersQuery.isFetching) {
+    if (automembersList && !automembersQuery.isFetching) {
       setAutomemberIdsList(automembersList);
     }
   }, [automembersList, automembersQuery.isFetching, userGroupsGeneralData]);

--- a/src/hooks/useUserGroupsRules.tsx
+++ b/src/hooks/useUserGroupsRules.tsx
@@ -87,14 +87,20 @@ const useUserGroupsRulesData = (): UserGroupsRulesData => {
   // API call: Get default group for automember
   const defaultGroupQuery = useDefaultGroupShowQuery("group");
   const defaultGroupError = defaultGroupQuery.error;
-  const defaultGroup = defaultGroupQuery.data || "";
+  const defaultGroupData = defaultGroupQuery.data || "";
   const defaultGroupLoading = defaultGroupQuery.isLoading;
 
   React.useEffect(() => {
-    if (defaultGroup && !defaultGroupQuery.isFetching) {
+    if (defaultGroupData && !defaultGroupQuery.isFetching) {
+      // Get from LDAP syntax. E.g: 'cn=groupname,ou=groups,dc=example,dc=com'
+      let defaultGroup = "";
+      if (defaultGroupData !== "No default (fallback) group set") {
+        const defaultSplitByComma = defaultGroupData[0].split(",")[0];
+        defaultGroup = defaultSplitByComma.replace("cn=", "");
+      }
       setDefaultUserGroup(defaultGroup);
     }
-  }, [defaultGroup, defaultGroupQuery.isFetching]);
+  }, [defaultGroupData, defaultGroupQuery.isFetching]);
 
   React.useEffect(() => {
     if (defaultGroupError) {

--- a/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
+++ b/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
@@ -48,6 +48,8 @@ import {
 // Errors
 import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
 import { SerializedError } from "@reduxjs/toolkit";
+// Modals
+import AddRule from "src/components/modals/Automember/AddRule";
 
 // Automembership user group rules
 const AutoMemUserRules = () => {
@@ -79,6 +81,10 @@ const AutoMemUserRules = () => {
   // Options for the default user group selector
   const [userGroupsOptions, setUserGroupsOptions] = React.useState<
     SelectOptionProps[]
+  >([]);
+  // Available elements ready to add
+  const [groupsAvailableToAdd, setGroupsAvailableToAdd] = React.useState<
+    string[]
   >([]);
 
   // Alerts to show in the UI
@@ -139,6 +145,15 @@ const AutoMemUserRules = () => {
         } else {
           setDefaultGroup(userGroupRulesData.defaultGroup);
         }
+
+        // Set available user groups to add (userGroupRulesData.userGroups and fullAutomemberIds)
+        const allAutomemberIds = fullAutomemberIds.map(
+          (item) => item.automemberRule
+        );
+        const availableItems = userGroupRulesData.userGroups.filter(
+          (item) => !allAutomemberIds.includes(item)
+        );
+        setGroupsAvailableToAdd(availableItems);
 
         // Set table count
         setTotalCount(totalAutomembersCount);
@@ -384,6 +399,21 @@ const AutoMemUserRules = () => {
     updateIsDisableEnableOp,
   };
 
+  // Modals functionality
+  const [showAddModal, setShowAddModal] = React.useState(false);
+
+  const onOpenAddModal = () => {
+    setShowAddModal(true);
+  };
+
+  const onCloseAddModal = () => {
+    setShowAddModal(false);
+  };
+
+  const onAddModalToggle = () => {
+    setShowAddModal(!showAddModal);
+  };
+
   // List of Toolbar items
   const toolbarItems: ToolbarItem[] = [
     {
@@ -450,7 +480,12 @@ const AutoMemUserRules = () => {
     {
       key: 6,
       element: (
-        <SecondaryButton isDisabled={!showTableRows}>Add</SecondaryButton>
+        <SecondaryButton
+          isDisabled={!showTableRows}
+          onClickHandler={onOpenAddModal}
+        >
+          Add
+        </SecondaryButton>
       ),
     },
     {
@@ -521,6 +556,15 @@ const AutoMemUserRules = () => {
           className="pf-v5-u-pb-0 pf-v5-u-pr-md"
         />
       </PageSection>
+      <AddRule
+        show={showAddModal}
+        handleModalToggle={onAddModalToggle}
+        onOpenAddModal={onOpenAddModal}
+        onCloseAddModal={onCloseAddModal}
+        onRefresh={refreshData}
+        groupsAvailableToAdd={groupsAvailableToAdd}
+        ruleType="group"
+      />
     </Page>
   );
 };

--- a/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
+++ b/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
@@ -50,6 +50,7 @@ import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
 import { SerializedError } from "@reduxjs/toolkit";
 // Modals
 import AddRule from "src/components/modals/Automember/AddRule";
+import DeleteRule from "src/components/modals/Automember/DeleteRule";
 
 // Automembership user group rules
 const AutoMemUserRules = () => {
@@ -401,6 +402,7 @@ const AutoMemUserRules = () => {
 
   // Modals functionality
   const [showAddModal, setShowAddModal] = React.useState(false);
+  const [showDeleteModal, setShowDeleteModal] = React.useState(false);
 
   const onOpenAddModal = () => {
     setShowAddModal(true);
@@ -412,6 +414,25 @@ const AutoMemUserRules = () => {
 
   const onAddModalToggle = () => {
     setShowAddModal(!showAddModal);
+  };
+
+  const onOpenDeleteModal = () => {
+    setShowDeleteModal(true);
+  };
+
+  const onToggleDeleteModal = () => {
+    setShowDeleteModal(!showDeleteModal);
+  };
+
+  // 'Delete automember rules data
+  const deleteButtonsData = {
+    updateIsDeleteButtonDisabled,
+    updateIsDeletion,
+  };
+
+  const selectedData = {
+    selectedItems: selectedAutomembers,
+    clearSelected: clearSelectedRules,
   };
 
   // List of Toolbar items
@@ -472,7 +493,10 @@ const AutoMemUserRules = () => {
     {
       key: 5,
       element: (
-        <SecondaryButton isDisabled={isDeleteButtonDisabled || !showTableRows}>
+        <SecondaryButton
+          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          onClickHandler={onOpenDeleteModal}
+        >
           Delete
         </SecondaryButton>
       ),
@@ -563,6 +587,14 @@ const AutoMemUserRules = () => {
         onCloseAddModal={onCloseAddModal}
         onRefresh={refreshData}
         groupsAvailableToAdd={groupsAvailableToAdd}
+        ruleType="group"
+      />
+      <DeleteRule
+        show={showDeleteModal}
+        handleModalToggle={onToggleDeleteModal}
+        onRefresh={refreshData}
+        buttonsData={deleteButtonsData}
+        selectedData={selectedData}
         ruleType="group"
       />
     </Page>

--- a/src/services/rpcAutomember.ts
+++ b/src/services/rpcAutomember.ts
@@ -6,6 +6,8 @@ import {
   FindRPCResponse,
   useGettingGenericQuery,
   GenericPayload,
+  BatchRPCResponse,
+  getBatchCommand,
 } from "./rpc";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 // Utils
@@ -39,6 +41,11 @@ export interface AutomemberShowPayload {
 
 export interface AddPayload {
   group: string;
+  type: string;
+}
+
+export interface RemovePayload {
+  groups: string[];
   type: string;
 }
 
@@ -243,6 +250,27 @@ const extendedApi = api.injectEndpoints({
         });
       },
     }),
+    /**
+     * Removes groups from automember
+     * @param RemovePayload
+     * @returns BatchRPCResponse
+     */
+    deleteFromAutomember: build.mutation<
+      BatchRPCResponse,
+      RemovePayload
+    >({
+      query: (payload) => {
+        const rulesToDelete = payload.groups;
+        const params = [rulesToDelete, { type: payload.type }];
+
+        const batchParams = {
+          method: "automember_del",
+          params: params,
+        };
+
+        return getBatchCommand([batchParams], API_VERSION_BACKUP);
+      },
+    }),
   }),
   overrideExisting: false,
 });
@@ -259,4 +287,5 @@ export const {
   useSearchUserGroupRulesEntriesMutation,
   useAutomemberFindBasicInfoQuery,
   useAddToAutomemberMutation,
+  useDeleteFromAutomemberMutation,
 } = extendedApi;

--- a/src/services/rpcAutomember.ts
+++ b/src/services/rpcAutomember.ts
@@ -24,6 +24,7 @@ import {
  * API commands:
  * - automember_default_group_show: https://freeipa.readthedocs.io/en/latest/api/automember_default_group_show.html
  * - automember_find: https://freeipa.readthedocs.io/en/latest/api/automember_find.html
+ * - automember_add: https://freeipa.readthedocs.io/en/latest/api/automember_add.html
  */
 
 export type AutomemberFullData = {
@@ -35,6 +36,12 @@ export interface AutomemberShowPayload {
   no_members: boolean | true;
   version: string;
 }
+
+export interface AddPayload {
+  group: string;
+  type: string;
+}
+
 
 const extendedApi = api.injectEndpoints({
   endpoints: (build) => ({
@@ -219,6 +226,23 @@ const extendedApi = api.injectEndpoints({
         return { data: fullAutomemberIdsList };
       },
     }),
+    /**
+     * Adds group to automember
+     * @param AddPayload
+     * @returns FindRPCResponse
+     */
+    addToAutomember: build.mutation<
+      FindRPCResponse,
+      AddPayload
+    >({
+      query: (payload) => {
+        const params = [[payload.group], { type: payload.type }];
+        return getCommand({
+          method: "automember_add",
+          params: params,
+        });
+      },
+    }),
   }),
   overrideExisting: false,
 });
@@ -234,4 +258,5 @@ export const {
   useDefaultGroupShowQuery,
   useSearchUserGroupRulesEntriesMutation,
   useAutomemberFindBasicInfoQuery,
+  useAddToAutomemberMutation,
 } = extendedApi;

--- a/src/services/rpcAutomember.ts
+++ b/src/services/rpcAutomember.ts
@@ -49,6 +49,10 @@ export interface RemovePayload {
   type: string;
 }
 
+export interface ChangeDefaultPayload {
+  defaultGroup: string;
+  type: string;
+}
 
 const extendedApi = api.injectEndpoints({
   endpoints: (build) => ({
@@ -238,10 +242,7 @@ const extendedApi = api.injectEndpoints({
      * @param AddPayload
      * @returns FindRPCResponse
      */
-    addToAutomember: build.mutation<
-      FindRPCResponse,
-      AddPayload
-    >({
+    addToAutomember: build.mutation<FindRPCResponse, AddPayload>({
       query: (payload) => {
         const params = [[payload.group], { type: payload.type }];
         return getCommand({
@@ -255,10 +256,7 @@ const extendedApi = api.injectEndpoints({
      * @param RemovePayload
      * @returns BatchRPCResponse
      */
-    deleteFromAutomember: build.mutation<
-      BatchRPCResponse,
-      RemovePayload
-    >({
+    deleteFromAutomember: build.mutation<BatchRPCResponse, RemovePayload>({
       query: (payload) => {
         const rulesToDelete = payload.groups;
         const params = [rulesToDelete, { type: payload.type }];
@@ -269,6 +267,27 @@ const extendedApi = api.injectEndpoints({
         };
 
         return getBatchCommand([batchParams], API_VERSION_BACKUP);
+      },
+    }),
+    /**
+     * Changes default group for automember
+     * @param ChangeDefaultPayload
+     * @returns FindRPCResponse
+     */
+    changeDefaultGroup: build.mutation<FindRPCResponse, ChangeDefaultPayload>({
+      query: (payload) => {
+        const params = [
+          [],
+          {
+            type: payload.type,
+            automemberdefaultgroup: payload.defaultGroup,
+            version: API_VERSION_BACKUP,
+          },
+        ];
+        return getCommand({
+          method: "automember_default_group_set",
+          params: params,
+        });
       },
     }),
   }),
@@ -288,4 +307,5 @@ export const {
   useAutomemberFindBasicInfoQuery,
   useAddToAutomemberMutation,
   useDeleteFromAutomemberMutation,
+  useChangeDefaultGroupMutation,
 } = extendedApi;

--- a/tests/features/automem_user_groups.feature
+++ b/tests/features/automem_user_groups.feature
@@ -1,0 +1,63 @@
+Feature: Automember > User group rules
+  Create and delete automember user group rules. Change default user group rule.
+
+  Background:
+    Given I am logged in as "Administrator"
+    Given I am on "user-group-rules" page
+
+  # Prep: Create a new user group to work with
+  Scenario: Create a new user group to work with
+    Given I am on "user-groups" page
+    When I click on "Add" button
+    * I type in the field "Group name" text "my_automember_group"
+    When in the modal dialog I click on "Add" button
+    * I should see "success" alert with text "New user group added"
+    When I close the alert
+    Then I should see "my_automember_group" entry in the data table
+
+  # User group rules operations
+  Scenario: Add a new automember user group rule
+    Given I am on "user-group-rules" page
+    When I click on "Add" button
+    * I click in the "Automember" selector field
+    * I select "my_automember_group" option in the "Automember" selector
+    * in the modal dialog I click on "Add" button
+    * I should see "success" alert with text "Entry successfully added"
+    When I close the alert
+    Then I should see "my_automember_group" entry in the data table
+
+  Scenario: Delete an automember user group rule
+    Given I am on "user-group-rules" page
+    Given I should see "my_automember_group" entry in the data table
+    Then I select entry "my_automember_group" in the data table
+    When I click on "Delete" button
+    * I see "Remove auto membership rules" modal
+    * I should see "my_automember_group" entry in the data table
+    When in the modal dialog I click on "Delete" button
+    * I should see "success" alert with text "The selected rules have been removed successfully"
+    When I close the alert
+    Then I should not see "my_automember_group" entry in the data table
+
+  Scenario: Set default user group rule
+    Given I am on "user-group-rules" page
+    When I click in the selector field with ID "typeahead-select-input"
+    * I click toolbar dropdown item "admins"
+    Then I see "Default user group" modal
+    When in the modal dialog I click on "OK" button
+    Then I should see "success" alert with text "Default group updated"
+    When I close the alert
+    * in the selector with ID "typeahead-select-input" I should see option "admins" selected
+
+  # Cleanup: Delete the user group
+  Scenario: Delete the user group
+    Given I am on "user-groups" page
+    Given I should see "my_automember_group" entry in the data table
+    Then I select entry "my_automember_group" in the data table
+    When I click on "Delete" button
+    * I see "Remove user groups" modal
+    * I should see "my_automember_group" entry in the data table
+    When in the modal dialog I click on "Delete" button
+    * I should see "success" alert with text "User groups removed"
+    When I close the alert
+    Then I should not see "my_automember_group" entry in the data table
+

--- a/tests/features/steps/common.ts
+++ b/tests/features/steps/common.ts
@@ -426,6 +426,12 @@ When("I click in the {string} selector field", (selectorName: string) => {
     .click();
 });
 
+When("I click in the selector field with ID {string}", (id: string) => {
+  cy.get("div.pf-v5-c-menu-toggle")
+    .find("div[id=" + id + "]")
+    .click();
+});
+
 When(
   "I select {string} in the {string} form selector field",
   (selection: string, selectorName: string) => {
@@ -448,6 +454,15 @@ Then(
       .next()
       .find("div.pf-v5-c-menu__content");
     options.should("contain", option);
+  }
+);
+
+Then(
+  "in the selector with ID {string} I should see option {string} selected",
+  (id: string, option: string) => {
+    cy.get("div.pf-v5-c-menu-toggle")
+      .find("div[id=" + id + "]")
+      .find("input[value='" + option + "']");
   }
 );
 

--- a/tests/features/steps/common.ts
+++ b/tests/features/steps/common.ts
@@ -714,7 +714,9 @@ Then("I click on the breadcrump link {string}", (value: string) => {
 
 // Dual list
 Then("I click on the dual list item {string}", (value: string) => {
-  cy.get(".pf-v5-c-dual-list-selector__item-text").contains(value).click();
+  cy.get(".pf-v5-c-dual-list-selector__item-text", { timeout: 2000 })
+    .contains(value)
+    .click();
 });
 
 Then("I click on the dual list add selected button", () => {

--- a/tests/features/sudo_rules_settings.feature
+++ b/tests/features/sudo_rules_settings.feature
@@ -188,20 +188,27 @@ Feature: Sudo rules - Settings page
   # 'Run command' subsection
   # - Allow
   # -- Prep a new command to add from the 'Sudo commands' page
-  Scenario: Add a new sudo command
+  Scenario: Add a new sudo commands
     Given I am on "sudo-commands" page
     When I click on "Add" button
     * I type in the field "Command name" text "command1"
     * I type in the field "Description" text "my description"
+    * in the modal dialog I click on "Add and add another" button
+    * I should see "success" alert with text "New sudo command added"
+    * I close the alert
+    * I type in the field "Command name" text "command2"
+    * I type in the field "Description" text "my description 2"
     * in the modal dialog I click on "Add" button
     * I should see "success" alert with text "New sudo command added"
     * I close the alert
     Then I should see "command1" entry in the data table
     * entry "command1" should have attribute "Description" set to "my description"
+    Then I should see "command2" entry in the data table
+    * entry "command2" should have attribute "Description" set to "my description 2"
 
   Scenario: Add a new sudo allow command
     Given I am on the "sudo-rules" > "sudoRule1" Settings page
-    When I click on "Add sudocmds" button
+    When I click on ID "add-allow-sudocmd" button
     Then I see a modal with title text "Add allow sudo commands into sudo rule 'sudoRule1'"
     And I click on the arrow icon to perform search in modal
     And I click on the dual list item "command1"
@@ -225,36 +232,43 @@ Feature: Sudo rules - Settings page
   Scenario: Add a new sudo command group
     Given I am on "sudo-command-groups" page
     When I click on "Add" button
-    * I type in the field "Command group name" text "cmdgroup1"
-    * I type in the field "Description" text "my description"
+    * I type in the field "Command group name" text "my-cmd-group"
     * in the modal dialog I click on "Add" button
     * I should see "success" alert with text "New sudo command group added"
     * I close the alert
-    Then I should see "cmdgroup1" entry in the data table
-    * entry "cmdgroup1" should have attribute "Description" set to "my description"
+    Then I should see "my-cmd-group" entry in the data table
+
+  Scenario: Add another sudo command group
+    Given I am on "sudo-command-groups" page
+    When I click on "Add" button
+    * I type in the field "Command group name" text "my-cmd-group-2"
+    * in the modal dialog I click on "Add" button
+    * I should see "success" alert with text "New sudo command group added"
+    * I close the alert
+    Then I should see "my-cmd-group-2" entry in the data table
 
   Scenario: Add a new sudo allow command group
     Given I am on the "sudo-rules" > "sudoRule1" Settings page
     When I click on "Sudo Allow Command Groups" page tab
-    And I click on "Add sudocmdgroups" button
+    And I click on ID "add-allow-sudocmdgroup" button
     Then I see a modal with title text "Add allow sudo command groups into sudo rule 'sudoRule1'"
     And I click on the arrow icon to perform search in modal
-    And I click on the dual list item "cmdgroup1"
+    And I click on the dual list item "my-cmd-group"
     And I click on the dual list add selected button
     And I click on the "Add" button located in the footer modal dialog
     And I should see "success" alert with text "Added new item(s) to 'sudoRule1'"
     Then I close the alert
-    And I should see "cmdgroup1" entry in the data table
+    And I should see "my-cmd-group" entry in the data table
 
   Scenario: Remove sudo allow command group from table
-    Given I should see "cmdgroup1" entry in the data table
-    When I select "cmdgroup1" entry with no link in the data table
+    Given I should see "my-cmd-group" entry in the data table
+    When I select "my-cmd-group" entry with no link in the data table
     And I click on "Delete" button
-    And the "cmdgroup1" element should be in the dialog table with id "remove-sudocmdgroups-table"
+    And the "my-cmd-group" element should be in the dialog table with id "remove-sudocmdgroups-table"
     When in the modal dialog I click on "Delete" button
     And I should see "success" alert with text "Removed item(s) from"
     Then I close the alert
-    And I should not see "cmdgroup1" entry in the data table
+    And I should not see "my-cmd-group" entry in the data table
 
   # - Deny
   Scenario: Add a new sudo deny command
@@ -262,44 +276,44 @@ Feature: Sudo rules - Settings page
     When I click on ID "add-deny-sudocmd" button
     Then I see a modal with title text "Add deny sudo commands into sudo rule 'sudoRule1'"
     And I click on the arrow icon to perform search in modal
-    And I click on the dual list item "command1"
+    And I click on the dual list item "command2"
     And I click on the dual list add selected button
     And I click on the "Add" button located in the footer modal dialog
     And I should see "success" alert with text "Added new item(s) to 'sudoRule1'"
     Then I close the alert
-    And I should see "command1" entry in the data table
+    And I should see "command2" entry in the data table
 
   Scenario: Remove sudo deny command from table
-    Given I should see "command1" entry in the data table
-    When I select "command1" entry with no link in the data table
+    Given I should see "command2" entry in the data table
+    When I select "command2" entry with no link in the data table
     And I click on "Delete" button
-    And the "command1" element should be in the dialog table with id "remove-sudocmds-table"
+    And the "command2" element should be in the dialog table with id "remove-sudocmds-table"
     When in the modal dialog I click on "Delete" button
     And I should see "success" alert with text "Removed item(s) from"
     Then I close the alert
-    And I should not see "command1" entry in the data table
+    And I should not see "command2" entry in the data table
 
   Scenario: Add a new sudo deny command group
     When I click on "Sudo Deny Command Groups" page tab
     And I click on ID "add-deny-sudocmdgroup" button
     Then I see a modal with title text "Add deny sudo command groups into sudo rule 'sudoRule1'"
     And I click on the arrow icon to perform search in modal
-    And I click on the dual list item "cmdgroup1"
+    And I click on the dual list item "my-cmd-group-2"
     And I click on the dual list add selected button
     And I click on the "Add" button located in the footer modal dialog
     And I should see "success" alert with text "Added new item(s) to 'sudoRule1'"
     Then I close the alert
-    And I should see "cmdgroup1" entry in the data table
+    And I should see "my-cmd-group-2" entry in the data table
 
   Scenario: Remove sudo deny command group from table
-    Given I should see "cmdgroup1" entry in the data table
-    When I select "cmdgroup1" entry with no link in the data table
+    Given I should see "my-cmd-group-2" entry in the data table
+    When I select "my-cmd-group-2" entry with no link in the data table
     And I click on "Delete" button
-    And the "cmdgroup1" element should be in the dialog table with id "remove-sudocmdgroups-table"
+    And the "my-cmd-group-2" element should be in the dialog table with id "remove-sudocmdgroups-table"
     When in the modal dialog I click on "Delete" button
     And I should see "success" alert with text "Removed item(s) from"
     Then I close the alert
-    And I should not see "cmdgroup1" entry in the data table
+    And I should not see "my-cmd-group-2" entry in the data table
 
   Scenario: Change command category - 'Specified Commands and Groups' to 'Any command'
     When I click on the "Any command" option under ID "cmdcategory" toggle group
@@ -309,32 +323,57 @@ Feature: Sudo rules - Settings page
     And I should see "Any command" selected in the ID "cmdcategory" toggle group
 
   # 'As whom' subsection
+  # - Prep: Create a new user to work with
+  Scenario: Add a new user
+    Given I am on "active-users" page
+    When I click on "Add" button
+    * I type in the field "First name" text "Han"
+    * I type in the field "Last name" text "Solo"
+    * in the modal dialog I click on "Add" button
+    * I should see "success" alert with text "New user added"
+    Then I close the alert
+    Then I should see "hsolo" entry in the data table
   # - RunAs User
   Scenario: Add a new runAs user
     Given I am on the "sudo-rules" > "sudoRule1" Settings page
     When I click on ID "add-runas-user" button
     Then I see a modal with title text "Add RunAs user into sudo rule sudoRule1"
     And I click on the arrow icon to perform search in modal
-    And I click on the dual list item "admin"
+    And I click on the dual list item "hsolo"
     And I click on the dual list add selected button
     And I click on the "Add" button located in the footer modal dialog
     And I should see "success" alert with text "Added new item(s) to 'sudoRule1'"
     Then I close the alert
-    And I should see "admin" entry in the data table
+    And I should see "hsolo" entry in the data table
 
   Scenario: Remove runAs user from table
     Given I am on the "sudo-rules" > "sudoRule1" Settings page
-    Given I should see "admin" entry in the data table with ID "keytab-user-table"
-    When I select "admin" entry with no link in the data table
+    Given I should see "hsolo" entry in the data table with ID "keytab-user-table"
+    When I select "hsolo" entry with no link in the data table
     And I click on "Delete" button
-    And the "admin" element should be in the dialog table with id "remove-users-table"
+    And the "hsolo" element should be in the dialog table with id "remove-users-table"
     When in the modal dialog I click on "Delete" button
     And I should see "success" alert with text "Removed item(s) from"
     Then I close the alert
-    And I should not see "admin" entry in the data table
+    And I should not see "hsolo" entry in the data table
+
+  # -- Remove hsolo user
+  Scenario: Cleanup: Delete 'hsolo' user
+    Given I am on "active-users" page
+    Given I should see partial "hsolo" entry in the data table
+    Then I select partial entry "hsolo" in the data table
+    When I click on "Delete" button
+    * I see "Remove Active Users" modal
+    * I should see partial "hsolo" entry in the data table
+    When in the modal dialog I check "Delete" radio selector
+    When in the modal dialog I click on "Delete" button
+    * I should see "success" alert with text "Users removed"
+    Then I close the alert
+    Then I should not see "hsolo" entry in the data table
 
   # - Group of runAs users
   Scenario: Add a new group of runAs users
+    Given I am on the "sudo-rules" > "sudoRule1" Settings page
     When I click on "Groups of RunAs Users" page tab
     And I click on ID "add-runas-group" button
     Then I see a modal with title text "Add host group into sudo rule sudoRule1"
@@ -357,28 +396,38 @@ Feature: Sudo rules - Settings page
     And I should not see "admins" entry in the data table
 
   # - RunAs Groups
+  # -- Prep: Create a new group to work with
+  Scenario: Add a new group
+    Given I am on "user-groups" page
+    When I click on "Add" button
+    * I type in the field "Group name" text "super_group"
+    * in the modal dialog I click on "Add" button
+    * I should see "success" alert with text "New user group added"
+    * I close the alert
+    Then I should see "super_group" entry in the data table
+
   Scenario: Add a new runAs group
     Given I am on the "sudo-rules" > "sudoRule1" Settings page
     When I click on ID "add-runas-group-group" button
     Then I see a modal with title text "Add RunAs groups into sudo rule sudoRule1"
     And I click on the arrow icon to perform search in modal
-    And I click on the dual list item "admins"
+    And I click on the dual list item "super_group"
     And I click on the dual list add selected button
     And I click on the "Add" button located in the footer modal dialog
     And I should see "success" alert with text "Added new item(s) to 'sudoRule1'"
     Then I close the alert
-    And I should see "admins" entry in the data table with ID "keytab-group-table"
+    And I should see "super_group" entry in the data table with ID "keytab-group-table"
 
   Scenario: Remove runAs group from table
     Given I am on the "sudo-rules" > "sudoRule1" Settings page
-    Given I should see "admins" entry in the data table with ID "keytab-group-table"
-    When I select "admins" entry with no link in the data table
+    Given I should see "super_group" entry in the data table with ID "keytab-group-table"
+    When I select "super_group" entry with no link in the data table
     And I click on "Delete" button
-    And the "admins" element should be in the dialog table with id "remove-groups-table"
+    And the "super_group" element should be in the dialog table with id "remove-groups-table"
     When in the modal dialog I click on "Delete" button
     And I should see "success" alert with text "Removed item(s) from"
     Then I close the alert
-    And I should not see "admins" entry in the data table with ID "keytab-group-table"
+    And I should not see "super_group" entry in the data table with ID "keytab-group-table"
 
   Scenario: Change runAs user and group categories
     Given I am on the "sudo-rules" > "sudoRule1" Settings page
@@ -389,6 +438,19 @@ Feature: Sudo rules - Settings page
     Then I close the alert
     And I should see "Anyone" selected in the ID "ipasudorunasusercategory" toggle group
     And I should see "Any Group" selected in the ID "ipasudorunasgroupcategory" toggle group
+
+  # -- Cleanup: Delete 'super_group' group
+  Scenario: Cleanup: Delete 'super_group' group
+    Given I am on "user-groups" page
+    Given I should see "super_group" entry in the data table
+    Then I select entry "super_group" in the data table
+    When I click on "Delete" button
+    * I see "Remove user groups" modal
+    * I should see "super_group" entry in the data table
+    When in the modal dialog I click on "Delete" button
+    * I should see "success" alert with text "User groups removed"
+    When I close the alert
+    Then I should not see "super_group" entry in the data table
 
   # Cleanup of created entities
   # - Host
@@ -430,18 +492,33 @@ Feature: Sudo rules - Settings page
     * I close the alert
     Then I should not see "command1" entry in the data table
 
+  Scenario: Delete another command
+    Given I am on "sudo-commands" page
+    Given I should see "command2" entry in the data table
+    When I select entry "command2" in the data table
+    * I click on "Delete" button
+    When I see "Remove sudo commands" modal
+    * I should see "command2" entry in the data table
+    * in the modal dialog I click on "Delete" button
+    * I should see "success" alert with text "Sudo commands removed"
+    * I close the alert
+    Then I should not see "command2" entry in the data table
+
   # - Command group
-  Scenario: Delete a command group
+  Scenario: Delete command groups
     Given I am on "sudo-command-groups" page
-    Given I should see "cmdgroup1" entry in the data table
-    When I select entry "cmdgroup1" in the data table
+    Given I should see "my-cmd-group" entry in the data table
+    When I select entry "my-cmd-group" in the data table
+    When I select entry "my-cmd-group-2" in the data table
     * I click on "Delete" button
     When I see "Remove sudo command groups" modal
-    * I should see "cmdgroup1" entry in the data table
+    * I should see "my-cmd-group" entry in the data table
+    * I should see "my-cmd-group-2" entry in the data table
     * in the modal dialog I click on "Delete" button
     * I should see "success" alert with text "Sudo command groups removed"
     * I close the alert
-    Then I should not see "cmdgroup1" entry in the data table
+    Then I should not see "my-cmd-group" entry in the data table
+    Then I should not see "my-cmd-group-2" entry in the data table
 
   # - Sudo rule
   Scenario: Delete the rule


### PR DESCRIPTION
The action buttons for the 'User group rules' page have been implemented. This includes:
- 'Add'
- 'Delete'
- Set default group via `Selector` component in toolbar
- Integration test to check its functionality

This PR has been created based on this one: https://github.com/freeipa/freeipa-webui/pull/625