### PR TITLE
[Identity Provider references] Fix radio buttons not working in the 'Add' modal

### DIFF
--- a/src/components/modals/IdpReferences/AddModal.tsx
+++ b/src/components/modals/IdpReferences/AddModal.tsx
@@ -129,9 +129,6 @@ const AddModal = (props: PropsToAddModal) => {
     setExtIdpUidAttr("");
     // Selector
     setSelectedProvider("Keycloak or Red Hat SSO");
-    // Radio buttons
-    setIsPreDefinedChecked(true);
-    setIsCustomChecked(false);
   };
 
   // on change radio functions


### PR DESCRIPTION
The radio buttons in the 'Add' modal within the Idp references page are not working fine when 'Custom' option is selected. This is because the IdP client fields are reset when any option is selected, including the radio buttons (by mistake).