### PR TITLE
'Subordinate IDs Statistics' page

### DIFF
--- a/src/components/layouts/PageLayout.tsx
+++ b/src/components/layouts/PageLayout.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+// PatternFly
+import { Page, PageSection, PageSectionVariants } from "@patternfly/react-core";
+// Hooks
+import useAlerts from "src/hooks/useAlerts";
+import useUpdateRoute from "src/hooks/useUpdateRoute";
+// Components
+import TitleLayout from "./TitleLayout";
+import ToolbarLayout, { ToolbarItem } from "./ToolbarLayout";
+
+interface PageLayoutProps {
+  title: string;
+  pathname: string;
+  hasAlerts: boolean;
+  toolbarItems?: ToolbarItem[];
+  children: React.ReactNode;
+  pagination?: React.ReactNode;
+  modals?: React.ReactNode;
+}
+
+const PageLayout = (props: PageLayoutProps) => {
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  const { browserTitle } = useUpdateRoute({ pathname: props.pathname });
+
+  // Set the page title to be shown in the browser tab
+  React.useEffect(() => {
+    document.title = browserTitle;
+  }, [browserTitle]);
+
+  return (
+    <Page>
+      {props.hasAlerts && <alerts.ManagedAlerts />}
+      <PageSection variant={PageSectionVariants.light}>
+        <TitleLayout
+          id={props.title + " title"}
+          headingLevel="h1"
+          text={props.title}
+        />
+      </PageSection>
+      <PageSection
+        variant={PageSectionVariants.light}
+        isFilled={false}
+        className="pf-v5-u-m-lg pf-v5-u-pb-md pf-v5-u-pl-0 pf-v5-u-pr-0"
+      >
+        {props.toolbarItems && props.toolbarItems.length > 0 && (
+          <ToolbarLayout
+            className="pf-v5-u-pt-0 pf-v5-u-pl-lg pf-v5-u-pr-md"
+            contentClassName="pf-v5-u-p-0"
+            toolbarItems={props.toolbarItems}
+          />
+        )}
+        {props.children}
+        {props.pagination && props.pagination}
+      </PageSection>
+      {props.modals && props.modals}
+    </Page>
+  );
+};
+
+export default PageLayout;

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -52,6 +52,7 @@ import SetupBrowserConfig from "src/pages/SetupBrowserConfig";
 import Configuration from "src/pages/Configuration/Configuration";
 import SyncOtpPage from "src/login/SyncOtpPage";
 import SubordinateIDs from "src/pages/SubordinateIDs/SubordinateIDs";
+import SubIdsStatistics from "src/pages/SubordinateIDs/SubIdsStatistics";
 
 // Renders routes (React)
 export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
@@ -339,6 +340,9 @@ export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
               </Route>
               <Route path="subordinate-ids">
                 <Route path="" element={<SubordinateIDs />} />
+              </Route>
+              <Route path="subordinate-id-statistics">
+                <Route path="" element={<SubIdsStatistics />} />
               </Route>
               <Route path="hbac-services">
                 <Route path="" element={<HBACServices />} />

--- a/src/navigation/NavRoutes.ts
+++ b/src/navigation/NavRoutes.ts
@@ -28,6 +28,7 @@ const UserGroupRulesGroupRef = "user-group-rules";
 const HostGroupRulesGroupRef = "host-group-rules";
 // - Subordinate IDs
 const SubordinateIDsGroupRef = "subordinate-ids";
+const SubordinateIDsStatsGroupRef = "subordinate-id-statistics";
 // POLICY
 // - Host-based access control
 const HostBasedAccessControlGroupRef = "host-based-access-control";
@@ -186,6 +187,12 @@ export const navigationRoutes = [
             group: SubordinateIDsGroupRef,
             title: `${BASE_TITLE} - Subordinate IDs`,
             path: "subordinate-ids",
+          },
+          {
+            label: "Subordinate ID Statistics",
+            group: SubordinateIDsStatsGroupRef,
+            title: `${BASE_TITLE} - Subordinate ID Statistics`,
+            path: "subordinate-id-statistics",
           },
         ],
       },

--- a/src/pages/SubordinateIDs/SubIdsStatistics.tsx
+++ b/src/pages/SubordinateIDs/SubIdsStatistics.tsx
@@ -1,7 +1,158 @@
 import React from "react";
+// PatternFly
+import {
+  Grid,
+  GridItem,
+  PageSection,
+  PageSectionVariants,
+} from "@patternfly/react-core";
+import TableLayout from "src/components/layouts/TableLayout";
+import { Td, Th, Tr } from "@patternfly/react-table";
+// components
+import { ToolbarItem } from "src/components/layouts/ToolbarLayout";
+import SecondaryButton from "src/components/layouts/SecondaryButton";
+import PageLayout from "src/components/layouts/PageLayout";
+import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
+import SkeletonOnTableLayout from "src/components/layouts/Skeleton/SkeletonOnTableLayout";
+// Hooks
+import useAlerts from "src/hooks/useAlerts";
+// RPC
+import { useSubidStatsQuery } from "src/services/rpcSubordinateIDs";
+
+interface SubidStats {
+  assigned_subids: number;
+  baseid: number;
+  dna_remaining: number;
+  rangesize: number;
+  remaining_subids: number;
+}
 
 const SubIdsStatistics = () => {
-  return <div>SubIdsStatistics</div>;
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
+  // States
+  const [subidStats, setSubidStats] = React.useState<SubidStats>({
+    assigned_subids: 0,
+    baseid: 0,
+    dna_remaining: 0,
+    rangesize: 0,
+    remaining_subids: 0,
+  });
+  const [showTableRows, setShowTableRows] = React.useState<boolean>(false);
+
+  // API call
+  const subidStatsResponse = useSubidStatsQuery();
+  const { data, isLoading, error } = subidStatsResponse;
+
+  React.useEffect(() => {
+    setShowTableRows(!isLoading);
+
+    if (!isLoading && error) {
+      alerts.addAlert("Error fetching data", error, "danger");
+    }
+
+    if (!isLoading && data) {
+      const subidStats = data.result.result;
+      setSubidStats(subidStats as unknown as SubidStats);
+    }
+  }, [data, isLoading]);
+
+  // On refresh
+  const onRefresh = () => {
+    setShowTableRows(false);
+    subidStatsResponse.refetch().then(() => {
+      setShowTableRows(true);
+    });
+  };
+
+  // List of Toolbar items
+  const toolbarItems: ToolbarItem[] = [
+    {
+      key: 0,
+      element: (
+        <SecondaryButton onClickHandler={onRefresh} isDisabled={!showTableRows}>
+          Refresh
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 1,
+      toolbarItemVariant: "separator",
+    },
+    {
+      key: 2,
+      element: <HelpTextWithIconLayout textContent="Help" />,
+    },
+  ];
+
+  // Table
+  // - Data
+  const headerData = [
+    "Base ID",
+    "Assigned Subordinate IDs",
+    "Remaining Subordinate IDs",
+    "Range Size",
+    "DNA Remaining",
+  ];
+
+  // - Header
+  const header = (
+    <Tr>
+      {headerData.map((entry, idx) => (
+        <Th modifier="wrap" key={idx}>
+          {entry}
+        </Th>
+      ))}
+    </Tr>
+  );
+
+  // - Body
+  const body = (
+    <Tr>
+      <Td dataLabel="Base ID">{subidStats.baseid}</Td>
+      <Td dataLabel="Assigned Subordinate IDs">{subidStats.assigned_subids}</Td>
+      <Td dataLabel="Remaining Subordinate IDs">
+        {subidStats.remaining_subids}
+      </Td>
+      <Td dataLabel="Range Size">{subidStats.rangesize}</Td>
+      <Td dataLabel="DNA Remaining">{subidStats.dna_remaining}</Td>
+    </Tr>
+  );
+
+  const skeleton = (
+    <SkeletonOnTableLayout
+      rows={1}
+      colSpan={5}
+      screenreaderText={"Loading table rows"}
+    />
+  );
+
+  return (
+    <PageLayout
+      title="Subordinate ID Statistics"
+      pathname="subordinate-id-statistics"
+      hasAlerts={true}
+      toolbarItems={toolbarItems}
+    >
+      <PageSection variant={PageSectionVariants.light}>
+        <Grid hasGutter>
+          <GridItem span={12}>
+            <TableLayout
+              ariaLabel={"subordinate id statistics table"}
+              variant="compact"
+              hasBorders={true}
+              classes={"pf-v5-u-mt-md"}
+              tableId={"subid-stats-table"}
+              tableHeader={header}
+              tableBody={!showTableRows ? skeleton : body}
+              isStickyHeader={false}
+            />
+          </GridItem>
+        </Grid>
+      </PageSection>
+    </PageLayout>
+  );
 };
 
 export default SubIdsStatistics;

--- a/src/pages/SubordinateIDs/SubIdsStatistics.tsx
+++ b/src/pages/SubordinateIDs/SubIdsStatistics.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const SubIdsStatistics = () => {
+  return <div>SubIdsStatistics</div>;
+};
+
+export default SubIdsStatistics;

--- a/src/services/rpcSubordinateIDs.ts
+++ b/src/services/rpcSubordinateIDs.ts
@@ -13,11 +13,13 @@ import { SubId } from "src/utils/datatypes/globalDataTypes";
 import { API_VERSION_BACKUP } from "src/utils/utils";
 
 /**
- * Endpoints: useGetSubIdEntriesQuery, useSearchSubIdEntriesMutation
+ * Endpoints: useGetSubIdEntriesQuery, useSearchSubIdEntriesMutation, useSubidGenerateMutation, useSubidFindQuery, useSubidStatsQuery
  *
  * API commands:
  * - subid_find: https://freeipa.readthedocs.io/en/latest/api/subid_find.html
  * - subid_show: https://freeipa.readthedocs.io/en/latest/api/subid_show.html
+ * - subid_generate: https://freeipa.readthedocs.io/en/latest/api/subid_generate.html
+ * - subid_stats: https://freeipa.readthedocs.io/en/latest/api/subid_stats.html
  */
 
 export interface SubIdDataPayload {
@@ -222,6 +224,18 @@ const extendedApi = api.injectEndpoints({
         });
       },
     }),
+    /**
+     * Get subordinate ID statistics
+     *
+     */
+    subidStats: build.query<FindRPCResponse, void>({
+      query: () => {
+        return getCommand({
+          method: "subid_stats",
+          params: [[], { all: true, version: API_VERSION_BACKUP }],
+        });
+      },
+    }),
   }),
 });
 
@@ -230,4 +244,5 @@ export const {
   useSearchSubIdEntriesMutation,
   useSubidGenerateMutation,
   useSubidFindQuery,
+  useSubidStatsQuery,
 } = extendedApi;


### PR DESCRIPTION
The Subordinate ID Statistics page should display the information retrieved from the `subid_stats` API call.