### PR TITLE
Fix: Allow 'Force' without IP address (Hosts page only)

### DIFF
--- a/src/components/modals/HostModals/AddHost.tsx
+++ b/src/components/modals/HostModals/AddHost.tsx
@@ -137,12 +137,6 @@ const AddHost = (props: PropsToAddHost) => {
     pfError: ValidatedOptions.default,
   });
 
-  useEffect(() => {
-    if (hostIpAddress === "") {
-      setForceCheckbox(false);
-    }
-  }, [hostIpAddress]);
-
   const hostNameValidationHandler = (hostname: string) => {
     if (hostname === "") {
       const hostNameVal = {
@@ -218,8 +212,6 @@ const AddHost = (props: PropsToAddHost) => {
         pfError: ValidatedOptions.error,
       };
       setHostIpAddressValidation(ipVal);
-      // Can not force DNS bypass without a valid IP address
-      setForceCheckbox(false);
     }
   }, [hostName, dnsZoneSelected, hostIpAddress]);
 
@@ -394,11 +386,12 @@ const AddHost = (props: PropsToAddHost) => {
             name="forceCheckbox"
             value="force"
             onChange={handleForceCheckbox}
-            isDisabled={hostIpAddressValidation.isError || hostIpAddress === ""}
+            isDisabled={hostIpAddressValidation.isError}
           />
           <HelperText>
             <HelperTextItem variant="indeterminate">
-              Requires valid IP address
+              Allow adding host objects that does not have DNS entries
+              associated with them
             </HelperTextItem>
           </HelperText>
         </div>
@@ -492,12 +485,24 @@ const AddHost = (props: PropsToAddHost) => {
     }
     const newHostPayload = {
       fqdn: hostName + "." + dnsZone,
-      userclass: hostClass,
-      ip_address: hostIpAddress,
-      force: forceCheckbox,
-      description: description,
-      random: generateOtpCheckbox,
     } as HostAddPayload;
+
+    // Add the rest of parameters if they are not empty
+    if (hostClass !== "") {
+      newHostPayload.userclass = hostClass;
+    }
+    if (hostIpAddress !== "") {
+      newHostPayload.ip_address = hostIpAddress;
+    }
+    if (forceCheckbox) {
+      newHostPayload.force = forceCheckbox;
+    }
+    if (description !== "") {
+      newHostPayload.description = description;
+    }
+    if (generateOtpCheckbox) {
+      newHostPayload.random = generateOtpCheckbox;
+    }
 
     // Add host via API call
     await executeHostAddCommand(newHostPayload).then((host) => {

--- a/src/services/rpcHosts.ts
+++ b/src/services/rpcHosts.ts
@@ -38,8 +38,8 @@ export interface HostAddPayload {
   fqdn: string;
   userclass?: string;
   ip_address?: string;
-  force: boolean; // skip DNS check
-  random: boolean; // otp generation
+  force?: boolean; // skip DNS check
+  random?: boolean; // otp generation
   description?: string;
 }
 
@@ -109,13 +109,16 @@ const extendedApi = api.injectEndpoints({
           [payloadData["fqdn"]],
           {
             version: API_VERSION_BACKUP,
-            userclass: payloadData["userclass"],
-            ip_address: payloadData["ip_address"],
-            force: payloadData["force"],
-            description: payloadData["description"],
-            random: payloadData["random"],
           },
         ];
+        // Add the rest of parameters if they are not undefined
+        Object.keys(payloadData).forEach((key) => {
+          if (payloadData[key] !== undefined && key !== "fqdn") {
+            params[1][key] = payloadData[key];
+          }
+        });
+        console.log("params", params);
+
         return getCommand({
           method: "host_add",
           params: params,

--- a/tests/features/hbac_rule_settings_handling.feature
+++ b/tests/features/hbac_rule_settings_handling.feature
@@ -105,6 +105,7 @@ Feature: Hbac rule settings manipulation
     When I click on "Add" button
     * I see "Add host" modal
     * I type in the field "Host name" text "my-new-host"
+    * I click on "Force" checkbox in modal
     * in the modal dialog I click on "Add" button
     * I should see "success" alert with text "New host added"
     * I close the alert

--- a/tests/features/host_handling.feature
+++ b/tests/features/host_handling.feature
@@ -8,6 +8,7 @@ Feature: Host manipulation
   Scenario: Add a new host
     When I click on "Add" button
     * I type in the field "Host name" text "myfirstserver"
+    * I click on "Force" checkbox in modal
     * in the modal dialog I click on "Add" button
     * I should see "success" alert with text "New host added"
     Then I should see partial "myfirstserver" entry in the data table
@@ -17,6 +18,7 @@ Feature: Host manipulation
     * I type in the field "Host name" text "addfullhost"
     * I type in the field "Description" text "my description"
     * I type in the field "Class" text "test class"
+    * I click on "Force" checkbox in modal
     When in the modal dialog I click on "Add" button
     * I should see "success" alert with text "New host added"
     Then I should see partial "addfullhost" entry in the data table
@@ -25,7 +27,7 @@ Feature: Host manipulation
   Scenario: Add a new host with all checkboxes set
     When I click on "Add" button
     * I type in the field "Host name" text "addChkBoxhost"
-    * I type in the field "IP address" text "1.1.1.1"
+    * I type in the field "IP address" text "1.1.1.2"
     * I click on "Force" checkbox in modal
     * I click on "Generate OTP" checkbox in modal
     * I click on "Suppress processing" checkbox in modal
@@ -33,12 +35,22 @@ Feature: Host manipulation
     * I should see "success" alert with text "New host added"
     Then I should see partial "addchkboxhost" entry in the data table
 
-  Scenario: Add one user after another
+  Scenario: Add a new host with 'Force' unchecked is expected to fail
+    When I click on "Add" button
+    * I type in the field "Host name" text "forcehost"
+    When in the modal dialog I click on "Add" button
+    * I see a modal with title text "IPA error 4019: DNSNotARecordError"
+    * I click on the "Cancel" button located in the footer modal dialog
+    * I click on the "Cancel" button located in the footer modal dialog
+
+  Scenario: Add one host after another
     When I click on "Add" button
     * I type in the field "Host name" text "myserver2"
+    * I click on "Force" checkbox in modal
     * in the modal dialog I click on "Add and add another" button
     * I should see "success" alert with text "New host added"
     * I type in the field "Host name" text "myserver3"
+    * I click on "Force" checkbox in modal
     * in the modal dialog I click on "Add" button
     * I should see "success" alert with text "New host added"
     Then I should see partial "myfirstserver" entry in the data table

--- a/tests/features/hostgroup_members.feature
+++ b/tests/features/hostgroup_members.feature
@@ -10,6 +10,7 @@ Feature: Hostgroup members
     Given I am on "hosts" page
     When I click on "Add" button
     * I type in the field "Host name" text "myhost"
+    * I click on "Force" checkbox in modal
     * in the modal dialog I click on "Add" button
     * I should see "success" alert with text "New host added"
     Then I should see partial "myhost" entry in the data table

--- a/tests/features/id_view_appliedto.feature
+++ b/tests/features/id_view_appliedto.feature
@@ -12,11 +12,13 @@ Feature: ID View applied to manipulation
     Given I am on "hosts" page
     When I click on "Add" button
     Then I type in the field "Host name" text "idviewhost1"
+    * I click on "Force" checkbox in modal
     * in the modal dialog I click on "Add" button
     * I should see "success" alert with text "New host added"
     Then I should see partial "idviewhost1" entry in the data table
     When I click on "Add" button
     Then I type in the field "Host name" text "idviewhost2"
+    * I click on "Force" checkbox in modal
     * in the modal dialog I click on "Add" button
     * I should see "success" alert with text "New host added"
     Then I should see partial "idviewhost2" entry in the data table

--- a/tests/features/netgroup_members.feature
+++ b/tests/features/netgroup_members.feature
@@ -120,6 +120,7 @@ Feature: Netgroup members
     Given I am on "hosts" page
     When I click on "Add" button
     * I type in the field "Host name" text "my-new-server"
+    * I click on "Force" checkbox in modal
     * in the modal dialog I click on "Add" button
     * I should see "success" alert with text "New host added"
     Then I should see partial "my-new-server" entry in the data table

--- a/tests/features/netgroup_settings_handling.feature
+++ b/tests/features/netgroup_settings_handling.feature
@@ -23,6 +23,7 @@ Feature: Netgroup settings manipulation
     Given I am on "hosts" page
     When I click on "Add" button
     * I type in the field "Host name" text "my-server"
+    * I click on "Force" checkbox in modal
     * in the modal dialog I click on "Add" button
     * I should see "success" alert with text "New host added"
     Then I should see partial "my-server" entry in the data table

--- a/tests/features/service_handling.feature
+++ b/tests/features/service_handling.feature
@@ -9,6 +9,7 @@ Feature: Service manipulation
     Given I am on "hosts" page
     When I click on "Add" button
     * I type in the field "Host name" text "service1"
+    * I click on "Force" checkbox in modal
     * in the modal dialog I click on "Add" button
     * I should see "success" alert with text "New host added"
     Then I should see partial "service1" entry in the data table

--- a/tests/features/sudo_rules_settings.feature
+++ b/tests/features/sudo_rules_settings.feature
@@ -115,6 +115,7 @@ Feature: Sudo rules - Settings page
     Given I am on "hosts" page
     When I click on "Add" button
     * I type in the field "Host name" text "my-temp-server"
+    * I click on "Force" checkbox in modal
     * in the modal dialog I click on "Add" button
     * I should see "success" alert with text "New host added"
     Then I should see partial "my-temp-server" entry in the data table


### PR DESCRIPTION
Adding host should allow use of 'force' checkbox without IP address added, as the idea is to allow adding host objects that
don't have DNS entries associated with them.

Fixes: https://github.com/freeipa/freeipa-webui/issues/624