### PR TITLE
Fix: 'as whom' test intermitent failures

### DIFF
--- a/tests/features/steps/common.ts
+++ b/tests/features/steps/common.ts
@@ -805,7 +805,9 @@ Then("I click on the breadcrump link {string}", (value: string) => {
 
 // Dual list
 Then("I click on the dual list item {string}", (value: string) => {
-  cy.get(".pf-v5-c-dual-list-selector__item-text", { timeout: 2000 })
+  cy.get("[role=dialog] .pf-v5-c-dual-list-selector__item-text", {
+    timeout: 2000,
+  })
     .contains(value)
     .click();
 });


### PR DESCRIPTION
The `sudo_rules_settings_as_whom` tests are failing in some arbitrary cases, depending on the context. This has been handled by specifying that the dual selector option must be in the modal dialog.

## Summary by Sourcery

Bug Fixes:
- Narrow the CSS selector for dual list items to `[role=dialog] .pf-v5-c-dual-list-selector__item-text` in the common step definition to prevent context collisions and flakiness