### PR TITLE
Align current version with `package-lock.json` file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freeipa-webui",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freeipa-webui",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@patternfly/patternfly": "^5.1.0",


### PR DESCRIPTION
The `package-lock.json` file should be updated on every change of version every time the `npm install` command is executed. This change was not added in the last version upgrade, so it should be added now.

## Summary by Sourcery

Chores:
- Synchronize package-lock.json with the project's current version number