### PR TITLE
Change icon importing

### DIFF
--- a/src/AppLayout.tsx
+++ b/src/AppLayout.tsx
@@ -18,12 +18,12 @@ import {
 } from "@patternfly/react-core";
 import React from "react";
 // Icons
-import BarsIcon from "@patternfly/react-icons/dist/esm/icons/bars-icon";
-import UserIcon from "@patternfly/react-icons/dist/esm/icons/user-icon";
-import KeyIcon from "@patternfly/react-icons/dist/esm/icons/key-icon";
-import CogIcon from "@patternfly/react-icons/dist/esm/icons/cog-icon";
-import UnknownIcon from "@patternfly/react-icons/dist/esm/icons/unknown-icon";
-import ShareSquareIcon from "@patternfly/react-icons/dist/esm/icons/share-square-icon";
+import { BarsIcon } from "@patternfly/react-icons";
+import { UserIcon } from "@patternfly/react-icons";
+import { KeyIcon } from "@patternfly/react-icons";
+import { CogIcon } from "@patternfly/react-icons";
+import { UnknownIcon } from "@patternfly/react-icons";
+import { ShareSquareIcon } from "@patternfly/react-icons";
 // Navigation
 import Navigation from "./navigation/Nav";
 // Images

--- a/src/components/ContextualHelpPanel/ContextualHelpPanel.tsx
+++ b/src/components/ContextualHelpPanel/ContextualHelpPanel.tsx
@@ -15,7 +15,7 @@ import {
 // JSON
 import DocumentationLinks from "src/assets/documentation/documentation-links.json";
 // Icons
-import ExternalLinkAltIcon from "@patternfly/react-icons/dist/esm/icons/external-link-alt-icon";
+import { ExternalLinkAltIcon } from "@patternfly/react-icons";
 // Components
 import TextLayout from "../layouts/TextLayout";
 

--- a/src/components/Form/IpaCertificateMappingData.tsx
+++ b/src/components/Form/IpaCertificateMappingData.tsx
@@ -19,7 +19,7 @@ import useAlerts from "src/hooks/useAlerts";
 // Modals
 import ConfirmationModal from "../modals/ConfirmationModal";
 // Icons
-import MapIcon from "@patternfly/react-icons/dist/esm/icons/map-icon";
+import { MapIcon } from "@patternfly/react-icons";
 
 interface PropsToIpaCertificateMappingData {
   ipaObject: Record<string, unknown>;

--- a/src/components/HostsSections/Enrollment.tsx
+++ b/src/components/HostsSections/Enrollment.tsx
@@ -4,8 +4,8 @@ import { Flex, FlexItem, Form, FormGroup, Icon } from "@patternfly/react-core";
 // Layouts
 import TextLayout from "../layouts/TextLayout";
 // Icons
-import CheckIcon from "@patternfly/react-icons/dist/esm/icons/check-icon";
-import ExclamationTriangleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon";
+import { CheckIcon } from "@patternfly/react-icons";
+import { ExclamationTriangleIcon } from "@patternfly/react-icons";
 // Data types
 import { Host } from "../../utils/datatypes/globalDataTypes";
 

--- a/src/components/ManagedBy/ManagedByTable.tsx
+++ b/src/components/ManagedBy/ManagedByTable.tsx
@@ -12,7 +12,7 @@ import {
 } from "@patternfly/react-core";
 import { Td, Th, Tr } from "@patternfly/react-table";
 // Icons
-import SearchIcon from "@patternfly/react-icons/dist/esm/icons/search-icon";
+import { SearchIcon } from "@patternfly/react-icons";
 // Layouts
 import TableLayout from "../layouts/TableLayout";
 import SkeletonOnTableLayout from "../layouts/Skeleton/SkeletonOnTableLayout";

--- a/src/components/ManagedBy/ManagedByToolbar.tsx
+++ b/src/components/ManagedBy/ManagedByToolbar.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 // PatternFly
 import { Pagination, ToolbarItemVariant, Text } from "@patternfly/react-core";
 // Icons
-import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
+import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
 // Data types
 import { Host } from "src/utils/datatypes/globalDataTypes";
 // Layouts

--- a/src/components/MemberOf/MemberOfSubIdToolbar.tsx
+++ b/src/components/MemberOf/MemberOfSubIdToolbar.tsx
@@ -12,7 +12,7 @@ import {
   ToolbarItemVariant,
 } from "@patternfly/react-core";
 // Icons
-import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
+import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
 
 interface MemberOfSubIdToolbarProps {
   // buttons

--- a/src/components/MemberOf/MemberOfToolbar.tsx
+++ b/src/components/MemberOf/MemberOfToolbar.tsx
@@ -16,7 +16,7 @@ import {
   ToolbarItemVariant,
 } from "@patternfly/react-core";
 // Icons
-import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
+import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
 // Components
 import SearchInputLayout from "../layouts/SearchInputLayout";
 

--- a/src/components/MemberOf/MemberOfToolbarOld.tsx
+++ b/src/components/MemberOf/MemberOfToolbarOld.tsx
@@ -13,7 +13,7 @@ import {
   Pagination,
 } from "@patternfly/react-core";
 // Icons
-import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
+import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
 // Toolbar layout
 import ToolbarLayout, {
   ToolbarItemAlignment,

--- a/src/components/ServicesSections/Provisioning.tsx
+++ b/src/components/ServicesSections/Provisioning.tsx
@@ -4,8 +4,8 @@ import { Flex, FlexItem, Form, FormGroup, Icon } from "@patternfly/react-core";
 // Layouts
 import TextLayout from "../layouts/TextLayout";
 // Icons
-import CheckIcon from "@patternfly/react-icons/dist/esm/icons/check-icon";
-import ExclamationTriangleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon";
+import { CheckIcon } from "@patternfly/react-icons";
+import { ExclamationTriangleIcon } from "@patternfly/react-icons";
 // Data types
 import { Metadata, Service } from "src/utils/datatypes/globalDataTypes";
 

--- a/src/components/TypeAheadSelectWithCreate.tsx
+++ b/src/components/TypeAheadSelectWithCreate.tsx
@@ -12,7 +12,7 @@ import {
   TextInputGroupMain,
   TextInputGroupUtilities,
 } from "@patternfly/react-core";
-import TimesIcon from "@patternfly/react-icons/dist/esm/icons/times-icon";
+import { TimesIcon } from "@patternfly/react-icons";
 
 interface PropsToTypeAheadSelectWithCreate {
   id: string;

--- a/src/components/errors/PageErrors.tsx
+++ b/src/components/errors/PageErrors.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Icon, Title } from "@patternfly/react-core";
-import ExclamationTriangleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon";
+import { ExclamationTriangleIcon } from "@patternfly/react-icons";
 
 const ErrorPage = (text: string) => {
   return (

--- a/src/components/layouts/DualListLayout.tsx
+++ b/src/components/layouts/DualListLayout.tsx
@@ -13,9 +13,9 @@ import SecondaryButton from "src/components/layouts/SecondaryButton";
 import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
 import SearchInputLayout from "src/components/layouts/SearchInputLayout";
 //Icons
-import InfoCircleIcon from "@patternfly/react-icons/dist/esm/icons/info-circle-icon";
-import ExclamationTriangleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon";
-import ArrowRightIcon from "@patternfly/react-icons/dist/esm/icons/arrow-right-icon";
+import { InfoCircleIcon } from "@patternfly/react-icons";
+import { ExclamationTriangleIcon } from "@patternfly/react-icons";
+import { ArrowRightIcon } from "@patternfly/react-icons";
 // RPC client
 import { useGetIDListMutation, GenericPayload } from "src/services/rpc";
 

--- a/src/components/layouts/ExpandableCardLayout.tsx
+++ b/src/components/layouts/ExpandableCardLayout.tsx
@@ -12,7 +12,7 @@ import {
   FlexItem,
 } from "@patternfly/react-core";
 // Icons
-import EllipsisVIcon from "@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon";
+import { EllipsisVIcon } from "@patternfly/react-icons";
 
 interface PropsToCardLayout {
   className?: string;

--- a/src/components/layouts/HelpTextWithIconLayout.tsx
+++ b/src/components/layouts/HelpTextWithIconLayout.tsx
@@ -2,7 +2,7 @@ import React from "react";
 // PatternFly
 import { Button } from "@patternfly/react-core";
 // Icons
-import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
+import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
 
 interface PropsToHelpTextLayout {
   textContent: string;

--- a/src/components/layouts/KebabLayout.tsx
+++ b/src/components/layouts/KebabLayout.tsx
@@ -7,7 +7,7 @@ import {
   MenuToggleElement,
 } from "@patternfly/react-core";
 // Icons
-import EllipsisVIcon from "@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon";
+import { EllipsisVIcon } from "@patternfly/react-icons";
 
 interface PropsToKebab {
   // Dropdown

--- a/src/components/layouts/PasswordInput.tsx
+++ b/src/components/layouts/PasswordInput.tsx
@@ -7,8 +7,8 @@ import {
   TextInput,
   InputGroupItem,
 } from "@patternfly/react-core";
-import EyeSlashIcon from "@patternfly/react-icons/dist/esm/icons/eye-slash-icon";
-import EyeIcon from "@patternfly/react-icons/dist/esm/icons/eye-icon";
+import { EyeSlashIcon } from "@patternfly/react-icons";
+import { EyeIcon } from "@patternfly/react-icons";
 
 interface PropsToPasswordInput {
   classname?: string;

--- a/src/components/layouts/PopoverWithIconLayout.tsx
+++ b/src/components/layouts/PopoverWithIconLayout.tsx
@@ -2,7 +2,7 @@ import React from "react";
 // PatternFly
 import { Popover } from "@patternfly/react-core";
 // Icons
-import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
+import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
 
 interface PropsToPopover {
   message: React.ReactNode | ((hide: () => void) => React.ReactNode);

--- a/src/components/modals/UserModals/AddUser.tsx
+++ b/src/components/modals/UserModals/AddUser.tsx
@@ -11,7 +11,7 @@ import {
   ValidatedOptions,
 } from "@patternfly/react-core";
 // Icons
-import HelpIcon from "@patternfly/react-icons/dist/esm/icons/help-icon";
+import { HelpIcon } from "@patternfly/react-icons";
 // Layout
 import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
 import SecondaryButton from "src/components/layouts/SecondaryButton";

--- a/src/components/tables/EmptyBodyTable.tsx
+++ b/src/components/tables/EmptyBodyTable.tsx
@@ -12,7 +12,7 @@ import {
   EmptyStateVariant,
 } from "@patternfly/react-core";
 // Icons
-import SearchIcon from "@patternfly/react-icons/dist/esm/icons/search-icon";
+import { SearchIcon } from "@patternfly/react-icons";
 
 interface EmptyBodyTableProps {
   colSpan?: number;

--- a/src/login/LoginMainPage.tsx
+++ b/src/login/LoginMainPage.tsx
@@ -16,7 +16,7 @@ import {
 // Hooks
 import useAlerts from "src/hooks/useAlerts";
 // Icons
-import ExclamationCircleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon";
+import { ExclamationCircleIcon } from "@patternfly/react-icons";
 // Images
 import BrandImg from "src/assets/images/product-name.png";
 import BackgroundImg from "src/assets/images/login-screen-background.jpg";

--- a/src/pages/ActiveUsers/ActiveUsersTabs.tsx
+++ b/src/pages/ActiveUsers/ActiveUsersTabs.tsx
@@ -24,7 +24,7 @@ import DataSpinner from "src/components/layouts/DataSpinner";
 // Hooks
 import { useUserSettings } from "src/hooks/useUserSettingsData";
 // Icons
-import LockIcon from "@patternfly/react-icons/dist/esm/icons/lock-icon";
+import { LockIcon } from "@patternfly/react-icons";
 // Redux
 import { useAppDispatch } from "src/store/hooks";
 import { updateBreadCrumbPath } from "src/store/Global/routes-slice";

--- a/src/pages/AutoMemUserRules/AutoMemSettings.tsx
+++ b/src/pages/AutoMemUserRules/AutoMemSettings.tsx
@@ -25,7 +25,7 @@ import useUpdateRoute from "src/hooks/useUpdateRoute";
 // Data types
 import { Automember, Metadata } from "../../utils/datatypes/globalDataTypes";
 // Icons
-import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
+import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
 // RPC
 import { ErrorResult } from "src/services/rpc";
 import {

--- a/src/pages/HBACRules/HBACRulesSettings.tsx
+++ b/src/pages/HBACRules/HBACRulesSettings.tsx
@@ -35,7 +35,7 @@ import useUpdateRoute from "src/hooks/useUpdateRoute";
 import { HBACRule, Metadata } from "../../utils/datatypes/globalDataTypes";
 import HBACRulesMemberTable from "./HBACRulesMemberTable";
 // Icons
-import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
+import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
 // RPC
 import { ErrorResult } from "src/services/rpc";
 import {

--- a/src/pages/IDViews/IDViewsOverrideGroups.tsx
+++ b/src/pages/IDViews/IDViewsOverrideGroups.tsx
@@ -34,7 +34,7 @@ import DeleteIdOverrideGroupsModal from "src/components/modals/IdOverrideModals/
 // Data types
 import { IDViewOverrideGroup } from "src/utils/datatypes/globalDataTypes";
 // Icons
-import OutlinedQuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon";
+import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
 // RPC
 import {
   IDOverridePayload,

--- a/src/pages/IDViews/IDViewsSettings.tsx
+++ b/src/pages/IDViews/IDViewsSettings.tsx
@@ -14,7 +14,7 @@ import { asRecord } from "../../utils/hostUtils";
 import useAlerts from "src/hooks/useAlerts";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 // Icons
-import HelpIcon from "@patternfly/react-icons/dist/esm/icons/help-icon";
+import { HelpIcon } from "@patternfly/react-icons";
 // Data types
 import { IDView, Metadata } from "../../utils/datatypes/globalDataTypes";
 // RPC


### PR DESCRIPTION
Changes the imports from `import Icon from
"@patternfly/react-icons/dist/esm/icons/icon"`
 to `import { Icon } from "@patternfly/react-icons"`.
 This allows Jest to work with CJS and WebPack with ESM.

Fixes: #653