### PR TITLE
Add 'Certificate Identity mapping rules' main page

### DIFF
--- a/src/components/tables/MainTable.tsx
+++ b/src/components/tables/MainTable.tsx
@@ -8,6 +8,8 @@ import SkeletonOnTableLayout from "../layouts/Skeleton/SkeletonOnTableLayout";
 // React router DOM
 import { Link } from "react-router-dom";
 import EmptyBodyTable from "./EmptyBodyTable";
+// Icons
+import { CheckIcon, MinusIcon } from "@patternfly/react-icons";
 
 /**
  * This component renders a table with the specified columns and rows.
@@ -51,6 +53,7 @@ export interface PropsToTable<T> {
   elementsData?: SelectedElementsData<T>;
   buttonsData?: ButtonsData;
   paginationData?: PaginationData;
+  statusElementName?: string; // This will be used to determine the status and style the table rows (grey if disabled)
 }
 
 const MainTable = <T,>(props: PropsToTable<T>) => {
@@ -181,6 +184,35 @@ const MainTable = <T,>(props: PropsToTable<T>) => {
     </Tr>
   );
 
+  type Status = "true" | "false";
+
+  // Helper method: Set styles depending on the status
+  const setStyleOnStatus = (status: Status) => {
+    if (status === "false") {
+      return { color: "grey" };
+    } else if (status === "true") {
+      return { color: "black" };
+    }
+  };
+
+  // Helper function to process boolean elements and return a string
+  // (used for displaying statuses values in the table)
+  const processBoolean = (value: boolean | string) => {
+    if (value === "false" || value === false) {
+      return (
+        <>
+          <MinusIcon key="minus-icon" /> {" Disabled"}
+        </>
+      );
+    } else {
+      return (
+        <>
+          <CheckIcon key="check-icon" /> {" Enabled"}
+        </>
+      );
+    }
+  };
+
   const body = shownElementsList.map((element, rowIndex) => {
     const elementName = element[props.pk].toString();
 
@@ -205,18 +237,34 @@ const MainTable = <T,>(props: PropsToTable<T>) => {
           )}
           {/* Table rows */}
           {props.keyNames.map((keyName, idx) => (
-            <Td dataLabel={columnNames[keyName]} key={idx} id={idx.toString()}>
-              {idx === 0 && !!props.showLink ? (
-                <Link
-                  to={"/" + props.pathname + "/" + element[keyName]}
-                  state={element}
-                >
-                  {element[keyName]}
-                </Link>
-              ) : (
-                <>{element[keyName]}</>
-              )}
-            </Td>
+            <>
+              <Td
+                dataLabel={columnNames[keyName]}
+                key={idx}
+                id={idx.toString()}
+                style={setStyleOnStatus(element[keyName])}
+                aria-label={keyName}
+              >
+                {idx === 0 && !!props.showLink ? (
+                  <Link
+                    to={"/" + props.pathname + "/" + element[keyName]}
+                    state={element}
+                  >
+                    {props.statusElementName &&
+                    keyName === props.statusElementName
+                      ? processBoolean(element[keyName])
+                      : element[keyName]}
+                  </Link>
+                ) : (
+                  <>
+                    {props.statusElementName &&
+                    keyName === props.statusElementName
+                      ? processBoolean(element[keyName])
+                      : element[keyName]}
+                  </>
+                )}
+              </Td>
+            </>
           ))}
         </Tr>
       );

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -57,6 +57,7 @@ import SubIdsTabs from "src/pages/SubordinateIDs/SubIdsTabs";
 import PasswordPoliciesTabs from "src/pages/PasswordPolicies/PasswordPoliciesTabs";
 import IdpReferences from "src/pages/IdPReferences/IdpReferences";
 import IdpReferencesTabs from "src/pages/IdPReferences/IdpReferencesTabs";
+import CertificateMappingPage from "src/pages/CertificateMapping/CertificateMapping";
 
 // Renders routes (React)
 export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
@@ -438,6 +439,9 @@ export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
                     element={<IdpReferencesTabs section="settings" />}
                   />
                 </Route>
+              </Route>
+              <Route path="cert-id-mapping-rules">
+                <Route path="" element={<CertificateMappingPage />} />
               </Route>
               <Route path="configuration" element={<Configuration />} />
               {/* Redirect to Active users page if user is logged in and navigates to the root page */}

--- a/src/navigation/NavRoutes.ts
+++ b/src/navigation/NavRoutes.ts
@@ -49,6 +49,7 @@ const PasswordPoliciesGroupRef = "password-policies";
 const KerberosTicketPolicyGroupRef = "kerberos-ticket-policy";
 // AUTHENTICATION
 const IdentityProviderReferencesGroupRef = "identity-provider-references";
+const CertificateMappingGroupRef = "cert-id-mapping-rules";
 // IPA SERVER
 // - Configuration
 const ConfigRef = "configuration";
@@ -298,6 +299,13 @@ export const navigationRoutes = [
         group: IdentityProviderReferencesGroupRef,
         title: `${BASE_TITLE} - Identity Provider references`,
         path: "identity-provider-references",
+        items: [],
+      },
+      {
+        label: "Certificate identity mapping rules",
+        group: CertificateMappingGroupRef,
+        title: `${BASE_TITLE} - Certificate identity mapping rules`,
+        path: "cert-id-mapping-rules",
         items: [],
       },
     ],

--- a/src/pages/CertificateMapping/CertificateMapping.tsx
+++ b/src/pages/CertificateMapping/CertificateMapping.tsx
@@ -1,0 +1,494 @@
+import React from "react";
+// PatternFly
+import {
+  Page,
+  PageSection,
+  PageSectionVariants,
+  PaginationVariant,
+} from "@patternfly/react-core";
+import {
+  InnerScrollContainer,
+  OuterScrollContainer,
+} from "@patternfly/react-table";
+// Data types
+import { CertificateMapping } from "src/utils/datatypes/globalDataTypes";
+// Hooks
+import useAlerts from "src/hooks/useAlerts";
+import useUpdateRoute from "src/hooks/useUpdateRoute";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
+import useApiError from "src/hooks/useApiError";
+// Redux
+import { useAppSelector } from "src/store/hooks";
+// RPC
+import {
+  useGetCertMapRuleEntriesQuery,
+  useSearchCertMapRuleEntriesMutation,
+} from "src/services/rpcCertMapping";
+// Utils
+import { isCertMapSelectable } from "src/utils/utils";
+import { apiToCertificateMapping } from "src/utils/certMappingUtils";
+// React router
+import { useNavigate } from "react-router";
+// Components
+import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
+import { SerializedError } from "@reduxjs/toolkit";
+import ToolbarLayout, {
+  ToolbarItem,
+} from "src/components/layouts/ToolbarLayout";
+import SearchInputLayout from "src/components/layouts/SearchInputLayout";
+import SecondaryButton from "src/components/layouts/SecondaryButton";
+import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
+import TitleLayout from "src/components/layouts/TitleLayout";
+import GlobalErrors from "src/components/errors/GlobalErrors";
+import MainTable from "src/components/tables/MainTable";
+import BulkSelectorPrep from "src/components/BulkSelectorPrep";
+
+const CertificateMappingPage = () => {
+  const navigate = useNavigate();
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  const { browserTitle } = useUpdateRoute({
+    pathname: "cert-id-mapping-rules",
+  });
+
+  // Set the page title to be shown in the browser tab
+  React.useEffect(() => {
+    document.title = browserTitle;
+  }, [browserTitle]);
+
+  // Retrieve API version from environment data
+  const apiVersion = useAppSelector(
+    (state) => state.global.environment.api_version
+  ) as string;
+
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
+  // URL parameters: page number, page size, search value
+  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+    useListPageSearchParams();
+
+  // Handle API calls errors
+  const globalErrors = useApiError([]);
+
+  // Page indexes
+  const firstUserIdx = (page - 1) * perPage;
+  const lastUserIdx = page * perPage;
+
+  // States
+  const [certMapRules, setCertMapRules] = React.useState<CertificateMapping[]>(
+    []
+  );
+  const [isSearchDisabled, setIsSearchDisabled] = React.useState(false);
+  const [totalCount, setTotalCount] = React.useState(0);
+
+  // API calls
+  const certMapsResponse = useGetCertMapRuleEntriesQuery({
+    searchValue,
+    apiVersion,
+    sizelimit: perPage,
+    startIdx: firstUserIdx,
+    stopIdx: lastUserIdx,
+  });
+
+  const { data, isLoading, error } = certMapsResponse;
+
+  // Handle data when the API call is finished
+  React.useEffect(() => {
+    if (certMapsResponse.isFetching) {
+      setShowTableRows(false);
+      // Reset selected elements on refresh
+      setTotalCount(0);
+      globalErrors.clear();
+      return;
+    }
+
+    // API response: Success
+    if (
+      certMapsResponse.isSuccess &&
+      certMapsResponse.data &&
+      data !== undefined
+    ) {
+      const listResult = data.result.results;
+      const totalCount = data.result.totalCount;
+      const listSize = data.result.count;
+      const elementsList: CertificateMapping[] = [];
+
+      for (let i = 0; i < listSize; i++) {
+        elementsList.push(apiToCertificateMapping(listResult[i].result));
+      }
+
+      setTotalCount(totalCount);
+      // Update the list of elements
+      setCertMapRules(elementsList);
+      // Show table elements
+      setShowTableRows(true);
+    }
+
+    // API response: Error
+    if (
+      !certMapsResponse.isLoading &&
+      certMapsResponse.isError &&
+      certMapsResponse.error !== undefined
+    ) {
+      // This normally happens when the user is not authorized to view the data
+      // So instead of adding an error, refresh page
+      navigate("/login");
+      window.location.reload();
+    }
+  }, [certMapsResponse]);
+
+  // Selected elements
+  const [selectedElements, setSelectedElements] = React.useState<
+    CertificateMapping[]
+  >([]);
+  const [selectedPerPage, setSelectedPerPage] = React.useState<number>(0);
+
+  // Refresh button handling
+  const refreshData = () => {
+    // Hide table
+    setShowTableRows(false);
+
+    // Reset selected elements on refresh
+    setTotalCount(0);
+
+    certMapsResponse.refetch().then(() => {
+      setShowTableRows(true);
+    });
+  };
+
+  // 'Delete' button state
+  const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
+    React.useState<boolean>(true);
+
+  const [isDeletion, setIsDeletion] = React.useState(false);
+
+  // 'Enable' button state
+  const [isEnableButtonDisabled] = React.useState<boolean>(true);
+
+  // 'Disable' button state
+  const [isDisableButtonDisabled] = React.useState<boolean>(true);
+
+  // Table-related shared functionality
+  // - Selectable checkboxes on table
+  const selectableCertMapRulesTable = certMapRules.filter(isCertMapSelectable); // elements per Table
+
+  const updateSelectedCertMapRules = (
+    certMapRule: CertificateMapping[],
+    isSelected: boolean
+  ) => {
+    let newSelectedCertMapRules: CertificateMapping[] = [];
+    if (isSelected) {
+      newSelectedCertMapRules = JSON.parse(JSON.stringify(selectedElements));
+      for (let i = 0; i < certMapRule.length; i++) {
+        if (
+          selectedElements.find(
+            (selectedCertMapRule) =>
+              selectedCertMapRule.cn === certMapRule[i].cn
+          )
+        ) {
+          // Already in the list
+          continue;
+        }
+        // Add element to list
+        newSelectedCertMapRules.push(certMapRule[i]);
+      }
+    } else {
+      // Remove element
+      for (let i = 0; i < selectedElements.length; i++) {
+        let found = false;
+        for (let ii = 0; ii < certMapRule.length; ii++) {
+          if (selectedElements[i].cn === certMapRule[ii].cn) {
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          // Keep this valid selected entry
+          newSelectedCertMapRules.push(selectedElements[i]);
+        }
+      }
+    }
+    setSelectedElements(newSelectedCertMapRules);
+    setIsDeleteButtonDisabled(newSelectedCertMapRules.length === 0);
+  };
+
+  // - Helper method to set the selected entries from the table
+  const setCertMapRulesSelected = (
+    certMapRule: CertificateMapping,
+    isSelecting = true
+  ) => {
+    if (isCertMapSelectable(certMapRule)) {
+      updateSelectedCertMapRules([certMapRule], isSelecting);
+    }
+  };
+
+  // Always refetch data when the component is loaded.
+  // This ensures the data is always up-to-date.
+  React.useEffect(() => {
+    certMapsResponse.refetch();
+  }, []);
+
+  // Show table rows
+  const [showTableRows, setShowTableRows] = React.useState(!isLoading);
+
+  // Show table rows only when data is fully retrieved
+  React.useEffect(() => {
+    if (showTableRows !== !isLoading) {
+      setShowTableRows(!isLoading);
+    }
+  }, [isLoading]);
+
+  // Search API call
+  const [searchEntry] = useSearchCertMapRuleEntriesMutation();
+
+  const submitSearchValue = () => {
+    searchEntry({
+      searchValue: searchValue,
+      apiVersion,
+      sizelimit: 100,
+      startIdx: 0,
+      stopIdx: 200, // Search will consider a max. of elements
+    }).then((result) => {
+      if ("data" in result) {
+        const searchError = result.data?.error as
+          | FetchBaseQueryError
+          | SerializedError;
+
+        if (searchError) {
+          // Error
+          let error: string | undefined = "";
+          if ("error" in searchError) {
+            error = searchError.error;
+          } else if ("message" in searchError) {
+            error = searchError.message;
+          }
+          alerts.addAlert(
+            "submit-search-value-error",
+            error || "Error when searching for IdPs",
+            "danger"
+          );
+        } else {
+          // Success
+          const listResult = result.data?.result.results || [];
+          const listSize = result.data?.result.count || 0;
+          const totalCount = result.data?.result.totalCount || 0;
+          const elementsList: CertificateMapping[] = [];
+
+          for (let i = 0; i < listSize; i++) {
+            elementsList.push(listResult[i].result);
+          }
+
+          setTotalCount(totalCount);
+          setCertMapRules(elementsList);
+          setShowTableRows(true);
+        }
+        setIsSearchDisabled(false);
+      }
+    });
+  };
+
+  // Data wrappers
+  // TODO: Better separation of concerts
+  // - 'PaginationLayout'
+  const paginationData = {
+    page,
+    perPage,
+    updatePage: setPage,
+    updatePerPage: setPerPage,
+    updateSelectedPerPage: setSelectedPerPage,
+    updateShownElementsList: setCertMapRules,
+    totalCount,
+  };
+
+  // SearchInputLayout
+  const searchValueData = {
+    searchValue,
+    updateSearchValue: setSearchValue,
+    submitSearchValue,
+  };
+
+  // - 'BulkSelectorrep'
+  const bulkSelectorData = {
+    selected: selectedElements,
+    updateSelected: updateSelectedCertMapRules,
+    selectableTable: selectableCertMapRulesTable,
+    nameAttr: "cn",
+  };
+
+  const selectedPerPageData = {
+    selectedPerPage,
+    updateSelectedPerPage: setSelectedPerPage,
+  };
+
+  // List of Toolbar items
+  const toolbarItems: ToolbarItem[] = [
+    {
+      key: 0,
+      element: (
+        <BulkSelectorPrep
+          list={certMapRules}
+          shownElementsList={certMapRules}
+          elementData={bulkSelectorData}
+          buttonsData={{
+            updateIsDeleteButtonDisabled: setIsDeleteButtonDisabled,
+          }}
+          selectedPerPageData={selectedPerPageData}
+        />
+      ),
+    },
+    {
+      key: 1,
+      element: (
+        <SearchInputLayout
+          name="search"
+          ariaLabel="Search certificate mapping rules"
+          placeholder="Search"
+          searchValueData={searchValueData}
+          isDisabled={isSearchDisabled}
+        />
+      ),
+      toolbarItemVariant: "search-filter",
+      toolbarItemSpacer: { default: "spacerMd" },
+    },
+    {
+      key: 2,
+      toolbarItemVariant: "separator",
+    },
+    {
+      key: 3,
+      element: (
+        <SecondaryButton
+          onClickHandler={refreshData}
+          isDisabled={!showTableRows}
+        >
+          Refresh
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 4,
+      element: (
+        <SecondaryButton isDisabled={isDeleteButtonDisabled || !showTableRows}>
+          Delete
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 5,
+      element: (
+        <SecondaryButton isDisabled={!showTableRows}>Add</SecondaryButton>
+      ),
+    },
+    {
+      key: 6,
+      element: (
+        <SecondaryButton isDisabled={isDisableButtonDisabled || !showTableRows}>
+          Disable
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 7,
+      element: (
+        <SecondaryButton isDisabled={isEnableButtonDisabled || !showTableRows}>
+          Enable
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 8,
+      toolbarItemVariant: "separator",
+    },
+    {
+      key: 9,
+      element: <HelpTextWithIconLayout textContent="Help" />,
+    },
+    {
+      key: 10,
+      element: (
+        <PaginationLayout
+          list={certMapRules}
+          paginationData={paginationData}
+          widgetId="pagination-options-menu-top"
+          isCompact={true}
+        />
+      ),
+      toolbarItemAlignment: { default: "alignRight" },
+    },
+  ];
+
+  // Render component
+  return (
+    <Page>
+      <alerts.ManagedAlerts />
+      <PageSection variant={PageSectionVariants.light}>
+        <TitleLayout
+          id="Certificate Identity mapping rules page"
+          headingLevel="h1"
+          text="Certificate Identity mapping rules"
+        />
+      </PageSection>
+      <PageSection
+        variant={PageSectionVariants.light}
+        isFilled={false}
+        className="pf-v5-u-m-lg pf-v5-u-pb-md pf-v5-u-pl-0 pf-v5-u-pr-0"
+      >
+        <ToolbarLayout
+          className="pf-v5-u-pt-0 pf-v5-u-pl-lg pf-v5-u-pr-md"
+          contentClassName="pf-v5-u-p-0"
+          toolbarItems={toolbarItems}
+        />
+        <div style={{ height: `calc(100vh - 352.2px)` }}>
+          <OuterScrollContainer>
+            <InnerScrollContainer>
+              {error !== undefined && error ? (
+                <GlobalErrors errors={globalErrors.getAll()} />
+              ) : (
+                <MainTable
+                  tableTitle="Certificate Identity mapping table"
+                  shownElementsList={certMapRules}
+                  pk="cn"
+                  keyNames={["cn", "ipaenabledflag", "description"]}
+                  columnNames={["Rule name", "Status", "Description"]}
+                  hasCheckboxes={true}
+                  pathname="cert-id-mapping-rules"
+                  showTableRows={showTableRows}
+                  showLink={false}
+                  elementsData={{
+                    isElementSelectable: isCertMapSelectable,
+                    selectedElements,
+                    selectableElementsTable: selectableCertMapRulesTable,
+                    setElementsSelected: setCertMapRulesSelected,
+                    clearSelectedElements: () => setSelectedElements([]),
+                  }}
+                  buttonsData={{
+                    updateIsDeleteButtonDisabled: (value) =>
+                      setIsDeleteButtonDisabled(value),
+                    isDeletion,
+                    updateIsDeletion: (value) => setIsDeletion(value),
+                  }}
+                  paginationData={{
+                    selectedPerPage,
+                    updateSelectedPerPage: setSelectedPerPage,
+                  }}
+                  statusElementName="ipaenabledflag"
+                />
+              )}
+            </InnerScrollContainer>
+          </OuterScrollContainer>
+        </div>
+        <PaginationLayout
+          list={certMapRules}
+          paginationData={paginationData}
+          variant={PaginationVariant.bottom}
+          widgetId="pagination-options-menu-bottom"
+          className="pf-v5-u-pb-0 pf-v5-u-pr-md"
+        />
+      </PageSection>
+    </Page>
+  );
+};
+
+export default CertificateMappingPage;

--- a/src/services/rpcCertMapping.ts
+++ b/src/services/rpcCertMapping.ts
@@ -1,0 +1,229 @@
+import {
+  api,
+  Command,
+  getBatchCommand,
+  BatchRPCResponse,
+  FindRPCResponse,
+  getCommand,
+} from "./rpc";
+// utils
+import { API_VERSION_BACKUP } from "../utils/utils";
+// Data types
+import { cnType } from "src/utils/datatypes/globalDataTypes";
+
+/**
+ * Password policies-related endpoints: useCertMapRuleFindQuery, useGetCertMapRuleEntriesQuery,
+ *                             useSearchCertMapRuleEntriesMutation
+ *
+ * API commands:
+ * - certmaprule_find: https://freeipa.readthedocs.io/en/ipa-4-11/api/certmaprule_find.html
+ * - certmaprule_show: https://freeipa.readthedocs.io/en/ipa-4-11/api/certmaprule_show.html
+ */
+
+export interface CertMapFindPayload {
+  searchValue: string;
+  pkeyOnly: boolean;
+  sizeLimit: number;
+  version?: string;
+}
+
+export interface CertMapFullDataPayload {
+  searchValue: string;
+  apiVersion: string;
+  sizelimit: number;
+  startIdx: number;
+  stopIdx: number;
+}
+
+const extendedApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    /**
+     * Get certificate mapping IDs
+     * @param {CertMapFindPayload} - Payload with search value and options
+     * @returns {Promise<FindRPCResponse>} - Promise with the response data
+     *
+     */
+    certMapRuleFind: build.query<FindRPCResponse, CertMapFindPayload>({
+      query: (payload) => {
+        const certmapruleParams = {
+          pkey_only: payload.pkeyOnly,
+          sizelimit: payload.sizeLimit,
+          version: payload.version || API_VERSION_BACKUP,
+        };
+
+        return getCommand({
+          method: "certmaprule_find",
+          params: [[payload.searchValue], certmapruleParams],
+        });
+      },
+    }),
+    /**
+     * Find certificate mapping full data.
+     * @param CertMapFullDataPayload
+     * @returns List of certificate mapping entries
+     *
+     */
+    getCertMapRuleEntries: build.query<
+      BatchRPCResponse,
+      CertMapFullDataPayload
+    >({
+      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
+        const { searchValue, apiVersion, sizelimit, startIdx, stopIdx } =
+          payloadData;
+
+        if (apiVersion === undefined) {
+          return {
+            error: {
+              status: "CUSTOM_ERROR",
+              data: "",
+              error: "API version not available",
+            },
+          };
+        }
+
+        // FETCH CERT. MAPPING DATA VIA "certmaprule_find" COMMAND
+        // Prepare search parameters
+        const certMapIdsParams = {
+          pkey_only: true,
+          sizelimit: sizelimit,
+          version: apiVersion,
+        };
+
+        // Prepare payload
+        const payloadDataCertMap: Command = {
+          method: "certmaprule_find",
+          params: [[searchValue], certMapIdsParams],
+        };
+
+        // Make call using 'fetchWithBQ'
+        const getResultCertMap = await fetchWithBQ(
+          getCommand(payloadDataCertMap)
+        );
+        // Return possible errors
+        if (getResultCertMap.error) {
+          return { error: getResultCertMap.error };
+        }
+        // If no error: cast and assign 'ids'
+        const responseDataCertMap = getResultCertMap.data as FindRPCResponse;
+
+        const certMapIds: string[] = [];
+        const certMapItemsCount = responseDataCertMap.result.result
+          .length as number;
+
+        for (let i = startIdx; i < certMapItemsCount && i < stopIdx; i++) {
+          const certMapId = responseDataCertMap.result.result[i] as cnType;
+          const { cn } = certMapId;
+          certMapIds.push(cn[0] as string);
+        }
+
+        // FETCH CERT. MAPPING DATA VIA "certmaprule_show" COMMAND
+        const commands: Command[] = [];
+        certMapIds.forEach((certMapId) => {
+          commands.push({
+            method: "certmaprule_show",
+            params: [[certMapId], {}],
+          });
+        });
+
+        const certMapShowResult = await fetchWithBQ(
+          getBatchCommand(commands, apiVersion)
+        );
+
+        const response = certMapShowResult.data as BatchRPCResponse;
+        if (response) {
+          response.result.totalCount = certMapItemsCount;
+        }
+
+        // Return results
+        return { data: response };
+      },
+    }),
+    /**
+     * Search for a specific password policy.
+     * @param CertMapFullDataPayload
+     * @returns Certificate mapping entries that match with the search criteria
+     */
+    searchCertMapRuleEntries: build.mutation<
+      BatchRPCResponse,
+      CertMapFullDataPayload
+    >({
+      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
+        const { searchValue, apiVersion, sizelimit, startIdx, stopIdx } =
+          payloadData;
+
+        if (apiVersion === undefined) {
+          return {
+            error: {
+              status: "CUSTOM_ERROR",
+              data: "",
+              error: "API version not available",
+            },
+          };
+        }
+
+        // FETCH CERT. MAPPING DATA VIA "certmaprule_find" COMMAND
+        // Prepare search parameters
+        const certMapIdsParams = {
+          pkey_only: true,
+          sizelimit: sizelimit,
+          version: apiVersion,
+        };
+
+        // Prepare payload
+        const payloadDataCertMap: Command = {
+          method: "certmaprule_find",
+          params: [[searchValue], certMapIdsParams],
+        };
+
+        // Make call using 'fetchWithBQ'
+        const getResultCertMap = await fetchWithBQ(
+          getCommand(payloadDataCertMap)
+        );
+        // Return possible errors
+        if (getResultCertMap.error) {
+          return { error: getResultCertMap.error };
+        }
+        // If no error: cast and assign 'ids'
+        const responseDataCertMap = getResultCertMap.data as FindRPCResponse;
+
+        const certMapIds: string[] = [];
+        const certMapItemsCount = responseDataCertMap.result.result
+          .length as number;
+
+        for (let i = startIdx; i < certMapItemsCount && i < stopIdx; i++) {
+          const certMapId = responseDataCertMap.result.result[i] as cnType;
+          const { cn } = certMapId;
+          certMapIds.push(cn[0] as string);
+        }
+
+        // FETCH CERT. MAPPING DATA VIA "certmaprule_show" COMMAND
+        const commands: Command[] = [];
+        certMapIds.forEach((certMapId) => {
+          commands.push({
+            method: "certmaprule_show",
+            params: [[certMapId], {}],
+          });
+        });
+
+        const certMapShowResult = await fetchWithBQ(
+          getBatchCommand(commands, apiVersion)
+        );
+
+        const response = certMapShowResult.data as BatchRPCResponse;
+        if (response) {
+          response.result.totalCount = certMapItemsCount;
+        }
+
+        // Return results
+        return { data: response };
+      },
+    }),
+  }),
+  overrideExisting: false,
+});
+
+export const {
+  useCertMapRuleFindQuery,
+  useGetCertMapRuleEntriesQuery,
+  useSearchCertMapRuleEntriesMutation,
+} = extendedApi;

--- a/src/utils/certMappingUtils.tsx
+++ b/src/utils/certMappingUtils.tsx
@@ -1,0 +1,47 @@
+// Data types
+import { CertificateMapping } from "./datatypes/globalDataTypes";
+import { convertApiObj } from "src/utils/ipaObjectUtils";
+
+const simpleValues = new Set([
+  "cn",
+  "dn",
+  "description",
+  "ipacertmapmaprule",
+  "ipacertmapmatchrule",
+  "ipacertmappriority",
+  "ipaenabledflag",
+]);
+const dateValues = new Set([]);
+
+export function apiToCertificateMapping(
+  apiRecord: Record<string, unknown>
+): CertificateMapping {
+  const converted = convertApiObj(
+    apiRecord,
+    simpleValues,
+    dateValues
+  ) as Partial<CertificateMapping>;
+  return partialCertMappingToCertMapping(converted);
+}
+
+export function partialCertMappingToCertMapping(
+  partialcertMapping: Partial<CertificateMapping>
+) {
+  return {
+    ...createEmptyCertMapping(),
+    ...partialcertMapping,
+  };
+}
+
+export function createEmptyCertMapping(): CertificateMapping {
+  return {
+    cn: "",
+    dn: "",
+    description: "",
+    ipacertmapmaprule: "",
+    ipacertmapmatchrule: "",
+    associateddomain: [],
+    ipacertmappriority: "",
+    ipaenabledflag: false,
+  };
+}

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -710,3 +710,14 @@ export interface PasswordValidationType {
   message: string;
   pfError: ValidatedOptions;
 }
+
+export interface CertificateMapping {
+  cn: string;
+  dn: string;
+  description: string;
+  ipacertmapmaprule: string;
+  ipacertmapmatchrule: string;
+  associateddomain: string[];
+  ipacertmappriority: string;
+  ipaenabledflag: boolean;
+}

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -21,6 +21,7 @@ import {
   AutomemberEntry,
   PwPolicy,
   IDPServer,
+  CertificateMapping,
 } from "./datatypes/globalDataTypes";
 // Errors
 import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
@@ -123,6 +124,9 @@ export const isPwPolicySelectable = (pwPolicy: PwPolicy) => pwPolicy.cn !== "";
 
 export const isIdpServerSelectable = (idpServer: IDPServer) =>
   idpServer.cn !== "";
+
+export const isCertMapSelectable = (certMap: CertificateMapping) =>
+  certMap.cn !== "";
 
 // Write JSX error messages into 'apiErrorsJsx' array
 export const apiErrorToJsXError = (

--- a/tests/features/steps/common.ts
+++ b/tests/features/steps/common.ts
@@ -4,7 +4,7 @@ import { When, Then, Given } from "@badeball/cypress-cucumber-preprocessor";
 Given("I am on {string} page", (handle: string) => {
   cy.url().then(($url) => {
     if (!$url.includes(handle)) {
-      cy.visit(Cypress.env("base_url") + "/" + handle, { timeout: 6000 });
+      cy.visit(Cypress.env("base_url") + "/" + handle, { timeout: 10000 });
     }
   });
 });

--- a/tests/features/sudo_rules_settings_as_whom.feature
+++ b/tests/features/sudo_rules_settings_as_whom.feature
@@ -25,7 +25,7 @@ Feature: Sudo rules - Settings page > 'As whom' section
         * I should see "success" alert with text "New user added"
         Then I close the alert
         Then I should see "hsolo" entry in the data table
-        Then I wait for 5 seconds
+        Then I wait for 10 seconds
     # - RunAs User
     Scenario: Add a new runAs user
         Given The "hsolo" element exists in the table with ID "active-users-table" located in page "active-users"


### PR DESCRIPTION
The Certificate identity mapping rules must show a list of the available mapping rules (provided by the `certmaprule_find` and `certmaprule_show` API calls) and show them in the main table.