### PR TITLE
Add 'DNS zones' main page functionality

### DIFF
--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -61,6 +61,7 @@ import CertificateMappingPage from "src/pages/CertificateMapping/CertificateMapp
 import CertificateMappingGlobalConfig from "src/pages/CertificateMapping/CertificateMappingGlobalConfig";
 import CertificateMappingMatch from "src/pages/CertificateMapping/CertificateMappingMatch";
 import CertificateMappingTabs from "src/pages/CertificateMapping/CertificateMappingTabs";
+import DnsZones from "src/pages/DNSZones/DnsZones";
 
 // Renders routes (React)
 export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
@@ -457,6 +458,9 @@ export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
               </Route>
               <Route path="cert-id-mapping-match">
                 <Route path="" element={<CertificateMappingMatch />} />
+              </Route>
+              <Route path="dns-zones">
+                <Route path="" element={<DnsZones />} />
               </Route>
               <Route path="configuration" element={<Configuration />} />
               {/* Redirect to Active users page if user is logged in and navigates to the root page */}

--- a/src/navigation/NavRoutes.ts
+++ b/src/navigation/NavRoutes.ts
@@ -52,6 +52,9 @@ const IdentityProviderReferencesGroupRef = "identity-provider-references";
 const CertificateMappingGroupRef = "cert-id-mapping-rules";
 const CertificateMappingConfigGroupRef = "cert-id-mapping-global-config";
 const CertificateMappingMatchGroupRef = "cert-id-mapping-match";
+// NETWORK SERVICES
+// - DNS zones
+const DNSZonesGroupRef = "dns-zones";
 // IPA SERVER
 // - Configuration
 const ConfigRef = "configuration";
@@ -328,6 +331,29 @@ export const navigationRoutes = [
             group: CertificateMappingMatchGroupRef,
             title: `${BASE_TITLE} - Certificate identity mapping match`,
             path: "cert-id-mapping-match",
+            items: [],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    label: "Network services",
+    group: "",
+    title: `${BASE_TITLE} - Network services`,
+    path: "",
+    items: [
+      {
+        label: "DNS",
+        group: DNSZonesGroupRef,
+        title: `${BASE_TITLE} - DNS`,
+        path: "",
+        items: [
+          {
+            label: "DNS zones",
+            group: DNSZonesGroupRef,
+            title: `${BASE_TITLE} - DNS zones`,
+            path: "dns-zones",
             items: [],
           },
         ],

--- a/src/pages/DNSZones/DnsZones.tsx
+++ b/src/pages/DNSZones/DnsZones.tsx
@@ -173,6 +173,7 @@ const DnsZones = () => {
   // - Selectable checkboxes on table
   const selectableDnsZonesTable = dnsZones.filter(isDnsZoneSelectable); // elements per Table
 
+  // - Manage the selected elements in the table (add/remove)
   const updateSelectedDnsZones = (dnsZones: DNSZone[], isSelected: boolean) => {
     let newSelectedDnsZones: DNSZone[] = [];
     if (isSelected) {

--- a/src/pages/DNSZones/DnsZones.tsx
+++ b/src/pages/DNSZones/DnsZones.tsx
@@ -1,0 +1,487 @@
+import React from "react";
+// PatternFly
+import {
+  Page,
+  PageSection,
+  PageSectionVariants,
+  PaginationVariant,
+} from "@patternfly/react-core";
+import {
+  InnerScrollContainer,
+  OuterScrollContainer,
+} from "@patternfly/react-table";
+// Data types
+import { DNSZone } from "src/utils/datatypes/globalDataTypes";
+// Hooks
+import useAlerts from "src/hooks/useAlerts";
+import useUpdateRoute from "src/hooks/useUpdateRoute";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
+import useApiError from "src/hooks/useApiError";
+// Redux
+import { useAppSelector } from "src/store/hooks";
+// RPC
+import {
+  useGetDnsZonesFullDataQuery,
+  useSearchDnsZonesEntriesMutation,
+} from "src/services/rpcDnsZones";
+// Utils
+import { isDnsZoneSelectable } from "src/utils/utils";
+import { apiToDnsZone } from "src/utils/dnsZonesUtils";
+// React router
+import { useNavigate } from "react-router";
+// Components
+import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
+import { SerializedError } from "@reduxjs/toolkit";
+import ToolbarLayout, {
+  ToolbarItem,
+} from "src/components/layouts/ToolbarLayout";
+import SearchInputLayout from "src/components/layouts/SearchInputLayout";
+import SecondaryButton from "src/components/layouts/SecondaryButton";
+import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
+import TitleLayout from "src/components/layouts/TitleLayout";
+import GlobalErrors from "src/components/errors/GlobalErrors";
+import MainTable from "src/components/tables/MainTable";
+import BulkSelectorPrep from "src/components/BulkSelectorPrep";
+
+const DnsZones = () => {
+  const navigate = useNavigate();
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  const { browserTitle } = useUpdateRoute({
+    pathname: "dns-zones",
+  });
+
+  // Set the page title to be shown in the browser tab
+  React.useEffect(() => {
+    document.title = browserTitle;
+  }, [browserTitle]);
+
+  // Retrieve API version from environment data
+  const apiVersion = useAppSelector(
+    (state) => state.global.environment.api_version
+  ) as string;
+
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
+  // URL parameters: page number, page size, search value
+  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+    useListPageSearchParams();
+
+  // Handle API calls errors
+  const globalErrors = useApiError([]);
+
+  // Page indexes
+  const firstUserIdx = (page - 1) * perPage;
+  const lastUserIdx = page * perPage;
+
+  // States
+  const [dnsZones, setDnsZones] = React.useState<DNSZone[]>([]);
+  const [isSearchDisabled, setIsSearchDisabled] = React.useState(false);
+  const [totalCount, setTotalCount] = React.useState(0);
+
+  // API calls
+  const dnsZonesResponse = useGetDnsZonesFullDataQuery({
+    searchValue,
+    apiVersion,
+    sizelimit: perPage,
+    startIdx: firstUserIdx,
+    stopIdx: lastUserIdx,
+  });
+
+  const { data, isLoading, error } = dnsZonesResponse;
+
+  // Handle data when the API call is finished
+  React.useEffect(() => {
+    if (dnsZonesResponse.isFetching) {
+      setShowTableRows(false);
+      // Reset selected elements on refresh
+      setTotalCount(0);
+      globalErrors.clear();
+      return;
+    }
+
+    // API response: Success
+    if (
+      dnsZonesResponse.isSuccess &&
+      dnsZonesResponse.data &&
+      data !== undefined
+    ) {
+      const listResult = data.result.results;
+      const totalCount = data.result.totalCount;
+      const listSize = data.result.count;
+      const elementsList: DNSZone[] = [];
+
+      for (let i = 0; i < listSize; i++) {
+        elementsList.push(apiToDnsZone(listResult[i].result));
+      }
+
+      setTotalCount(totalCount);
+      // Update the list of elements
+      setDnsZones(elementsList);
+      // Show table elements
+      setShowTableRows(true);
+    }
+
+    // API response: Error
+    if (
+      !dnsZonesResponse.isLoading &&
+      dnsZonesResponse.isError &&
+      dnsZonesResponse.error !== undefined
+    ) {
+      // This normally happens when the user is not authorized to view the data
+      // So instead of adding an error, refresh page
+      navigate("/login");
+      window.location.reload();
+    }
+  }, [dnsZonesResponse]);
+
+  // Selected elements
+  const [selectedElements, setSelectedElements] = React.useState<DNSZone[]>([]);
+  const [selectedPerPage, setSelectedPerPage] = React.useState<number>(0);
+
+  // Refresh button handling
+  const refreshData = () => {
+    // Hide table
+    setShowTableRows(false);
+
+    // Reset selected elements on refresh
+    setTotalCount(0);
+
+    dnsZonesResponse.refetch().then(() => {
+      setShowTableRows(true);
+    });
+  };
+
+  // 'Delete' button state
+  const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
+    React.useState<boolean>(true);
+
+  const [isDeletion, setIsDeletion] = React.useState(false);
+
+  // 'Enable' button state
+  const [isEnableButtonDisabled, setIsEnableButtonDisabled] =
+    React.useState<boolean>(true);
+
+  // 'Disable' button state
+  const [isDisableButtonDisabled, setIsDisableButtonDisabled] =
+    React.useState<boolean>(true);
+
+  // Table-related shared functionality
+  // - Selectable checkboxes on table
+  const selectableDnsZonesTable = dnsZones.filter(isDnsZoneSelectable); // elements per Table
+
+  const updateSelectedDnsZones = (dnsZones: DNSZone[], isSelected: boolean) => {
+    let newSelectedDnsZones: DNSZone[] = [];
+    if (isSelected) {
+      newSelectedDnsZones = JSON.parse(JSON.stringify(selectedElements));
+      for (let i = 0; i < dnsZones.length; i++) {
+        if (
+          selectedElements.find(
+            (selectedDnsZone) =>
+              selectedDnsZone.idnsname === dnsZones[i].idnsname
+          )
+        ) {
+          // Already in the list
+          continue;
+        }
+        // Add element to list
+        newSelectedDnsZones.push(dnsZones[i]);
+      }
+    } else {
+      // Remove element
+      for (let i = 0; i < selectedElements.length; i++) {
+        let found = false;
+        for (let ii = 0; ii < dnsZones.length; ii++) {
+          if (selectedElements[i].idnsname === dnsZones[ii].idnsname) {
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          // Keep this valid selected entry
+          newSelectedDnsZones.push(selectedElements[i]);
+        }
+      }
+    }
+    setSelectedElements(newSelectedDnsZones);
+    setIsDeleteButtonDisabled(newSelectedDnsZones.length === 0);
+  };
+
+  // - Helper method to set the selected entries from the table
+  const setDnsZonesSelected = (dnsZone: DNSZone, isSelecting = true) => {
+    if (isDnsZoneSelectable(dnsZone)) {
+      updateSelectedDnsZones([dnsZone], isSelecting);
+    }
+  };
+
+  // Always refetch data when the component is loaded.
+  // This ensures the data is always up-to-date.
+  React.useEffect(() => {
+    dnsZonesResponse.refetch();
+  }, []);
+
+  // Show table rows
+  const [showTableRows, setShowTableRows] = React.useState(!isLoading);
+
+  // Show table rows only when data is fully retrieved
+  React.useEffect(() => {
+    if (showTableRows !== !isLoading) {
+      setShowTableRows(!isLoading);
+    }
+  }, [isLoading]);
+
+  // Search API call
+  const [searchEntry] = useSearchDnsZonesEntriesMutation();
+
+  const submitSearchValue = () => {
+    searchEntry({
+      searchValue: searchValue,
+      apiVersion,
+      sizelimit: 100,
+      startIdx: 0,
+      stopIdx: 200, // Search will consider a max. of elements
+    }).then((result) => {
+      if ("data" in result) {
+        const searchError = result.data?.error as
+          | FetchBaseQueryError
+          | SerializedError;
+
+        if (searchError) {
+          // Error
+          let error: string | undefined = "";
+          if ("error" in searchError) {
+            error = searchError.error;
+          } else if ("message" in searchError) {
+            error = searchError.message;
+          }
+          alerts.addAlert(
+            "submit-search-value-error",
+            error || "Error when searching for elements",
+            "danger"
+          );
+        } else {
+          // Success
+          const listResult = result.data?.result.results || [];
+          const listSize = result.data?.result.count || 0;
+          const totalCount = result.data?.result.totalCount || 0;
+          const elementsList: DNSZone[] = [];
+
+          for (let i = 0; i < listSize; i++) {
+            elementsList.push(listResult[i].result);
+          }
+
+          setTotalCount(totalCount);
+          setDnsZones(elementsList);
+          setShowTableRows(true);
+        }
+        setIsSearchDisabled(false);
+      }
+    });
+  };
+
+  // Data wrappers
+  // TODO: Better separation of concerts
+  // - 'PaginationLayout'
+  const paginationData = {
+    page,
+    perPage,
+    updatePage: setPage,
+    updatePerPage: setPerPage,
+    updateSelectedPerPage: setSelectedPerPage,
+    updateShownElementsList: setDnsZones,
+    totalCount,
+  };
+
+  // SearchInputLayout
+  const searchValueData = {
+    searchValue,
+    updateSearchValue: setSearchValue,
+    submitSearchValue,
+  };
+
+  // - 'BulkSelectorrep'
+  const bulkSelectorData = {
+    selected: selectedElements,
+    updateSelected: updateSelectedDnsZones,
+    selectableTable: selectableDnsZonesTable,
+    nameAttr: "idnsname",
+  };
+
+  const selectedPerPageData = {
+    selectedPerPage,
+    updateSelectedPerPage: setSelectedPerPage,
+  };
+
+  // List of Toolbar items
+  const toolbarItems: ToolbarItem[] = [
+    {
+      key: 0,
+      element: (
+        <BulkSelectorPrep
+          list={dnsZones}
+          shownElementsList={dnsZones}
+          elementData={bulkSelectorData}
+          buttonsData={{
+            updateIsDeleteButtonDisabled: setIsDeleteButtonDisabled,
+          }}
+          selectedPerPageData={selectedPerPageData}
+        />
+      ),
+    },
+    {
+      key: 1,
+      element: (
+        <SearchInputLayout
+          name="search"
+          ariaLabel="Search dns zones"
+          placeholder="Search"
+          searchValueData={searchValueData}
+          isDisabled={isSearchDisabled}
+        />
+      ),
+      toolbarItemVariant: "search-filter",
+      toolbarItemSpacer: { default: "spacerMd" },
+    },
+    {
+      key: 2,
+      toolbarItemVariant: "separator",
+    },
+    {
+      key: 3,
+      element: (
+        <SecondaryButton
+          onClickHandler={refreshData}
+          isDisabled={!showTableRows}
+        >
+          Refresh
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 4,
+      element: (
+        <SecondaryButton isDisabled={isDeleteButtonDisabled || !showTableRows}>
+          Delete
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 5,
+      element: (
+        <SecondaryButton isDisabled={!showTableRows}>Add</SecondaryButton>
+      ),
+    },
+    {
+      key: 6,
+      element: (
+        <SecondaryButton isDisabled={isDisableButtonDisabled || !showTableRows}>
+          Disable
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 7,
+      element: (
+        <SecondaryButton isDisabled={isEnableButtonDisabled || !showTableRows}>
+          Enable
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 8,
+      toolbarItemVariant: "separator",
+    },
+    {
+      key: 9,
+      element: <HelpTextWithIconLayout textContent="Help" />,
+    },
+    {
+      key: 10,
+      element: (
+        <PaginationLayout
+          list={dnsZones}
+          paginationData={paginationData}
+          widgetId="pagination-options-menu-top"
+          isCompact={true}
+        />
+      ),
+      toolbarItemAlignment: { default: "alignRight" },
+    },
+  ];
+
+  // Render component
+  return (
+    <Page>
+      <alerts.ManagedAlerts />
+      <PageSection variant={PageSectionVariants.light}>
+        <TitleLayout id="DNS zones page" headingLevel="h1" text="DNS zones" />
+      </PageSection>
+      <PageSection
+        variant={PageSectionVariants.light}
+        isFilled={false}
+        className="pf-v5-u-m-lg pf-v5-u-pb-md pf-v5-u-pl-0 pf-v5-u-pr-0"
+      >
+        <ToolbarLayout
+          className="pf-v5-u-pt-0 pf-v5-u-pl-lg pf-v5-u-pr-md"
+          contentClassName="pf-v5-u-p-0"
+          toolbarItems={toolbarItems}
+        />
+        <div style={{ height: `calc(100vh - 352.2px)` }}>
+          <OuterScrollContainer>
+            <InnerScrollContainer>
+              {error !== undefined && error ? (
+                <GlobalErrors errors={globalErrors.getAll()} />
+              ) : (
+                <MainTable
+                  tableTitle="DNS zones table"
+                  shownElementsList={dnsZones}
+                  pk="idnsname"
+                  keyNames={["idnsname", "idnszoneactive"]}
+                  columnNames={["Zone name", "Status"]}
+                  hasCheckboxes={true}
+                  pathname="dns-zones"
+                  showTableRows={showTableRows}
+                  showLink={false}
+                  elementsData={{
+                    isElementSelectable: isDnsZoneSelectable,
+                    selectedElements,
+                    selectableElementsTable: selectableDnsZonesTable,
+                    setElementsSelected: setDnsZonesSelected,
+                    clearSelectedElements: () => setSelectedElements([]),
+                  }}
+                  buttonsData={{
+                    updateIsDeleteButtonDisabled: (value) =>
+                      setIsDeleteButtonDisabled(value),
+                    isDeletion,
+                    updateIsDeletion: (value) => setIsDeletion(value),
+                    updateIsEnableButtonDisabled: (value) =>
+                      setIsEnableButtonDisabled(value),
+                    updateIsDisableButtonDisabled: (value) =>
+                      setIsDisableButtonDisabled(value),
+                    isDisableEnableOp: true,
+                  }}
+                  paginationData={{
+                    selectedPerPage,
+                    updateSelectedPerPage: setSelectedPerPage,
+                  }}
+                  statusElementName="idnszoneactive"
+                />
+              )}
+            </InnerScrollContainer>
+          </OuterScrollContainer>
+        </div>
+        <PaginationLayout
+          list={dnsZones}
+          paginationData={paginationData}
+          variant={PaginationVariant.bottom}
+          widgetId="pagination-options-menu-bottom"
+          className="pf-v5-u-pb-0 pf-v5-u-pr-md"
+        />
+      </PageSection>
+    </Page>
+  );
+};
+
+export default DnsZones;

--- a/src/pages/DNSZones/DnsZones.tsx
+++ b/src/pages/DNSZones/DnsZones.tsx
@@ -78,8 +78,9 @@ const DnsZones = () => {
 
   // States
   const [dnsZones, setDnsZones] = React.useState<DNSZone[]>([]);
-  const [isSearchDisabled, setIsSearchDisabled] = React.useState(false);
-  const [totalCount, setTotalCount] = React.useState(0);
+  const [isSearchDisabled, setIsSearchDisabled] =
+    React.useState<boolean>(false);
+  const [totalCount, setTotalCount] = React.useState<number>(0);
 
   // API calls
   const dnsZonesResponse = useGetDnsZonesFullDataQuery({
@@ -158,7 +159,7 @@ const DnsZones = () => {
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
     React.useState<boolean>(true);
 
-  const [isDeletion, setIsDeletion] = React.useState(false);
+  const [isDeletion, setIsDeletion] = React.useState<boolean>(false);
 
   // 'Enable' button state
   const [isEnableButtonDisabled, setIsEnableButtonDisabled] =
@@ -223,7 +224,7 @@ const DnsZones = () => {
   }, []);
 
   // Show table rows
-  const [showTableRows, setShowTableRows] = React.useState(!isLoading);
+  const [showTableRows, setShowTableRows] = React.useState<boolean>(!isLoading);
 
   // Show table rows only when data is fully retrieved
   React.useEffect(() => {

--- a/src/pages/DNSZones/DnsZones.tsx
+++ b/src/pages/DNSZones/DnsZones.tsx
@@ -263,17 +263,10 @@ const DnsZones = () => {
           );
         } else {
           // Success
-          const listResult = result.data?.result.results || [];
-          const listSize = result.data?.result.count || 0;
-          const totalCount = result.data?.result.totalCount || 0;
-          const elementsList: DNSZone[] = [];
-
-          for (let i = 0; i < listSize; i++) {
-            elementsList.push(listResult[i].result);
-          }
+          const dnsZones = result.data?.result || [];
 
           setTotalCount(totalCount);
-          setDnsZones(elementsList);
+          setDnsZones(dnsZones);
           setShowTableRows(true);
         }
         setIsSearchDisabled(false);

--- a/src/services/rpcDnsZones.ts
+++ b/src/services/rpcDnsZones.ts
@@ -36,7 +36,7 @@ export interface DnsZonesFullDataPayload {
   stopIdx: number;
 }
 
-export interface DNSZoneBatchResponse {
+export interface DnsZoneBatchResponse {
   error: string;
   id: string;
   principal: string;
@@ -154,10 +154,10 @@ const extendedApi = api.injectEndpoints({
     /**
      * Search for a specific DNS zone
      * @param {DnsZonesFullDataPayload} payload - The payload containing search parameters
-     * @returns {DNSZoneBatchResponse} - List of DNS zones full data
+     * @returns {DnsZoneBatchResponse} - List of DNS zones full data
      */
     searchDnsZonesEntries: build.mutation<
-      DNSZoneBatchResponse,
+      DnsZoneBatchResponse,
       DnsZonesFullDataPayload
     >({
       async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {

--- a/src/services/rpcDnsZones.ts
+++ b/src/services/rpcDnsZones.ts
@@ -154,7 +154,7 @@ const extendedApi = api.injectEndpoints({
     /**
      * Search for a specific DNS zone
      * @param {DnsZonesFullDataPayload} payload - The payload containing search parameters
-     * @returns {BatchRPCResponse} - List of DNS zones full data
+     * @returns {DNSZoneBatchResponse} - List of DNS zones full data
      */
     searchDnsZonesEntries: build.mutation<
       DNSZoneBatchResponse,

--- a/src/services/rpcDnsZones.ts
+++ b/src/services/rpcDnsZones.ts
@@ -1,0 +1,235 @@
+import {
+  api,
+  Command,
+  getBatchCommand,
+  BatchRPCResponse,
+  FindRPCResponse,
+  getCommand,
+} from "./rpc";
+// utils
+import { API_VERSION_BACKUP } from "../utils/utils";
+// Data types
+import { dnsZoneType } from "src/utils/datatypes/globalDataTypes";
+
+/**
+ * DNS zones-related endpoints: useDnsZonesFindQuery, useGetDnsZonesFullDataQuery,
+                            useSearchDnsZonesEntriesMutation,
+ *
+ * API commands:
+ * - dnszone_find: https://freeipa.readthedocs.io/en/latest/api/dnszone_find.html
+ * - dnszone_show: https://freeipa.readthedocs.io/en/latest/api/dnszone_show.html
+ */
+
+export interface DnsZonesFindPayload {
+  searchValue: string;
+  pkeyOnly: boolean;
+  sizeLimit: number;
+  version?: string;
+}
+
+export interface DnsZonesFullDataPayload {
+  searchValue: string;
+  apiVersion: string;
+  sizelimit: number;
+  startIdx: number;
+  stopIdx: number;
+}
+
+const extendedApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    /**
+     * Get DNS zones IDs
+     * @param {DnsZonesFindPayload} payload - The payload containing search parameters
+     * @returns {Command<FindRPCResponse<DNSZone>>} - Promise with the response data
+     *
+     */
+    dnsZonesFind: build.query<FindRPCResponse, DnsZonesFindPayload>({
+      query: (payload) => {
+        const dnsZonesParams = {
+          pkey_only: payload.pkeyOnly,
+          sizelimit: payload.sizeLimit,
+          version: payload.version || API_VERSION_BACKUP,
+        };
+
+        return getCommand({
+          method: "dnszone_find",
+          params: [[payload.searchValue], dnsZonesParams],
+        });
+      },
+    }),
+    /**
+     * Find DNS zones full data
+     * @param {DnsZonesFullDataPayload} payload - The payload containing search parameters
+     * @returns {BatchRPCResponse} - List of DNS zones full data
+     *
+     */
+    getDnsZonesFullData: build.query<BatchRPCResponse, DnsZonesFullDataPayload>(
+      {
+        async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
+          const { searchValue, apiVersion, sizelimit, startIdx, stopIdx } =
+            payloadData;
+
+          if (apiVersion === undefined) {
+            return {
+              error: {
+                status: "CUSTOM_ERROR",
+                data: "",
+                error: "API version not available",
+              },
+            };
+          }
+
+          // FETCH DNS ZONES DATA VIA "dnszone_find" COMMAND
+          // Prepare search parameters
+          const dnsZonesIdsParams = {
+            pkey_only: true,
+            sizelimit: sizelimit,
+            version: apiVersion,
+          };
+
+          // Prepare payload
+          const payloadDataDnsZones: Command = {
+            method: "dnszone_find",
+            params: [[searchValue], dnsZonesIdsParams],
+          };
+
+          // Make call using 'fetchWithBQ'
+          const getResultDnsZones = await fetchWithBQ(
+            getCommand(payloadDataDnsZones)
+          );
+          // Return possible errors
+          if (getResultDnsZones.error) {
+            return { error: getResultDnsZones.error };
+          }
+          // If no error: cast and assign 'ids'
+          const responseDataDnsZones =
+            getResultDnsZones.data as FindRPCResponse;
+
+          const dnsZonesIds: string[] = [];
+          const dnsZonesItemsCount = responseDataDnsZones.result.result
+            .length as number;
+
+          for (let i = startIdx; i < dnsZonesItemsCount && i < stopIdx; i++) {
+            const dnsZoneId = responseDataDnsZones.result.result[
+              i
+            ] as dnsZoneType;
+            const dnsName = dnsZoneId.idnsname[0]["__dns_name__"];
+            if (dnsName) {
+              dnsZonesIds.push(dnsName as string);
+            }
+          }
+
+          // FETCH DNS ZONE DATA VIA "dnszone_show" COMMAND
+          const commands: Command[] = [];
+          dnsZonesIds.forEach((dnsZoneId) => {
+            commands.push({
+              method: "dnszone_show",
+              params: [[dnsZoneId], {}],
+            });
+          });
+
+          const dnsZonesShowResult = await fetchWithBQ(
+            getBatchCommand(commands, apiVersion)
+          );
+
+          const response = dnsZonesShowResult.data as BatchRPCResponse;
+          if (response) {
+            response.result.totalCount = dnsZonesItemsCount;
+          }
+
+          // Return results
+          return { data: response };
+        },
+      }
+    ),
+    /**
+     * Search for a specific DNS zone
+     * @param {DnsZonesFullDataPayload} payload - The payload containing search parameters
+     * @returns {BatchRPCResponse} - List of DNS zones full data
+     */
+    searchDnsZonesEntries: build.mutation<
+      BatchRPCResponse,
+      DnsZonesFullDataPayload
+    >({
+      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
+        const { searchValue, apiVersion, sizelimit, startIdx, stopIdx } =
+          payloadData;
+
+        if (apiVersion === undefined) {
+          return {
+            error: {
+              status: "CUSTOM_ERROR",
+              data: "",
+              error: "API version not available",
+            },
+          };
+        }
+
+        // FETCH DNS ZONES DATA VIA "dnszone_find" COMMAND
+        // Prepare search parameters
+        const dnsZonesIdsParams = {
+          pkey_only: true,
+          sizelimit: sizelimit,
+          version: apiVersion,
+        };
+
+        // Prepare payload
+        const payloadDataDnsZones: Command = {
+          method: "dnszone_find",
+          params: [[searchValue], dnsZonesIdsParams],
+        };
+
+        // Make call using 'fetchWithBQ'
+        const getResultDnsZones = await fetchWithBQ(
+          getCommand(payloadDataDnsZones)
+        );
+        // Return possible errors
+        if (getResultDnsZones.error) {
+          return { error: getResultDnsZones.error };
+        }
+        // If no error: cast and assign 'ids'
+        const responseDataDnsZones = getResultDnsZones.data as FindRPCResponse;
+
+        const dnsZonesIds: string[] = [];
+        const dnsZonesItemsCount = responseDataDnsZones.result.result
+          .length as number;
+
+        for (let i = startIdx; i < dnsZonesItemsCount && i < stopIdx; i++) {
+          const dnsZoneId = responseDataDnsZones.result.result[
+            i
+          ] as dnsZoneType;
+          const { idnsname } = dnsZoneId;
+          dnsZonesIds.push(idnsname[0]);
+        }
+
+        // FETCH DNS ZONE DATA VIA "dnszone_show" COMMAND
+        const commands: Command[] = [];
+        dnsZonesIds.forEach((dnsZoneId) => {
+          commands.push({
+            method: "dnszone_show",
+            params: [[dnsZoneId], {}],
+          });
+        });
+
+        const dnsZonesShowResult = await fetchWithBQ(
+          getBatchCommand(commands, apiVersion)
+        );
+
+        const response = dnsZonesShowResult.data as BatchRPCResponse;
+        if (response) {
+          response.result.totalCount = dnsZonesItemsCount;
+        }
+
+        // Return results
+        return { data: response };
+      },
+    }),
+  }),
+  overrideExisting: false,
+});
+
+export const {
+  useDnsZonesFindQuery,
+  useGetDnsZonesFullDataQuery,
+  useSearchDnsZonesEntriesMutation,
+} = extendedApi;

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -616,6 +616,11 @@ export interface sudoCmdType {
   description: string;
 }
 
+export interface dnsZoneType {
+  dn: string;
+  idnsname: string[];
+}
+
 export interface automemberType {
   cn: string;
   automembertargetgroup: string;
@@ -656,6 +661,30 @@ export interface SubId {
 
 export interface DNSZone {
   idnsname: string;
+  idnssoarname: string;
+  idnssoamname: string;
+  idnssoaserial: number;
+  idnssoaexpire: number;
+  idnssoarefresh: number;
+  idnsallowdynupdate: boolean;
+  idnssoaminimum: number;
+  idnsallowquery: string;
+  idnssoaretry: number;
+  nsrecord: string[];
+  idnsupdatepolicy: string;
+  idnszoneactive: boolean;
+  idnsallowtransfer: string;
+  dn: string;
+  name_from_ip: string;
+  idnsforwarders: string[];
+  idnsforwardpolicy: string;
+  managedby: string;
+  dnsttl: number;
+  dnsdefaultttl: number;
+  dnsclass: string;
+  idnsallowsyncptr: boolean;
+  idnssecinlinesigning: boolean;
+  nsec3paramrecord: string;
 }
 
 export interface Automember {

--- a/src/utils/dnsZonesUtils.tsx
+++ b/src/utils/dnsZonesUtils.tsx
@@ -41,7 +41,11 @@ const simpleValues = new Set([
   "nsec3paramrecord",
 ]);
 const dateValues = new Set([]);
-const complexValues = new Map([["idnsname", "__dns_name__"]]);
+const complexValues = new Map([
+  ["idnsname", "__dns_name__"],
+  ["idnssoamname", "__dns_name__"],
+  ["idnssoarname", "__dns_name__"],
+]);
 
 export function apiToDnsZone(apiRecord: Record<string, unknown>): DNSZone {
   const converted = convertApiObj(

--- a/src/utils/dnsZonesUtils.tsx
+++ b/src/utils/dnsZonesUtils.tsx
@@ -1,0 +1,91 @@
+// Data types
+import { DNSZone } from "./datatypes/globalDataTypes";
+import { convertApiObj } from "src/utils/ipaObjectUtils";
+
+export const dnsZoneAsRecord = (
+  element: Partial<DNSZone>,
+  onElementChange: (element: Partial<DNSZone>) => void
+) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ipaObject = element as Record<string, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function recordOnChange(ipaObject: Record<string, any>) {
+    onElementChange(ipaObject as DNSZone);
+  }
+
+  return { ipaObject, recordOnChange };
+};
+
+const simpleValues = new Set([
+  "idnssoarname",
+  "idnssoamname",
+  "idnssoaserial",
+  "idnssoaexpire",
+  "idnssoarefresh",
+  "idnsallowdynupdate",
+  "idnssoaminimum",
+  "idnsallowquery",
+  "idnssoaretry",
+  "idnsupdatepolicy",
+  "idnszoneactive",
+  "idnsallowtransfer",
+  "dn",
+  "name_from_ip",
+  "idnsforwardpolicy",
+  "managedby",
+  "dnsttl",
+  "dnsdefaultttl",
+  "dnsclass",
+  "idnsallowsyncptr",
+  "idnssecinlinesigning",
+  "nsec3paramrecord",
+]);
+const dateValues = new Set([]);
+const complexValues = new Map([["idnsname", "__dns_name__"]]);
+
+export function apiToDnsZone(apiRecord: Record<string, unknown>): DNSZone {
+  const converted = convertApiObj(
+    apiRecord,
+    simpleValues,
+    dateValues,
+    complexValues
+  ) as Partial<DNSZone>;
+  return partialDnsZoneToDnsZone(converted);
+}
+
+export function partialDnsZoneToDnsZone(partialDnsZone: Partial<DNSZone>) {
+  return {
+    ...createEmptyDnsZone(),
+    ...partialDnsZone,
+  };
+}
+
+export function createEmptyDnsZone(): DNSZone {
+  return {
+    idnsname: "",
+    idnssoarname: "",
+    idnssoamname: "",
+    idnssoaserial: 1,
+    idnssoaexpire: 1209600, // 14 days in seconds
+    idnssoarefresh: 3600, // 1 hour in seconds
+    idnsallowdynupdate: false,
+    idnssoaminimum: 3600, // 1 hour in seconds
+    idnsallowquery: "",
+    idnssoaretry: 900, // 15 minutes in seconds
+    nsrecord: [],
+    idnsupdatepolicy: "",
+    idnszoneactive: true,
+    idnsallowtransfer: "",
+    dn: "",
+    name_from_ip: "",
+    idnsforwarders: [],
+    idnsforwardpolicy: "",
+    managedby: "",
+    dnsttl: 0,
+    dnsdefaultttl: 0,
+    dnsclass: "",
+    idnsallowsyncptr: true,
+    idnssecinlinesigning: false,
+    nsec3paramrecord: "",
+  };
+}

--- a/src/utils/ipaObjectUtils.ts
+++ b/src/utils/ipaObjectUtils.ts
@@ -172,7 +172,8 @@ export function convertToString(value: BasicType): string {
 export function convertApiObj(
   apiRecord: Record<string, unknown>,
   simpleValues: Set<string>,
-  dateValues: Set<string>
+  dateValues: Set<string>,
+  complexValues: Map<string, string> = new Map() // E.g. [["idnsname", "__dns_name__"]]
 ) {
   const obj = {};
   if (apiRecord !== undefined) {
@@ -181,6 +182,15 @@ export function convertApiObj(
         obj[key] = convertToString(value as BasicType);
       } else if (dateValues.has(key)) {
         obj[key] = parseAPIDatetime(value);
+      } else if (complexValues.has(key)) {
+        const complexKey = complexValues.get(key);
+        if (
+          Array.isArray(value) &&
+          complexKey &&
+          typeof complexKey === "string"
+        ) {
+          obj[key] = (value[0] as Record<string, unknown>)[complexKey];
+        }
       } else {
         obj[key] = value;
       }

--- a/src/utils/ipaObjectUtils.ts
+++ b/src/utils/ipaObjectUtils.ts
@@ -190,6 +190,10 @@ export function convertApiObj(
           typeof complexKey === "string"
         ) {
           obj[key] = (value[0] as Record<string, unknown>)[complexKey];
+        } else {
+          console.error(
+            `Complex value for key ${key} is not an array or complexKey is not a string`
+          );
         }
       } else {
         obj[key] = value;

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -22,6 +22,7 @@ import {
   PwPolicy,
   IDPServer,
   CertificateMapping,
+  DNSZone,
 } from "./datatypes/globalDataTypes";
 // Errors
 import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
@@ -140,6 +141,9 @@ export const isIdpServerSelectable = (idpServer: IDPServer) =>
 
 export const isCertMapSelectable = (certMap: CertificateMapping) =>
   certMap.cn !== "";
+
+export const isDnsZoneSelectable = (dnsZone: DNSZone) =>
+  dnsZone.idnsname !== "";
 
 // Write JSX error messages into 'apiErrorsJsx' array
 export const apiErrorToJsXError = (


### PR DESCRIPTION
The `DNS zones` main page must be located under `Network services` > `DNS` section and contain the main table with the DNS zones to show and its status.

## Summary by Sourcery

Introduce DNS zones management by adding a main page under Network services > DNS, integrating UI table, search, pagination, bulk actions, data type definitions, and backend RPC hooks

New Features:
- Add DNS zones page component with searchable and paginated table including bulk actions

Enhancements:
- Extend global data types with DNS zone definitions and fields
- Implement RPC service endpoints and hooks for dnszone_find, dnszone_show, and search operations
- Integrate DNS zones route in navigation under Network services > DNS
- Enhance API object conversion to handle complex DNS zone values and add isDnsZoneSelectable helper