### PR TITLE
Doc: Add default credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ $ npm run build
 Now your dev environment is ready, you can do changes and see them at:
 `https://server.ipa.demo/ipa/modern_ui/`
 
+The default credentials are **admin** and **Secret123**.
+
 ### Considerations
 
 - Live reload is currently not available.


### PR DESCRIPTION
One has to open Vagrantfile to figure out the credentials, this is not very convenient, I think they should be mentioned in the README.

Fixes: #633