### PR TITLE
Add Password Input unit tests

### DIFF
--- a/src/components/layouts/PasswordInput/PasswordInput.test.tsx
+++ b/src/components/layouts/PasswordInput/PasswordInput.test.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+// Component
+import PasswordInput, { PropsToPasswordInput } from "./PasswordInput";
+
+const mockOnChange = vi.fn();
+const mockOnRevealHandler = vi.fn();
+
+const initialProps: PropsToPasswordInput = {
+  name: "Password",
+  onChange: mockOnChange,
+  onRevealHandler: mockOnRevealHandler,
+  value: "Secret123",
+};
+
+describe("PasswordInput Component", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    cleanup();
+  });
+
+  it("renders the PasswordInput component", async () => {
+    render(<PasswordInput {...initialProps} />);
+
+    const password = screen.getByLabelText("Password");
+    expect(password).toHaveValue("Secret123");
+    expect(password).toHaveAttribute("type", "text");
+  });
+
+  it("renders the PasswordInput component unobscured", async () => {
+    const props: PropsToPasswordInput = {
+      ...initialProps,
+      passwordHidden: true,
+    };
+
+    render(<PasswordInput {...props} />);
+
+    const password = screen.getByLabelText("Password");
+    expect(password).toHaveValue("Secret123");
+    expect(password).toHaveAttribute("type", "password");
+  });
+
+  it("allows changing PasswordInput component", async () => {
+    const props: PropsToPasswordInput = {
+      ...initialProps,
+      value: "",
+    };
+
+    const PASSWORD = "Secret123";
+
+    render(<PasswordInput {...props} />);
+
+    const password = screen.getByLabelText("Password");
+    expect(password).toHaveValue("");
+    expect(password).toHaveAttribute("type", "text");
+
+    fireEvent.change(password, { target: { value: PASSWORD } });
+    expect(mockOnChange).toHaveBeenCalledExactlyOnceWith(PASSWORD);
+  });
+
+  it("allows to preview the PasswordInput component", async () => {
+    render(<PasswordInput {...initialProps} />);
+
+    const password = screen.getByLabelText("Password");
+    expect(password).toHaveValue("Secret123");
+    expect(password).toHaveAttribute("type", "text");
+
+    // Show
+    const hideButton = screen.getByLabelText("Hide password");
+    fireEvent.click(hideButton);
+
+    expect(mockOnRevealHandler).toHaveBeenCalledExactlyOnceWith(true);
+  });
+});

--- a/src/components/layouts/PasswordInput/PasswordInput.tsx
+++ b/src/components/layouts/PasswordInput/PasswordInput.tsx
@@ -9,15 +9,14 @@ import {
 import { EyeSlashIcon } from "@patternfly/react-icons";
 import { EyeIcon } from "@patternfly/react-icons";
 
-interface PropsToPasswordInput {
-  classname?: string;
+export interface PropsToPasswordInput {
+  ariaLabel?: string;
   name?: string;
   id?: string;
   value?: string;
-  passwordHidden?: boolean | true;
-  onFocus?: React.MouseEventHandler<HTMLButtonElement> | undefined;
+  passwordHidden?: boolean;
+  onFocus?: React.MouseEventHandler<HTMLButtonElement>;
   onChange: (value: string) => void;
-  onClick?: React.MouseEventHandler<HTMLButtonElement> | undefined;
   onRevealHandler: (value: boolean) => void;
   validated?: "success" | "warning" | "error" | "default";
   isRequired?: boolean;
@@ -31,6 +30,7 @@ const PasswordInput = (props: PropsToPasswordInput) => {
     <InputGroup>
       <InputGroupItem isFill>
         <TextInput
+          aria-label={props.ariaLabel ?? props.name}
           type={props.passwordHidden ? "password" : "text"}
           id={props.id}
           name={props.name}

--- a/src/components/layouts/PasswordInput/index.ts
+++ b/src/components/layouts/PasswordInput/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./PasswordInput";
+export * from "./PasswordInput";


### PR DESCRIPTION
Also slightly simplifies types in `PasswordInput.tsx`, as some of the specified types were unnecessary.
Adds aria label for better accessibility.

## Summary by Sourcery

Refine PasswordInput component by simplifying prop types and adding an aria-label prop, introduce comprehensive unit tests, and add an index file for exports.

New Features:
- Add "ariaLabel" prop to PasswordInput for improved accessibility

Enhancements:
- Simplify PropsToPasswordInput type definitions by removing unnecessary optional types

Tests:
- Add unit tests for PasswordInput covering render, input change, and reveal/hide functionality

Chores:
- Introduce index file for streamlined PasswordInput exports