### PR TITLE
'Certificate identity mapping global configuration' page

### DIFF
--- a/src/components/Form/IpaCheckbox/IpaCheckbox.tsx
+++ b/src/components/Form/IpaCheckbox/IpaCheckbox.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { Checkbox } from "@patternfly/react-core";
 // Utils
 import {
+  BasicType,
   IPAParamDefinition,
   getParamProperties,
   updateIpaObject,
@@ -34,14 +35,20 @@ const IpaCheckbox = (props: CheckboxOption) => {
     }
   };
 
-  const checked =
-    value &&
-    ((typeof value === "string" &&
-      (value.toLowerCase() === "true" ||
-        (props.altTrue && props.altTrue === value))) ||
-      value === true)
-      ? true
-      : false;
+  const determineIfChecked = (value: BasicType) => {
+    const valueToString =
+      value === undefined || value === null ? "" : String(value);
+    if (
+      (valueToString && valueToString.toLowerCase() === "true") ||
+      (props.altTrue && props.altTrue === value)
+    ) {
+      return true;
+    } else {
+      return false;
+    }
+  };
+
+  const checked = determineIfChecked(value);
 
   return (
     <Checkbox

--- a/src/hooks/useCertMapConfigData.tsx
+++ b/src/hooks/useCertMapConfigData.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+// RPC
+import { useGetObjectMetadataQuery } from "src/services/rpc";
+import { useCertMapConfigFindQuery } from "src/services/rpcCertMapping";
+// Data types
+import {
+  CertificateMappingConfig,
+  Metadata,
+} from "src/utils/datatypes/globalDataTypes";
+
+type CertMapConfigSettingsData = {
+  isLoading: boolean;
+  isFetching: boolean;
+  modified: boolean;
+  setModified: (value: boolean) => void;
+  resetValues: () => void;
+  metadata: Metadata;
+  originalCertMapConfig: Partial<CertificateMappingConfig>;
+  certMapConfig: Partial<CertificateMappingConfig>;
+  setCertMapConfig: (cn: Partial<CertificateMappingConfig>) => void;
+  refetch: () => void;
+  modifiedValues: () => Partial<CertificateMappingConfig>;
+};
+
+const useCertMapConfigData = (): CertMapConfigSettingsData => {
+  // [API call] Metadata
+  const metadataQuery = useGetObjectMetadataQuery();
+  const metadata = metadataQuery.data || {};
+  const metadataLoading = metadataQuery.isLoading;
+
+  // [API call] Certificate Mapping Config
+  const certMapConfigDetails = useCertMapConfigFindQuery();
+  const certMapConfigData = certMapConfigDetails.data;
+  const isCertMapConfigDataLoading = certMapConfigDetails.isLoading;
+
+  const [modified, setModified] = React.useState(false);
+
+  // Data displayed and modified by the user
+  const [certMapConfig, setCertMapConfig] = React.useState<
+    Partial<CertificateMappingConfig>
+  >({});
+
+  React.useEffect(() => {
+    if (certMapConfigData && !certMapConfigDetails.isFetching) {
+      setCertMapConfig({ ...certMapConfigData });
+    }
+  }, [certMapConfigData, certMapConfigDetails.isFetching]);
+
+  const settings: CertMapConfigSettingsData = {
+    isLoading: metadataLoading || isCertMapConfigDataLoading,
+    isFetching: certMapConfigDetails.isFetching,
+    modified,
+    setModified,
+    metadata,
+    resetValues: () => {},
+    originalCertMapConfig: certMapConfig,
+    setCertMapConfig,
+    refetch: certMapConfigDetails.refetch,
+    certMapConfig,
+    modifiedValues: () => certMapConfig,
+  };
+
+  const getModifiedValues = (): Partial<CertificateMappingConfig> => {
+    if (!certMapConfigData) {
+      return {};
+    }
+
+    const modifiedValues = {};
+
+    Object.keys(certMapConfig).forEach((key) => {
+      if (certMapConfigData[key] !== certMapConfig[key]) {
+        modifiedValues[key] = certMapConfig[key];
+      }
+    });
+
+    return modifiedValues;
+  };
+  settings.modifiedValues = getModifiedValues;
+
+  // Detect any change in 'originalPwPolicy' and 'pwPolicy' objects
+  React.useEffect(() => {
+    if (!certMapConfigData) {
+      return;
+    }
+    let modified = false;
+    for (const [key, value] of Object.entries(certMapConfig)) {
+      if (Array.isArray(value)) {
+        // Using 'JSON.stringify' when comparing arrays (to prevent data type false positives)
+        if (JSON.stringify(certMapConfigData[key]) !== JSON.stringify(value)) {
+          modified = true;
+          break;
+        }
+      } else {
+        if (certMapConfigData[key] !== value) {
+          modified = true;
+          break;
+        }
+      }
+    }
+    setModified(modified);
+  }, [certMapConfig, certMapConfigData]);
+
+  // Reset values
+  const onResetValues = () => {
+    setModified(false);
+  };
+  settings.resetValues = onResetValues;
+
+  return settings;
+};
+
+export { useCertMapConfigData };

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -58,6 +58,7 @@ import PasswordPoliciesTabs from "src/pages/PasswordPolicies/PasswordPoliciesTab
 import IdpReferences from "src/pages/IdPReferences/IdpReferences";
 import IdpReferencesTabs from "src/pages/IdPReferences/IdpReferencesTabs";
 import CertificateMappingPage from "src/pages/CertificateMapping/CertificateMapping";
+import CertificateMappingGlobalConfig from "src/pages/CertificateMapping/CertificateMappingGlobalConfig";
 
 // Renders routes (React)
 export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
@@ -442,6 +443,9 @@ export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
               </Route>
               <Route path="cert-id-mapping-rules">
                 <Route path="" element={<CertificateMappingPage />} />
+              </Route>
+              <Route path="cert-id-mapping-global-config">
+                <Route path="" element={<CertificateMappingGlobalConfig />} />
               </Route>
               <Route path="configuration" element={<Configuration />} />
               {/* Redirect to Active users page if user is logged in and navigates to the root page */}

--- a/src/navigation/NavRoutes.ts
+++ b/src/navigation/NavRoutes.ts
@@ -50,6 +50,7 @@ const KerberosTicketPolicyGroupRef = "kerberos-ticket-policy";
 // AUTHENTICATION
 const IdentityProviderReferencesGroupRef = "identity-provider-references";
 const CertificateMappingGroupRef = "cert-id-mapping-rules";
+const CertificateMappingConfigGroupRef = "cert-id-mapping-global-config";
 // IPA SERVER
 // - Configuration
 const ConfigRef = "configuration";
@@ -306,6 +307,13 @@ export const navigationRoutes = [
         group: CertificateMappingGroupRef,
         title: `${BASE_TITLE} - Certificate identity mapping rules`,
         path: "cert-id-mapping-rules",
+        items: [],
+      },
+      {
+        label: "Certificate identity mapping global configuration",
+        group: CertificateMappingConfigGroupRef,
+        title: `${BASE_TITLE} - Certificate identity mapping global configuration`,
+        path: "cert-id-mapping-global-config",
         items: [],
       },
     ],

--- a/src/pages/CertificateMapping/CertificateMappingGlobalConfig.tsx
+++ b/src/pages/CertificateMapping/CertificateMappingGlobalConfig.tsx
@@ -1,0 +1,198 @@
+import React from "react";
+// PatternFly
+import {
+  Flex,
+  FlexItem,
+  Form,
+  FormGroup,
+  Sidebar,
+  SidebarContent,
+  SidebarPanel,
+} from "@patternfly/react-core";
+// Hooks
+import { useCertMapConfigData } from "src/hooks/useCertMapConfigData";
+import useAlerts from "src/hooks/useAlerts";
+import useUpdateRoute from "src/hooks/useUpdateRoute";
+// RPC
+import {
+  CertMapConfigPayload,
+  useCertMapConfigModMutation,
+} from "src/services/rpcCertMapping";
+// Utils
+import { certMapConfigAsRecord } from "src/utils/certMappingUtils";
+// Icons
+import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
+// Components
+import { NotFound } from "src/components/errors/PageErrors";
+import DataSpinner from "src/components/layouts/DataSpinner";
+import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
+import SecondaryButton from "src/components/layouts/SecondaryButton";
+import PageWithGrayBorderLayout from "src/components/layouts/PageWithGrayBorderLayout";
+import IpaCheckbox from "src/components/Form/IpaCheckbox";
+
+const CertificateMappingGlobalConfig = () => {
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
+  // API calls
+  const certMapConfigData = useCertMapConfigData();
+  const [saveConfigInfo] = useCertMapConfigModMutation();
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  const { browserTitle } = useUpdateRoute({
+    pathname: "cert-id-mapping-global-config",
+  });
+
+  // Set the page title to be shown in the browser tab
+  React.useEffect(() => {
+    document.title = browserTitle;
+  }, [browserTitle]);
+
+  // States
+  const [isDataLoading, setIsDataLoading] = React.useState(false);
+
+  // Get 'ipaObject' and 'recordOnChange' to use in 'IpaTextInput'
+  const { ipaObject, recordOnChange } = certMapConfigAsRecord(
+    certMapConfigData.certMapConfig,
+    certMapConfigData.setCertMapConfig
+  );
+
+  // 'Revert' handler method
+  const onRevert = () => {
+    certMapConfigData.setCertMapConfig(certMapConfigData.originalCertMapConfig);
+    certMapConfigData.refetch();
+    alerts.addAlert(
+      "revert-success",
+      "Certificate mapping configuration data reverted",
+      "success"
+    );
+  };
+
+  // on Save handler method
+  const onSave = () => {
+    setIsDataLoading(true);
+    const modifiedValues = certMapConfigData.modifiedValues();
+
+    const payload: CertMapConfigPayload = {
+      ipacertmappromptusername:
+        modifiedValues.ipacertmappromptusername as boolean,
+    };
+
+    saveConfigInfo(payload).then((response) => {
+      if ("data" in response) {
+        const data = response.data;
+        if (data?.error) {
+          alerts.addAlert("error", (data.error as Error).message, "danger");
+        }
+        if (data?.result) {
+          certMapConfigData.setCertMapConfig(data.result.result);
+          alerts.addAlert(
+            "success",
+            "Certificate mapping configuration updated",
+            "success"
+          );
+          // Reset values. Disable 'revert' and 'save' buttons
+          certMapConfigData.resetValues();
+        }
+      }
+      setIsDataLoading(false);
+    });
+  };
+
+  // Toolbar
+  const toolbarFields = [
+    {
+      key: 0,
+      element: (
+        <SecondaryButton onClickHandler={certMapConfigData.refetch}>
+          Refresh
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 1,
+      element: (
+        <SecondaryButton
+          isDisabled={!certMapConfigData.modified || isDataLoading}
+          onClickHandler={onRevert}
+        >
+          Revert
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 2,
+      element: (
+        <SecondaryButton
+          isDisabled={!certMapConfigData.modified || isDataLoading}
+          onClickHandler={onSave}
+        >
+          Save
+        </SecondaryButton>
+      ),
+    },
+  ];
+
+  // Handling of the API data
+  if (
+    certMapConfigData.isLoading ||
+    !certMapConfigData.certMapConfig ||
+    !certMapConfigData.metadata
+  ) {
+    return <DataSpinner />;
+  }
+
+  // Show the 'NotFound' page if the host is not found
+  if (
+    !certMapConfigData.isLoading &&
+    Object.keys(certMapConfigData.certMapConfig).length === 0
+  ) {
+    return <NotFound />;
+  }
+
+  // Return component
+  return (
+    <PageWithGrayBorderLayout
+      id="certificate-id-mapping-global-config-page"
+      pageTitle="Certificate Identity Mapping Global Configuration"
+      toolbarItems={toolbarFields}
+    >
+      <>
+        <alerts.ManagedAlerts />
+        <Sidebar isPanelRight className="pf-v5-u-mb-0">
+          <SidebarPanel variant="sticky">
+            <HelpTextWithIconLayout
+              textContent="Help"
+              icon={
+                <OutlinedQuestionCircleIcon className="pf-v5-u-primary-color-100 pf-v5-u-mr-sm" />
+              }
+            />
+          </SidebarPanel>
+          <SidebarContent className="pf-v5-u-mr-xl">
+            <Flex direction={{ default: "column", lg: "row" }}>
+              <FlexItem flex={{ default: "flex_1" }}>
+                <Form className="pf-v5-u-mb-lg">
+                  <FormGroup fieldId="ipacertmappromptusername" role="group">
+                    <IpaCheckbox
+                      name="ipacertmappromptusername"
+                      value={String(
+                        certMapConfigData.certMapConfig.ipacertmappromptusername
+                      )}
+                      text="Prompt for the username"
+                      ipaObject={ipaObject}
+                      onChange={recordOnChange}
+                      objectName="certmapconfig"
+                      metadata={certMapConfigData.metadata}
+                    />
+                  </FormGroup>
+                </Form>
+              </FlexItem>
+            </Flex>
+          </SidebarContent>
+        </Sidebar>
+      </>
+    </PageWithGrayBorderLayout>
+  );
+};
+
+export default CertificateMappingGlobalConfig;

--- a/src/services/rpcCertMapping.ts
+++ b/src/services/rpcCertMapping.ts
@@ -9,7 +9,10 @@ import {
 // utils
 import { API_VERSION_BACKUP } from "../utils/utils";
 // Data types
-import { cnType } from "src/utils/datatypes/globalDataTypes";
+import {
+  CertificateMappingConfig,
+  cnType,
+} from "src/utils/datatypes/globalDataTypes";
 
 /**
  * Password policies-related endpoints: useCertMapRuleFindQuery, useGetCertMapRuleEntriesQuery,
@@ -33,6 +36,10 @@ export interface CertMapFullDataPayload {
   sizelimit: number;
   startIdx: number;
   stopIdx: number;
+}
+
+export interface CertMapConfigPayload {
+  ipacertmappromptusername: boolean;
 }
 
 const extendedApi = api.injectEndpoints({
@@ -218,6 +225,45 @@ const extendedApi = api.injectEndpoints({
         return { data: response };
       },
     }),
+    /**
+     * Get certificate mapping global configuration
+     * @param {void} - No payload
+     * @returns {Promise<FindRPCResponse>} - Promise with the response data
+     */
+    certMapConfigFind: build.query<CertificateMappingConfig, void>({
+      query: () => {
+        return getCommand({
+          method: "certmapconfig_show",
+          params: [
+            [],
+            { all: true, rights: true, version: API_VERSION_BACKUP },
+          ],
+        });
+      },
+      transformResponse: (response: FindRPCResponse) => {
+        // Create a new object with the converted value
+        return response.result.result as unknown as CertificateMappingConfig;
+      },
+    }),
+    /**
+     * Modify certificate mapping global configuration
+     * @param {CertMapConfigPayload} - Data to modify
+     * @returns {Promise<FindRPCResponse>} - Promise with the response data
+     */
+    certMapConfigMod: build.mutation<FindRPCResponse, CertMapConfigPayload>({
+      query: (payload) => {
+        const certMapConfigParams = {
+          ipacertmappromptusername: payload.ipacertmappromptusername,
+          all: true,
+          rights: true,
+          version: API_VERSION_BACKUP,
+        };
+        return getCommand({
+          method: "certmapconfig_mod",
+          params: [[], certMapConfigParams],
+        });
+      },
+    }),
   }),
   overrideExisting: false,
 });
@@ -226,4 +272,6 @@ export const {
   useCertMapRuleFindQuery,
   useGetCertMapRuleEntriesQuery,
   useSearchCertMapRuleEntriesMutation,
+  useCertMapConfigFindQuery,
+  useCertMapConfigModMutation,
 } = extendedApi;

--- a/src/utils/certMappingUtils.tsx
+++ b/src/utils/certMappingUtils.tsx
@@ -1,6 +1,37 @@
 // Data types
-import { CertificateMapping } from "./datatypes/globalDataTypes";
+import {
+  CertificateMapping,
+  CertificateMappingConfig,
+} from "./datatypes/globalDataTypes";
 import { convertApiObj } from "src/utils/ipaObjectUtils";
+
+export const certMapConfigAsRecord = (
+  element: Partial<CertificateMappingConfig>,
+  onElementChange: (element: Partial<CertificateMappingConfig>) => void
+) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ipaObject = element as Record<string, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function recordOnChange(ipaObject: Record<string, any>) {
+    onElementChange(ipaObject as CertificateMappingConfig);
+  }
+
+  return { ipaObject, recordOnChange };
+};
+
+export const certMapRuleAsRecord = (
+  element: Partial<CertificateMapping>,
+  onElementChange: (element: Partial<CertificateMapping>) => void
+) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ipaObject = element as Record<string, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function recordOnChange(ipaObject: Record<string, any>) {
+    onElementChange(ipaObject as CertificateMapping);
+  }
+
+  return { ipaObject, recordOnChange };
+};
 
 const simpleValues = new Set([
   "cn",

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -721,3 +721,7 @@ export interface CertificateMapping {
   ipacertmappriority: string;
   ipaenabledflag: boolean;
 }
+
+export interface CertificateMappingConfig {
+  ipacertmappromptusername: boolean;
+}

--- a/tests/features/sudo_rules_settings_as_whom.feature
+++ b/tests/features/sudo_rules_settings_as_whom.feature
@@ -30,6 +30,8 @@ Feature: Sudo rules - Settings page > 'As whom' section
     Scenario: Add a new runAs user
         Given The "hsolo" element exists in the table with ID "active-users-table" located in page "active-users"
         Given I am on the "sudo-rules" > "sudoRule2" Settings page
+        Then I wait for 3 seconds
+        When I click on "RunAs Users" page tab
         When I click on ID "add-runas-user" button
         Then I see a modal with title text "Add RunAs user into sudo rule sudoRule2"
         And I click on the arrow icon to perform search in modal

--- a/tests/features/sudo_rules_settings_run_commands.feature
+++ b/tests/features/sudo_rules_settings_run_commands.feature
@@ -34,6 +34,7 @@ Feature: Sudo rules - Settings page > 'Run commands' section
         * entry "command1" should have attribute "Description" set to "my description"
         Then I should see "command2" entry in the data table
         * entry "command2" should have attribute "Description" set to "my description 2"
+        Then I wait for 3 seconds
 
     Scenario: Add a new sudo allow command
         Given I am on the "sudo-rules" > "sudoRule2" Settings page


### PR DESCRIPTION
The 'Certificate id. mapping global configuration' page must display the data retrieved from the `certmapconfig_show` API command. That data must be able to modify the fields via `certmapconfig_mod` command.

This PR depends on this one to be merged: https://github.com/freeipa/freeipa-webui/pull/693