### PR TITLE
Fix routes and navigation

### DIFF
--- a/src/hooks/useListPageSearchParams.tsx
+++ b/src/hooks/useListPageSearchParams.tsx
@@ -52,32 +52,31 @@ const useListPageSearchParams = () => {
 
   // Handle URLs with navigation parameters
   React.useEffect(() => {
-    let searchParamsNew = {};
+    setParams(
+      (params) => {
+        if (page > 1) {
+          params.set("p", page.toString());
+        } else {
+          params.delete("p");
+        }
 
-    if (page > 1) {
-      searchParamsNew = {
-        ...searchParamsNew,
-        p: page.toString(),
-      };
-    }
-    if (searchValue !== "") {
-      searchParamsNew = {
-        ...searchParamsNew,
-        search: searchValue,
-      };
-    }
-    if (membershipDirection !== "direct") {
-      searchParamsNew = {
-        ...searchParamsNew,
-        membership: membershipDirection,
-      };
-    }
-    searchParamsNew = {
-      ...searchParamsNew,
-      size: perPage.toString(),
-    };
+        if (searchValue !== "") {
+          params.set("search", searchValue);
+        } else {
+          params.delete("search");
+        }
 
-    setParams(searchParamsNew, { replace: true });
+        if (membershipDirection !== "direct") {
+          params.set("membership", membershipDirection);
+        } else {
+          params.delete("membership");
+        }
+
+        params.set("size", perPage.toString());
+        return params;
+      },
+      { replace: true }
+    );
   }, [page, searchValue, membershipDirection, perPage]);
 
   return {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -21,11 +21,17 @@ const root = ReactDOM.createRoot(
 );
 
 root.render(
-  <Provider store={store}>
-    <React.StrictMode>
-      <BrowserRouter basename={URL_PREFIX}>
+  <React.StrictMode>
+    <Provider store={store}>
+      <BrowserRouter
+        basename={URL_PREFIX}
+        future={{
+          v7_relativeSplatPath: true,
+          v7_startTransition: true,
+        }}
+      >
         <App />
       </BrowserRouter>
-    </React.StrictMode>
-  </Provider>
+    </Provider>
+  </React.StrictMode>
 );

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -460,10 +460,13 @@ export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
               </Route>
               <Route path="configuration" element={<Configuration />} />
               {/* Redirect to Active users page if user is logged in and navigates to the root page */}
+              <Route path="login" element={<Navigate to={"/"} replace />} />
               <Route
-                path="*"
+                path=""
                 element={<Navigate to={"active-users"} replace />}
               />
+              {/* 404 page */}
+              <Route path="*" element={<NotFound />} />
             </>
           ) : (
             <>
@@ -471,15 +474,13 @@ export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
               <Route path="reset-password">
                 <Route path=":uid" element={<ResetPasswordPage />} />
               </Route>
-              <Route path="*" element={<Navigate to={"login"} replace />} />
+              <Route path="*" element={<Navigate to={"/login"} replace />} />
             </>
           )}
           {/* Browser configuration page */}
           <Route path="browser-config" element={<SetupBrowserConfig />} />
           {/* Sync OTP token page */}
           <Route path="sync-otp" element={<SyncOtpPage />} />
-          {/* 404 page */}
-          <Route path="*" element={<NotFound />} />
         </Routes>
       )}
     </>

--- a/src/pages/ActiveUsers/UserMemberOf.tsx
+++ b/src/pages/ActiveUsers/UserMemberOf.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { TabTitleText, Tab, Tabs, Badge } from "@patternfly/react-core";
 // Data types
 import { User } from "src/utils/datatypes/globalDataTypes";
@@ -57,13 +57,6 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
   const onRefreshUserData = () => {
     userQuery.refetch();
   };
-
-  // Tab
-  const [activeTabKey, setActiveTabKey] = useState("group");
-
-  React.useEffect(() => {
-    setActiveTabKey(props.tab);
-  }, [props.tab]);
 
   const [groupCount, setGroupCount] = React.useState(0);
   const [netgroupCount, setNetgroupCount] = React.useState(0);
@@ -214,9 +207,8 @@ const UserMemberOf = (props: PropsToUserMemberOf) => {
   return (
     <TabLayout id="memberOf">
       <Tabs
-        activeKey={activeTabKey}
+        activeKey={props.tab}
         onSelect={(_event, tabIndex) => {
-          setActiveTabKey(tabIndex as string);
           navigate(
             "/" + props.from + "/" + props.user.uid + "/memberof_" + tabIndex
           );

--- a/src/pages/AutoMemUserRules/AutoMemRulesTabs.tsx
+++ b/src/pages/AutoMemUserRules/AutoMemRulesTabs.tsx
@@ -45,14 +45,7 @@ const AutoMemUserRulesTabs = (props: AutoMemUserRulesTabsProps) => {
     BreadCrumbItem[]
   >([]);
 
-  // Tab
-  const [activeTabKey, setActiveTabKey] = React.useState(section);
-
-  const handleTabClick = (
-    _event: React.MouseEvent<HTMLElement, MouseEvent>,
-    tabIndex: number | string
-  ) => {
-    setActiveTabKey(tabIndex as string);
+  const handleTabClick = () => {
     navigate("/" + pathname + "/" + cn);
   };
 
@@ -115,7 +108,7 @@ const AutoMemUserRulesTabs = (props: AutoMemUserRulesTabsProps) => {
       </PageSection>
       <PageSection type="tabs" variant={PageSectionVariants.light} isFilled>
         <Tabs
-          activeKey={activeTabKey}
+          activeKey={section}
           onSelect={handleTabClick}
           variant="light300"
           isBox

--- a/src/pages/CertificateMapping/CertificateMappingTabs.tsx
+++ b/src/pages/CertificateMapping/CertificateMappingTabs.tsx
@@ -41,15 +41,10 @@ const CertificateMappingTabs = ({ section }) => {
     cn as string
   );
 
-  // Tab
-  const [activeTabKey, setActiveTabKey] = React.useState(section);
-
   const handleTabClick = (
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
-    setActiveTabKey(tabIndex as string);
-
     if (tabIndex === "settings") {
       navigate("/" + pathname + "/" + id);
     }
@@ -74,7 +69,6 @@ const CertificateMappingTabs = ({ section }) => {
         },
       ];
       setBreadcrumbItems(currentPath);
-      setActiveTabKey("settings");
     }
   }, [cn]);
 
@@ -111,7 +105,7 @@ const CertificateMappingTabs = ({ section }) => {
       </PageSection>
       <PageSection type="tabs" variant={PageSectionVariants.light} isFilled>
         <Tabs
-          activeKey={activeTabKey}
+          activeKey={section}
           onSelect={handleTabClick}
           variant="light300"
           isBox

--- a/src/pages/HBACRules/HBACRulesTabs.tsx
+++ b/src/pages/HBACRules/HBACRulesTabs.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 // PatternFly
 import {
   PageSection,
@@ -33,14 +33,7 @@ const HBACRulesTabs = ({ section }) => {
     BreadCrumbItem[]
   >([]);
 
-  // Tab
-  const [activeTabKey, setActiveTabKey] = useState(section);
-
-  const handleTabClick = (
-    _event: React.MouseEvent<HTMLElement, MouseEvent>,
-    tabIndex: number | string
-  ) => {
-    setActiveTabKey(tabIndex as string);
+  const handleTabClick = () => {
     navigate("/hbac-rules/" + cn);
   };
 
@@ -62,7 +55,6 @@ const HBACRulesTabs = ({ section }) => {
         },
       ];
       setBreadcrumbItems(currentPath);
-      setActiveTabKey("settings");
       dispatch(updateBreadCrumbPath(currentPath));
     }
   }, [cn]);
@@ -72,7 +64,6 @@ const HBACRulesTabs = ({ section }) => {
     if (!section) {
       navigate(URL_PREFIX + "/hbac-rules/" + cn);
     }
-    setActiveTabKey(section);
   }, [section]);
 
   if (settingsData.isLoading || settingsData.rule.cn === undefined) {
@@ -100,7 +91,7 @@ const HBACRulesTabs = ({ section }) => {
       </PageSection>
       <PageSection type="tabs" variant={PageSectionVariants.light} isFilled>
         <Tabs
-          activeKey={activeTabKey}
+          activeKey={section}
           onSelect={handleTabClick}
           variant="light300"
           isBox

--- a/src/pages/HBACServiceGroups/HBACServiceGroupsMembers.tsx
+++ b/src/pages/HBACServiceGroups/HBACServiceGroupsMembers.tsx
@@ -46,7 +46,6 @@ const HBACSvcGroupMembers = (props: PropsToSvcGroupsMembers) => {
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
-    setActiveTabKey(tabIndex as string);
     navigate("/hbac-service-groups/" + props.hbacsvcgroup.cn + "/" + tabIndex);
   };
 

--- a/src/pages/HBACServiceGroups/HBACServiceGroupsTabs.tsx
+++ b/src/pages/HBACServiceGroups/HBACServiceGroupsTabs.tsx
@@ -43,7 +43,6 @@ const HBACServiceGroupsTabs = ({ section }) => {
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
-    setActiveTabKey(tabIndex as string);
     if (tabIndex === "settings") {
       navigate("/hbac-service-groups/" + cn);
     } else if (tabIndex === "members") {
@@ -80,7 +79,9 @@ const HBACServiceGroupsTabs = ({ section }) => {
       navigate(URL_PREFIX + "/hbac-service-groups/" + cn);
     }
     const section_string = section as string;
-    if (section_string.startsWith("member_")) {
+    if (section_string === "settings") {
+      setActiveTabKey("settings");
+    } else if (section_string.startsWith("member_")) {
       setActiveTabKey("members");
     }
   }, [section]);

--- a/src/pages/HBACServices/HBACServicesMemberOf.tsx
+++ b/src/pages/HBACServices/HBACServicesMemberOf.tsx
@@ -46,7 +46,6 @@ const HBACServicesMemberOf = (props: PropsToMemberOf) => {
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
-    setActiveTabKey(tabIndex as string);
     navigate("/hbac-services/" + props.hbacService.cn + "/" + tabIndex);
   };
 

--- a/src/pages/HBACServices/HBACServicesTabs.tsx
+++ b/src/pages/HBACServices/HBACServicesTabs.tsx
@@ -42,7 +42,6 @@ const HBACServicesTabs = ({ section }) => {
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
-    setActiveTabKey(tabIndex as string);
     if (tabIndex === "settings") {
       navigate("/hbac-services/" + cn);
     } else if (tabIndex === "memberof") {
@@ -79,7 +78,9 @@ const HBACServicesTabs = ({ section }) => {
       navigate(URL_PREFIX + "/hbac-services/" + cn);
     }
     const section_string = section as string;
-    if (section_string.startsWith("memberof")) {
+    if (section_string === "settings") {
+      setActiveTabKey("settings");
+    } else if (section_string.startsWith("memberof")) {
       setActiveTabKey("memberof");
     }
   }, [section]);

--- a/src/pages/HostGroups/HostGroupsMemberManagers.tsx
+++ b/src/pages/HostGroups/HostGroupsMemberManagers.tsx
@@ -40,25 +40,17 @@ const HostGroupsMemberManagers = (props: PropsToHostGroupsMembers) => {
   // Update current route data to Redux and highlight the current page in the Nav bar
   useUpdateRoute({ pathname: "host-groups", noBreadcrumb: true });
 
-  // Tab
-  const [activeTabKey, setActiveTabKey] = useState("member_user");
-
   const handleTabClick = (
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
-    setActiveTabKey(tabIndex as string);
     navigate("/host-groups/" + props.hostGroup.cn + "/" + tabIndex);
   };
-
-  React.useEffect(() => {
-    setActiveTabKey(props.tabSection);
-  }, [props.tabSection]);
 
   return (
     <TabLayout id="managers">
       <Tabs
-        activeKey={activeTabKey}
+        activeKey={props.tabSection}
         onSelect={handleTabClick}
         isBox={false}
         mountOnEnter

--- a/src/pages/HostGroups/HostGroupsMemberOf.tsx
+++ b/src/pages/HostGroups/HostGroupsMemberOf.tsx
@@ -44,19 +44,12 @@ const HostGroupsMemberOf = (props: PropsToMemberOf) => {
   // Update current route data to Redux and highlight the current page in the Nav bar
   useUpdateRoute({ pathname: "host-groups", noBreadcrumb: true });
 
-  // Tab
-  const [activeTabKey, setActiveTabKey] = useState("memberof_hostgroup");
   const handleTabClick = (
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
-    setActiveTabKey(tabIndex as string);
     navigate("/host-groups/" + props.hostGroup.cn + "/" + tabIndex);
   };
-
-  React.useEffect(() => {
-    setActiveTabKey(props.tabSection);
-  }, [props.tabSection]);
 
   const [groupCount, setGroupCount] = React.useState(0);
   const [hbacCount, setHbacCount] = React.useState(0);
@@ -154,7 +147,7 @@ const HostGroupsMemberOf = (props: PropsToMemberOf) => {
   return (
     <TabLayout id="memberof">
       <Tabs
-        activeKey={activeTabKey}
+        activeKey={props.tabSection}
         onSelect={handleTabClick}
         isBox={false}
         mountOnEnter

--- a/src/pages/HostGroups/HostGroupsMembers.tsx
+++ b/src/pages/HostGroups/HostGroupsMembers.tsx
@@ -111,25 +111,17 @@ const HostGroupsMembers = (props: PropsToHostGroupsMembers) => {
     }
   }, [hostGroup]);
 
-  // Tab
-  const [activeTabKey, setActiveTabKey] = useState("member_host");
-
   const handleTabClick = (
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
-    setActiveTabKey(tabIndex as string);
     navigate("/host-groups/" + props.hostGroup.cn + "/" + tabIndex);
   };
-
-  React.useEffect(() => {
-    setActiveTabKey(props.tabSection);
-  }, [props.tabSection]);
 
   return (
     <TabLayout id="members">
       <Tabs
-        activeKey={activeTabKey}
+        activeKey={props.tabSection}
         onSelect={handleTabClick}
         isBox={false}
         mountOnEnter

--- a/src/pages/HostGroups/HostGroupsTabs.tsx
+++ b/src/pages/HostGroups/HostGroupsTabs.tsx
@@ -46,7 +46,6 @@ const HostGroupsTabs = ({ section }) => {
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
-    setActiveTabKey(tabIndex as string);
     if (tabIndex === "settings") {
       navigate("/host-groups/" + cn);
     } else if (tabIndex === "member") {
@@ -88,7 +87,9 @@ const HostGroupsTabs = ({ section }) => {
       navigate(URL_PREFIX + "/host-groups/" + groupId);
     }
     const section_string = section as string;
-    if (section_string.startsWith("memberof_")) {
+    if (section_string === "settings") {
+      setActiveTabKey("settings");
+    } else if (section_string.startsWith("memberof_")) {
       setActiveTabKey("memberof");
     } else if (section_string.startsWith("member_")) {
       setActiveTabKey("member");

--- a/src/pages/Hosts/HostsMemberOf.tsx
+++ b/src/pages/Hosts/HostsMemberOf.tsx
@@ -46,20 +46,12 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
   // Update current route data to Redux and highlight the current page in the Nav bar
   useUpdateRoute({ pathname: "hosts", noBreadcrumb: true });
 
-  // Tab
-  const [activeTabKey, setActiveTabKey] = useState("memberof_hostgroup");
-
   const handleTabClick = (
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
-    setActiveTabKey(tabIndex as string);
     navigate("/hosts/" + props.host.fqdn + "/" + tabIndex);
   };
-
-  React.useEffect(() => {
-    setActiveTabKey(props.tabSection);
-  }, [props.tabSection]);
 
   const [groupCount, setGroupCount] = React.useState(0);
   const [netgroupCount, setNetgroupCount] = React.useState(0);
@@ -210,7 +202,7 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
   return (
     <TabLayout id="memberof">
       <Tabs
-        activeKey={activeTabKey}
+        activeKey={props.tabSection}
         onSelect={handleTabClick}
         isBox={false}
         mountOnEnter

--- a/src/pages/Hosts/HostsTabs.tsx
+++ b/src/pages/Hosts/HostsTabs.tsx
@@ -75,12 +75,15 @@ const HostsTabs = ({ section }) => {
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
-    setActiveTabKey(tabIndex as string);
-
+    const tabIdx = tabIndex.toString();
     if (tabIndex === "settings") {
       navigate("/hosts/" + hostId);
-    } else if (tabIndex === "memberof") {
-      navigate("/hosts/" + hostId + "/memberof_hostgroup");
+    } else if (tabIdx.startsWith("memberof")) {
+      if (tabIdx === "memberof") {
+        navigate("/hosts/" + hostId + "/" + tabIdx + "_hostgroup");
+      } else {
+        navigate("/hosts/" + hostId + "/" + tabIdx);
+      }
     } else if (tabIndex === "managedby") {
       navigate("/hosts/" + hostId + "/managedby_host");
     }
@@ -118,7 +121,9 @@ const HostsTabs = ({ section }) => {
 
     // Case: any of the 'member of' sections is clicked
     if (section !== "settings" && section !== "managedby") {
-      setActiveTabKey("memberof");
+      setActiveTabKey("memberof_hostgroup");
+    } else {
+      setActiveTabKey(section);
     }
   }, [section]);
 
@@ -189,7 +194,7 @@ const HostsTabs = ({ section }) => {
               />
             </Tab>
             <Tab
-              eventKey={"memberof"}
+              eventKey={"memberof_hostgroup"}
               name="memberof-details"
               title={<TabTitleText>Is a member of</TabTitleText>}
             >

--- a/src/pages/IDViews/IDViewsOverrides.tsx
+++ b/src/pages/IDViews/IDViewsOverrides.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 // PatternFly
 import { Badge, Tab, Tabs, TabTitleText } from "@patternfly/react-core";
 // Data types
@@ -24,18 +24,10 @@ const IDViewsOverrides = (props: PropsToOverrides) => {
   // Update current route data to Redux and highlight the current page in the Nav bar
   useUpdateRoute({ pathname: "id-views", noBreadcrumb: true });
 
-  // Tab
-  const [activeTabKey, setActiveTabKey] = useState("override-users");
-
-  React.useEffect(() => {
-    setActiveTabKey(props.tabSection);
-  }, [props.tabSection]);
-
   const handleTabClick = (
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
-    setActiveTabKey(tabIndex as string);
     navigate("/id-views/" + props.idView.cn + "/" + tabIndex);
   };
 
@@ -43,7 +35,7 @@ const IDViewsOverrides = (props: PropsToOverrides) => {
   return (
     <TabLayout id="override sections">
       <Tabs
-        activeKey={activeTabKey}
+        activeKey={props.tabSection}
         onSelect={handleTabClick}
         isBox={false}
         mountOnEnter

--- a/src/pages/IDViews/IDViewsTabs.tsx
+++ b/src/pages/IDViews/IDViewsTabs.tsx
@@ -45,7 +45,6 @@ const IDViewsTabs = ({ section }) => {
     tabIndex: number | string
   ) => {
     const tabName = tabIndex as string;
-    setActiveTabKey(tabName);
     if (tabName === "settings") {
       navigate("/id-views/" + cn);
     } else if (tabName.startsWith("override")) {

--- a/src/pages/IdPReferences/IdpReferencesTabs.tsx
+++ b/src/pages/IdPReferences/IdpReferencesTabs.tsx
@@ -45,8 +45,6 @@ const IdpReferencesTabs = ({ section }) => {
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
-    setActiveTabKey(tabIndex as string);
-
     if (tabIndex === "settings") {
       navigate("/" + pathname + "/" + id);
     }

--- a/src/pages/Netgroups/NetgroupsMemberOf.tsx
+++ b/src/pages/Netgroups/NetgroupsMemberOf.tsx
@@ -41,19 +41,12 @@ const NetgroupsMemberOf = (props: PropsToMemberOf) => {
   // Update current route data to Redux and highlight the current page in the Nav bar
   useUpdateRoute({ pathname: "netgroups", noBreadcrumb: true });
 
-  // Tab
-  const [activeTabKey, setActiveTabKey] = React.useState("memberof_netgroup");
   const handleTabClick = (
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
-    setActiveTabKey(tabIndex as string);
     navigate("/netgroups/" + props.netgroup.cn + "/" + tabIndex);
   };
-
-  React.useEffect(() => {
-    setActiveTabKey(props.tabSection);
-  }, [props.tabSection]);
 
   const [netgroupCount, setNetgroupCount] = React.useState(0);
 
@@ -69,7 +62,7 @@ const NetgroupsMemberOf = (props: PropsToMemberOf) => {
   return (
     <TabLayout id="memberof">
       <Tabs
-        activeKey={activeTabKey}
+        activeKey={props.tabSection}
         onSelect={handleTabClick}
         isBox={false}
         mountOnEnter

--- a/src/pages/Netgroups/NetgroupsMembers.tsx
+++ b/src/pages/Netgroups/NetgroupsMembers.tsx
@@ -106,25 +106,17 @@ const NetgroupsMembers = (props: PropsToNetgroupsMembers) => {
     );
   }, [netgroup]);
 
-  // Tab
-  const [activeTabKey, setActiveTabKey] = useState("member_user");
-
   const handleTabClick = (
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
-    setActiveTabKey(tabIndex as string);
     navigate("/netgroups/" + props.netgroup.cn + "/" + tabIndex);
   };
-
-  React.useEffect(() => {
-    setActiveTabKey(props.tabSection);
-  }, [props.tabSection]);
 
   return (
     <TabLayout id="members">
       <Tabs
-        activeKey={activeTabKey}
+        activeKey={props.tabSection}
         onSelect={handleTabClick}
         isBox={false}
         mountOnEnter

--- a/src/pages/Netgroups/NetgroupsTabs.tsx
+++ b/src/pages/Netgroups/NetgroupsTabs.tsx
@@ -43,7 +43,6 @@ const NetgroupsTabs = ({ section }) => {
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
-    setActiveTabKey(tabIndex as string);
     if (tabIndex === "settings") {
       navigate("/netgroups/" + cn);
     } else if (tabIndex === "member") {
@@ -82,7 +81,9 @@ const NetgroupsTabs = ({ section }) => {
       navigate(URL_PREFIX + "/netgroups/" + cn);
     }
     const section_string = section as string;
-    if (section_string.startsWith("memberof_")) {
+    if (section_string === "settings") {
+      setActiveTabKey("settings");
+    } else if (section_string.startsWith("memberof_")) {
       setActiveTabKey("memberof");
     } else if (section_string.startsWith("member_")) {
       setActiveTabKey("member");

--- a/src/pages/Services/ServicesManagedBy.tsx
+++ b/src/pages/Services/ServicesManagedBy.tsx
@@ -11,16 +11,12 @@ import TabLayout from "src/components/layouts/TabLayout";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 // RPC
 import { useGetServiceByIdQuery } from "src/services/rpcServices";
-// Navigation
-import { useNavigate } from "react-router-dom";
 
 interface PropsToServicesManagedBy {
   service: Service;
 }
 
 const ServicesManagedBy = (props: PropsToServicesManagedBy) => {
-  const navigate = useNavigate();
-
   // Service full data
   const serviceQuery = useGetServiceByIdQuery(props.service.krbcanonicalname);
   const serviceData = serviceQuery.data || {};
@@ -40,21 +36,9 @@ const ServicesManagedBy = (props: PropsToServicesManagedBy) => {
   // Update current route data to Redux and highlight the current page in the Nav bar
   useUpdateRoute({ pathname: "services", noBreadcrumb: true });
 
-  // Encoded data to pass to the URL
-  const encodedServiceId = encodeURIComponent(props.service.krbcanonicalname);
-
   return (
     <TabLayout id="managedby">
-      <Tabs
-        activeKey={0}
-        isBox={false}
-        mountOnEnter
-        unmountOnExit
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        onSelect={(_event) => {
-          navigate("/services/" + encodedServiceId + "/managedby_host");
-        }}
-      >
+      <Tabs activeKey={0} isBox={false} mountOnEnter unmountOnExit>
         <Tab
           eventKey={0}
           name="managedby_host"

--- a/src/pages/Services/ServicesTabs.tsx
+++ b/src/pages/Services/ServicesTabs.tsx
@@ -80,7 +80,6 @@ const ServicesTabs = ({ section }) => {
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
-    setActiveTabKey(tabIndex as string);
     if (tabIndex === "settings") {
       navigate("/services/" + doubleEncodedId);
     } else if (tabIndex === "memberof") {

--- a/src/pages/SudoCmdGroups/SudoCmdGroupsMembers.tsx
+++ b/src/pages/SudoCmdGroups/SudoCmdGroupsMembers.tsx
@@ -39,25 +39,17 @@ const SudoCmdGroupMembers = (props: PropsToSudoGroupsMembers) => {
   // Update current route data to Redux and highlight the current page in the Nav bar
   useUpdateRoute({ pathname: "sudo-command-groups", noBreadcrumb: true });
 
-  // Tab
-  const [activeTabKey, setActiveTabKey] = useState("member_sudocmd");
-
   const handleTabClick = (
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
-    setActiveTabKey(tabIndex as string);
     navigate("/sudo-command-groups/" + props.sudocmdgroup.cn + "/" + tabIndex);
   };
-
-  React.useEffect(() => {
-    setActiveTabKey(props.tabSection);
-  }, [props.tabSection]);
 
   return (
     <TabLayout id="members">
       <Tabs
-        activeKey={activeTabKey}
+        activeKey={props.tabSection}
         onSelect={handleTabClick}
         isBox={false}
         mountOnEnter

--- a/src/pages/SudoCmdGroups/SudoCmdGroupsTabs.tsx
+++ b/src/pages/SudoCmdGroups/SudoCmdGroupsTabs.tsx
@@ -42,7 +42,6 @@ const SudoCmdGroupsTabs = ({ section }) => {
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
-    setActiveTabKey(tabIndex as string);
     if (tabIndex === "settings") {
       navigate("/sudo-command-groups/" + cn);
     } else if (tabIndex === "member") {
@@ -79,7 +78,9 @@ const SudoCmdGroupsTabs = ({ section }) => {
       navigate(URL_PREFIX + "/sudo-command-groups/" + cn);
     }
     const section_string = section as string;
-    if (section_string.startsWith("member_")) {
+    if (section_string === "settings") {
+      setActiveTabKey("settings");
+    } else if (section_string.startsWith("member_")) {
       setActiveTabKey("member");
     }
   }, [section]);

--- a/src/pages/SudoCmds/SudoCmdsMemberOf.tsx
+++ b/src/pages/SudoCmds/SudoCmdsMemberOf.tsx
@@ -40,25 +40,18 @@ const SudoCmdsMemberOf = (props: PropsToMemberOf) => {
   // Update current route data to Redux and highlight the current page in the Nav bar
   useUpdateRoute({ pathname: "sudo-commands", noBreadcrumb: true });
 
-  // Tab
-  const [activeTabKey, setActiveTabKey] = useState("memberof_sudocmdgroup");
   const handleTabClick = (
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
-    setActiveTabKey(tabIndex as string);
     navigate("/sudo-commands/" + props.sudoCmd.sudocmd + "/" + tabIndex);
   };
-
-  React.useEffect(() => {
-    setActiveTabKey(props.tabSection);
-  }, [props.tabSection]);
 
   // Render component
   return (
     <TabLayout id="memberof">
       <Tabs
-        activeKey={activeTabKey}
+        activeKey={props.tabSection}
         onSelect={handleTabClick}
         isBox={false}
         mountOnEnter

--- a/src/pages/SudoCmds/SudoCmdsTabs.tsx
+++ b/src/pages/SudoCmds/SudoCmdsTabs.tsx
@@ -42,7 +42,6 @@ const SudoCmdsTabs = ({ section }) => {
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
-    setActiveTabKey(tabIndex as string);
     if (tabIndex === "settings") {
       navigate("/sudo-commands/" + sudocmd);
     } else if (tabIndex === "memberof") {
@@ -80,7 +79,9 @@ const SudoCmdsTabs = ({ section }) => {
     }
     setActiveTabKey(section);
     const section_string = section as string;
-    if (section_string.startsWith("memberof")) {
+    if (section_string === "settings") {
+      setActiveTabKey("settings");
+    } else if (section_string.startsWith("memberof")) {
       setActiveTabKey("memberof");
     }
   }, [section]);

--- a/src/pages/UserGroups/UserGroupsMemberManagers.tsx
+++ b/src/pages/UserGroups/UserGroupsMemberManagers.tsx
@@ -40,25 +40,17 @@ const UserGroupsMemberManagers = (props: PropsToUserGroupsMembers) => {
   // Update current route data to Redux and highlight the current page in the Nav bar
   useUpdateRoute({ pathname: "user-groups", noBreadcrumb: true });
 
-  // Tab
-  const [activeTabKey, setActiveTabKey] = useState("member_user");
-
   const handleTabClick = (
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
-    setActiveTabKey(tabIndex as string);
     navigate("/user-groups/" + props.userGroup.cn + "/" + tabIndex);
   };
-
-  React.useEffect(() => {
-    setActiveTabKey(props.tabSection);
-  }, [props.tabSection]);
 
   return (
     <TabLayout id="managers">
       <Tabs
-        activeKey={activeTabKey}
+        activeKey={props.tabSection}
         onSelect={handleTabClick}
         isBox={false}
         mountOnEnter

--- a/src/pages/UserGroups/UserGroupsMemberOf.tsx
+++ b/src/pages/UserGroups/UserGroupsMemberOf.tsx
@@ -46,19 +46,12 @@ const UserGroupsMemberOf = (props: PropsToMemberOf) => {
   // Update current route data to Redux and highlight the current page in the Nav bar
   useUpdateRoute({ pathname: "user-groups", noBreadcrumb: true });
 
-  // Tab
-  const [activeTabKey, setActiveTabKey] = useState("memberof_usergroup");
   const handleTabClick = (
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
-    setActiveTabKey(tabIndex as string);
     navigate("/user-groups/" + props.userGroup.cn + "/" + tabIndex);
   };
-
-  React.useEffect(() => {
-    setActiveTabKey(props.tabSection);
-  }, [props.tabSection]);
 
   const [groupCount, setGroupCount] = React.useState(0);
   const [netgroupCount, setNetgroupCount] = React.useState(0);
@@ -214,7 +207,7 @@ const UserGroupsMemberOf = (props: PropsToMemberOf) => {
   return (
     <TabLayout id="memberof">
       <Tabs
-        activeKey={activeTabKey}
+        activeKey={props.tabSection}
         onSelect={handleTabClick}
         isBox={false}
         mountOnEnter

--- a/src/pages/UserGroups/UserGroupsMembers.tsx
+++ b/src/pages/UserGroups/UserGroupsMembers.tsx
@@ -148,28 +148,20 @@ const UserGroupsMembers = (props: PropsToUserGroupsMembers) => {
     );
   }, [userGroup]);
 
-  // Tab
-  const [activeTabKey, setActiveTabKey] = useState("member_user");
-
   const handleTabClick = (
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
-    setActiveTabKey(tabIndex as string);
     // id override not implemented yet
     if (tabIndex !== "member_iduseroverride") {
       navigate("/user-groups/" + props.userGroup.cn + "/" + tabIndex);
     }
   };
 
-  React.useEffect(() => {
-    setActiveTabKey(props.tabSection);
-  }, [props.tabSection]);
-
   return (
     <TabLayout id="members">
       <Tabs
-        activeKey={activeTabKey}
+        activeKey={props.tabSection}
         onSelect={handleTabClick}
         isBox={false}
         mountOnEnter

--- a/src/pages/UserGroups/UserGroupsTabs.tsx
+++ b/src/pages/UserGroups/UserGroupsTabs.tsx
@@ -47,7 +47,6 @@ const UserGroupsTabs = ({ section }) => {
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
-    setActiveTabKey(tabIndex as string);
     if (tabIndex === "settings") {
       navigate("/user-groups/" + cn);
     } else if (tabIndex === "member") {
@@ -89,7 +88,9 @@ const UserGroupsTabs = ({ section }) => {
       navigate(URL_PREFIX + "/user-groups/" + groupId);
     }
     const section_string = section as string;
-    if (section_string.startsWith("memberof_")) {
+    if (section_string === "settings") {
+      setActiveTabKey("settings");
+    } else if (section_string.startsWith("memberof_")) {
       setActiveTabKey("memberof");
     } else if (section_string.startsWith("member_")) {
       setActiveTabKey("member");

--- a/tests/features/contextual_help_panel.feature
+++ b/tests/features/contextual_help_panel.feature
@@ -32,16 +32,6 @@ Feature: Contextual help links panel
     When I click on close button in the panel
     Then I should not see contextual help panel
 
-  # - Stage users > Settings page
-  Scenario: Open and close the contextual help links panel on Stage users > Settings page
-    Given I am on "stage-users-settings" page
-    When I click on "Help" button
-    Then I should see contextual help panel
-    And I should see a title "Links" in the panel
-    * I should see a list of links
-    When I click on close button in the panel
-    Then I should not see contextual help panel
-
   # Preserved users page
   Scenario: Open the contextual help links panel on 'preserved-users' main page
     Given I am on "preserved-users" page
@@ -53,16 +43,6 @@ Feature: Contextual help links panel
   Scenario: Close the contextual help links panel on 'Preserved users' main page
     Given I am on "preserved-users" page
     Given I should see contextual help panel
-    When I click on close button in the panel
-    Then I should not see contextual help panel
-
-  # - Preserved users > Settings page
-  Scenario: Open and close the contextual help links panel on 'preserved-users-settings' main page
-    Given I am on "preserved-users-settings" page
-    When I click on "Help" button
-    Then I should see contextual help panel
-    And I should see a title "Links" in the panel
-    * I should see a list of links
     When I click on close button in the panel
     Then I should not see contextual help panel
 
@@ -91,15 +71,5 @@ Feature: Contextual help links panel
   Scenario: Close the contextual help links panel on 'Services' main page
     Given I am on "services" page
     Given I should see contextual help panel
-    When I click on close button in the panel
-    Then I should not see contextual help panel
-
-  # - Services > Settings page
-  Scenario: Open and close the contextual help links panel on 'services-settings' main page
-    Given I am on "services-settings" page
-    When I click on "Help" button
-    Then I should see contextual help panel
-    And I should see a title "Links" in the panel
-    * I should see a list of links
     When I click on close button in the panel
     Then I should not see contextual help panel


### PR DESCRIPTION
There was an issue when we tried to update react-router to latest version. I have realized this issue is not caused by react-router, rather us doing state management the wrong way, this patch fixes that. Also fixes 404, which could never be navigated to. Simplifies logic where possible.
Patch updating react-router can and should follow.

## Summary by Sourcery

Fix navigation and routing issues by refactoring URL state handling, streamlining tab components, and updating route definitions for proper 404 and login redirects.

Bug Fixes:
- Correct search parameter handling in useListPageSearchParams to properly add and remove URL params.
- Restore reachable 404 page by mapping wildcard paths to NotFound and adjust login redirect logic.

Enhancements:
- Remove redundant activeKey state from tab components and use URL-derived props.section for active tabs.
- Simplify tab onSelect handlers by consolidating navigation logic and removing unused hooks.
- Reorder React.StrictMode and Redux Provider, wrap BrowserRouter with React Router future v7 flags in main.tsx.
- Clean up navigation code by removing unused useNavigate and encodeURIComponent calls.