### PR TITLE
Fix failing tests for sudorules and usergroups

### DIFF
--- a/tests/features/steps/common.ts
+++ b/tests/features/steps/common.ts
@@ -683,7 +683,9 @@ Then(
 );
 
 When("I click on the arrow icon to perform search in modal", () => {
-  cy.get("[role=dialog] button[aria-label=Search]").eq(0).click().wait(1000);
+  cy.get("[role=dialog] button[aria-label=Search]", { timeout: 1000 })
+    .eq(0)
+    .click();
 });
 
 Then("I click on the X icon to clear the modal search field", () => {

--- a/tests/features/sudo_rules_settings.feature
+++ b/tests/features/sudo_rules_settings.feature
@@ -61,7 +61,7 @@ Feature: Sudo rules - Settings page
   Scenario: Add a new user
     When I click on "Add users" button
     Then I see a modal with title text "Add user into sudo rule sudoRule1"
-    And I click on the arrow icon to perform search
+    And I click on the arrow icon to perform search in modal
     And I click on the dual list item "admin"
     And I click on the dual list add selected button
     And I click on the "Add" button located in the footer modal dialog
@@ -84,7 +84,7 @@ Feature: Sudo rules - Settings page
     When I click on "User groups" page tab
     And I click on "Add groups" button
     Then I see a modal with title text "Add group into sudo rule sudoRule1"
-    And I click on the arrow icon to perform search
+    And I click on the arrow icon to perform search in modal
     And I click on the dual list item "admins"
     And I click on the dual list add selected button
     And I click on the "Add" button located in the footer modal dialog
@@ -115,6 +115,7 @@ Feature: Sudo rules - Settings page
     Given I am on "hosts" page
     When I click on "Add" button
     * I type in the field "Host name" text "my-temp-server"
+    * I click on "Force" checkbox in modal
     * in the modal dialog I click on "Add" button
     * I should see "success" alert with text "New host added"
     Then I close the alert
@@ -124,7 +125,7 @@ Feature: Sudo rules - Settings page
     Given I am on the "sudo-rules" > "sudoRule1" Settings page
     When I click on "Add hosts" button
     Then I see a modal with title text "Add host into sudo rule sudoRule1"
-    And I click on the arrow icon to perform search
+    And I click on the arrow icon to perform search in modal
     And I click on the dual list item "my-temp-server"
     And I click on the dual list add selected button
     And I click on the "Add" button located in the footer modal dialog
@@ -159,7 +160,7 @@ Feature: Sudo rules - Settings page
     When I click on "Host groups" page tab
     And I click on "Add hostgroups" button
     Then I see a modal with title text "Add host group into sudo rule sudoRule1"
-    And I click on the arrow icon to perform search
+    And I click on the arrow icon to perform search in modal
     And I click on the dual list item "a_host_group"
     And I click on the dual list add selected button
     And I click on the "Add" button located in the footer modal dialog
@@ -202,7 +203,7 @@ Feature: Sudo rules - Settings page
     Given I am on the "sudo-rules" > "sudoRule1" Settings page
     When I click on "Add sudocmds" button
     Then I see a modal with title text "Add allow sudo commands into sudo rule 'sudoRule1'"
-    And I click on the arrow icon to perform search
+    And I click on the arrow icon to perform search in modal
     And I click on the dual list item "command1"
     And I click on the dual list add selected button
     And I click on the "Add" button located in the footer modal dialog
@@ -237,7 +238,7 @@ Feature: Sudo rules - Settings page
     When I click on "Sudo Allow Command Groups" page tab
     And I click on "Add sudocmdgroups" button
     Then I see a modal with title text "Add allow sudo command groups into sudo rule 'sudoRule1'"
-    And I click on the arrow icon to perform search
+    And I click on the arrow icon to perform search in modal
     And I click on the dual list item "cmdgroup1"
     And I click on the dual list add selected button
     And I click on the "Add" button located in the footer modal dialog
@@ -260,7 +261,7 @@ Feature: Sudo rules - Settings page
     Given I am on the "sudo-rules" > "sudoRule1" Settings page
     When I click on ID "add-deny-sudocmd" button
     Then I see a modal with title text "Add deny sudo commands into sudo rule 'sudoRule1'"
-    And I click on the arrow icon to perform search
+    And I click on the arrow icon to perform search in modal
     And I click on the dual list item "command1"
     And I click on the dual list add selected button
     And I click on the "Add" button located in the footer modal dialog
@@ -282,7 +283,7 @@ Feature: Sudo rules - Settings page
     When I click on "Sudo Deny Command Groups" page tab
     And I click on ID "add-deny-sudocmdgroup" button
     Then I see a modal with title text "Add deny sudo command groups into sudo rule 'sudoRule1'"
-    And I click on the arrow icon to perform search
+    And I click on the arrow icon to perform search in modal
     And I click on the dual list item "cmdgroup1"
     And I click on the dual list add selected button
     And I click on the "Add" button located in the footer modal dialog
@@ -313,7 +314,7 @@ Feature: Sudo rules - Settings page
     Given I am on the "sudo-rules" > "sudoRule1" Settings page
     When I click on ID "add-runas-user" button
     Then I see a modal with title text "Add RunAs user into sudo rule sudoRule1"
-    And I click on the arrow icon to perform search
+    And I click on the arrow icon to perform search in modal
     And I click on the dual list item "admin"
     And I click on the dual list add selected button
     And I click on the "Add" button located in the footer modal dialog
@@ -337,7 +338,7 @@ Feature: Sudo rules - Settings page
     When I click on "Groups of RunAs Users" page tab
     And I click on ID "add-runas-group" button
     Then I see a modal with title text "Add host group into sudo rule sudoRule1"
-    And I click on the arrow icon to perform search
+    And I click on the arrow icon to perform search in modal
     And I click on the dual list item "admins"
     And I click on the dual list add selected button
     And I click on the "Add" button located in the footer modal dialog
@@ -360,7 +361,7 @@ Feature: Sudo rules - Settings page
     Given I am on the "sudo-rules" > "sudoRule1" Settings page
     When I click on ID "add-runas-group-group" button
     Then I see a modal with title text "Add RunAs groups into sudo rule sudoRule1"
-    And I click on the arrow icon to perform search
+    And I click on the arrow icon to perform search in modal
     And I click on the dual list item "admins"
     And I click on the dual list add selected button
     And I click on the "Add" button located in the footer modal dialog

--- a/tests/features/usergroup_members.feature
+++ b/tests/features/usergroup_members.feature
@@ -7,37 +7,50 @@ Feature: Usergroup members
     Given I am logged in as "Administrator"
     Given I am on "user-groups" page
 
-  Scenario: Add test user
+  # Add a new test user
+  Scenario: Add a new testing user
     Given I am on "active-users" page
-    Given sample testing user "armadillo" exists
+    When I click on "Add" button
+    * I type in the field "First name" text "Alan"
+    * I type in the field "Last name" text "Turing"
+    * in the modal dialog I click on "Add" button
+    Then I should see "aturing" entry in the data table
+
+  # Add a new test user group
+  Scenario: Add a new testing user group
+    Given I am on "user-groups" page
+    When I click on "Add" button
+    * I type in the field "Group name" text "imitation-game-group"
+    When in the modal dialog I click on "Add" button
+    Then I should see "imitation-game-group" entry in the data table
 
   #
   # Test "User" members
   #
   Scenario: Add a User member into the user group
-    Given I click on "admins" entry in the data table
+    Given I click on "imitation-game-group" entry in the data table
     Given I click on "Members" page tab
-    Given I am on "admins" group > Members > "Users" section
-    Then I should see the "user" tab count is "1"
+    Given I am on "imitation-game-group" group > Members > "Users" section
+    Then I should see the "user" tab count is "0"
     When I click on "Add" button located in the toolbar
-    Then I should see the dialog with title "Assign users to user group: admins"
-    When I move user "armadillo" from the available list and move it to the chosen options
+    Then I should see the dialog with title "Assign users to user group: imitation-game-group"
+    When I move user "aturing" from the available list and move it to the chosen options
     And in the modal dialog I click on "Add" button
-    * I should see "success" alert with text "Assigned new users to user group 'admins'"
+    * I should see "success" alert with text "Assigned new users to user group 'imitation-game-group'"
     * I close the alert
-    Then I should see the element "armadillo" in the table
-    Then I should see the "user" tab count is "2"
+    Then I should see the element "aturing" in the table
+    Then I should see the "user" tab count is "1"
 
   Scenario: Search for a user
-    When I type "armadillo" in the search field
-    Then I should see the "armadillo" text in the search input field
+    When I type "aturing" in the search field
+    Then I should see the "aturing" text in the search input field
     When I click on the arrow icon to perform search
-    Then I should see the element "armadillo" in the table
+    Then I should see the element "aturing" in the table
     * I click on the X icon to clear the search field
     When I type "notthere" in the search field
     Then I should see the "notthere" text in the search input field
     When I click on the arrow icon to perform search
-    Then I should not see the element "armadillo" in the table
+    Then I should not see the element "aturing" in the table
     * I click on the X icon to clear the search field
     Then I click on the arrow icon to perform search
 
@@ -45,31 +58,31 @@ Feature: Usergroup members
     When I click on the "indirect" button
     Then I should see the "user" tab count is "0"
     When I click on the "direct" button
-    Then I should see the "user" tab count is "2"
-
-  Scenario: Remove User from the user group admins
-    When I select entry "armadillo" in the data table
-    And I click on "Delete" button located in the toolbar
-    Then I should see the dialog with title "Delete users from user group: admins"
-    And the "armadillo" element should be in the dialog table
-    When in the modal dialog I click on "Delete" button
-    Then I should see "success" alert with text "Removed users from user group 'admins'"
-    * I close the alert
-    And I should not see the element "armadillo" in the table
     Then I should see the "user" tab count is "1"
+
+  Scenario: Remove User from the user group imitation-game-group
+    When I select entry "aturing" in the data table
+    And I click on "Delete" button located in the toolbar
+    Then I should see the dialog with title "Delete users from user group: imitation-game-group"
+    And the "aturing" element should be in the dialog table
+    When in the modal dialog I click on "Delete" button
+    Then I should see "success" alert with text "Removed users from user group 'imitation-game-group'"
+    * I close the alert
+    And I should not see the element "aturing" in the table
+    Then I should see the "user" tab count is "0"
 
   #
   # Test "UserGroup" members
   #
   Scenario: Add a Usergroup member into the user group
     Given I click on "User groups" page tab
-    Given I am on "admins" group > Members > "User groups" section
+    Given I am on "imitation-game-group" group > Members > "User groups" section
     Then I should see the "usergroup" tab count is "0"
     When I click on "Add" button located in the toolbar
-    Then I should see the dialog with title "Assign user groups to user group: admins"
+    Then I should see the dialog with title "Assign user groups to user group: imitation-game-group"
     When I move user "editors" from the available list and move it to the chosen options
     And in the modal dialog I click on "Add" button
-    * I should see "success" alert with text "Assigned new user groups to user group 'admins'"
+    * I should see "success" alert with text "Assigned new user groups to user group 'imitation-game-group'"
     * I close the alert
     Then I should see the element "editors" in the table
     Then I should see the "usergroup" tab count is "1"
@@ -94,13 +107,13 @@ Feature: Usergroup members
     When I click on the "direct" button
     Then I should see the "usergroup" tab count is "1"
 
-  Scenario: Remove Usergroup from the user group admins
+  Scenario: Remove Usergroup from the user group imitation-game-group
     When I select entry "editors" in the data table
     And I click on "Delete" button located in the toolbar
-    Then I should see the dialog with title "Delete user groups from user group: admins"
+    Then I should see the dialog with title "Delete user groups from user group: imitation-game-group"
     And the "editors" element should be in the dialog table
     When in the modal dialog I click on "Delete" button
-    Then I should see "success" alert with text "Removed user groups from user group 'admins'"
+    Then I should see "success" alert with text "Removed user groups from user group 'imitation-game-group'"
     * I close the alert
     And I should not see the element "editors" in the table
     Then I should see the "usergroup" tab count is "0"
@@ -110,13 +123,13 @@ Feature: Usergroup members
   #
   Scenario: Add a Service member into the user group
     Given I click on "Services" page tab
-    Given I am on "admins" group > Members > "Services" section
+    Given I am on "imitation-game-group" group > Members > "Services" section
     Then I should see the "service" tab count is "0"
     When I click on "Add" button located in the toolbar
-    Then I should see the dialog with title "Assign services to user group: admins"
+    Then I should see the dialog with title "Assign services to user group: imitation-game-group"
     When I move user "DNS/server.ipa.demo@DOM-IPA.DEMO" from the available list and move it to the chosen options
     And in the modal dialog I click on "Add" button
-    * I should see "success" alert with text "Assigned new services to user group 'admins'"
+    * I should see "success" alert with text "Assigned new services to user group 'imitation-game-group'"
     * I close the alert
     Then I should see partial "DNS" entry in the data table
     Then I should see the "service" tab count is "1"
@@ -141,13 +154,37 @@ Feature: Usergroup members
     When I click on the "direct" button
     Then I should see the "service" tab count is "1"
 
-  Scenario: Remove service from the user group admins
+  Scenario: Remove service from the user group imitation-game-group
     When I select partial entry "DNS" in the data table
     And I click on "Delete" button located in the toolbar
-    Then I should see the dialog with title "Delete services from user group: admins"
+    Then I should see the dialog with title "Delete services from user group: imitation-game-group"
     And the "DNS" element should be in the dialog table
     When in the modal dialog I click on "Delete" button
-    Then I should see "success" alert with text "Removed services from user group 'admins'"
+    Then I should see "success" alert with text "Removed services from user group 'imitation-game-group'"
     * I close the alert
     And I should not see the element "DNS" in the table
     Then I should see the "service" tab count is "0"
+
+  # Cleanup
+  Scenario: Remove testing user aturing
+    Given I am on "active-users" page
+    Given I should see "aturing" entry in the data table
+    Then I select entry "aturing" in the data table
+    When I click on "Delete" button
+    * I see "Remove Active Users" modal
+    * I should see "aturing" entry in the data table
+    When in the modal dialog I check "Delete" radio selector
+    And in the modal dialog I click on "Delete" button
+    * I should see "success" alert with text "Users removed"
+    Then I should not see "aturing" entry in the data table
+
+  Scenario: Remove testing user group imitation-game-group
+    Given I am on "user-groups" page
+    Given I should see "imitation-game-group" entry in the data table
+    Then I select entry "imitation-game-group" in the data table
+    When I click on "Delete" button
+    * I see "Remove user groups" modal
+    * I should see "imitation-game-group" entry in the data table
+    When in the modal dialog I click on "Delete" button
+    * I should see "success" alert with text "User groups removed"
+    Then I should not see "imitation-game-group" entry in the data table


### PR DESCRIPTION
The `sudo_rules_settings` and `usergroup_members` tests are failing in some cases and those errors tend to be the same alongside many PRs. Those needs to be checked and corrected based on the right context of the page/section.