### PR TITLE
IdP references > 'Settings' page and kebab

### DIFF
--- a/src/components/Form/IpaPasswordInput.tsx
+++ b/src/components/Form/IpaPasswordInput.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+// PatternFly
+import { TextInput } from "@patternfly/react-core";
+// Utils
+import {
+  IPAParamDefinition,
+  getParamProperties,
+  convertToString,
+} from "src/utils/ipaObjectUtils";
+import { HIDDEN_PASSWORD } from "src/utils/utils";
+
+const IpaPasswordInput = (props: IPAParamDefinition) => {
+  const { required, readOnly, value, onChange } = getParamProperties(props);
+
+  const [textInputValue, setTextInputValue] = React.useState<string>(
+    convertToString(value)
+  );
+
+  // Parse the value to be shown in the input field
+  // - Some passwords are encoded, so those must be shown as hidden
+  // - Undefined passwords must be shown as empty
+  React.useEffect(() => {
+    console.log("value", value);
+    console.log("typeof value", typeof value);
+    if (typeof value === "object") {
+      setTextInputValue(HIDDEN_PASSWORD);
+    } else if (typeof value === undefined) {
+      setTextInputValue("");
+    } else {
+      setTextInputValue(convertToString(value));
+    }
+  }, [value]);
+
+  return (
+    <TextInput
+      type="password"
+      id={props.name}
+      name={props.name}
+      value={textInputValue}
+      onChange={(_event, value) => {
+        setTextInputValue(value);
+        onChange(value);
+      }}
+      aria-label={props.ariaLabel !== undefined ? props.ariaLabel : props.name}
+      isRequired={required}
+      readOnlyVariant={readOnly ? "plain" : undefined}
+    />
+  );
+};
+
+export default IpaPasswordInput;

--- a/src/components/ResetIdpPassword.tsx
+++ b/src/components/ResetIdpPassword.tsx
@@ -1,0 +1,209 @@
+import React from "react";
+// PatternFly
+import {
+  Button,
+  HelperText,
+  HelperTextItem,
+  ValidatedOptions,
+} from "@patternfly/react-core";
+// Data types
+import {
+  IDPServer,
+  PasswordValidationType,
+} from "src/utils/datatypes/globalDataTypes";
+// Modals
+import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
+// Components
+import PasswordInput from "src/components/layouts/PasswordInput";
+// RPC
+import { IdpModPayload, useIdpModMutation } from "src/services/rpcIdp";
+// Hooks
+import useAlerts from "src/hooks/useAlerts";
+
+interface PropsToResetIdpPassword {
+  idpId: string;
+  isOpen: boolean;
+  onClose: () => void;
+  onIdpRefChange: (idpRef: Partial<IDPServer>) => void;
+  onRefresh: () => void;
+}
+
+const ResetIdpPassword = (props: PropsToResetIdpPassword) => {
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
+  // RPC
+  const [resetPassword] = useIdpModMutation();
+
+  // States
+  const [newPassword, setNewPassword] = React.useState("");
+  const [verifyPassword, setVerifyPassword] = React.useState("");
+  const [passwordHidden, setPasswordHidden] = React.useState(true);
+  const [verifyPasswordHidden, setVerifyPasswordHidden] = React.useState(true);
+
+  // Verify password
+  const [passwordValidationResult, setPasswordValidationResult] =
+    React.useState<PasswordValidationType>({
+      isError: false,
+      message: "",
+      pfError: ValidatedOptions.default,
+    });
+
+  // Reset the verify password field
+  const resetVerifyPassword = () => {
+    setPasswordValidationResult({
+      isError: false,
+      message: "",
+      pfError: ValidatedOptions.default,
+    });
+  };
+
+  // Checks that the passwords are the same
+  const validatePasswords = () => {
+    if (newPassword !== verifyPassword) {
+      setPasswordValidationResult({
+        isError: true,
+        message: "Passwords must match",
+        pfError: ValidatedOptions.error,
+      });
+      return true; // is error
+    }
+    resetVerifyPassword();
+    return false;
+  };
+
+  // Fields
+  const fields = [
+    {
+      id: "reset-password-new-password",
+      name: "New Password",
+      pfComponent: (
+        <PasswordInput
+          id="modal-form-reset-password-new-password"
+          name="password"
+          value={newPassword}
+          aria-label="new password text input"
+          onFocus={resetVerifyPassword}
+          onChange={setNewPassword}
+          onRevealHandler={setPasswordHidden}
+          passwordHidden={passwordHidden}
+        />
+      ),
+    },
+    {
+      id: "reset-password-verify-password",
+      name: "Verify password",
+      pfComponent: (
+        <>
+          <PasswordInput
+            id="modal-form-reset-password-verify-password"
+            name="password2"
+            value={verifyPassword}
+            aria-label="verify password text input"
+            onFocus={resetVerifyPassword}
+            onChange={setVerifyPassword}
+            onRevealHandler={setVerifyPasswordHidden}
+            passwordHidden={verifyPasswordHidden}
+            validated={passwordValidationResult.pfError}
+          />
+          <HelperText>
+            <HelperTextItem variant="error">
+              {passwordValidationResult.message}
+            </HelperTextItem>
+          </HelperText>
+        </>
+      ),
+    },
+  ];
+
+  // Verify the passwords are the same when we update a password value
+  React.useEffect(() => {
+    validatePasswords();
+  }, [newPassword, verifyPassword]);
+
+  // Reset fields and close modal
+  const resetFieldsAndCloseModal = () => {
+    // Reset fields
+    setNewPassword("");
+    setVerifyPassword("");
+    setPasswordHidden(true);
+    setVerifyPasswordHidden(true);
+    // Close modal
+    props.onClose();
+  };
+
+  // API call to reset password
+  const onResetPassword = () => {
+    const payload: IdpModPayload = {
+      idpId: props.idpId,
+      ipaidpclientsecret: newPassword,
+    };
+
+    resetPassword(payload).then((response) => {
+      if ("data" in response) {
+        const data = response.data;
+        if (data.error) {
+          alerts.addAlert("error", (data.error as Error).message, "danger");
+        }
+        if (data.result) {
+          props.onIdpRefChange(data.result.result);
+          alerts.addAlert(
+            "success",
+            "Identity Provider password successfully updated",
+            "success"
+          );
+          // Refresh the data
+          props.onRefresh();
+          // Reset values and close
+          resetFieldsAndCloseModal();
+        }
+      }
+    });
+  };
+
+  const actions = [
+    <Button
+      key={"reset-password"}
+      variant="primary"
+      onClick={onResetPassword}
+      isDisabled={
+        passwordValidationResult.isError ||
+        newPassword === "" ||
+        verifyPassword === ""
+      }
+    >
+      Reset password
+    </Button>,
+    <Button
+      key={"cancel-reset-password"}
+      variant="link"
+      onClick={resetFieldsAndCloseModal}
+    >
+      Cancel
+    </Button>,
+  ];
+
+  // Return component
+  return (
+    <>
+      <alerts.ManagedAlerts />
+      <ModalWithFormLayout
+        variantType="small"
+        modalPosition="top"
+        title="Reset password"
+        description={
+          "Reset the password for the selected Identity Provider '" +
+          props.idpId +
+          "'"
+        }
+        formId="reset-password-form"
+        fields={fields}
+        show={props.isOpen}
+        onClose={resetFieldsAndCloseModal}
+        actions={actions}
+      />
+    </>
+  );
+};
+
+export default ResetIdpPassword;

--- a/src/components/modals/IdpReferences/AddModal.tsx
+++ b/src/components/modals/IdpReferences/AddModal.tsx
@@ -127,8 +127,6 @@ const AddModal = (props: PropsToAddModal) => {
     setJwksUri("");
     setScope("");
     setExtIdpUidAttr("");
-    // Selector
-    setSelectedProvider("Keycloak or Red Hat SSO");
   };
 
   // on change radio functions
@@ -153,6 +151,11 @@ const AddModal = (props: PropsToAddModal) => {
       cn: idpRefName,
       ipaidpclientid: clientId,
     };
+
+    // Check if secret is defined
+    if (secret !== "" && verifySecret !== "" && secret === verifySecret) {
+      payload.ipaidpclientsecret = secret;
+    }
 
     // Define payload based on the radio buttons and selected provider
     if (isPreDefinedChecked) {
@@ -186,7 +189,6 @@ const AddModal = (props: PropsToAddModal) => {
       }
     } else if (isCustomChecked) {
       const customData: CustomIdpAddPayload = {
-        // cn: idpRefName,
         ipaidpclientid: clientId,
         ipaidpauthendpoint: authUri,
         ipaidpdevauthendpoint: devAuthUri,
@@ -624,7 +626,11 @@ const AddModal = (props: PropsToAddModal) => {
     <Button
       key="add-new"
       variant="secondary"
-      isDisabled={isAddButtonSpinning || areMandatoryFieldsEmpty}
+      isDisabled={
+        isAddButtonSpinning ||
+        areMandatoryFieldsEmpty ||
+        secret !== verifySecret
+      }
       form="add-modal-form"
       onClick={() => {
         onAdd(false);
@@ -635,7 +641,11 @@ const AddModal = (props: PropsToAddModal) => {
     <Button
       key="add-new-again"
       variant="secondary"
-      isDisabled={isAddAnotherButtonSpinning || areMandatoryFieldsEmpty}
+      isDisabled={
+        isAddAnotherButtonSpinning ||
+        areMandatoryFieldsEmpty ||
+        secret !== verifySecret
+      }
       form="add-again-modal-form"
       onClick={() => {
         onAdd(true);

--- a/src/hooks/useIdpRefSettingsData.tsx
+++ b/src/hooks/useIdpRefSettingsData.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+// RPC
+import { useGetObjectMetadataQuery } from "src/services/rpc";
+import { useIdpShowQuery } from "src/services/rpcIdp";
+// Data types
+import { IDPServer, Metadata } from "src/utils/datatypes/globalDataTypes";
+
+type IdpRefSettingsData = {
+  isLoading: boolean;
+  isFetching: boolean;
+  modified: boolean;
+  setModified: (value: boolean) => void;
+  resetValues: () => void;
+  metadata: Metadata;
+  originalIdpRef: Partial<IDPServer>;
+  idpRef: Partial<IDPServer>;
+  setIdpRef: (fqdn: Partial<IDPServer>) => void;
+  refetch: () => void;
+  modifiedValues: () => Partial<IDPServer>;
+};
+
+const useIdpRefSettingsData = (idpRefId: string): IdpRefSettingsData => {
+  // [API call] Metadata
+  const metadataQuery = useGetObjectMetadataQuery();
+  const metadata = metadataQuery.data || {};
+  const metadataLoading = metadataQuery.isLoading;
+
+  // [API call] IdP Reference
+  const idpRefDetails = useIdpShowQuery(idpRefId);
+  const idpRefData = idpRefDetails.data;
+  const isIdpRefDataLoading = idpRefDetails.isLoading;
+
+  const [modified, setModified] = React.useState(false);
+
+  // Data displayed and modified by the user
+  const [idpRef, setIdpRef] = React.useState<Partial<IDPServer>>({});
+
+  React.useEffect(() => {
+    if (idpRefData && !idpRefDetails.isFetching) {
+      setIdpRef({ ...idpRefData });
+    }
+  }, [idpRefData, idpRefDetails.isFetching]);
+
+  const settings: IdpRefSettingsData = {
+    isLoading: metadataLoading || isIdpRefDataLoading,
+    isFetching: idpRefDetails.isFetching,
+    modified,
+    setModified,
+    metadata,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    resetValues: () => {},
+    originalIdpRef: idpRef,
+    setIdpRef,
+    refetch: idpRefDetails.refetch,
+    idpRef,
+    modifiedValues: () => idpRef,
+  };
+
+  const getModifiedValues = (): Partial<IDPServer> => {
+    if (!idpRefData) {
+      return {};
+    }
+
+    const modifiedValues = {};
+    for (const [key, value] of Object.entries(idpRef)) {
+      if (Array.isArray(value)) {
+        // Using 'JSON.stringify' when comparing arrays (to prevent data type false positives)
+        if (JSON.stringify(idpRef[key]) !== JSON.stringify(value)) {
+          modifiedValues[key] = value;
+        }
+      } else if (idpRefData[key] !== value) {
+        modifiedValues[key] = value;
+      }
+    }
+    return modifiedValues;
+  };
+  settings.modifiedValues = getModifiedValues;
+
+  // Detect any change in 'originalIdpRef' and 'idpRef' objects
+  React.useEffect(() => {
+    if (!idpRefData) {
+      return;
+    }
+    let modified = false;
+    for (const [key, value] of Object.entries(idpRef)) {
+      if (Array.isArray(value)) {
+        // Using 'JSON.stringify' when comparing arrays (to prevent data type false positives)
+        if (JSON.stringify(idpRefData[key]) !== JSON.stringify(value)) {
+          modified = true;
+          break;
+        }
+      } else {
+        if (idpRefData[key] !== value) {
+          modified = true;
+          break;
+        }
+      }
+    }
+    setModified(modified);
+  }, [idpRef, idpRefData]);
+
+  // Reset values
+  const onResetValues = () => {
+    setModified(false);
+  };
+  settings.resetValues = onResetValues;
+
+  return settings;
+};
+
+export { useIdpRefSettingsData };

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -56,6 +56,7 @@ import SubIdsStatistics from "src/pages/SubordinateIDs/SubIdsStatistics";
 import SubIdsTabs from "src/pages/SubordinateIDs/SubIdsTabs";
 import PasswordPoliciesTabs from "src/pages/PasswordPolicies/PasswordPoliciesTabs";
 import IdpReferences from "src/pages/IdPReferences/IdpReferences";
+import IdpReferencesTabs from "src/pages/IdPReferences/IdpReferencesTabs";
 
 // Renders routes (React)
 export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
@@ -431,6 +432,12 @@ export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
               </Route>
               <Route path="identity-provider-references">
                 <Route path="" element={<IdpReferences />} />
+                <Route path=":cn">
+                  <Route
+                    path=""
+                    element={<IdpReferencesTabs section="settings" />}
+                  />
+                </Route>
               </Route>
               <Route path="configuration" element={<Configuration />} />
               {/* Redirect to Active users page if user is logged in and navigates to the root page */}

--- a/src/pages/IdPReferences/IdpReferences.tsx
+++ b/src/pages/IdPReferences/IdpReferences.tsx
@@ -456,7 +456,7 @@ const IdpReferences = () => {
                   hasCheckboxes={true}
                   pathname="identity-provider-references"
                   showTableRows={showTableRows}
-                  showLink={false}
+                  showLink={true}
                   elementsData={{
                     isElementSelectable: isIdpServerSelectable,
                     selectedElements,

--- a/src/pages/IdPReferences/IdpReferencesSettings.tsx
+++ b/src/pages/IdPReferences/IdpReferencesSettings.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 // PatternFly
 import {
+  DropdownItem,
   Flex,
   FlexItem,
   Form,
@@ -30,6 +31,8 @@ import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayou
 import IpaTextContent from "src/components/Form/IpaTextContent/IpaTextContent";
 import TitleLayout from "src/components/layouts/TitleLayout";
 import IpaPasswordInput from "src/components/Form/IpaPasswordInput";
+import KebabLayout from "src/components/layouts/KebabLayout";
+import ResetIdpPassword from "src/components/ResetIdpPassword";
 
 interface PropsToIdpRefSettings {
   idpRef: Partial<IDPServer>;
@@ -136,6 +139,22 @@ const IdpRefSettings = (props: PropsToIdpRefSettings) => {
     });
   };
 
+  // 'Reset password' option
+  const [isResetPasswordModalOpen, setIsResetPasswordModalOpen] =
+    React.useState(false);
+
+  // Kebab
+  const [isKebabOpen, setIsKebabOpen] = React.useState(false);
+
+  const kebabItems = [
+    <DropdownItem
+      key="reset password"
+      onClick={() => setIsResetPasswordModalOpen(true)}
+    >
+      Reset password
+    </DropdownItem>,
+  ];
+
   // Toolbar
   const toolbarFields = [
     {
@@ -166,6 +185,19 @@ const IdpRefSettings = (props: PropsToIdpRefSettings) => {
         >
           Save
         </SecondaryButton>
+      ),
+    },
+    {
+      key: 3,
+      element: (
+        <KebabLayout
+          direction={"up"}
+          onDropdownSelect={() => setIsKebabOpen(!isKebabOpen)}
+          onKebabToggle={() => setIsKebabOpen(!isKebabOpen)}
+          idKebab="toggle-action-buttons"
+          isKebabOpen={isKebabOpen}
+          dropdownItems={kebabItems}
+        />
       ),
     },
   ];
@@ -356,6 +388,13 @@ const IdpRefSettings = (props: PropsToIdpRefSettings) => {
             </Flex>
           </SidebarContent>
         </Sidebar>
+        <ResetIdpPassword
+          idpId={props.idpRef.cn as string}
+          isOpen={isResetPasswordModalOpen}
+          onClose={() => setIsResetPasswordModalOpen(false)}
+          onIdpRefChange={props.onIdpRefChange}
+          onRefresh={props.onRefresh}
+        />
       </TabLayout>
     </>
   );

--- a/src/pages/IdPReferences/IdpReferencesSettings.tsx
+++ b/src/pages/IdPReferences/IdpReferencesSettings.tsx
@@ -1,0 +1,364 @@
+import React from "react";
+// PatternFly
+import {
+  Flex,
+  FlexItem,
+  Form,
+  FormGroup,
+  JumpLinks,
+  JumpLinksItem,
+  Sidebar,
+  SidebarContent,
+  SidebarPanel,
+} from "@patternfly/react-core";
+// Data types
+import { IDPServer, Metadata } from "src/utils/datatypes/globalDataTypes";
+// Hooks
+import useUpdateRoute from "src/hooks/useUpdateRoute";
+import useAlerts from "src/hooks/useAlerts";
+// Utils
+import { asRecord } from "src/utils/subIdUtils";
+// Icons
+import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
+// RPC
+import { IdpModPayload, useIdpModMutation } from "src/services/rpcIdp";
+// Components
+import IpaTextInput from "src/components/Form/IpaTextInput/IpaTextInput";
+import TabLayout from "src/components/layouts/TabLayout";
+import SecondaryButton from "src/components/layouts/SecondaryButton";
+import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
+import IpaTextContent from "src/components/Form/IpaTextContent/IpaTextContent";
+import TitleLayout from "src/components/layouts/TitleLayout";
+import IpaPasswordInput from "src/components/Form/IpaPasswordInput";
+
+interface PropsToIdpRefSettings {
+  idpRef: Partial<IDPServer>;
+  originalIdpRef: Partial<IDPServer>;
+  metadata: Metadata;
+  onIdpRefChange: (idpRef: Partial<IDPServer>) => void;
+  onRefresh: () => void;
+  isModified: boolean;
+  isDataLoading?: boolean;
+  modifiedValues: () => Partial<IDPServer>;
+  onResetValues: () => void;
+  pathname: string;
+}
+
+const IdpRefSettings = (props: PropsToIdpRefSettings) => {
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  useUpdateRoute({ pathname: props.pathname });
+
+  // States
+  const [isDataLoading, setIsDataLoading] = React.useState(false);
+
+  // Get 'ipaObject' and 'recordOnChange' to use in 'IpaTextInput'
+  const { ipaObject, recordOnChange } = asRecord(
+    props.idpRef,
+    props.onIdpRefChange
+  );
+
+  // API calls
+  const [saveIdpRef] = useIdpModMutation();
+
+  // 'Revert' handler method
+  const onRevert = () => {
+    props.onIdpRefChange(props.originalIdpRef);
+    props.onRefresh();
+    alerts.addAlert(
+      "revert-success",
+      "Identity Provider data reverted",
+      "success"
+    );
+  };
+
+  // Helper method to build the payload based on values
+  const buildPayload = (
+    modifiedValues: Partial<IDPServer>,
+    keyArray: string[]
+  ): IdpModPayload => {
+    const payload: IdpModPayload = {
+      idpId: props.idpRef.cn?.toString() as string,
+    };
+
+    keyArray.forEach((key) => {
+      // Modified values are either the value (in string) or an array ([]) when set to empty string
+      if (modifiedValues[key] !== undefined) {
+        if (modifiedValues[key] === "") {
+          payload[key] = [];
+        } else {
+          payload[key] = modifiedValues[key].toString();
+        }
+      }
+    });
+    return payload;
+  };
+
+  // on Save handler method
+  const onSave = () => {
+    setIsDataLoading(true);
+    const modifiedValues = props.modifiedValues();
+
+    // Generate payload
+    const payload = buildPayload(modifiedValues, [
+      "ipaidpclientid",
+      "ipaidpclientsecret",
+      "ipaidpscope",
+      "ipaidpsub",
+      "ipaidpauthendpoint",
+      "ipaidpdevauthendpoint",
+      "ipaidptokenendpoint",
+      "ipaidpuserinfoendpoint",
+      "ipaidpkeysendpoint",
+      "ipaidpissuerurl",
+    ]);
+
+    saveIdpRef(payload).then((response) => {
+      if ("data" in response) {
+        const data = response.data;
+        if (data.error) {
+          alerts.addAlert("error", (data.error as Error).message, "danger");
+        }
+        if (data.result) {
+          props.onIdpRefChange(data.result.result);
+          alerts.addAlert(
+            "success",
+            "Identity Provider '" + props.idpRef.cn + "' updated",
+            "success"
+          );
+          // Reset values. Disable 'revert' and 'save' buttons
+          props.onResetValues();
+        }
+      }
+      setIsDataLoading(false);
+    });
+  };
+
+  // Toolbar
+  const toolbarFields = [
+    {
+      key: 0,
+      element: (
+        <SecondaryButton onClickHandler={props.onRefresh}>
+          Refresh
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 1,
+      element: (
+        <SecondaryButton
+          isDisabled={!props.isModified || isDataLoading}
+          onClickHandler={onRevert}
+        >
+          Revert
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 2,
+      element: (
+        <SecondaryButton
+          isDisabled={!props.isModified || isDataLoading}
+          onClickHandler={onSave}
+        >
+          Save
+        </SecondaryButton>
+      ),
+    },
+  ];
+
+  // Render component
+  return (
+    <>
+      <TabLayout id="settings-page" toolbarItems={toolbarFields}>
+        <alerts.ManagedAlerts />
+        <Sidebar isPanelRight>
+          <SidebarPanel variant="sticky">
+            <HelpTextWithIconLayout
+              textContent="Help"
+              icon={
+                <OutlinedQuestionCircleIcon className="pf-v5-u-primary-color-100 pf-v5-u-mr-sm" />
+              }
+            />
+            <JumpLinks
+              isVertical
+              label="Jump to section"
+              scrollableSelector="#idp-reference-page"
+              offset={220} // for masthead
+              expandable={{ default: "expandable", md: "nonExpandable" }}
+              className="pf-v5-u-mt-md"
+            >
+              <JumpLinksItem key={0} href="#oauth-client-settings">
+                OAuth 2.0 client details
+              </JumpLinksItem>
+              <JumpLinksItem key={1} href="#idp-details">
+                Identity provider details
+              </JumpLinksItem>
+            </JumpLinks>
+          </SidebarPanel>
+          <SidebarContent className="pf-v5-u-mr-xl">
+            <TitleLayout
+              key={0}
+              id="oauth-client-settings"
+              text="OAuth 2.0 client details"
+              headingLevel="h2"
+              className="pf-v5-u-mt-lg pf-v5-u-mb-md"
+            />
+            <Flex direction={{ default: "column", lg: "row" }}>
+              <FlexItem flex={{ default: "flex_1" }}>
+                <Form className="pf-v5-u-mb-lg">
+                  <FormGroup
+                    label="Identity Provider reference name"
+                    fieldId="cn"
+                  >
+                    <IpaTextContent
+                      name={"cn"}
+                      ariaLabel={"Identity Provider reference name"}
+                      ipaObject={ipaObject}
+                      objectName="idp"
+                      metadata={props.metadata}
+                    />
+                  </FormGroup>
+                  <FormGroup
+                    label="Client identifier"
+                    fieldId="ipaidpclientid"
+                    isRequired
+                  >
+                    <IpaTextInput
+                      name={"ipaidpclientid"}
+                      ariaLabel={"Client identifier"}
+                      ipaObject={ipaObject}
+                      onChange={recordOnChange}
+                      objectName="idp"
+                      metadata={props.metadata}
+                    />
+                  </FormGroup>
+                  <FormGroup label="Secret" fieldId="ipaidpclientsecret">
+                    <IpaPasswordInput
+                      name={"ipaidpclientsecret"}
+                      ariaLabel={"Secret"}
+                      ipaObject={ipaObject}
+                      onChange={recordOnChange}
+                      objectName="idp"
+                      metadata={props.metadata}
+                    />
+                  </FormGroup>
+                </Form>
+              </FlexItem>
+            </Flex>
+            <TitleLayout
+              key={1}
+              headingLevel="h2"
+              id="idp-details"
+              text="Identity provider details"
+              className="pf-v5-u-mt-lg pf-v5-u-mb-md"
+            />
+            <Flex direction={{ default: "column", lg: "row" }}>
+              <FlexItem flex={{ default: "flex_1" }}>
+                <Form className="pf-v5-u-mb-lg">
+                  <FormGroup label="Scope" fieldId="ipaidpscope">
+                    <IpaTextInput
+                      name={"ipaidpscope"}
+                      ariaLabel={"Scope"}
+                      ipaObject={ipaObject}
+                      onChange={recordOnChange}
+                      objectName="idp"
+                      metadata={props.metadata}
+                    />
+                  </FormGroup>
+                  <FormGroup
+                    label="External IdP user identifier attribute"
+                    fieldId="ipaidpsub"
+                  >
+                    <IpaTextInput
+                      name={"ipaidpsub"}
+                      ariaLabel={"External IdP user identifier attribute"}
+                      ipaObject={ipaObject}
+                      onChange={recordOnChange}
+                      objectName="idp"
+                      metadata={props.metadata}
+                    />
+                  </FormGroup>
+                  <FormGroup
+                    label="Authorization URI"
+                    fieldId="ipaidpauthendpoint"
+                  >
+                    <IpaTextInput
+                      name={"ipaidpauthendpoint"}
+                      ariaLabel={"Authorization URI"}
+                      ipaObject={ipaObject}
+                      onChange={recordOnChange}
+                      objectName="idp"
+                      metadata={props.metadata}
+                    />
+                  </FormGroup>
+                  <FormGroup
+                    label="Device authorization URI"
+                    fieldId="ipaidpdevauthendpoint"
+                  >
+                    <IpaTextInput
+                      name={"ipaidpdevauthendpoint"}
+                      ariaLabel={"Device authorization URI"}
+                      ipaObject={ipaObject}
+                      onChange={recordOnChange}
+                      objectName="idp"
+                      metadata={props.metadata}
+                    />
+                  </FormGroup>
+                  <FormGroup label="Token URI" fieldId="ipaidptokenendpoint">
+                    <IpaTextInput
+                      name={"ipaidptokenendpoint"}
+                      ariaLabel={"Token URI"}
+                      ipaObject={ipaObject}
+                      onChange={recordOnChange}
+                      objectName="idp"
+                      metadata={props.metadata}
+                    />
+                  </FormGroup>
+                  <FormGroup
+                    label="User info URI"
+                    fieldId="ipaidpuserinfoendpoint"
+                  >
+                    <IpaTextInput
+                      name={"ipaidpuserinfoendpoint"}
+                      ariaLabel={"User info URI"}
+                      ipaObject={ipaObject}
+                      onChange={recordOnChange}
+                      objectName="idp"
+                      metadata={props.metadata}
+                    />
+                  </FormGroup>
+                  <FormGroup label="JWKS URI" fieldId="ipaidpkeysendpoint">
+                    <IpaTextInput
+                      name={"ipaidpkeysendpoint"}
+                      ariaLabel={"JWKS URI"}
+                      ipaObject={ipaObject}
+                      onChange={recordOnChange}
+                      objectName="idp"
+                      metadata={props.metadata}
+                    />
+                  </FormGroup>
+                  <FormGroup label="OIDC URL" fieldId="ipaidpissuerurl">
+                    <IpaTextInput
+                      name={"ipaidpissuerurl"}
+                      ariaLabel={"OIDC URL"}
+                      ipaObject={ipaObject}
+                      onChange={recordOnChange}
+                      objectName="idp"
+                      metadata={props.metadata}
+                    />
+                  </FormGroup>
+                </Form>
+              </FlexItem>
+            </Flex>
+          </SidebarContent>
+        </Sidebar>
+      </TabLayout>
+    </>
+  );
+};
+
+export default IdpRefSettings;

--- a/src/pages/IdPReferences/IdpReferencesTabs.tsx
+++ b/src/pages/IdPReferences/IdpReferencesTabs.tsx
@@ -1,0 +1,140 @@
+import React from "react";
+// PatternFly
+import {
+  PageSection,
+  PageSectionVariants,
+  Tabs,
+  Tab,
+  TabTitleText,
+} from "@patternfly/react-core";
+// React Router DOM
+import { useNavigate, useParams } from "react-router-dom";
+// Navigation
+import { URL_PREFIX } from "src/navigation/NavRoutes";
+import { NotFound } from "src/components/errors/PageErrors";
+// Hooks
+import { useIdpRefSettingsData } from "src/hooks/useIdpRefSettingsData";
+// Components
+import TitleLayout from "src/components/layouts/TitleLayout";
+import DataSpinner from "src/components/layouts/DataSpinner";
+import BreadCrumb, {
+  BreadCrumbItem,
+} from "src/components/layouts/BreadCrumb/BreadCrumb";
+import IdpRefSettings from "./IdpReferencesSettings";
+
+// eslint-disable-next-line react/prop-types
+const IdpReferencesTabs = ({ section }) => {
+  const { cn } = useParams();
+  const navigate = useNavigate();
+  const pathname = "identity-provider-references";
+
+  const [breadcrumbItems, setBreadcrumbItems] = React.useState<
+    BreadCrumbItem[]
+  >([]);
+
+  // States - Identifier of the entity (IdP -> cn)
+  const [id, setId] = React.useState("");
+
+  // Data loaded from the API
+  const idpRefSettingsData = useIdpRefSettingsData(cn as string);
+
+  // Tab
+  const [activeTabKey, setActiveTabKey] = React.useState(section);
+
+  const handleTabClick = (
+    _event: React.MouseEvent<HTMLElement, MouseEvent>,
+    tabIndex: number | string
+  ) => {
+    setActiveTabKey(tabIndex as string);
+
+    if (tabIndex === "settings") {
+      navigate("/" + pathname + "/" + id);
+    }
+  };
+
+  React.useEffect(() => {
+    if (!cn) {
+      // Redirect to the main page
+      navigate(URL_PREFIX + "/" + pathname);
+    } else {
+      setId(cn);
+      // Update breadcrumb route
+      const currentPath: BreadCrumbItem[] = [
+        {
+          name: "Identity provider references",
+          url: URL_PREFIX + "/" + pathname,
+        },
+        {
+          name: cn,
+          url: URL_PREFIX + "/" + pathname + "/" + cn,
+          isActive: true,
+        },
+      ];
+      setBreadcrumbItems(currentPath);
+      setActiveTabKey("settings");
+    }
+  }, [cn]);
+
+  // Handling of the API data
+  if (idpRefSettingsData.isLoading || !idpRefSettingsData.idpRef) {
+    return <DataSpinner />;
+  }
+
+  // Show the 'NotFound' page if the host is not found
+  if (
+    !idpRefSettingsData.isLoading &&
+    Object.keys(idpRefSettingsData.idpRef).length === 0
+  ) {
+    return <NotFound />;
+  }
+
+  // Return component
+  return (
+    <>
+      <PageSection variant={PageSectionVariants.light} className="pf-v5-u-pr-0">
+        <BreadCrumb
+          className="pf-v5-u-mb-md"
+          breadcrumbItems={breadcrumbItems}
+        />
+        <TitleLayout
+          id={id}
+          preText="Identity provider reference:"
+          text={id}
+          headingLevel="h1"
+        />
+      </PageSection>
+      <PageSection type="tabs" variant={PageSectionVariants.light} isFilled>
+        <Tabs
+          activeKey={activeTabKey}
+          onSelect={handleTabClick}
+          variant="light300"
+          isBox
+          className="pf-v5-u-ml-lg"
+          mountOnEnter
+          unmountOnExit
+        >
+          <Tab
+            eventKey={"settings"}
+            name="settings-details"
+            title={<TabTitleText>Settings</TabTitleText>}
+          >
+            <IdpRefSettings
+              idpRef={idpRefSettingsData.idpRef}
+              originalIdpRef={idpRefSettingsData.originalIdpRef}
+              metadata={idpRefSettingsData.metadata}
+              onIdpRefChange={idpRefSettingsData.setIdpRef}
+              onRefresh={idpRefSettingsData.refetch}
+              isModified={idpRefSettingsData.modified}
+              isDataLoading={idpRefSettingsData.isLoading}
+              modifiedValues={idpRefSettingsData.modifiedValues}
+              onResetValues={idpRefSettingsData.resetValues}
+              pathname={pathname}
+            />
+          </Tab>
+        </Tabs>
+      </PageSection>
+    </>
+  );
+};
+
+export default IdpReferencesTabs;

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { ValidatedOptions } from "@patternfly/react-core";
+
 export interface User {
   [key: string]: unknown; // to fulfill Record<string, unknown> type
   // identity
@@ -701,4 +703,10 @@ export interface KrbTicket {
   krbmaxrenewableage: string;
   aci: string[];
   dn: string;
+}
+
+export interface PasswordValidationType {
+  isError: boolean;
+  message: string;
+  pfError: ValidatedOptions;
 }

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -428,3 +428,8 @@ export function paginate<Type>(
 export function containsAny(array1: unknown[], array2: unknown[]): boolean {
   return array1.some((item) => array2.includes(item));
 }
+
+/**
+ * Returns hidden password string
+ */
+export const HIDDEN_PASSWORD = "********";


### PR DESCRIPTION
The 'Settings' page should display and manage the available information of a given Identity Provider.
In order to track the changes on the `Secret` field, a new Ipa component `IpaPasswordInput` has been created.

Also, the kebab option (located next to the 'Save' button) should contain the 'Reset password' option to reset the password of the current IdP entry.

## Summary by Sourcery

Add a 'Settings' page for Identity Providers to manage their information, including a new password input component and a reset password option. Enhance IdP-related endpoints with new queries and mutations for better data management.

New Features:
- Introduce a new 'Settings' page for managing Identity Provider (IdP) information, including a new component 'IpaPasswordInput' for handling password inputs.
- Add a 'Reset password' option in the kebab menu next to the 'Save' button for resetting the password of the current IdP entry.

Enhancements:
- Enhance the IdP-related endpoints by adding new queries and mutations such as 'useIdpShowQuery' and 'useIdpModMutation' for showing and modifying IdP data.