### PR TITLE
Add 'Certificate mapping match' page

### DIFF
--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -59,6 +59,7 @@ import IdpReferences from "src/pages/IdPReferences/IdpReferences";
 import IdpReferencesTabs from "src/pages/IdPReferences/IdpReferencesTabs";
 import CertificateMappingPage from "src/pages/CertificateMapping/CertificateMapping";
 import CertificateMappingGlobalConfig from "src/pages/CertificateMapping/CertificateMappingGlobalConfig";
+import CertificateMappingMatch from "src/pages/CertificateMapping/CertificateMappingMatch";
 
 // Renders routes (React)
 export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
@@ -446,6 +447,9 @@ export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
               </Route>
               <Route path="cert-id-mapping-global-config">
                 <Route path="" element={<CertificateMappingGlobalConfig />} />
+              </Route>
+              <Route path="cert-id-mapping-match">
+                <Route path="" element={<CertificateMappingMatch />} />
               </Route>
               <Route path="configuration" element={<Configuration />} />
               {/* Redirect to Active users page if user is logged in and navigates to the root page */}

--- a/src/navigation/NavRoutes.ts
+++ b/src/navigation/NavRoutes.ts
@@ -51,6 +51,7 @@ const KerberosTicketPolicyGroupRef = "kerberos-ticket-policy";
 const IdentityProviderReferencesGroupRef = "identity-provider-references";
 const CertificateMappingGroupRef = "cert-id-mapping-rules";
 const CertificateMappingConfigGroupRef = "cert-id-mapping-global-config";
+const CertificateMappingMatchGroupRef = "cert-id-mapping-match";
 // IPA SERVER
 // - Configuration
 const ConfigRef = "configuration";
@@ -303,18 +304,33 @@ export const navigationRoutes = [
         items: [],
       },
       {
-        label: "Certificate identity mapping rules",
+        label: "Certificate mapping",
         group: CertificateMappingGroupRef,
-        title: `${BASE_TITLE} - Certificate identity mapping rules`,
-        path: "cert-id-mapping-rules",
-        items: [],
-      },
-      {
-        label: "Certificate identity mapping global configuration",
-        group: CertificateMappingConfigGroupRef,
-        title: `${BASE_TITLE} - Certificate identity mapping global configuration`,
-        path: "cert-id-mapping-global-config",
-        items: [],
+        title: `${BASE_TITLE} - Certificate mapping`,
+        path: "",
+        items: [
+          {
+            label: "Certificate identity mapping rules",
+            group: CertificateMappingGroupRef,
+            title: `${BASE_TITLE} - Certificate identity mapping rules`,
+            path: "cert-id-mapping-rules",
+            items: [],
+          },
+          {
+            label: "Certificate identity mapping global configuration",
+            group: CertificateMappingConfigGroupRef,
+            title: `${BASE_TITLE} - Certificate identity mapping global configuration`,
+            path: "cert-id-mapping-global-config",
+            items: [],
+          },
+          {
+            label: "Certificate identity mapping match",
+            group: CertificateMappingMatchGroupRef,
+            title: `${BASE_TITLE} - Certificate identity mapping match`,
+            path: "cert-id-mapping-match",
+            items: [],
+          },
+        ],
       },
     ],
   },

--- a/src/pages/CertificateMapping/CertificateMappingMatch.tsx
+++ b/src/pages/CertificateMapping/CertificateMappingMatch.tsx
@@ -1,0 +1,356 @@
+import React from "react";
+// PatternFly
+import {
+  Button,
+  Flex,
+  FlexItem,
+  Form,
+  FormGroup,
+  Sidebar,
+  SidebarContent,
+  SidebarPanel,
+  TextArea,
+  TextInput,
+} from "@patternfly/react-core";
+import { Th, Tr } from "@patternfly/react-table";
+// Data types
+import { Certificate } from "src/utils/datatypes/globalDataTypes";
+// Hooks
+import useAlerts from "src/hooks/useAlerts";
+import useUpdateRoute from "src/hooks/useUpdateRoute";
+// Icons
+import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
+// Utils
+import { removeCertificateDelimiters } from "src/utils/utils";
+// RPC
+import { useMatchCertificateMutation } from "src/services/rpcCertMapping";
+import { ErrorResult } from "src/services/rpc";
+// Components
+import TitleLayout from "src/components/layouts/TitleLayout";
+import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
+import PageWithGrayBorderLayout from "src/components/layouts/PageWithGrayBorderLayout";
+import TableLayout from "src/components/layouts/TableLayout";
+
+interface TableEntry {
+  userLogin: string;
+  domain: string;
+}
+
+const CertificateMappingMatch = () => {
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  const { browserTitle } = useUpdateRoute({
+    pathname: "cert-id-mapping-match",
+  });
+
+  // Set the page title to be shown in the browser tab
+  React.useEffect(() => {
+    document.title = browserTitle;
+  }, [browserTitle]);
+
+  // API calls
+  const [matchCertificate] = useMatchCertificateMutation();
+
+  // States
+  const [certificateText, setCertificateText] = React.useState<string>("");
+  const [issuedBy, setIssuedBy] = React.useState<string>("");
+  const [issuedTo, setIssuedTo] = React.useState<string>("");
+  const [serialNumber, setSerialNumber] = React.useState<string>("");
+  const [serialNumberHex, setSerialNumberHex] = React.useState<string>("");
+  const [validFrom, setValidFrom] = React.useState<string>("");
+  const [validTo, setValidTo] = React.useState<string>("");
+  const [fingerprintSha1, setFingerprintSha1] = React.useState<string>("");
+  const [fingerprintSha256, setFingerprintSha256] = React.useState<string>("");
+  // Table data
+  const [tableElements, setTableElements] = React.useState<TableEntry[]>([]);
+
+  // Extract subject values
+  const extractSubjectValues = (subject: string) => {
+    // Split the subject string into an array of strings
+    const subjectArray = subject.split(",");
+    // Find the "CN" and "O" values in the subject array
+    const cnValueWithIndicator = subjectArray.find((item) =>
+      item.trim().startsWith("CN=")
+    );
+    const oValueWithIndicator = subjectArray.find((item) =>
+      item.trim().startsWith("O=")
+    );
+    // Extract the values from the strings
+    const cnValue = cnValueWithIndicator
+      ? cnValueWithIndicator.split("=")[1].trim()
+      : "";
+    const oValue = oValueWithIndicator
+      ? oValueWithIndicator.split("=")[1].trim()
+      : "";
+
+    return { cnValue, oValue };
+  };
+
+  // On match certificate
+  const onMatchCertificate = () => {
+    const parsedCert = removeCertificateDelimiters(certificateText);
+
+    matchCertificate(parsedCert).then((response) => {
+      if ("data" in response && response.data?.result) {
+        if (response.data.result.results[0].error) {
+          const errorMessage = response.data.result.results[0].error as string;
+          alerts.addAlert("match-certificate-error-1", errorMessage, "danger");
+        } else {
+          const certData = response.data.result.results[1]
+            .result[0] as Certificate;
+          // Set certificate data
+          setIssuedBy(certData.issuer);
+          setIssuedTo(certData.subject);
+          setSerialNumber(certData.serial_number);
+          setSerialNumberHex(certData.serial_number_hex);
+          setValidFrom(certData.valid_not_before);
+          setValidTo(certData.valid_not_after);
+          setFingerprintSha1(certData.sha1_fingerprint);
+          setFingerprintSha256(certData.sha256_fingerprint);
+          // Set table data
+          const matchedUsers: TableEntry[] = [];
+          const subject = certData.subject;
+          const { cnValue, oValue } = extractSubjectValues(subject);
+          // Add the values to the matchedUsers array
+          if (cnValue && oValue) {
+            matchedUsers.push({
+              userLogin: cnValue,
+              domain: oValue,
+            });
+          }
+          setTableElements(matchedUsers);
+
+          // Set alert: success
+          alerts.addAlert(
+            "match-certificate-success",
+            response.data.result.results[0].summary,
+            "success"
+          );
+        }
+      } else if ("data" in response && response.data?.error) {
+        // Set alert: error
+        const errorMessage = response.data.error as unknown as ErrorResult;
+        alerts.addAlert(
+          "match-certificate-error",
+          errorMessage.message,
+          "danger"
+        );
+      }
+    });
+  };
+
+  // On clear certificate data
+  const onClearCertificate = () => {
+    setCertificateText("");
+    setIssuedBy("");
+    setIssuedTo("");
+    setSerialNumber("");
+    setSerialNumberHex("");
+    setValidFrom("");
+    setValidTo("");
+    setFingerprintSha1("");
+    setFingerprintSha256("");
+    setTableElements([]);
+  };
+
+  // Toolbar
+  const toolbarFields = [
+    {
+      key: 0,
+      element: <Button onClick={onMatchCertificate}>Match</Button>,
+    },
+    {
+      key: 1,
+      element: (
+        <Button variant="secondary" onClick={onClearCertificate}>
+          Clear
+        </Button>
+      ),
+    },
+  ];
+
+  // Table
+  const header = (
+    <Tr key="header" id="table-header">
+      <Th modifier="wrap" key="user_login">
+        User login
+      </Th>
+      <Th modifier="wrap" key="domain">
+        Domain
+      </Th>
+    </Tr>
+  );
+
+  const body = tableElements.map((element, rowIndex) => {
+    return (
+      <Tr key={rowIndex} id={`table-row-${rowIndex}`}>
+        <td>{element.userLogin}</td>
+        <td>{element.domain}</td>
+      </Tr>
+    );
+  });
+
+  // Return component
+  return (
+    <PageWithGrayBorderLayout
+      id="certificate-mapping-match"
+      pageTitle="Certificate Mapping Match"
+      toolbarItems={toolbarFields}
+    >
+      <>
+        <alerts.ManagedAlerts />
+        <Sidebar isPanelRight className="pf-v5-u-mb-0">
+          <SidebarPanel variant="sticky" className="pf-v5-u-pl-md">
+            <HelpTextWithIconLayout
+              textContent="Help"
+              icon={
+                <OutlinedQuestionCircleIcon className="pf-v5-u-primary-color-100 pf-v5-u-mr-sm" />
+              }
+            />
+          </SidebarPanel>
+          <SidebarContent className="pf-v5-u-mt-0">
+            <Flex direction={{ default: "column", lg: "row" }}>
+              <FlexItem flex={{ default: "flex_1" }}>
+                <TitleLayout
+                  key={0}
+                  headingLevel="h1"
+                  id="certificate-for-match"
+                  text="Certificate for match"
+                  className="pf-v5-u-mt-0 pf-v5-u-ml-0 pf-v5-u-mb-md"
+                />
+                <Form className="pf-v5-u-mb-lg">
+                  <FormGroup label="Certificate" fieldId="cert_textarea">
+                    <TextArea
+                      name="cert_textarea"
+                      aria-label="Certificate"
+                      value={certificateText}
+                      onChange={(_event, value) => setCertificateText(value)}
+                      resizeOrientation="vertical"
+                      rows={15}
+                    />
+                  </FormGroup>
+                </Form>
+              </FlexItem>
+              <FlexItem flex={{ default: "flex_1" }}>
+                <TitleLayout
+                  key={1}
+                  headingLevel="h1"
+                  id="certificate-data"
+                  text="Certificate data"
+                  className="pf-v5-u-mt-lg pf-v5-u-mb-md"
+                />
+                <Form className="pf-v5-u-mb-lg">
+                  <FormGroup label="Issued by" fieldId="issuer">
+                    <TextInput
+                      name="issuer"
+                      aria-label="Issued by text input"
+                      type="text"
+                      value={issuedBy}
+                      isDisabled
+                    />
+                  </FormGroup>
+                  <FormGroup label="Issued to" fieldId="subject">
+                    <TextInput
+                      name="subject"
+                      aria-label="Issued to text input"
+                      type="text"
+                      value={issuedTo}
+                      isDisabled
+                    />
+                  </FormGroup>
+                  <FormGroup label="Serial number" fieldId="serial_number">
+                    <TextInput
+                      name="serial_number"
+                      aria-label="Serial number text input"
+                      type="text"
+                      value={serialNumber}
+                      isDisabled
+                    />
+                  </FormGroup>
+                  <FormGroup
+                    label="Serial number (hex)"
+                    fieldId="serial_number_hex"
+                  >
+                    <TextInput
+                      name="serial_number_hex"
+                      aria-label="Serial number in hexadecimal text input"
+                      type="text"
+                      value={serialNumberHex}
+                      isDisabled
+                    />
+                  </FormGroup>
+                  <FormGroup label="Valid from" fieldId="valid_not_before">
+                    <TextInput
+                      name="valid_not_before"
+                      aria-label="Valid from text input"
+                      type="text"
+                      value={validFrom}
+                      isDisabled
+                    />
+                  </FormGroup>
+                  <FormGroup label="Valid to" fieldId="valid_not_after">
+                    <TextInput
+                      name="valid_not_after"
+                      aria-label="Valid to text input"
+                      type="text"
+                      value={validTo}
+                      isDisabled
+                    />
+                  </FormGroup>
+                  <FormGroup
+                    label="SHA1 Fingerprint"
+                    fieldId="sha1_fingerprint"
+                  >
+                    <TextArea
+                      name="sha1_fingerprint"
+                      aria-label="SHA1 Fingerprint text input"
+                      value={fingerprintSha1}
+                      resizeOrientation="vertical"
+                      rows={2}
+                      isDisabled
+                    />
+                  </FormGroup>
+                  <FormGroup
+                    label="SHA256 Fingerprint"
+                    fieldId="sha256_fingerprint"
+                  >
+                    <TextArea
+                      name="sha256_fingerprint"
+                      aria-label="SHA256 Fingerprint text input"
+                      value={fingerprintSha256}
+                      resizeOrientation="vertical"
+                      rows={2}
+                      isDisabled
+                      autoResize={false}
+                    />
+                  </FormGroup>
+                </Form>
+              </FlexItem>
+            </Flex>
+            <TitleLayout
+              key={2}
+              headingLevel="h1"
+              id="matched-users"
+              text="Matched users"
+              className="pf-v5-u-mt-lg pf-v5-u-mb-md"
+            />
+            <TableLayout
+              ariaLabel={"Matched users"}
+              variant={"compact"}
+              hasBorders={true}
+              classes={"pf-v5-u-mt-md"}
+              tableId={"matched-users-table"}
+              isStickyHeader={true}
+              tableHeader={header}
+              tableBody={body}
+            />
+          </SidebarContent>
+        </Sidebar>
+      </>
+    </PageWithGrayBorderLayout>
+  );
+};
+
+export default CertificateMappingMatch;

--- a/src/services/rpcCertMapping.ts
+++ b/src/services/rpcCertMapping.ts
@@ -264,6 +264,26 @@ const extendedApi = api.injectEndpoints({
         });
       },
     }),
+    /**
+     * Match certificate
+     * @param {string} - Certificate to match
+     * @returns {Promise<BatchRPCResponse>} - Promise with the response data
+     */
+    matchCertificate: build.mutation<BatchRPCResponse, string>({
+      query: (certificate) => {
+        const matchCertificateCommands: Command[] = [
+          {
+            method: "certmap_match",
+            params: [[certificate], {}],
+          },
+          {
+            method: "cert_find",
+            params: [[], { all: true, certificate: certificate }],
+          },
+        ];
+        return getBatchCommand(matchCertificateCommands, API_VERSION_BACKUP);
+      },
+    }),
   }),
   overrideExisting: false,
 });
@@ -274,4 +294,5 @@ export const {
   useSearchCertMapRuleEntriesMutation,
   useCertMapConfigFindQuery,
   useCertMapConfigModMutation,
+  useMatchCertificateMutation,
 } = extendedApi;

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -435,3 +435,14 @@ export function containsAny(array1: unknown[], array2: unknown[]): boolean {
  * Returns hidden password string
  */
 export const HIDDEN_PASSWORD = "********";
+
+/**
+ * Remove certificate delimiters
+  - This is needed to process the certificate in the API call
+ */
+export const removeCertificateDelimiters = (certificate: string) => {
+  return certificate
+    .replace(/-----BEGIN CERTIFICATE-----/g, "")
+    .replace(/-----END CERTIFICATE-----/g, "")
+    .replace(/\n/g, "");
+};


### PR DESCRIPTION
The 'Certificate mapping match' must validate and perform `certmap_match` operation to show the data of a given
user certificate.

This PR depends on this one to be merged: https://github.com/freeipa/freeipa-webui/pull/697

## Summary by Sourcery

Add a new 'Certificate mapping match' page to validate and perform certificate mapping operations

New Features:
- Implement a new page for certificate mapping match functionality
- Add ability to match and validate user certificates
- Create a detailed view for certificate information and matched users

Enhancements:
- Extend navigation routes to include certificate mapping sections
- Add utility functions for certificate processing
- Improve table and form components to support certificate mapping features