### PR TITLE
Fix: error add another host group

### DIFF
--- a/src/components/modals/Automember/AddRule.tsx
+++ b/src/components/modals/Automember/AddRule.tsx
@@ -180,7 +180,7 @@ const AddRule = (props: PropsToAddRule) => {
   const onAddAndAddAnother = () => {
     const addPayload: AddPayload = {
       group: groupSelected,
-      type: "group",
+      type: props.ruleType,
     };
 
     setAddAgainBtnSpinning(true);


### PR DESCRIPTION
There is an error when trying to add and add another host group in the Automember pages. This is due to a hardcoded value that needs to be dynamic.

Fixes: https://github.com/freeipa/freeipa-webui/issues/708

## Summary by Sourcery

Bug Fixes:
- Use dynamic ruleType prop in AddRule modal to fix 'add another host group' error instead of hardcoded 'group'