### PR TITLE
Add Subordinate IDs main page

### DIFF
--- a/src/components/tables/MainTable.tsx
+++ b/src/components/tables/MainTable.tsx
@@ -1,0 +1,250 @@
+import React from "react";
+// PatternFly
+import { Td, Th, Tr } from "@patternfly/react-table";
+// Tables
+import TableLayout from "../layouts/TableLayout";
+// Layouts
+import SkeletonOnTableLayout from "../layouts/Skeleton/SkeletonOnTableLayout";
+// Data types
+import { SubId } from "src/utils/datatypes/globalDataTypes";
+// React router DOM
+import { Link } from "react-router-dom";
+import EmptyBodyTable from "./EmptyBodyTable";
+
+/**
+ * This component renders a table with the specified columns and rows.
+ * It also allows the user to select rows and perform operations on them.
+ *
+ */
+
+type DataType = SubId; // TODO: add more data types separated by an 'or' operator ('|')
+
+interface SelectedElementsData {
+  isElementSelectable: (element: DataType) => boolean;
+  selectedElements: DataType[];
+  selectableElementsTable: DataType[];
+  setElementsSelected: (rule: DataType, isSelecting?: boolean) => void;
+  clearSelectedElements: () => void;
+}
+
+interface ButtonsData {
+  updateIsDeleteButtonDisabled: (value: boolean) => void;
+  isDeletion: boolean;
+  updateIsDeletion: (value: boolean) => void;
+  updateIsEnableButtonDisabled?: (value: boolean) => void;
+  updateIsDisableButtonDisabled?: (value: boolean) => void;
+  isDisableEnableOp?: boolean;
+  updateIsDisableEnableOp?: (value: boolean) => void;
+}
+
+interface PaginationData {
+  selectedPerPage: number;
+  updateSelectedPerPage: (selected: number) => void;
+}
+
+export interface PropsToTable {
+  tableTitle: string;
+  shownElementsList: DataType[];
+  pk: string; // E.g. Primary key for users --> "uid"
+  keyNames: string[]; // E.g. for user.uid, user.description --> ["uid", "description"]
+  columnNames: string[]; // E.g. ["User ID", "Description"]
+  hasCheckboxes: boolean;
+  pathname: string; // E.g. "active-users" (without the leading '/')
+  showTableRows: boolean;
+  showLink: boolean;
+  elementsData?: SelectedElementsData;
+  buttonsData?: ButtonsData;
+  paginationData?: PaginationData;
+}
+
+const MainTable = (props: PropsToTable) => {
+  // Retrieve elements data from props
+  const shownElementsList = [...props.shownElementsList];
+  const columnNames = [...props.columnNames];
+
+  // When user status is updated, unselect selected rows
+  React.useEffect(() => {
+    if (props.buttonsData && props.buttonsData.isDisableEnableOp) {
+      props.elementsData?.clearSelectedElements();
+    }
+  }, [props.buttonsData?.isDisableEnableOp]);
+
+  const isElementSelected = (element: DataType) => {
+    if (
+      props.elementsData?.selectedElements.find(
+        (selectedElement) => selectedElement[props.pk] === element[props.pk]
+      )
+    ) {
+      return true;
+    } else {
+      return false;
+    }
+  };
+
+  // To allow shift+click to select/deselect multiple rows
+  const [recentSelectedRowIndex, setRecentSelectedRowIndex] = React.useState<
+    number | null
+  >(null);
+  const [shifting, setShifting] = React.useState(false);
+
+  // On selecting one single row
+  const onSelectElement = (
+    element: DataType,
+    rowIndex: number,
+    isSelecting: boolean
+  ) => {
+    // If the element is shift + selecting the checkboxes, then all intermediate checkboxes should be selected
+    if (shifting && recentSelectedRowIndex !== null) {
+      const numberSelected = rowIndex - recentSelectedRowIndex;
+      const intermediateIndexes = Array.from(
+        new Array(Math.abs(numberSelected) + 1),
+        (_, i) => i + Math.min(recentSelectedRowIndex, rowIndex)
+      );
+      intermediateIndexes.forEach((index) =>
+        props.elementsData?.setElementsSelected(
+          shownElementsList[index],
+          isSelecting
+        )
+      );
+    } else {
+      props.elementsData?.setElementsSelected(element, isSelecting);
+    }
+    setRecentSelectedRowIndex(rowIndex);
+
+    // Resetting 'isDisableEnableOp'
+    props.buttonsData?.updateIsDeleteButtonDisabled(false);
+
+    // Update elementSelected array
+    if (isSelecting) {
+      // Increment the elements selected per page (++)
+      props.paginationData?.updateSelectedPerPage(
+        props.paginationData?.selectedPerPage + 1
+      );
+    } else {
+      // Decrement the elements selected per page (--)
+      props.paginationData?.updateSelectedPerPage(
+        props.paginationData?.selectedPerPage - 1
+      );
+    }
+  };
+
+  // Reset 'selectedElements array if a delete operation has been done
+  React.useEffect(() => {
+    if (props.buttonsData?.isDeletion) {
+      props.elementsData?.clearSelectedElements();
+      props.buttonsData.updateIsDeletion(false);
+    }
+  }, [props.buttonsData?.isDeletion]);
+
+  // Enable 'Delete' button (if any element selected)
+  React.useEffect(() => {
+    if (props.elementsData && props.elementsData.selectedElements.length > 0) {
+      props.buttonsData?.updateIsDeleteButtonDisabled(false);
+    }
+
+    if (
+      props.elementsData &&
+      props.elementsData.selectedElements.length === 0
+    ) {
+      props.buttonsData?.updateIsDeleteButtonDisabled(true);
+    }
+  }, [props.elementsData?.selectedElements]);
+
+  // Keyboard event
+  React.useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Shift") {
+        setShifting(true);
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === "Shift") {
+        setShifting(false);
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("keyup", onKeyUp);
+
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("keyup", onKeyUp);
+    };
+  }, []);
+
+  // Defining table header and body from here to avoid passing specific names to the Table Layout
+  const header = (
+    <Tr key="header" id="table-header">
+      {props.hasCheckboxes && <Th modifier="wrap"></Th>}
+      {props.columnNames.map((columnName, idx) => (
+        <Th modifier="wrap" key={idx}>
+          {columnName}
+        </Th>
+      ))}
+    </Tr>
+  );
+
+  const body = shownElementsList.map((element, rowIndex) => {
+    if (element !== undefined) {
+      return (
+        <Tr key={"row-" + rowIndex} id={"row-" + rowIndex}>
+          {/* Checkboxes (if specified) */}
+          {props.hasCheckboxes && (
+            <Td
+              key={rowIndex}
+              id={rowIndex.toString()}
+              dataLabel="checkbox"
+              select={{
+                rowIndex,
+                onSelect: (_event, isSelecting) =>
+                  onSelectElement(element, rowIndex, isSelecting),
+                isSelected: isElementSelected(element),
+                isDisabled: !props.elementsData?.isElementSelectable(element),
+              }}
+            />
+          )}
+          {/* Table rows */}
+          {props.keyNames.map((keyName, idx) => (
+            <Td dataLabel={columnNames[keyName]} key={idx} id={idx.toString()}>
+              {idx === 0 && !!props.showLink ? (
+                <Link
+                  to={"/" + props.pathname + "/" + element[keyName]}
+                  state={element}
+                >
+                  {element[keyName]}
+                </Link>
+              ) : (
+                <>{element[keyName]}</>
+              )}
+            </Td>
+          ))}
+        </Tr>
+      );
+    } else {
+      return <EmptyBodyTable key={"empty-row-" + rowIndex} />;
+    }
+  });
+
+  const skeleton = (
+    <SkeletonOnTableLayout
+      rows={4}
+      colSpan={9}
+      screenreaderText={"Loading table rows"}
+    />
+  );
+
+  return (
+    <TableLayout
+      ariaLabel={props.tableTitle}
+      variant={"compact"}
+      hasBorders={true}
+      classes={"pf-v5-u-mt-md"}
+      tableId={props.pathname + "-table"}
+      isStickyHeader={true}
+      tableHeader={header}
+      tableBody={!props.showTableRows ? skeleton : body}
+    />
+  );
+};
+
+export default MainTable;

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -51,6 +51,7 @@ import ResetPasswordPage from "src/login/ResetPasswordPage";
 import SetupBrowserConfig from "src/pages/SetupBrowserConfig";
 import Configuration from "src/pages/Configuration/Configuration";
 import SyncOtpPage from "src/login/SyncOtpPage";
+import SubordinateIDs from "src/pages/SubordinateIDs/SubordinateIDs";
 
 // Renders routes (React)
 export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
@@ -335,6 +336,9 @@ export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
                     element={<HBACRulesTabs section="settings" />}
                   />
                 </Route>
+              </Route>
+              <Route path="subordinate-ids">
+                <Route path="" element={<SubordinateIDs />} />
               </Route>
               <Route path="hbac-services">
                 <Route path="" element={<HBACServices />} />

--- a/src/navigation/NavRoutes.ts
+++ b/src/navigation/NavRoutes.ts
@@ -26,6 +26,8 @@ const IdViewsGroupRef = "id-views";
 const AutomemberGroupRef = "automember";
 const UserGroupRulesGroupRef = "user-group-rules";
 const HostGroupRulesGroupRef = "host-group-rules";
+// - Subordinate IDs
+const SubordinateIDsGroupRef = "subordinate-ids";
 // POLICY
 // - Host-based access control
 const HostBasedAccessControlGroupRef = "host-based-access-control";
@@ -170,6 +172,20 @@ export const navigationRoutes = [
             group: HostGroupRulesGroupRef,
             title: `${BASE_TITLE} - Host group rules`,
             path: "host-group-rules",
+          },
+        ],
+      },
+      {
+        label: "Subordinate IDs",
+        group: SubordinateIDsGroupRef,
+        title: `${BASE_TITLE} - Subordinate IDs`,
+        path: "",
+        items: [
+          {
+            label: "Subordinate IDs",
+            group: SubordinateIDsGroupRef,
+            title: `${BASE_TITLE} - Subordinate IDs`,
+            path: "subordinate-ids",
           },
         ],
       },

--- a/src/pages/SubordinateIDs/SubordinateIDs.tsx
+++ b/src/pages/SubordinateIDs/SubordinateIDs.tsx
@@ -1,0 +1,377 @@
+import React from "react";
+// PatternFly
+import {
+  Page,
+  PageSection,
+  PageSectionVariants,
+  PaginationVariant,
+} from "@patternfly/react-core";
+import {
+  InnerScrollContainer,
+  OuterScrollContainer,
+} from "@patternfly/react-table";
+// Data types
+import { SubId } from "src/utils/datatypes/globalDataTypes";
+// Hooks
+import useAlerts from "src/hooks/useAlerts";
+import useUpdateRoute from "src/hooks/useUpdateRoute";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
+// Redux
+import { useAppSelector } from "src/store/hooks";
+// Components
+import TitleLayout from "src/components/layouts/TitleLayout";
+import ToolbarLayout, {
+  ToolbarItem,
+} from "src/components/layouts/ToolbarLayout";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
+import SearchInputLayout from "src/components/layouts/SearchInputLayout";
+import SecondaryButton from "src/components/layouts/SecondaryButton";
+import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
+import MainTable from "src/components/tables/MainTable";
+// Errors
+import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
+import { SerializedError } from "@reduxjs/toolkit";
+import useApiError from "src/hooks/useApiError";
+import GlobalErrors from "src/components/errors/GlobalErrors";
+// RPC
+import {
+  SubIdDataPayload,
+  useGetSubIdEntriesQuery,
+  useSearchSubIdEntriesMutation,
+} from "src/services/rpcSubordinateIDs";
+
+const SubordinateIDs = () => {
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  const { browserTitle } = useUpdateRoute({ pathname: "subordinate-ids" });
+
+  // Set the page title to be shown in the browser tab
+  React.useEffect(() => {
+    document.title = browserTitle;
+  }, [browserTitle]);
+
+  // Retrieve API version from environment data
+  const apiVersion = useAppSelector(
+    (state) => state.global.environment.api_version
+  ) as string;
+
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
+  // URL parameters: page number, page size, search value
+  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+    useListPageSearchParams();
+
+  // Handle API calls errors
+  const globalErrors = useApiError([]);
+
+  // Page indexes
+  const firstUserIdx = (page - 1) * perPage;
+  const lastUserIdx = page * perPage;
+
+  // States
+  const [subIds, setSubIds] = React.useState<SubId[]>([]);
+  const [searchDisabled, setSearchIsDisabled] = React.useState<boolean>(false);
+  const [totalCount, setTotalCount] = React.useState<number>(0);
+
+  // API calls
+  const subIdsDataResponse = useGetSubIdEntriesQuery({
+    searchValue: searchValue,
+    apiVersion,
+    sizelimit: 100,
+    startIdx: firstUserIdx,
+    stopIdx: lastUserIdx,
+  } as SubIdDataPayload);
+
+  const {
+    data: batchResponse,
+    isLoading: isBatchLoading,
+    error: batchError,
+  } = subIdsDataResponse;
+
+  // Handle data when the API call is finished
+  React.useEffect(() => {
+    if (subIdsDataResponse.isFetching) {
+      setShowTableRows(false);
+      // Reset selected elements on refresh
+      setTotalCount(0);
+      globalErrors.clear();
+      return;
+    }
+
+    // API response: Success
+    if (
+      subIdsDataResponse.isSuccess &&
+      subIdsDataResponse.data &&
+      batchResponse !== undefined
+    ) {
+      const listResult = batchResponse.result.results;
+      const totalCount = batchResponse.result.totalCount;
+      const listSize = batchResponse.result.count;
+      const elementsList: SubId[] = [];
+
+      for (let i = 0; i < listSize; i++) {
+        elementsList.push(listResult[i].result);
+      }
+
+      setTotalCount(totalCount);
+      // Update the list of elements
+      setSubIds(elementsList);
+      // Show table elements
+      setShowTableRows(true);
+    }
+
+    // API response: Error
+    if (
+      !subIdsDataResponse.isLoading &&
+      subIdsDataResponse.isError &&
+      subIdsDataResponse.error !== undefined
+    ) {
+      // This normally happens when the user is not authorized to view the data
+      // So instead of adding an error, refresh page
+      window.location.reload();
+    }
+  }, [batchResponse]);
+
+  // Refresh button handling
+  const refreshData = () => {
+    // Hide table
+    setShowTableRows(false);
+
+    // Reset selected elements on refresh
+    setTotalCount(0);
+
+    subIdsDataResponse.refetch().then(() => {
+      setShowTableRows(true);
+    });
+  };
+
+  // Always refetch data when the component is loaded.
+  // This ensures the data is always up-to-date.
+  React.useEffect(() => {
+    subIdsDataResponse.refetch();
+  }, []);
+
+  // Show table rows
+  const [showTableRows, setShowTableRows] = React.useState(!isBatchLoading);
+
+  // Show table rows only when data is fully retrieved
+  React.useEffect(() => {
+    if (showTableRows !== !isBatchLoading) {
+      setShowTableRows(!isBatchLoading);
+    }
+  }, [isBatchLoading]);
+
+  // Pagination
+  const updatePage = (newPage: number) => {
+    setPage(newPage);
+  };
+
+  const updatePerPage = (newSetPerPage: number) => {
+    setPerPage(newSetPerPage);
+  };
+
+  // Elements displayed on the first page
+  const updateShownElementsList = (newShownElementsList: SubId[]) => {
+    setSubIds(newShownElementsList);
+  };
+
+  // Update search input valie
+  const updateSearchValue = (value: string) => {
+    setSearchValue(value);
+  };
+
+  // Search API call
+  const [searchEntry] = useSearchSubIdEntriesMutation();
+
+  const submitSearchValue = () => {
+    searchEntry({
+      searchValue: searchValue,
+      apiVersion,
+      sizelimit: 100,
+      startIdx: firstUserIdx,
+      stopIdx: lastUserIdx,
+    }).then((result) => {
+      if ("data" in result) {
+        const searchError = result.data.error as
+          | FetchBaseQueryError
+          | SerializedError;
+
+        if (searchError) {
+          // Error
+          let error: string | undefined = "";
+          if ("error" in searchError) {
+            error = searchError.error;
+          } else if ("message" in searchError) {
+            error = searchError.message;
+          }
+          alerts.addAlert(
+            "submit-search-value-error",
+            error || "Error when searching for subordinate IDs",
+            "danger"
+          );
+        } else {
+          // Success
+          const listResult = result.data.result.results;
+          const listSize = result.data.result.count;
+          const totalCount = result.data.result.totalCount;
+          const elementsList: SubId[] = [];
+
+          for (let i = 0; i < listSize; i++) {
+            elementsList.push(listResult[i].result);
+          }
+
+          setTotalCount(totalCount);
+          setSubIds(elementsList);
+          setShowTableRows(true);
+        }
+        setSearchIsDisabled(false);
+      }
+    });
+  };
+
+  // Data wrappers
+  // TODO: Better separation of concerts
+  // - 'PaginationLayout'
+  const paginationData = {
+    page,
+    perPage,
+    updatePage,
+    updatePerPage,
+    // As of now, this function is not used
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    updateSelectedPerPage: () => {},
+    updateShownElementsList: updateShownElementsList,
+    totalCount,
+  };
+
+  // SearchInputLayout
+  const searchValueData = {
+    searchValue,
+    updateSearchValue,
+    submitSearchValue,
+  };
+
+  // List of Toolbar items
+  const toolbarItems: ToolbarItem[] = [
+    {
+      key: 0,
+      element: (
+        <SearchInputLayout
+          name="search"
+          ariaLabel="Search subIds"
+          placeholder="Search"
+          searchValueData={searchValueData}
+          isDisabled={searchDisabled}
+        />
+      ),
+      toolbarItemVariant: "search-filter",
+      toolbarItemSpacer: { default: "spacerMd" },
+    },
+    {
+      key: 1,
+      toolbarItemVariant: "separator",
+    },
+    {
+      key: 2,
+      element: (
+        <SecondaryButton
+          onClickHandler={refreshData}
+          isDisabled={!showTableRows}
+        >
+          Refresh
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 3,
+      element: (
+        <SecondaryButton isDisabled={!showTableRows}>Add</SecondaryButton>
+      ),
+    },
+    {
+      key: 4,
+      toolbarItemVariant: "separator",
+    },
+    {
+      key: 5,
+      element: <HelpTextWithIconLayout textContent="Help" />,
+    },
+    {
+      key: 6,
+      element: (
+        <PaginationLayout
+          list={subIds}
+          paginationData={paginationData}
+          widgetId="pagination-options-menu-top"
+          isCompact={true}
+        />
+      ),
+      toolbarItemAlignment: { default: "alignRight" },
+    },
+  ];
+
+  // Render component
+  return (
+    <Page>
+      <alerts.ManagedAlerts />
+      <PageSection variant={PageSectionVariants.light}>
+        <TitleLayout
+          id="Subordinate IDs page"
+          headingLevel="h1"
+          text="Subordinate IDs"
+        />
+      </PageSection>
+      <PageSection
+        variant={PageSectionVariants.light}
+        isFilled={false}
+        className="pf-v5-u-m-lg pf-v5-u-pb-md pf-v5-u-pl-0 pf-v5-u-pr-0"
+      >
+        <ToolbarLayout
+          className="pf-v5-u-pt-0 pf-v5-u-pl-lg pf-v5-u-pr-md"
+          contentClassName="pf-v5-u-p-0"
+          toolbarItems={toolbarItems}
+        />
+        <div style={{ height: `calc(100vh - 352.2px)` }}>
+          <OuterScrollContainer>
+            <InnerScrollContainer>
+              {batchError !== undefined && batchError ? (
+                <GlobalErrors errors={globalErrors.getAll()} />
+              ) : (
+                <MainTable
+                  tableTitle="Subordinate IDs table"
+                  shownElementsList={subIds}
+                  pk="ipauniqueid"
+                  keyNames={[
+                    "ipauniqueid",
+                    "ipaowner",
+                    "ipasubgidnumber",
+                    "ipasubuidnumber",
+                  ]}
+                  columnNames={[
+                    "Unique ID",
+                    "Owner",
+                    "SubGID range start",
+                    "SubUID range start",
+                  ]}
+                  hasCheckboxes={false}
+                  pathname="subordinate-ids"
+                  showTableRows={showTableRows}
+                  showLink={false}
+                />
+              )}
+            </InnerScrollContainer>
+          </OuterScrollContainer>
+        </div>
+        <PaginationLayout
+          list={subIds}
+          paginationData={paginationData}
+          variant={PaginationVariant.bottom}
+          widgetId="pagination-options-menu-bottom"
+          className="pf-v5-u-pb-0 pf-v5-u-pr-md"
+        />
+      </PageSection>
+    </Page>
+  );
+};
+
+export default SubordinateIDs;

--- a/src/services/rpcSubordinateIDs.ts
+++ b/src/services/rpcSubordinateIDs.ts
@@ -1,0 +1,187 @@
+import {
+  api,
+  BatchRPCResponse,
+  Command,
+  FindRPCResponse,
+  getBatchCommand,
+  getCommand,
+} from "./rpc";
+import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
+// Data types
+import { SubId } from "src/utils/datatypes/globalDataTypes";
+
+/**
+ * Endpoints: useGetSubIdEntriesQuery, useSearchSubIdEntriesMutation
+ *
+ * API commands:
+ * - subid_find: https://freeipa.readthedocs.io/en/latest/api/subid_find.html
+ * - subid_show: https://freeipa.readthedocs.io/en/latest/api/subid_show.html
+ */
+
+export interface SubIdDataPayload {
+  searchValue: string;
+  apiVersion: string;
+  sizelimit: number;
+  startIdx: number;
+  stopIdx: number;
+}
+
+// API
+const extendedApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    /**
+     * Find subordinate IDs.
+     * @param SubIdDataPayload
+     * @returns List of subordinate IDs entries
+     *
+     */
+    getSubIdEntries: build.query<BatchRPCResponse, SubIdDataPayload>({
+      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
+        const { searchValue, apiVersion, sizelimit, startIdx, stopIdx } =
+          payloadData;
+
+        if (apiVersion === undefined) {
+          return {
+            error: {
+              status: "CUSTOM_ERROR",
+              data: "",
+              error: "API version not available",
+            } as FetchBaseQueryError,
+          };
+        }
+
+        // FETCH SUBID DATA VIA "subid_find" COMMAND
+        // Prepare search parameters
+        const subidsParams = {
+          pkey_only: true,
+          sizelimit: sizelimit,
+          version: apiVersion,
+        };
+
+        // Prepare payload
+        const payloadDataSubids: Command = {
+          method: "subid_find",
+          params: [[searchValue], subidsParams],
+        };
+
+        // Make call using 'fetchWithBQ'
+        const getResultSubid = await fetchWithBQ(getCommand(payloadDataSubids));
+        // Return possible errors
+        if (getResultSubid.error) {
+          return { error: getResultSubid.error as FetchBaseQueryError };
+        }
+        // If no error: cast and assign 'ids'
+        const responseDataSubid = getResultSubid.data as FindRPCResponse;
+
+        const subidIds: string[] = [];
+        const subidsItemsCount = responseDataSubid.result.result
+          .length as number;
+
+        for (let i = startIdx; i < subidsItemsCount && i < stopIdx; i++) {
+          const subidId = responseDataSubid.result.result[i] as SubId;
+          const { ipauniqueid } = subidId;
+          subidIds.push(ipauniqueid[0] as string);
+        }
+
+        // FETCH SUBID DATA VIA "subid_show" COMMAND
+        const commands: Command[] = [];
+        subidIds.forEach((subidId) => {
+          commands.push({
+            method: "subid_show",
+            params: [[subidId], {}],
+          });
+        });
+
+        const subIdsShowResult = await fetchWithBQ(
+          getBatchCommand(commands, apiVersion)
+        );
+
+        const response = subIdsShowResult.data as BatchRPCResponse;
+        if (response) {
+          response.result.totalCount = subidsItemsCount;
+        }
+
+        // Return results
+        return { data: response };
+      },
+    }),
+    /**
+     * Search for a specific subordinate ID.
+     * @param SubIdDataPayload
+     * @returns Subordinate ID entry
+     */
+    searchSubIdEntries: build.mutation<BatchRPCResponse, SubIdDataPayload>({
+      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
+        const { searchValue, apiVersion, sizelimit, startIdx, stopIdx } =
+          payloadData;
+
+        if (apiVersion === undefined) {
+          return {
+            error: {
+              status: "CUSTOM_ERROR",
+              data: "",
+              error: "API version not available",
+            } as FetchBaseQueryError,
+          };
+        }
+
+        // FETCH SUBID DATA VIA "subid_find" COMMAND
+        // Prepare search parameters
+        const subidsParams = {
+          pkey_only: true,
+          sizelimit: sizelimit,
+          version: apiVersion,
+        };
+
+        // Prepare payload
+        const payloadDataSubids: Command = {
+          method: "subid_find",
+          params: [[searchValue], subidsParams],
+        };
+
+        // Make call using 'fetchWithBQ'
+        const getResultSubid = await fetchWithBQ(getCommand(payloadDataSubids));
+        // Return possible errors
+        if (getResultSubid.error) {
+          return { error: getResultSubid.error as FetchBaseQueryError };
+        }
+        // If no error: cast and assign 'ids'
+        const responseDataSubid = getResultSubid.data as FindRPCResponse;
+
+        const subidIds: string[] = [];
+        const subidsItemsCount = responseDataSubid.result.result
+          .length as number;
+
+        for (let i = startIdx; i < subidsItemsCount && i < stopIdx; i++) {
+          const subidId = responseDataSubid.result.result[i] as SubId;
+          const { ipauniqueid } = subidId;
+          subidIds.push(ipauniqueid[0] as string);
+        }
+
+        // FETCH SUBID DATA VIA "subid_show" COMMAND
+        const commands: Command[] = [];
+        subidIds.forEach((subidId) => {
+          commands.push({
+            method: "subid_show",
+            params: [[subidId], {}],
+          });
+        });
+
+        const subIdsShowResult = await fetchWithBQ(
+          getBatchCommand(commands, apiVersion)
+        );
+
+        const response = subIdsShowResult.data as BatchRPCResponse;
+        if (response) {
+          response.result.totalCount = subidsItemsCount;
+        }
+
+        // Return results
+        return { data: response };
+      },
+    }),
+  }),
+});
+
+export const { useGetSubIdEntriesQuery, useSearchSubIdEntriesMutation } =
+  extendedApi;

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -639,11 +639,11 @@ export interface OTPToken {
 export interface SubId {
   ipauniqueid: string;
   ipaowner: string;
-  ipasubgidnumber: string;
-  ipasubuidnumber: string;
-  description: string;
-  ipasubuidcount: string;
-  ipasubgidcount: string;
+  ipasubgidnumber?: string;
+  ipasubuidnumber?: string;
+  description?: string;
+  ipasubuidcount?: string;
+  ipasubgidcount?: string;
   dn: string;
 }
 

--- a/src/utils/subIdUtils.tsx
+++ b/src/utils/subIdUtils.tsx
@@ -1,0 +1,62 @@
+// Data types
+import { SubId } from "src/utils/datatypes/globalDataTypes";
+// Utils
+import { convertApiObj } from "./ipaObjectUtils";
+
+export const asRecord = (
+  element: Partial<SubId>,
+  onElementChange: (element: Partial<SubId>) => void
+) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ipaObject = element as Record<string, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function recordOnChange(ipaObject: Record<string, any>) {
+    onElementChange(ipaObject as SubId);
+  }
+
+  return { ipaObject, recordOnChange };
+};
+
+const simpleValues = new Set([
+  "ipauniqueid",
+  "ipaowner",
+  "ipasubgidnumber",
+  "ipasubuidnumber",
+  "description",
+  "ipasubuidcount",
+  "ipasubgidcount",
+  "dn",
+]);
+const dateValues = new Set([]);
+
+export function apiToSubId(apiRecord: Record<string, unknown>): SubId {
+  const converted = convertApiObj(
+    apiRecord,
+    simpleValues,
+    dateValues
+  ) as Partial<SubId>;
+  return partialSubIdToSubId(converted) as SubId;
+}
+
+export function partialSubIdToSubId(partialSudoRule: Partial<SubId>): SubId {
+  return {
+    ...createEmptySubId(),
+    ...partialSudoRule,
+  };
+}
+
+// Get empty User object initialized with default values
+export function createEmptySubId(): SubId {
+  const subId: SubId = {
+    ipauniqueid: "",
+    ipaowner: "",
+    ipasubgidnumber: "",
+    ipasubuidnumber: "",
+    description: "",
+    ipasubuidcount: "",
+    ipasubgidcount: "",
+    dn: "",
+  };
+
+  return subId;
+}


### PR DESCRIPTION
The 'Subordinate IDs' page should show the data related to a given user that has a subordinate ID and its range.

The current solution provides functionality for some buttons ('Refresh') and pagination. The rest of the functionality will be provided in another PR.

The main page is being rendered using a reusable component `MainPage` that allows listing elements with some basic configuration (showing links or checkboxes, and selection functionality).