### PR TITLE
DNS zones > Action buttons

### DIFF
--- a/src/components/modals/DnsZones/AddDnsZoneModal.tsx
+++ b/src/components/modals/DnsZones/AddDnsZoneModal.tsx
@@ -90,7 +90,6 @@ const AddDnsZoneModal = (props: PropsToAddModal) => {
     };
 
     addDnsZone(payload).then((response) => {
-      console.log("response:", response);
       if ("data" in response) {
         const data = response.data?.result;
         const error = response.data?.error as SerializedError;
@@ -127,26 +126,40 @@ const AddDnsZoneModal = (props: PropsToAddModal) => {
     props.onClose();
   };
 
+  const zoneNameLabel = <b>Zone name</b>;
+  const reverseZoneLabel = <b>Reverse zone</b>;
+  const skipLabel = (
+    <>
+      Skip overlap check
+      <CustomTooltip
+        message={skipOverlapCheckMessage}
+        id="skip-overlap-check-tooltip"
+        ariaLabel="Skip overlap check tooltip with message"
+      >
+        <InfoCircleIcon className="pf-v5-u-ml-sm" />
+      </CustomTooltip>
+    </>
+  );
+
   // Form fields
   const formFields = (
     <>
-      <Radio
-        name="dnszone_name_type"
-        id="dnszone_name_type"
-        onChange={() => {
-          setIsZoneNameRadioChecked(true);
-          setIsReverseZoneIpRadioChecked(false);
-          setReverseZoneIp(""); // Clear reverse zone IP when switching to DNS zone name
-        }}
-        isChecked={isZoneNameRadioChecked}
-        aria-label="DNS zone name radio button"
-        className="pf-v5-u-mb-md"
-      />
       <div className="pf-v5-u-ml-lg pf-v5-u-mb-md">
         <Form id="add-modal-form-zone-name">
+          <Radio
+            name="dnszone_name_type"
+            id="dnszone_name_type"
+            onChange={() => {
+              setIsZoneNameRadioChecked(true);
+              setIsReverseZoneIpRadioChecked(false);
+              setReverseZoneIp(""); // Clear reverse zone IP when switching to DNS zone name
+            }}
+            isChecked={isZoneNameRadioChecked}
+            aria-label="DNS zone name radio button"
+            label={zoneNameLabel}
+          />
           <FormGroup
             key="zone-name"
-            label="Zone name"
             fieldId="zone-name"
             isRequired={isZoneNameRadioChecked}
           >
@@ -165,23 +178,23 @@ const AddDnsZoneModal = (props: PropsToAddModal) => {
           </FormGroup>
         </Form>
       </div>
-      <Radio
-        name="reverse_zone_type"
-        id="reverse_zone_type"
-        onChange={() => {
-          setIsZoneNameRadioChecked(false);
-          setIsReverseZoneIpRadioChecked(true);
-          setDnsZoneName(""); // Clear DNS zone name when switching to reverse zone IP
-        }}
-        isChecked={isReverseZoneIpRadioChecked}
-        aria-label="Reverse zone IP radio button"
-        className="pf-v5-u-mb-md"
-      />
       <div className="pf-v5-u-ml-lg pf-v5-u-mb-md">
         <Form id="add-modal-form-reverse-zone">
+          <Radio
+            name="reverse_zone_type"
+            id="reverse_zone_type"
+            onChange={() => {
+              setIsZoneNameRadioChecked(false);
+              setIsReverseZoneIpRadioChecked(true);
+              setDnsZoneName(""); // Clear DNS zone name when switching to reverse zone IP
+            }}
+            isChecked={isReverseZoneIpRadioChecked}
+            aria-label="Reverse zone IP radio button"
+            className="pf-v5-u-mt-md"
+            label={reverseZoneLabel}
+          />
           <FormGroup
             key="reverse-zone"
-            label="Reverse zone"
             fieldId="reverse-zone"
             isRequired={isReverseZoneIpRadioChecked}
           >
@@ -219,7 +232,6 @@ const AddDnsZoneModal = (props: PropsToAddModal) => {
       <Form>
         <FormGroup
           key="skip-overlap-check"
-          label="Skip overlap check"
           fieldId="skip-overlap-check"
           labelIcon={
             <CustomTooltip
@@ -230,6 +242,7 @@ const AddDnsZoneModal = (props: PropsToAddModal) => {
               <InfoCircleIcon className="pf-v5-u-ml-sm" />
             </CustomTooltip>
           }
+          className="pf-v5-u-ml-lg pf-v5-u-mt-md pf-v5-u-mb-md"
         >
           <Checkbox
             id="skip-overlap-check"
@@ -238,6 +251,7 @@ const AddDnsZoneModal = (props: PropsToAddModal) => {
             onChange={(_event, checked: boolean) =>
               setSkipOverlapCheck(checked)
             }
+            label={skipLabel}
           />
         </FormGroup>
       </Form>

--- a/src/components/modals/DnsZones/AddDnsZoneModal.tsx
+++ b/src/components/modals/DnsZones/AddDnsZoneModal.tsx
@@ -1,0 +1,317 @@
+import React from "react";
+// PatternFly
+import {
+  Button,
+  Checkbox,
+  Form,
+  FormGroup,
+  HelperText,
+  HelperTextItem,
+  Modal,
+  Radio,
+  Spinner,
+  TextInput,
+  ValidatedOptions,
+} from "@patternfly/react-core";
+// Components
+import CustomTooltip from "src/components/layouts/CustomTooltip";
+// RPC
+import {
+  AddDnsZonePayload,
+  useAddDnsZoneMutation,
+} from "src/services/rpcDnsZones";
+// Hooks
+import useAlerts from "src/hooks/useAlerts";
+// Errors
+import { SerializedError } from "@reduxjs/toolkit";
+// Icons
+import { InfoCircleIcon } from "@patternfly/react-icons";
+
+interface PropsToAddModal {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  onRefresh: () => void;
+}
+
+const AddDnsZoneModal = (props: PropsToAddModal) => {
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
+  // API calls
+  const [addDnsZone] = useAddDnsZoneMutation();
+
+  // States
+  const [isAddButtonSpinning, setIsAddButtonSpinning] =
+    React.useState<boolean>(false);
+  const [isAddAnotherButtonSpinning, setIsAddAnotherButtonSpinning] =
+    React.useState<boolean>(false);
+  const [dnsZoneName, setDnsZoneName] = React.useState<string>("");
+  const [reverseZoneIp, setReverseZoneIp] = React.useState<string>("");
+  const [skipOverlapCheck, setSkipOverlapCheck] =
+    React.useState<boolean>(false);
+  // - Radios
+  const [isZoneNameRadioChecked, setIsZoneNameRadioChecked] =
+    React.useState<boolean>(true);
+  const [isReverseZoneIpRadioChecked, setIsReverseZoneIpRadioChecked] =
+    React.useState<boolean>(false);
+
+  // Tooltip messages
+  const skipOverlapCheckMessage =
+    "Force DNS zone creation even if it will overlap with an existing zone.";
+
+  // Clear form fields
+  const clearFields = () => {
+    setDnsZoneName("");
+    setReverseZoneIp("");
+    setSkipOverlapCheck(false);
+  };
+
+  // Error message
+  const reverseZoneIpErrorMessage =
+    "Not a valid network address (examples: 2001:db8::/64, 192.0.2.0/24)";
+
+  const validateReverseZoneIp = (value: string): boolean => {
+    // Regular expression to validate format. Examples: 2001:db8::/64, 192.0.2.0/24, etc.
+    const regex =
+      /^(?:(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|(?:[0-9]{1,3}\.){3}[0-9]{1,3}\/\d{1,2})$/;
+    return regex.test(value);
+  };
+
+  // Add DNS zone handler
+  const onAddDnsZone = (keepModalOpen: boolean) => {
+    setIsAddButtonSpinning(true);
+    setIsAddAnotherButtonSpinning(true);
+
+    const payload: AddDnsZonePayload = {
+      idnsname: dnsZoneName,
+      nameFromIp: reverseZoneIp,
+      skipOverlapCheck: skipOverlapCheck,
+    };
+
+    addDnsZone(payload).then((response) => {
+      console.log("response:", response);
+      if ("data" in response) {
+        const data = response.data?.result;
+        const error = response.data?.error as SerializedError;
+
+        if (error) {
+          alerts.addAlert("add-dnszone-error", error.message, "danger");
+        }
+
+        if (data) {
+          alerts.addAlert(
+            "add-dnszone-success",
+            "DNS Zone successfully added",
+            "success"
+          );
+          // Reset selected item
+          clearFields();
+          // Update data
+          props.onRefresh();
+          // 'Add and add another' will keep the modal open
+          if (!keepModalOpen) {
+            props.onClose();
+          }
+        }
+      }
+      // Reset button spinners
+      setIsAddButtonSpinning(false);
+      setIsAddAnotherButtonSpinning(false);
+    });
+  };
+
+  // Clean and close modal
+  const cleanAndCloseModal = () => {
+    clearFields();
+    props.onClose();
+  };
+
+  // Form fields
+  const formFields = (
+    <>
+      <Radio
+        name="dnszone_name_type"
+        id="dnszone_name_type"
+        onChange={() => {
+          setIsZoneNameRadioChecked(true);
+          setIsReverseZoneIpRadioChecked(false);
+          setReverseZoneIp(""); // Clear reverse zone IP when switching to DNS zone name
+        }}
+        isChecked={isZoneNameRadioChecked}
+        aria-label="DNS zone name radio button"
+        className="pf-v5-u-mb-md"
+      />
+      <div className="pf-v5-u-ml-lg pf-v5-u-mb-md">
+        <Form id="add-modal-form-zone-name">
+          <FormGroup
+            key="zone-name"
+            label="Zone name"
+            fieldId="zone-name"
+            isRequired={isZoneNameRadioChecked}
+          >
+            <TextInput
+              type="text"
+              id="dns-name"
+              name="idnsname"
+              value={dnsZoneName}
+              aria-label="DNS zone text input"
+              onChange={(_event, value: string) => setDnsZoneName(value)}
+              isDisabled={
+                !isZoneNameRadioChecked && isReverseZoneIpRadioChecked
+              }
+              isRequired={isZoneNameRadioChecked}
+            />
+          </FormGroup>
+        </Form>
+      </div>
+      <Radio
+        name="reverse_zone_type"
+        id="reverse_zone_type"
+        onChange={() => {
+          setIsZoneNameRadioChecked(false);
+          setIsReverseZoneIpRadioChecked(true);
+          setDnsZoneName(""); // Clear DNS zone name when switching to reverse zone IP
+        }}
+        isChecked={isReverseZoneIpRadioChecked}
+        aria-label="Reverse zone IP radio button"
+        className="pf-v5-u-mb-md"
+      />
+      <div className="pf-v5-u-ml-lg pf-v5-u-mb-md">
+        <Form id="add-modal-form-reverse-zone">
+          <FormGroup
+            key="reverse-zone"
+            label="Reverse zone"
+            fieldId="reverse-zone"
+            isRequired={isReverseZoneIpRadioChecked}
+          >
+            <>
+              <TextInput
+                type="text"
+                id="reverse-zone-ip"
+                name="name_from_ip"
+                value={reverseZoneIp}
+                aria-label="Reverse zone IP text input"
+                onChange={(_event, value: string) => setReverseZoneIp(value)}
+                isDisabled={
+                  !isReverseZoneIpRadioChecked && isZoneNameRadioChecked
+                }
+                isRequired={isReverseZoneIpRadioChecked}
+                validated={
+                  reverseZoneIp !== "" &&
+                  isReverseZoneIpRadioChecked &&
+                  !validateReverseZoneIp(reverseZoneIp)
+                    ? ValidatedOptions.error
+                    : ValidatedOptions.default
+                }
+              />
+              <HelperText>
+                {reverseZoneIp !== "" &&
+                  isReverseZoneIpRadioChecked &&
+                  !validateReverseZoneIp(reverseZoneIp) && (
+                    <HelperTextItem>{reverseZoneIpErrorMessage}</HelperTextItem>
+                  )}
+              </HelperText>
+            </>
+          </FormGroup>
+        </Form>
+      </div>
+      <Form>
+        <FormGroup
+          key="skip-overlap-check"
+          label="Skip overlap check"
+          fieldId="skip-overlap-check"
+          labelIcon={
+            <CustomTooltip
+              message={skipOverlapCheckMessage}
+              id="skip-overlap-check-tooltip"
+              ariaLabel="Skip overlap check tooltip with message"
+            >
+              <InfoCircleIcon className="pf-v5-u-ml-sm" />
+            </CustomTooltip>
+          }
+        >
+          <Checkbox
+            id="skip-overlap-check"
+            name="skip_overlap_check"
+            isChecked={skipOverlapCheck}
+            onChange={(_event, checked: boolean) =>
+              setSkipOverlapCheck(checked)
+            }
+          />
+        </FormGroup>
+      </Form>
+    </>
+  );
+
+  // Actions
+  const modalActions: JSX.Element[] = [
+    <Button
+      key="add-new"
+      variant="secondary"
+      isDisabled={
+        isAddButtonSpinning ||
+        (isZoneNameRadioChecked && dnsZoneName === "") ||
+        (isReverseZoneIpRadioChecked && reverseZoneIp === "")
+      }
+      form="add-modal-form"
+      onClick={() => {
+        onAddDnsZone(false);
+      }}
+    >
+      {isAddButtonSpinning ? (
+        <>
+          <Spinner size="sm" />
+          {"Adding"}
+        </>
+      ) : (
+        "Add"
+      )}
+    </Button>,
+    <Button
+      key="add-new-another"
+      variant="secondary"
+      isDisabled={
+        isAddAnotherButtonSpinning ||
+        (isZoneNameRadioChecked && dnsZoneName === "") ||
+        (isReverseZoneIpRadioChecked && reverseZoneIp === "")
+      }
+      form="add-another-modal-form"
+      onClick={() => {
+        onAddDnsZone(true);
+      }}
+    >
+      {isAddAnotherButtonSpinning ? (
+        <>
+          <Spinner size="sm" className="pf-v6-u-mr-sm" />
+          {"Adding"}
+        </>
+      ) : (
+        "Add and add another"
+      )}
+    </Button>,
+    <Button key="cancel-new" variant="link" onClick={cleanAndCloseModal}>
+      Cancel
+    </Button>,
+  ];
+
+  // Return component
+  return (
+    <>
+      <alerts.ManagedAlerts />
+      <Modal
+        variant="small"
+        title={props.title}
+        position="top"
+        positionOffset="76px"
+        isOpen={props.isOpen}
+        onClose={props.onClose}
+        actions={modalActions}
+      >
+        {formFields}
+      </Modal>
+    </>
+  );
+};
+
+export default AddDnsZoneModal;

--- a/src/components/modals/DnsZones/DeleteDnsZonesModal.tsx
+++ b/src/components/modals/DnsZones/DeleteDnsZonesModal.tsx
@@ -1,0 +1,209 @@
+import React from "react";
+// PatternFly
+import {
+  Button,
+  TextContent,
+  Text,
+  TextVariants,
+  Spinner,
+} from "@patternfly/react-core";
+// Hooks
+import useAlerts from "src/hooks/useAlerts";
+// RPC
+import { useDnsZoneDeleteMutation } from "src/services/rpcDnsZones";
+// Data types
+import { DNSZone, ErrorData } from "src/utils/datatypes/globalDataTypes";
+import { BatchRPCResponse } from "src/services/rpc";
+import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
+// Components
+import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
+import DeletedElementsTable from "src/components/tables/DeletedElementsTable";
+import { SerializedError } from "@reduxjs/toolkit";
+import ErrorModal from "../ErrorModal";
+
+interface DeleteDnsZonesModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  elementsToDelete: DNSZone[];
+  clearSelectedElements: () => void;
+  columnNames: string[]; // E.g. ["DNS Zone Name", "Reverse Zone IP"]
+  keyNames: string[]; // E.g. for dns_zone.name, dns_zone.reverse_zone_ip --> ["name", "reverse_zone_ip"]
+  onRefresh: () => void;
+  updateIsDeleteButtonDisabled: (value: boolean) => void;
+  updateIsDeletion: (value: boolean) => void;
+}
+
+const DeleteDnsZonesModal = (props: DeleteDnsZonesModalProps) => {
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
+  // RPC calls
+  const [deleteDnsZones] = useDnsZoneDeleteMutation();
+
+  // States
+  const [spinning, setBtnSpinning] = React.useState<boolean>(false);
+
+  // Handle API error data
+  const [isModalErrorOpen, setIsModalErrorOpen] = React.useState(false);
+  const [errorTitle, setErrorTitle] = React.useState("");
+  const [errorMessage, setErrorMessage] = React.useState("");
+
+  const closeAndCleanErrorParameters = () => {
+    setIsModalErrorOpen(false);
+    setErrorTitle("");
+    setErrorMessage("");
+  };
+
+  const errorModalActions = [
+    <Button key="cancel" variant="link" onClick={closeAndCleanErrorParameters}>
+      OK
+    </Button>,
+  ];
+
+  const handleAPIError = (error: FetchBaseQueryError | SerializedError) => {
+    if ("code" in error) {
+      setErrorTitle("IPA error " + error.code + ": " + error.name);
+      if (error.message !== undefined) {
+        setErrorMessage(error.message);
+      }
+    } else if ("data" in error) {
+      const errorData = error.data as ErrorData;
+      const errorCode = errorData.code;
+      const errorName = errorData.name;
+      const errorMessage = errorData.error;
+
+      setErrorTitle("IPA error " + errorCode + ": " + errorName);
+      setErrorMessage(errorMessage);
+    }
+    setIsModalErrorOpen(true);
+  };
+
+  const onDelete = () => {
+    setBtnSpinning(true);
+
+    const elementsToDelete = props.elementsToDelete.map((element) =>
+      element.idnsname.toString()
+    );
+
+    deleteDnsZones(elementsToDelete).then((response) => {
+      if ("data" in response) {
+        const data = response.data as BatchRPCResponse;
+        const result = data.result;
+
+        if (result) {
+          if ("error" in result.results[0] && result.results[0].error) {
+            const errorData = {
+              code: result.results[0].error_code,
+              name: result.results[0].error_name,
+              error: result.results[0].error,
+            } as ErrorData;
+
+            const error = {
+              status: "CUSTOM_ERROR",
+              data: errorData,
+            } as FetchBaseQueryError;
+
+            // Handle error
+            handleAPIError(error);
+          } else {
+            props.clearSelectedElements();
+            props.updateIsDeleteButtonDisabled(true);
+            props.updateIsDeletion(true);
+
+            alerts.addAlert(
+              "remove-dnszones-success",
+              "DNS zones removed",
+              "success"
+            );
+
+            setBtnSpinning(false);
+            props.onClose();
+            // Refresh data
+            props.onRefresh();
+          }
+        }
+      }
+    });
+  };
+
+  // List of fields
+  const fields = [
+    {
+      id: "question-text",
+      pfComponent: (
+        <TextContent>
+          <Text component={TextVariants.p}>
+            Are you sure you want to delete the selected entries?
+          </Text>
+        </TextContent>
+      ),
+    },
+    {
+      id: "deleted-elements-table",
+      pfComponent: (
+        <DeletedElementsTable
+          mode="passing_full_data"
+          elementsToDelete={props.elementsToDelete}
+          columnNames={props.columnNames}
+          columnIds={props.keyNames}
+          elementType="DNS zone" // the final 's' is handled by the component
+          idAttr={"idnsname"}
+        />
+      ),
+    },
+  ];
+
+  const modalActions: JSX.Element[] = [
+    <Button
+      key="delete-dnszones"
+      variant="danger"
+      onClick={onDelete}
+      form="delete-dnszones-modal"
+      spinnerAriaValueText="Deleting"
+      spinnerAriaLabel="Deleting"
+      isLoading={spinning}
+      isDisabled={spinning}
+    >
+      {spinning ? (
+        <>
+          <Spinner size="sm" />
+          {"Deleting"}
+        </>
+      ) : (
+        "Delete"
+      )}
+    </Button>,
+    <Button key="cancel-delete-dnszones" variant="link" onClick={props.onClose}>
+      Cancel
+    </Button>,
+  ];
+
+  // Render component
+  return (
+    <>
+      <alerts.ManagedAlerts />
+      <ModalWithFormLayout
+        variantType="medium"
+        modalPosition="top"
+        offPosition="76px"
+        title="Remove DNS zones"
+        formId="remove-dnszones-modal"
+        fields={fields}
+        show={props.isOpen}
+        onClose={props.onClose}
+        actions={modalActions}
+      />
+      {isModalErrorOpen && (
+        <ErrorModal
+          title={errorTitle}
+          isOpen={isModalErrorOpen}
+          onClose={closeAndCleanErrorParameters}
+          actions={errorModalActions}
+          errorMessage={errorMessage}
+        />
+      )}
+    </>
+  );
+};
+
+export default DeleteDnsZonesModal;

--- a/src/components/modals/DnsZones/EnableDisableDnsZonesModal.tsx
+++ b/src/components/modals/DnsZones/EnableDisableDnsZonesModal.tsx
@@ -1,0 +1,106 @@
+import React from "react";
+// PatternFly
+import { Button } from "@patternfly/react-core";
+// Hooks
+import useAlerts from "src/hooks/useAlerts";
+// RPC
+import {
+  useDnsZoneDisableMutation,
+  useDnsZoneEnableMutation,
+} from "src/services/rpcDnsZones";
+// Components
+import ConfirmationModal from "../ConfirmationModal";
+// Utils
+import capitalizeFirstLetter from "src/utils/utils";
+
+interface EnableDisableDnsZonesModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  elementsList: string[];
+  setElementsList: (elementsList: string[]) => void;
+  operation: "enable" | "disable";
+  setShowTableRows: (value: boolean) => void;
+  onRefresh: () => void;
+}
+
+const EnableDisableDnsZonesModal = (props: EnableDisableDnsZonesModalProps) => {
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
+  // RPC calls
+  const [disableRule] = useDnsZoneDisableMutation();
+  const [enableRule] = useDnsZoneEnableMutation();
+
+  // Enable/Disable operation
+  const onEnableDisable = () => {
+    const operation = props.operation === "enable" ? enableRule : disableRule;
+
+    props.setShowTableRows(false);
+    operation(props.elementsList).then((response) => {
+      if ("data" in response) {
+        const { data } = response;
+        if (data?.error) {
+          alerts.addAlert("error", data.error, "danger");
+        }
+        if (data?.result) {
+          alerts.addAlert("success", "DNS zone status changed", "success");
+          // Clear selected elements
+          props.setElementsList([]);
+          // Refresh data
+          props.onRefresh();
+          onClose();
+        }
+        props.setShowTableRows(true);
+      }
+    });
+  };
+
+  const onClose = () => {
+    props.setShowTableRows(true);
+    props.setElementsList([]);
+    props.onClose();
+  };
+
+  const onCloseWithoutClearingElements = () => {
+    props.setShowTableRows(true);
+    props.onClose();
+  };
+
+  const modalActions: JSX.Element[] = [
+    <Button
+      key={props.operation + "-dnszones"}
+      variant="primary"
+      onClick={onEnableDisable}
+    >
+      OK
+    </Button>,
+    <Button
+      key={"cancel-" + props.operation + "-dnszones"}
+      variant="secondary"
+      onClick={onCloseWithoutClearingElements}
+    >
+      Cancel
+    </Button>,
+  ];
+
+  // Render component
+  return (
+    <>
+      <alerts.ManagedAlerts />
+      <ConfirmationModal
+        title={capitalizeFirstLetter(props.operation) + " confirmation"}
+        isOpen={props.isOpen}
+        onClose={onClose}
+        actions={modalActions}
+        messageText={
+          "Are you sure you want to " +
+          props.operation +
+          " the following element(s)?"
+        }
+        messageObj={props.elementsList.join(", ")}
+      />
+    </>
+  );
+};
+
+export default EnableDisableDnsZonesModal;

--- a/src/components/tables/DeletedElementsTable.tsx
+++ b/src/components/tables/DeletedElementsTable.tsx
@@ -67,8 +67,8 @@ const DeletedElementsTable = <T,>(props: PropsToDeletedElementsTable<T>) => {
     const colNamesArray: string[] = [];
     if (props.mode === "passing_full_data") {
       props.columnNames.map((column) => {
-        const result = column.replace(/([A-Z])/g, " $1");
-        const simplifiedName = result.charAt(0).toUpperCase() + result.slice(1);
+        // Simplify the column name to have the first letter capital
+        const simplifiedName = column.charAt(0).toUpperCase() + column.slice(1);
         colNamesArray.push(simplifiedName);
       });
       setColumnNames(colNamesArray);

--- a/src/pages/DNSZones/DnsZones.tsx
+++ b/src/pages/DNSZones/DnsZones.tsx
@@ -45,6 +45,7 @@ import MainTable from "src/components/tables/MainTable";
 import BulkSelectorPrep from "src/components/BulkSelectorPrep";
 import AddDnsZoneModal from "src/components/modals/DnsZones/AddDnsZoneModal";
 import DeleteDnsZonesModal from "src/components/modals/DnsZones/DeleteDnsZonesModal";
+import EnableDisableDnsZonesModal from "src/components/modals/DnsZones/EnableDisableDnsZonesModal";
 
 const DnsZones = () => {
   const navigate = useNavigate();
@@ -314,6 +315,22 @@ const DnsZones = () => {
   // Modals functionality
   const [showAddModal, setShowAddModal] = React.useState<boolean>(false);
   const [showDeleteModal, setShowDeleteModal] = React.useState<boolean>(false);
+  const [showEnableDisableModal, setShowEnableDisableModal] =
+    React.useState<boolean>(false);
+  const [operation, setOperation] = React.useState<"enable" | "disable">(
+    "disable"
+  );
+
+  // Open modal and set operation to 'disable' or "enable"
+  const onEnableOperation = () => {
+    setOperation("enable");
+    setShowEnableDisableModal(true);
+  };
+
+  const onDisableOperation = () => {
+    setOperation("disable");
+    setShowEnableDisableModal(true);
+  };
 
   // List of Toolbar items
   const toolbarItems: ToolbarItem[] = [
@@ -385,7 +402,10 @@ const DnsZones = () => {
     {
       key: 6,
       element: (
-        <SecondaryButton isDisabled={isDisableButtonDisabled || !showTableRows}>
+        <SecondaryButton
+          isDisabled={isDisableButtonDisabled || !showTableRows}
+          onClickHandler={onDisableOperation}
+        >
           Disable
         </SecondaryButton>
       ),
@@ -393,7 +413,10 @@ const DnsZones = () => {
     {
       key: 7,
       element: (
-        <SecondaryButton isDisabled={isEnableButtonDisabled || !showTableRows}>
+        <SecondaryButton
+          isDisabled={isEnableButtonDisabled || !showTableRows}
+          onClickHandler={onEnableOperation}
+        >
           Enable
         </SecondaryButton>
       ),
@@ -505,6 +528,19 @@ const DnsZones = () => {
         onRefresh={refreshData}
         updateIsDeleteButtonDisabled={setIsDeleteButtonDisabled}
         updateIsDeletion={setIsDeletion}
+      />
+      <EnableDisableDnsZonesModal
+        isOpen={showEnableDisableModal}
+        onClose={() => setShowEnableDisableModal(false)}
+        elementsList={selectedElements.map((dnszone) => dnszone.idnsname)}
+        setElementsList={(value) =>
+          setSelectedElements(
+            value.map((idnsname) => ({ idnsname }) as DNSZone)
+          )
+        }
+        operation={operation}
+        setShowTableRows={setShowTableRows}
+        onRefresh={refreshData}
       />
     </Page>
   );

--- a/src/pages/DNSZones/DnsZones.tsx
+++ b/src/pages/DNSZones/DnsZones.tsx
@@ -44,6 +44,7 @@ import GlobalErrors from "src/components/errors/GlobalErrors";
 import MainTable from "src/components/tables/MainTable";
 import BulkSelectorPrep from "src/components/BulkSelectorPrep";
 import AddDnsZoneModal from "src/components/modals/DnsZones/AddDnsZoneModal";
+import DeleteDnsZonesModal from "src/components/modals/DnsZones/DeleteDnsZonesModal";
 
 const DnsZones = () => {
   const navigate = useNavigate();
@@ -311,7 +312,8 @@ const DnsZones = () => {
   };
 
   // Modals functionality
-  const [showAddModal, setShowAddModal] = React.useState(false);
+  const [showAddModal, setShowAddModal] = React.useState<boolean>(false);
+  const [showDeleteModal, setShowDeleteModal] = React.useState<boolean>(false);
 
   // List of Toolbar items
   const toolbarItems: ToolbarItem[] = [
@@ -361,7 +363,10 @@ const DnsZones = () => {
     {
       key: 4,
       element: (
-        <SecondaryButton isDisabled={isDeleteButtonDisabled || !showTableRows}>
+        <SecondaryButton
+          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          onClickHandler={() => setShowDeleteModal(true)}
+        >
           Delete
         </SecondaryButton>
       ),
@@ -489,6 +494,17 @@ const DnsZones = () => {
         onClose={() => setShowAddModal(false)}
         title="Add DNS zone"
         onRefresh={refreshData}
+      />
+      <DeleteDnsZonesModal
+        isOpen={showDeleteModal}
+        onClose={() => setShowDeleteModal(false)}
+        elementsToDelete={selectedElements}
+        clearSelectedElements={() => setSelectedElements([])}
+        columnNames={["DNS zone name"]}
+        keyNames={["idnsname"]}
+        onRefresh={refreshData}
+        updateIsDeleteButtonDisabled={setIsDeleteButtonDisabled}
+        updateIsDeletion={setIsDeletion}
       />
     </Page>
   );

--- a/src/pages/DNSZones/DnsZones.tsx
+++ b/src/pages/DNSZones/DnsZones.tsx
@@ -43,6 +43,7 @@ import TitleLayout from "src/components/layouts/TitleLayout";
 import GlobalErrors from "src/components/errors/GlobalErrors";
 import MainTable from "src/components/tables/MainTable";
 import BulkSelectorPrep from "src/components/BulkSelectorPrep";
+import AddDnsZoneModal from "src/components/modals/DnsZones/AddDnsZoneModal";
 
 const DnsZones = () => {
   const navigate = useNavigate();
@@ -309,6 +310,9 @@ const DnsZones = () => {
     updateSelectedPerPage: setSelectedPerPage,
   };
 
+  // Modals functionality
+  const [showAddModal, setShowAddModal] = React.useState(false);
+
   // List of Toolbar items
   const toolbarItems: ToolbarItem[] = [
     {
@@ -365,7 +369,12 @@ const DnsZones = () => {
     {
       key: 5,
       element: (
-        <SecondaryButton isDisabled={!showTableRows}>Add</SecondaryButton>
+        <SecondaryButton
+          isDisabled={!showTableRows}
+          onClickHandler={() => setShowAddModal(true)}
+        >
+          Add
+        </SecondaryButton>
       ),
     },
     {
@@ -475,6 +484,12 @@ const DnsZones = () => {
           className="pf-v5-u-pb-0 pf-v5-u-pr-md"
         />
       </PageSection>
+      <AddDnsZoneModal
+        isOpen={showAddModal}
+        onClose={() => setShowAddModal(false)}
+        title="Add DNS zone"
+        onRefresh={refreshData}
+      />
     </Page>
   );
 };

--- a/src/services/rpcDnsZones.ts
+++ b/src/services/rpcDnsZones.ts
@@ -14,12 +14,14 @@ import { apiToDnsZone } from "src/utils/dnsZonesUtils";
 
 /**
  * DNS zones-related endpoints: useDnsZonesFindQuery, useGetDnsZonesFullDataQuery,
-                            useSearchDnsZonesEntriesMutation, useAddDnsZoneMutation
+                            useSearchDnsZonesEntriesMutation, useAddDnsZoneMutation,
+                            useDnsZoneDeleteMutation
  *
  * API commands:
  * - dnszone_find: https://freeipa.readthedocs.io/en/latest/api/dnszone_find.html
  * - dnszone_show: https://freeipa.readthedocs.io/en/latest/api/dnszone_show.html
  * - dnszone_add: https://freeipa.readthedocs.io/en/latest/api/dnszone_add.html
+ * - dnszone_del: https://freeipa.readthedocs.io/en/latest/api/dnszone_del.html
  */
 
 export interface DnsZonesFindPayload {
@@ -292,6 +294,24 @@ const extendedApi = api.injectEndpoints({
         });
       },
     }),
+    /**
+     * Delete DNS zones
+     * @param {string[]} dnsZoneIds - The IDs of the DNS zones to delete
+     * @returns {Promise<BatchRPCResponse>} - Promise with the response data
+     */
+    dnsZoneDelete: build.mutation<BatchRPCResponse, string[]>({
+      query: (dnsZoneIds) => {
+        const commands: Command[] = [];
+        dnsZoneIds.forEach((dnsZoneId) => {
+          commands.push({
+            method: "dnszone_del",
+            params: [[dnsZoneId], {}],
+          });
+        });
+
+        return getBatchCommand(commands, API_VERSION_BACKUP);
+      },
+    }),
   }),
   overrideExisting: false,
 });
@@ -301,4 +321,5 @@ export const {
   useGetDnsZonesFullDataQuery,
   useSearchDnsZonesEntriesMutation,
   useAddDnsZoneMutation,
+  useDnsZoneDeleteMutation,
 } = extendedApi;

--- a/src/services/rpcDnsZones.ts
+++ b/src/services/rpcDnsZones.ts
@@ -312,6 +312,42 @@ const extendedApi = api.injectEndpoints({
         return getBatchCommand(commands, API_VERSION_BACKUP);
       },
     }),
+    /**
+     * Disable DNS zones
+     * @param {string[]} dnsZoneIds - The IDs of the DNS zones to disable
+     * @returns {Promise<BatchRPCResponse>} - Promise with the response data
+     */
+    dnsZoneDisable: build.mutation<BatchRPCResponse, string[]>({
+      query: (dnsZoneIds) => {
+        const commands: Command[] = [];
+        dnsZoneIds.forEach((dnsZoneId) => {
+          commands.push({
+            method: "dnszone_disable",
+            params: [[dnsZoneId], {}],
+          });
+        });
+
+        return getBatchCommand(commands, API_VERSION_BACKUP);
+      },
+    }),
+    /**
+     * Enable DNS zones
+     * @param {string[]} dnsZoneIds - The IDs of the DNS zones to enable
+     * @returns {Promise<BatchRPCResponse>} - Promise with the response data
+     */
+    dnsZoneEnable: build.mutation<BatchRPCResponse, string[]>({
+      query: (dnsZoneIds) => {
+        const commands: Command[] = [];
+        dnsZoneIds.forEach((dnsZoneId) => {
+          commands.push({
+            method: "dnszone_enable",
+            params: [[dnsZoneId], {}],
+          });
+        });
+
+        return getBatchCommand(commands, API_VERSION_BACKUP);
+      },
+    }),
   }),
   overrideExisting: false,
 });
@@ -322,4 +358,6 @@ export const {
   useSearchDnsZonesEntriesMutation,
   useAddDnsZoneMutation,
   useDnsZoneDeleteMutation,
+  useDnsZoneDisableMutation,
+  useDnsZoneEnableMutation,
 } = extendedApi;

--- a/src/utils/dnsZonesUtils.tsx
+++ b/src/utils/dnsZonesUtils.tsx
@@ -17,8 +17,6 @@ export const dnsZoneAsRecord = (
 };
 
 const simpleValues = new Set([
-  "idnssoarname",
-  "idnssoamname",
   "idnssoaserial",
   "idnssoaexpire",
   "idnssoarefresh",
@@ -43,8 +41,8 @@ const simpleValues = new Set([
 const dateValues = new Set([]);
 const complexValues = new Map([
   ["idnsname", "__dns_name__"],
-  ["idnssoamname", "__dns_name__"],
   ["idnssoarname", "__dns_name__"],
+  ["idnssoamname", "__dns_name__"],
 ]);
 
 export function apiToDnsZone(apiRecord: Record<string, unknown>): DNSZone {

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -34,8 +34,8 @@ import TextLayout from "src/components/layouts/TextLayout";
  * Functions that can be reusable and called by several components throughout the application.
  */
 
-// Default API version (in case this is not available in Redux ATM)
-export const API_VERSION_BACKUP = "2.251";
+// Default latest API version (in case this is not available in Redux ATM)
+export const API_VERSION_BACKUP = "2.254";
 
 // Helper method: Given an users list and status, check if some entry has different status
 export const checkEqualStatus = (status: boolean, usersList: User[]) => {


### PR DESCRIPTION
The funcionality of `Add`, `Delete`, `Enable`, and `Disable` buttons has been implemented in the DNS zones main page. Additional fixes and updates have been addressed as well.

## Summary by Sourcery

Implement Add, Delete, Enable, and Disable DNS zone actions on the DNS zones page by adding service mutations, modal components, and toolbar button integrations.

New Features:
- Implement Add DNS zone functionality with a modal form and corresponding RPC mutation
- Add bulk Delete DNS zones functionality with a confirmation modal and RPC mutation
- Add Enable and Disable DNS zones operations via a confirmation modal and RPC mutations

Enhancements:
- Integrate Add, Delete, Enable, and Disable action buttons into the DNS zones main page toolbar
- Update default API version backup to 2.254
- Clean up unused simple value keys in DNS zone utilities