### PR TITLE
Whitelist react-router vulnerabilities

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -36,6 +36,8 @@
     "GHSA-c2qf-rxjj-qqgw|@babel/preset-env>semver",
     "GHSA-c2qf-rxjj-qqgw|babel-loader>make-dir>semver",
     "GHSA-c2qf-rxjj-qqgw|@babel/preset-env>babel-plugin-polyfill-corejs2>semver",
-    "GHSA-c2qf-rxjj-qqgw|@babel/preset-env>babel-plugin-polyfill-corejs2>@babel/helper-define-polyfill-provider>semver"
+    "GHSA-c2qf-rxjj-qqgw|@babel/preset-env>babel-plugin-polyfill-corejs2>@babel/helper-define-polyfill-provider>semver",
+    "GHSA-cpj6-fhp6-mr6j",
+    "GHSA-f46r-rw29-r322"
   ]
 }


### PR DESCRIPTION
There are two recent vulnerabilities[1][2] affecting `react-router` library (versions: `>= 7.2.0` and `<= 7.5.1`) when this is used in framework mode [3]. The modern WebUI uses v6 but not in framework mode, so it can be safely added to whitelist to unblock CI gating.

[1] - https://github.com/advisories/GHSA-cpj6-fhp6-mr6j
[2] - https://github.com/advisories/GHSA-f46r-rw29-r322
[3] - https://reactrouter.com/start/framework/installation

## Summary by Sourcery

Bug Fixes:
- Addressed two known react-router vulnerabilities by whitelisting them in the audit configuration