### PR TITLE
Idp references integration tests

### DIFF
--- a/src/components/modals/IdpReferences/AddModal.tsx
+++ b/src/components/modals/IdpReferences/AddModal.tsx
@@ -338,7 +338,7 @@ const AddModal = (props: PropsToAddModal) => {
     },
     {
       id: "provider-type-radios",
-      name: "Provider type",
+      name: "",
       pfComponent: (
         <>
           <Radio

--- a/tests/features/idp_references_handling.feature
+++ b/tests/features/idp_references_handling.feature
@@ -1,0 +1,173 @@
+Feature: Identity provider references manipulation
+  Create and delete identity provider references
+
+  Background:
+    Given I am logged in as "Administrator"
+    Given I am on "identity-provider-references" page
+
+  Scenario: Add a new 'Keycloak or Red Hat SSO' identity provider reference (with no secret)
+    When I click on "Add" button
+    Then I see "Add Identity Provider reference" modal
+    * In the modal, I type into the field with ID "identity-provider-reference-name" text "idpKeycloak"
+    * In the modal, I type into the field with ID "client-id" text "idpKeycloakClient"
+    * in the modal dialog I check "Pre-defined IdP template" radio selector
+    * I click in the "Provider type" selector field
+    * I select "Keycloak or Red Hat SSO" option in the "Provider type" selector
+    * In the modal, I type into the field with ID "org" text "myOrg"
+    * In the modal, I type into the field with ID "base-url" text "myOrg.example.test"
+    * In the modal, I type into the field with ID "scope" text "myScopeKeycloak"
+    * In the modal, I type into the field with ID "ext-idp-uid-attr" text "exampleAttributeKeycloak"
+    When in the modal dialog I click on "Add" button
+    * I should see "success" alert with text "Identity provider successfully added"
+    * I close the alert
+    Then I should see "idpKeycloak" entry in the data table with ID "identity-provider-references-table"
+
+  Scenario: Add a new 'Keycloak or Red Hat SSO' identity provider reference (with secret)
+    When I click on "Add" button
+    Then I see "Add Identity Provider reference" modal
+    * In the modal, I type into the field with ID "identity-provider-reference-name" text "idpSecretKeycloak"
+    * In the modal, I type into the field with ID "client-id" text "idpKeycloakSecretClient"
+    * In the modal, I type into the field with ID "secret" text "mySecret"
+    * In the modal, I type into the field with ID "verify-secret" text "mySecret"
+    * in the modal dialog I check "Pre-defined IdP template" radio selector
+    * I click in the "Provider type" selector field
+    * I select "Keycloak or Red Hat SSO" option in the "Provider type" selector
+    * In the modal, I type into the field with ID "org" text "mySecretOrg"
+    * In the modal, I type into the field with ID "base-url" text "mySecretOrg.example.test"
+    * In the modal, I type into the field with ID "scope" text "myScopeSecretKeycloak"
+    * In the modal, I type into the field with ID "ext-idp-uid-attr" text "exampleAttributeSecretKeycloak"
+    When in the modal dialog I click on "Add" button
+    * I should see "success" alert with text "Identity provider successfully added"
+    * I close the alert
+    Then I should see "idpSecretKeycloak" entry in the data table with ID "identity-provider-references-table"
+
+  Scenario: Add a new Google identity provider reference
+    When I click on "Add" button
+    Then I see "Add Identity Provider reference" modal
+    * In the modal, I type into the field with ID "identity-provider-reference-name" text "idpGoogle"
+    * In the modal, I type into the field with ID "client-id" text "idpGoogleClient"
+    * in the modal dialog I check "Pre-defined IdP template" radio selector
+    * I click in the "Provider type" selector field
+    * I select "Google" option in the "Provider type" selector
+    * In the modal, I type into the field with ID "scope" text "myScopeGoogle"
+    * In the modal, I type into the field with ID "ext-idp-uid-attr" text "exampleAttributeGoogle"
+    When in the modal dialog I click on "Add" button
+    * I should see "success" alert with text "Identity provider successfully added"
+    * I close the alert
+    Then I should see "idpGoogle" entry in the data table with ID "identity-provider-references-table"
+
+  Scenario: Add a new Github identity provider reference
+    When I click on "Add" button
+    Then I see "Add Identity Provider reference" modal
+    * In the modal, I type into the field with ID "identity-provider-reference-name" text "idpGithub"
+    * In the modal, I type into the field with ID "client-id" text "idpGithubClient"
+    * in the modal dialog I check "Pre-defined IdP template" radio selector
+    * I click in the "Provider type" selector field
+    * I select "Github" option in the "Provider type" selector
+    * In the modal, I type into the field with ID "scope" text "myScopeGithub"
+    * In the modal, I type into the field with ID "ext-idp-uid-attr" text "exampleAttributeGithub"
+    When in the modal dialog I click on "Add" button
+    * I should see "success" alert with text "Identity provider successfully added"
+    * I close the alert
+    Then I should see "idpGithub" entry in the data table with ID "identity-provider-references-table"
+
+  Scenario: Add a new 'Microsoft or Azure' identity provider reference
+    When I click on "Add" button
+    Then I see "Add Identity Provider reference" modal
+    * In the modal, I type into the field with ID "identity-provider-reference-name" text "idpMicrosoft"
+    * In the modal, I type into the field with ID "client-id" text "idpMicrosoftClient"
+    * in the modal dialog I check "Pre-defined IdP template" radio selector
+    * I click in the "Provider type" selector field
+    * I select "Microsoft or Azure" option in the "Provider type" selector
+    * In the modal, I type into the field with ID "org" text "myOrg2"
+    * In the modal, I type into the field with ID "scope" text "myScopeMicrosoft"
+    * In the modal, I type into the field with ID "ext-idp-uid-attr" text "exampleAttributeMicrosoft"
+    When in the modal dialog I click on "Add" button
+    * I should see "success" alert with text "Identity provider successfully added"
+    * I close the alert
+    Then I should see "idpMicrosoft" entry in the data table with ID "identity-provider-references-table"
+
+  Scenario: Add a new 'Okta' identity provider reference
+    When I click on "Add" button
+    Then I see "Add Identity Provider reference" modal
+    * In the modal, I type into the field with ID "identity-provider-reference-name" text "idpOkta"
+    * In the modal, I type into the field with ID "client-id" text "idpOktaClient"
+    * in the modal dialog I check "Pre-defined IdP template" radio selector
+    * I click in the "Provider type" selector field
+    * I select "Okta" option in the "Provider type" selector
+    * In the modal, I type into the field with ID "org" text "myOrg3"
+    * In the modal, I type into the field with ID "base-url" text "myOrg3.example.test"
+    * In the modal, I type into the field with ID "scope" text "myScopeOkta"
+    * In the modal, I type into the field with ID "ext-idp-uid-attr" text "exampleAttributeOkta"
+    When in the modal dialog I click on "Add" button
+    * I should see "success" alert with text "Identity provider successfully added"
+    * I close the alert
+    Then I should see "idpOkta" entry in the data table with ID "identity-provider-references-table"
+
+  Scenario: Add a new Custom identity provider reference
+    Given I am on "identity-provider-references" page
+    When I click on "Add" button
+    Then I see "Add Identity Provider reference" modal
+    * In the modal, I type into the field with ID "identity-provider-reference-name" text "idpCustom"
+    * In the modal, I type into the field with ID "client-id" text "idpCustomClient"
+    * in the modal dialog I check "Custom IdP definition" radio selector
+    * In the modal, I type into the field with ID "auth-uri" text "https://myUri.example.test"
+    * In the modal, I type into the field with ID "dev-auth-uri" text "https://myAuthDev.example.test"
+    * In the modal, I type into the field with ID "token-uri" text "https://myToken.example.test"
+    * In the modal, I type into the field with ID "user-info-uri" text "https://myUserInfo.example.test"
+    * In the modal, I type into the field with ID "jwks-uri" text "https://myJwks.example.test"
+    * In the modal, I type into the field with ID "scope" text "myCustomScope"
+    * In the modal, I type into the field with ID "ext-idp-uid-attr" text "exampleAttributeCustom"
+    When in the modal dialog I click on "Add" button
+    * I should see "success" alert with text "Identity provider successfully added"
+    * I close the alert
+    Then I should see "idpCustom" entry in the data table with ID "identity-provider-references-table"
+
+  Scenario: Delete identity provider references
+    Given I should see "idpKeycloak" entry in the data table with ID "identity-provider-references-table"
+    Given I should see "idpSecretKeycloak" entry in the data table with ID "identity-provider-references-table"
+    Given I should see "idpGoogle" entry in the data table with ID "identity-provider-references-table"
+    Given I should see "idpGithub" entry in the data table with ID "identity-provider-references-table"
+    Given I should see "idpMicrosoft" entry in the data table with ID "identity-provider-references-table"
+    Given I should see "idpOkta" entry in the data table with ID "identity-provider-references-table"
+    Given I should see "idpCustom" entry in the data table with ID "identity-provider-references-table"
+    # idpOkta and idpCustom are removed in the next step
+    Then I select entry "idpOkta" in the data table
+    Then I select entry "idpCustom" in the data table
+    When I click on "Delete" button
+    * I see "Remove Identity Provider references" modal
+    * I should see "idpOkta" entry in the data table
+    * I should see "idpCustom" entry in the data table
+    When in the modal dialog I click on "Delete" button
+    * I should see "success" alert with text "Identity Providers removed"
+    * I close the alert
+    Then I should not see "idpOkta" entry in the data table
+    Then I should not see "idpCustom" entry in the data table
+    # idpKeycloak, idpSecretKeycloak and idpGoogle are removed in the next step
+    Then I select entry "idpKeycloak" in the data table
+    * I select entry "idpSecretKeycloak" in the data table
+    * I select entry "idpGoogle" in the data table
+    When I click on "Delete" button
+    * I see "Remove Identity Provider references" modal
+    * I should see "idpKeycloak" entry in the data table
+    * I should see "idpSecretKeycloak" entry in the data table
+    * I should see "idpGoogle" entry in the data table
+    When in the modal dialog I click on "Delete" button
+    * I should see "success" alert with text "Identity Providers removed"
+    * I close the alert
+    Then I should not see "idpKeycloak" entry in the data table
+    * I should not see "idpSecretKeycloak" entry in the data table
+    * I should not see "idpGoogle" entry in the data table
+    # idpGithub and idpMicrosoft are removed in the next step
+    Then I select entry "idpGithub" in the data table
+    Then I select entry "idpMicrosoft" in the data table
+    When I click on "Delete" button
+    * I see "Remove Identity Provider references" modal
+    * I should see "idpGithub" entry in the data table
+    * I should see "idpMicrosoft" entry in the data table
+    When in the modal dialog I click on "Delete" button
+    * I should see "success" alert with text "Identity Providers removed"
+    * I close the alert
+    Then I should not see "idpGithub" entry in the data table
+    Then I should not see "idpMicrosoft" entry in the data table
+

--- a/tests/features/idp_references_settings.feature
+++ b/tests/features/idp_references_settings.feature
@@ -1,0 +1,129 @@
+Feature: Identity Providers references - Settings page
+  Modify identity providers fields and reset password
+
+  Background:
+    Given I am logged in as "Administrator"
+
+  Scenario: Prep: Create an Identity Provider reference (Keycloak - No secret)
+    Given I am on "identity-provider-references" page
+    When I click on "Add" button
+    Then I see "Add Identity Provider reference" modal
+    * In the modal, I type into the field with ID "identity-provider-reference-name" text "idpKeycloak"
+    * In the modal, I type into the field with ID "client-id" text "idpKeycloakClient"
+    * in the modal dialog I check "Pre-defined IdP template" radio selector
+    * I click in the "Provider type" selector field
+    * I select "Keycloak or Red Hat SSO" option in the "Provider type" selector
+    * In the modal, I type into the field with ID "org" text "myOrg"
+    * In the modal, I type into the field with ID "base-url" text "myOrg.example.test"
+    * In the modal, I type into the field with ID "scope" text "myScopeKeycloak"
+    * In the modal, I type into the field with ID "ext-idp-uid-attr" text "exampleAttributeKeycloak"
+    When in the modal dialog I click on "Add" button
+    * I should see "success" alert with text "Identity provider successfully added"
+    * I close the alert
+    Then I should see "idpKeycloak" entry in the data table with ID "identity-provider-references-table"
+
+  Scenario: Set 'Client identifier' field
+    Given I am on "identity-provider-references" page
+    When I click on "idpKeycloak" entry in the data table
+    When I clear the field "ipaidpclientid"
+    When I type in the field with ID "ipaidpclientid" the text "my_client_identifier"
+    Then I click on "Save" button
+    * I should see "success" alert with text "Identity Provider 'idpKeycloak' updated"
+    * I close the alert
+
+  Scenario: Set 'Client secret' field
+    When I clear the field "ipaidpclientsecret"
+    When I type in the field with ID "ipaidpclientsecret" the text "my_client_secret"
+    Then I click on "Save" button
+    * I should see "success" alert with text "Identity Provider 'idpKeycloak' updated"
+    * I close the alert
+
+  Scenario: Set 'Scope' field
+    When I clear the field "ipaidpscope"
+    When I type in the field with ID "ipaidpscope" the text "my_scope"
+    Then I click on "Save" button
+    * I should see "success" alert with text "Identity Provider 'idpKeycloak' updated"
+    * I close the alert
+
+  Scenario: Set 'External IdP user identifier attribute' field
+    When I clear the field "ipaidpsub"
+    When I type in the field with ID "ipaidpsub" the text "my_external_idp_uid_attribute"
+    Then I click on "Save" button
+    * I should see "success" alert with text "Identity Provider 'idpKeycloak' updated"
+    * I close the alert
+
+  Scenario: Set 'Authorization URI' field
+    When I type in the field with ID "ipaidpauthendpoint" the text "https://my_authorization_uri.example.test"
+    Then I click on "Save" button
+    * I should see "success" alert with text "Identity Provider 'idpKeycloak' updated"
+    * I close the alert
+
+  Scenario: Set 'Device authorization URI' field
+    When I clear the field "ipaidpdevauthendpoint"
+    When I type in the field with ID "ipaidpdevauthendpoint" the text "https://my_device_authorization_uri.example.test"
+    Then I click on "Save" button
+    * I should see "success" alert with text "Identity Provider 'idpKeycloak' updated"
+    * I close the alert
+
+  Scenario: Set 'Token URI' field
+    When I clear the field "ipaidptokenendpoint"
+    When I type in the field with ID "ipaidptokenendpoint" the text "https://my_token_uri.example.test"
+    Then I click on "Save" button
+    * I should see "success" alert with text "Identity Provider 'idpKeycloak' updated"
+    * I close the alert
+
+  Scenario: Set 'User info URI' field
+    When I clear the field "ipaidpuserinfoendpoint"
+    When I type in the field with ID "ipaidpuserinfoendpoint" the text "https://my_user_info_uri.example.test"
+    Then I click on "Save" button
+    * I should see "success" alert with text "Identity Provider 'idpKeycloak' updated"
+    * I close the alert
+
+  Scenario: Set 'JWKS URI' field
+    When I clear the field "ipaidpkeysendpoint"
+    When I type in the field with ID "ipaidpkeysendpoint" the text "https://my_jwks_uri.example.test"
+    Then I click on "Save" button
+    * I should see "success" alert with text "Identity Provider 'idpKeycloak' updated"
+    * I close the alert
+
+  Scenario: Set 'OIDC URL' field
+    When I clear the field "ipaidpissuerurl"
+    When I type in the field with ID "ipaidpissuerurl" the text "https://my_oidc_url.example.test"
+    Then I click on "Save" button
+    * I should see "success" alert with text "Identity Provider 'idpKeycloak' updated"
+    * I close the alert
+
+  Scenario: Check fields are reverted
+    When I clear the field "ipaidpclientid"
+    And I type in the field with ID "ipaidpclientid" the text "another_client"
+    When I clear the field "ipaidpscope"
+    And I type in the field with ID "ipaidpscope" the text "another_scope"
+    When I clear the field "ipaidpsub"
+    And I type in the field with ID "ipaidpsub" the text "another_external_idp_uid_attribute"
+    Then I click on "Revert" button
+    * I should see "success" alert with text "Identity Provider data reverted"
+    * I close the alert
+    Then I should see input field with ID "ipaidpclientid" and value "my_client_identifier"
+    Then I should see input field with ID "ipaidpscope" and value "my_scope"
+    Then I should see input field with ID "ipaidpsub" and value "my_external_idp_uid_attribute"
+
+  Scenario: Reset IdP password via kebab menu
+    When I click on kebab menu and select "Reset password"
+    Then I see "Reset password" modal
+    * In the modal, I type into the field with ID "modal-form-reset-password-new-password" text "myNewPassword"
+    * In the modal, I type into the field with ID "modal-form-reset-password-verify-password" text "myNewPassword"
+    When in the modal dialog I click on "Reset password" button
+    * I should see "success" alert with text "Identity Provider password successfully updated"
+    * I close the alert
+
+  Scenario: Cleanup: Remove the Identity Provider reference
+    Given I click on the breadcrump link "Identity provider references"
+    Given I should see "idpKeycloak" entry in the data table
+    Then I select entry "idpKeycloak" in the data table
+    When I click on "Delete" button
+    * I see "Remove Identity Provider references" modal
+    * I should see "idpKeycloak" entry in the data table
+    When in the modal dialog I click on "Delete" button
+    * I should see "success" alert with text "Identity Providers removed"
+    * I close the alert
+    Then I should not see "idpKeycloak" entry in the data table

--- a/tests/features/steps/common.ts
+++ b/tests/features/steps/common.ts
@@ -296,6 +296,15 @@ Then(
   }
 );
 
+Then(
+  "I should see input field with ID {string} and value {string}",
+  (id: string, value: string) => {
+    cy.get("input#" + id)
+      .should("exist")
+      .and("have.value", value);
+  }
+);
+
 Then("I should not see {string} entry in the data table", (name: string) => {
   cy.get("tr[id='" + name + "']").should("not.exist");
 });

--- a/tests/features/steps/common.ts
+++ b/tests/features/steps/common.ts
@@ -199,6 +199,15 @@ When(
 );
 
 When(
+  "In the modal, I type into the field with ID {string} text {string}",
+  (id: string, text: string) => {
+    cy.get("[role=dialog] div.pf-v5-c-modal-box__body")
+      .find("input[id=" + id + "]")
+      .type(text);
+  }
+);
+
+When(
   "I type in the flex field {string} text {string}",
   (fieldName: string, content: string) => {
     const regex = new RegExp("^" + fieldName + "$", "i");


### PR DESCRIPTION
The test should cover all the use cases found in the Identity Provider references main and 'Settings' page, including the actions from the kebab menu.

This PR depends on this one to be merged: https://github.com/freeipa/freeipa-webui/pull/684

## Summary by Sourcery

Implement Identity Provider references integration tests and settings page functionality

New Features:
- Add detailed settings page for Identity Provider references
- Implement ability to modify IdP reference details
- Add support for resetting IdP password

Enhancements:
- Extend RPC service for IdP references with new mutation and query methods
- Add comprehensive form handling for IdP reference settings
- Implement dynamic routing for IdP reference details

CI:
- Add new feature tests for Identity Provider references

Tests:
- Add integration tests for creating IdP references with various providers
- Add tests for modifying IdP reference settings
- Add tests for password reset functionality