### PR TITLE
Bump Vagrant Fedora version to 41

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 
 Vagrant.configure("2") do |config|
   config.vm.hostname = "server.ipa.demo"
-  config.vm.box = "fedora/39-cloud-base"
+  config.vm.box = "fedora/41-cloud-base"
 
   config.vm.synced_folder ".", "/vagrant", disabled: true
   config.vm.synced_folder ".", "/usr/src/freeipa-webui"


### PR DESCRIPTION
Fedora 39 is EOL, move to Fedora 41.

## Summary by Sourcery

Bump the Fedora box version to 41 and disable the GitHub CI private network configuration in the Vagrant setup.

Enhancements:
- Update Vagrant Fedora base box from version 39 to 41.
- Comment out the GitHub CI private network configuration block in the Vagrantfile.