### PR TITLE
Add DnsForwardZone

### DIFF
--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -63,6 +63,7 @@ import CertificateMappingMatch from "src/pages/CertificateMapping/CertificateMap
 import CertificateMappingTabs from "src/pages/CertificateMapping/CertificateMappingTabs";
 import DnsZones from "src/pages/DNSZones/DnsZones";
 import DnsZonesTabs from "src/pages/DNSZones/DnsZonesTabs";
+import DnsForwardZones from "src/pages/DNSZones/DnsForwardZones";
 
 // Renders routes (React)
 export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
@@ -472,6 +473,9 @@ export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
                     element={<DnsZonesTabs section="dns-records" />}
                   />
                 </Route>
+              </Route>
+              <Route path="dns-forward-zones">
+                <Route path="" element={<DnsForwardZones />} />
               </Route>
               <Route path="configuration" element={<Configuration />} />
               {/* Redirect to Active users page if user is logged in and navigates to the root page */}

--- a/src/navigation/NavRoutes.ts
+++ b/src/navigation/NavRoutes.ts
@@ -55,6 +55,7 @@ const CertificateMappingMatchGroupRef = "cert-id-mapping-match";
 // NETWORK SERVICES
 // - DNS zones
 const DNSZonesGroupRef = "dns-zones";
+const DNSForwardZonesGroupRef = "dns-forward-zones";
 // IPA SERVER
 // - Configuration
 const ConfigRef = "configuration";
@@ -354,6 +355,13 @@ export const navigationRoutes = [
             group: DNSZonesGroupRef,
             title: `${BASE_TITLE} - DNS zones`,
             path: "dns-zones",
+            items: [],
+          },
+          {
+            label: "DNS forward zones",
+            group: DNSForwardZonesGroupRef,
+            title: `${BASE_TITLE} - DNS forward zones`,
+            path: "dns-forward-zones",
             items: [],
           },
         ],

--- a/src/pages/DNSZones/DnsForwardZones.tsx
+++ b/src/pages/DNSZones/DnsForwardZones.tsx
@@ -1,0 +1,483 @@
+import React from "react";
+// PatternFly
+import {
+  Page,
+  PageSection,
+  PageSectionVariants,
+  PaginationVariant,
+} from "@patternfly/react-core";
+import {
+  InnerScrollContainer,
+  OuterScrollContainer,
+} from "@patternfly/react-table";
+// Data types
+import { DNSForwardZone } from "src/utils/datatypes/globalDataTypes";
+// Hooks
+import useAlerts from "src/hooks/useAlerts";
+import useUpdateRoute from "src/hooks/useUpdateRoute";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
+import useApiError from "src/hooks/useApiError";
+// Redux
+import { useAppSelector } from "src/store/hooks";
+// RPC
+import {
+  useGetDnsForwardZonesFullDataQuery,
+  useSearchDnsForwardZonesEntriesMutation,
+} from "src/services/rpcDnsForwardZones";
+// Utils
+import { isDnsForwardZoneSelectable } from "src/utils/utils";
+// React router
+import { useNavigate } from "react-router";
+// Components
+import ToolbarLayout, {
+  ToolbarItem,
+} from "src/components/layouts/ToolbarLayout";
+import SearchInputLayout from "src/components/layouts/SearchInputLayout";
+import SecondaryButton from "src/components/layouts/SecondaryButton";
+import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
+import TitleLayout from "src/components/layouts/TitleLayout";
+import GlobalErrors from "src/components/errors/GlobalErrors";
+import MainTable from "src/components/tables/MainTable";
+import BulkSelectorPrep from "src/components/BulkSelectorPrep";
+import { apiToDnsForwardZone } from "src/utils/dnsForwardZonesUtils";
+
+const DnsForwardZones = () => {
+  const navigate = useNavigate();
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  const { browserTitle } = useUpdateRoute({
+    pathname: "dns-forward-zones",
+  });
+
+  // Set the page title to be shown in the browser tab
+  React.useEffect(() => {
+    document.title = browserTitle;
+  }, [browserTitle]);
+
+  // Retrieve API version from environment data
+  const apiVersion = useAppSelector(
+    (state) => state.global.environment.api_version
+  ) as string;
+
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
+  // URL parameters: page number, page size, search value
+  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+    useListPageSearchParams();
+
+  // Handle API calls errors
+  const globalErrors = useApiError([]);
+
+  // Page indexes
+  const firstUserIdx = (page - 1) * perPage;
+  const lastUserIdx = page * perPage;
+
+  // States
+  const [dnsForwardZones, setDnsForwardZones] = React.useState<
+    DNSForwardZone[]
+  >([]);
+  const [isSearchDisabled, setIsSearchDisabled] =
+    React.useState<boolean>(false);
+  const [totalCount, setTotalCount] = React.useState<number>(0);
+
+  // API calls
+  const forwardDnsZonesResponse = useGetDnsForwardZonesFullDataQuery({
+    searchValue,
+    apiVersion,
+    startIdx: firstUserIdx,
+    stopIdx: lastUserIdx,
+  });
+
+  const { data, isLoading, error } = forwardDnsZonesResponse;
+
+  // Handle data when the API call is finished
+  React.useEffect(() => {
+    if (forwardDnsZonesResponse.isFetching) {
+      setShowTableRows(false);
+      // Reset selected elements on refresh
+      setTotalCount(0);
+      globalErrors.clear();
+      return;
+    }
+
+    // API response: Success
+    if (
+      forwardDnsZonesResponse.isSuccess &&
+      forwardDnsZonesResponse.data &&
+      data != undefined
+    ) {
+      const listResult = data.result.results;
+      const elementsList: DNSForwardZone[] = (
+        listResult as unknown as Record<string, unknown>[]
+      )
+        .filter((result) => "result" in result)
+        .map((result) => apiToDnsForwardZone(result.result));
+
+      setTotalCount(forwardDnsZonesResponse.data.result.totalCount);
+      // Update the list of elements
+      setDnsForwardZones(elementsList);
+      // Show table elements
+      setShowTableRows(true);
+    }
+
+    // API response: Error
+    if (
+      !forwardDnsZonesResponse.isLoading &&
+      forwardDnsZonesResponse.isError &&
+      forwardDnsZonesResponse.error !== undefined
+    ) {
+      // This normally happens when the user is not authorized to view the data
+      // So instead of adding an error, refresh page
+      navigate("/login");
+      window.location.reload();
+    }
+  }, [forwardDnsZonesResponse]);
+
+  // Selected elements
+  const [selectedElements, setSelectedElements] = React.useState<
+    DNSForwardZone[]
+  >([]);
+  const [selectedPerPage, setSelectedPerPage] = React.useState<number>(0);
+
+  // Refresh button handling
+  const refreshData = () => {
+    // Hide table
+    setShowTableRows(false);
+
+    // Reset selected elements on refresh
+    setTotalCount(0);
+
+    forwardDnsZonesResponse.refetch().then(() => {
+      setShowTableRows(true);
+    });
+  };
+
+  // 'Delete' button state
+  const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
+    React.useState<boolean>(true);
+
+  const [isDeletion, setIsDeletion] = React.useState<boolean>(false);
+
+  // 'Enable' button state
+  const [isEnableButtonDisabled, setIsEnableButtonDisabled] =
+    React.useState<boolean>(true);
+
+  // 'Disable' button state
+  const [isDisableButtonDisabled, setIsDisableButtonDisabled] =
+    React.useState<boolean>(true);
+
+  // Table-related shared functionality
+  // - Selectable checkboxes on table
+  const selectableDnsZonesTable = dnsForwardZones.filter(
+    isDnsForwardZoneSelectable
+  ); // elements per Table
+
+  const updateSelectedDnsZones = (
+    dnsZones: DNSForwardZone[],
+    isSelected: boolean
+  ) => {
+    if (isSelected) {
+      setSelectedElements((current) => [...new Set([...current, ...dnsZones])]);
+    } else {
+      const newSelectedDnsZones = selectedElements.filter(
+        (current) =>
+          !dnsZones.some((newZone) => newZone.idnsname === current.idnsname)
+      );
+      setSelectedElements(newSelectedDnsZones);
+    }
+  };
+
+  // - Helper method to set the selected entries from the table
+  const setDnsZonesSelected = (dnsZone: DNSForwardZone, isSelecting = true) => {
+    if (isDnsForwardZoneSelectable(dnsZone)) {
+      updateSelectedDnsZones([dnsZone], isSelecting);
+    }
+  };
+
+  // Always refetch data when the component is loaded.
+  // This ensures the data is always up-to-date.
+  React.useEffect(() => {
+    forwardDnsZonesResponse.refetch();
+  }, []);
+
+  // Show table rows
+  const [showTableRows, setShowTableRows] = React.useState(!isLoading);
+
+  // Show table rows only when data is fully retrieved
+  React.useEffect(() => {
+    if (showTableRows !== !isLoading) {
+      setShowTableRows(!isLoading);
+    }
+  }, [isLoading]);
+
+  // Search API call
+  const [searchEntry] = useSearchDnsForwardZonesEntriesMutation();
+
+  const submitSearchValue = () => {
+    searchEntry({
+      searchValue: searchValue,
+      apiVersion,
+      startIdx: 0,
+      stopIdx: 200, // Search will consider a max. of elements
+    }).then((result) => {
+      if ("error" in result && !("data" in result)) {
+        const searchError = result.error;
+        let error: string | undefined = "";
+        if ("error" in searchError) {
+          error = searchError.error;
+        } else if ("message" in searchError) {
+          error = searchError.message;
+        }
+        alerts.addAlert(
+          "submit-search-value-error",
+          error || "Error when searching for elements",
+          "danger"
+        );
+      } else {
+        // Success
+        const dnsForwardZones = result.data?.result || [];
+
+        setTotalCount(dnsForwardZones.length);
+        setDnsForwardZones(dnsForwardZones);
+        setShowTableRows(true);
+      }
+      setIsSearchDisabled(false);
+    });
+  };
+
+  // Data wrappers
+  // TODO: Better separation of concerns
+  // - 'PaginationLayout'
+  const paginationData = {
+    page,
+    perPage,
+    updatePage: setPage,
+    updatePerPage: setPerPage,
+    updateSelectedPerPage: setSelectedPerPage,
+    updateShownElementsList: setDnsForwardZones,
+    totalCount,
+  };
+
+  // SearchInputLayout
+  const searchValueData = {
+    searchValue,
+    updateSearchValue: setSearchValue,
+    submitSearchValue,
+  };
+
+  // - 'BulkSelectorPrep'
+  const bulkSelectorData = {
+    selected: selectedElements,
+    updateSelected: updateSelectedDnsZones,
+    selectableTable: selectableDnsZonesTable,
+    nameAttr: "idnsname",
+  };
+
+  const selectedPerPageData = {
+    selectedPerPage,
+    updateSelectedPerPage: setSelectedPerPage,
+  };
+
+  // List of Toolbar items
+  const toolbarItems: ToolbarItem[] = [
+    {
+      key: 0,
+      element: (
+        <BulkSelectorPrep
+          list={dnsForwardZones}
+          shownElementsList={dnsForwardZones}
+          elementData={bulkSelectorData}
+          buttonsData={{
+            updateIsDeleteButtonDisabled: setIsDeleteButtonDisabled,
+          }}
+          selectedPerPageData={selectedPerPageData}
+        />
+      ),
+    },
+    {
+      key: 1,
+      element: (
+        <SearchInputLayout
+          name="search"
+          ariaLabel="Search dns zones"
+          placeholder="Search"
+          searchValueData={searchValueData}
+          isDisabled={isSearchDisabled}
+          dataCy={"search"}
+        />
+      ),
+      toolbarItemVariant: "search-filter",
+      toolbarItemSpacer: { default: "spacerMd" },
+    },
+    {
+      key: 2,
+      toolbarItemVariant: "separator",
+    },
+    {
+      key: 3,
+      element: (
+        <SecondaryButton
+          onClickHandler={refreshData}
+          isDisabled={!showTableRows}
+          dataCy={"dns-forward-zones-refresh"}
+        >
+          Refresh
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 4,
+      element: (
+        <SecondaryButton
+          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          dataCy={"dns-forward-zones-delete"}
+        >
+          Delete
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 5,
+      element: (
+        <SecondaryButton
+          isDisabled={!showTableRows}
+          dataCy={"dns-forward-zones-add"}
+        >
+          Add
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 6,
+      element: (
+        <SecondaryButton
+          isDisabled={isDisableButtonDisabled || !showTableRows}
+          dataCy={"dns-forward-zones-disable"}
+        >
+          Disable
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 7,
+      element: (
+        <SecondaryButton
+          isDisabled={isEnableButtonDisabled || !showTableRows}
+          dataCy={"dns-forward-zones-enable"}
+        >
+          Enable
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 8,
+      toolbarItemVariant: "separator",
+    },
+    {
+      key: 9,
+      element: <HelpTextWithIconLayout textContent="Help" />,
+    },
+    {
+      key: 10,
+      element: (
+        <PaginationLayout
+          list={dnsForwardZones}
+          paginationData={paginationData}
+          widgetId="pagination-options-menu-top"
+          isCompact={true}
+        />
+      ),
+      toolbarItemAlignment: { default: "alignRight" },
+    },
+  ];
+
+  // Render component
+  return (
+    <Page>
+      <alerts.ManagedAlerts />
+      <PageSection variant={PageSectionVariants.light}>
+        <TitleLayout
+          id="DNS forward zones page"
+          headingLevel="h1"
+          text="DNS forward zones"
+        />
+      </PageSection>
+      <PageSection
+        variant={PageSectionVariants.light}
+        isFilled={false}
+        className="pf-v5-u-m-lg pf-v5-u-pb-md pf-v5-u-pl-0 pf-v5-u-pr-0"
+      >
+        <ToolbarLayout
+          className="pf-v5-u-pt-0 pf-v5-u-pl-lg pf-v5-u-pr-md"
+          contentClassName="pf-v5-u-p-0"
+          toolbarItems={toolbarItems}
+        />
+        <div style={{ height: `calc(100vh - 352.2px)` }}>
+          <OuterScrollContainer>
+            <InnerScrollContainer>
+              {error !== undefined && error ? (
+                <GlobalErrors errors={globalErrors.getAll()} />
+              ) : (
+                <MainTable
+                  tableTitle="DNS forward zones table"
+                  shownElementsList={dnsForwardZones}
+                  pk="idnsname"
+                  keyNames={[
+                    "idnsname",
+                    "idnszoneactive",
+                    "idnsforwarders",
+                    "idnsforwardpolicy",
+                  ]}
+                  columnNames={[
+                    "Zone name",
+                    "Status",
+                    "Zone Forwarders",
+                    "Forward policy",
+                  ]}
+                  hasCheckboxes={true}
+                  pathname="dns-forward-zones"
+                  showTableRows={showTableRows}
+                  showLink={false}
+                  elementsData={{
+                    isElementSelectable: isDnsForwardZoneSelectable,
+                    selectedElements,
+                    selectableElementsTable: selectableDnsZonesTable,
+                    setElementsSelected: setDnsZonesSelected,
+                    clearSelectedElements: () => setSelectedElements([]),
+                  }}
+                  buttonsData={{
+                    updateIsDeleteButtonDisabled: (value) =>
+                      setIsDeleteButtonDisabled(value),
+                    isDeletion,
+                    updateIsDeletion: (value) => setIsDeletion(value),
+                    updateIsEnableButtonDisabled: (value) =>
+                      setIsEnableButtonDisabled(value),
+                    updateIsDisableButtonDisabled: (value) =>
+                      setIsDisableButtonDisabled(value),
+                    isDisableEnableOp: true,
+                  }}
+                  paginationData={{
+                    selectedPerPage,
+                    updateSelectedPerPage: setSelectedPerPage,
+                  }}
+                  statusElementName="idnszoneactive"
+                />
+              )}
+            </InnerScrollContainer>
+          </OuterScrollContainer>
+        </div>
+        <PaginationLayout
+          list={dnsForwardZones}
+          paginationData={paginationData}
+          variant={PaginationVariant.bottom}
+          widgetId="pagination-options-menu-bottom"
+          className="pf-v5-u-pb-0 pf-v5-u-pr-md"
+        />
+      </PageSection>
+    </Page>
+  );
+};
+
+export default DnsForwardZones;

--- a/src/services/rpc.ts
+++ b/src/services/rpc.ts
@@ -52,9 +52,11 @@ export interface BatchResponse {
 }
 
 export interface ErrorResult {
+  status: string;
   code: number;
   message: string;
   data: {
+    name: string;
     attr: string;
     value: string;
   };

--- a/src/services/rpcDnsForwardZones.ts
+++ b/src/services/rpcDnsForwardZones.ts
@@ -1,0 +1,269 @@
+import {
+  api,
+  BatchRPCResponse,
+  Command,
+  FindRPCResponse,
+  getBatchCommand,
+  getCommand,
+} from "./rpc";
+// utils
+import { API_VERSION_BACKUP } from "../utils/utils";
+// Data types
+import {
+  DNSForwardZone,
+  dnsZoneType,
+} from "src/utils/datatypes/globalDataTypes";
+import { apiToDnsForwardZone } from "src/utils/dnsForwardZonesUtils";
+
+/**
+ * Forward DNS zones-related endpoint: useDnsForwardZonesFindQuery, useGetDnsForwardZonesFullDataQuery,
+                            useSearchDnsForwardZonesEntriesMutation,
+ *
+ * API commands:
+ * - dnsforwardzone_find: https://freeipa.readthedocs.io/en/latest/api/dnsforwardzone_find.html
+ * - dnsforwardzone_show: https://freeipa.readthedocs.io/en/latest/api/dnsforwardzone_show.html
+ */
+
+export interface DnsForwardZonesFindPayload {
+  searchValue: string;
+  pkeyOnly: boolean;
+  version?: string;
+}
+
+export interface DnsForwardZonesFullDataPayload {
+  searchValue: string;
+  apiVersion: string;
+  startIdx: number;
+  stopIdx: number;
+}
+
+export interface DnsForwardZoneBatchResponse {
+  error: string;
+  id: string;
+  principal: string;
+  version: string;
+  result: DNSForwardZone[];
+}
+
+/**
+ * Get DNS forward zones IDs
+ * @param {DnsForwardZonesFindPayload} payload - The payload containing search parameters
+ * @returns {Command<FindRPCResponse<DNSForwardZone>>} - Promise with the response data
+ *
+ */
+const dnsForwardZonesFind = (
+  payload: DnsForwardZonesFindPayload,
+  method_name: string
+) => {
+  const dnsForwardZonesParams = {
+    pkey_only: payload.pkeyOnly,
+    version: payload.version || API_VERSION_BACKUP,
+  };
+
+  return getCommand({
+    method: method_name,
+    params: [[payload.searchValue], dnsForwardZonesParams],
+  });
+};
+
+const extendedApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    /**
+     * Get DNS zones IDs
+     * @param {DnsForwardZonesFindPayload} payload - The payload containing search parameters
+     * @returns {Command<FindRPCResponse<DNSZone>>} - Promise with the response data
+     *
+     */
+    dnsForwardZonesFind: build.query<
+      FindRPCResponse,
+      DnsForwardZonesFindPayload
+    >({
+      query: (payload) => {
+        return dnsForwardZonesFind(payload, "dnsforwardzone_find");
+      },
+    }),
+    /**
+     * Find DNS zones full data
+     * @param {DnsForwardZonesFullDataPayload} payload - The payload containing search parameters
+     * @returns {BatchRPCResponse} - List of DNS zones full data
+     *
+     */
+    getDnsForwardZonesFullData: build.query<
+      BatchRPCResponse,
+      DnsForwardZonesFullDataPayload
+    >({
+      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
+        const { searchValue, apiVersion, startIdx, stopIdx } = payloadData;
+
+        if (apiVersion === undefined) {
+          return {
+            error: {
+              status: "CUSTOM_ERROR",
+              data: "",
+              error: "API version not available",
+            },
+          };
+        }
+
+        // FETCH DNS FORWARD ZONES DATA VIA "dnsforwardzone_find" COMMAND
+        // Prepare search parameters
+        const dnsForwardZonesIdsParams: DnsForwardZonesFindPayload = {
+          pkeyOnly: true,
+          version: apiVersion,
+          searchValue,
+        };
+
+        // Make call using 'fetchWithBQ'
+        const getResultDnsForwardZones = await fetchWithBQ(
+          dnsForwardZonesFind(dnsForwardZonesIdsParams, "dnsforwardzone_find")
+        );
+        // Return possible errors
+        if (getResultDnsForwardZones.error) {
+          return { error: getResultDnsForwardZones.error };
+        }
+        // If no error: cast and assign 'ids'
+        const responseDataDnsForwardZones =
+          getResultDnsForwardZones.data as FindRPCResponse;
+
+        const dnsZonesIds: string[] = [];
+        const dnsZonesItemsCount = responseDataDnsForwardZones.result.result
+          .length as number;
+
+        for (let i = startIdx; i < dnsZonesItemsCount && i < stopIdx; i++) {
+          const dnsZoneId = responseDataDnsForwardZones.result.result[
+            i
+          ] as dnsZoneType;
+          const dnsName = dnsZoneId.idnsname[0]["__dns_name__"];
+          if (dnsName) {
+            dnsZonesIds.push(dnsName as string);
+          }
+        }
+
+        // FETCH DNS FORWARD ZONE DATA VIA "dnsforwardzone_show" COMMAND
+        const commands: Command[] = [];
+        dnsZonesIds.forEach((dnsZoneId) => {
+          commands.push({
+            method: "dnsforwardzone_show",
+            params: [[dnsZoneId], {}],
+          });
+        });
+
+        const dnsForwardZonesShowResult = await fetchWithBQ(
+          getBatchCommand(commands, apiVersion)
+        );
+
+        const response = dnsForwardZonesShowResult.data as BatchRPCResponse;
+        if (response) {
+          response.result.totalCount = dnsZonesItemsCount;
+        }
+
+        // Return results
+        return { data: response };
+      },
+    }),
+    /**
+     * Search for a specific DNS zone
+     * @param {DnsForwardZonesFullDataPayload} payload - The payload containing search parameters
+     * @returns {DnsForwardZoneBatchResponse} - List of DNS zones full data
+     */
+    searchDnsForwardZonesEntries: build.mutation<
+      DnsForwardZoneBatchResponse,
+      DnsForwardZonesFullDataPayload
+    >({
+      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
+        const { searchValue, apiVersion, startIdx, stopIdx } = payloadData;
+
+        if (apiVersion === undefined) {
+          return {
+            error: {
+              status: "CUSTOM_ERROR",
+              data: "",
+              error: "API version not available",
+            },
+          };
+        }
+
+        // FETCH DNS ZONES DATA VIA "dnszone_find" COMMAND
+        // Prepare search parameters
+        const dnsForwardZonesIdsParams: DnsForwardZonesFindPayload = {
+          pkeyOnly: true,
+          version: apiVersion,
+          searchValue,
+        };
+
+        // Make call using 'fetchWithBQ'
+        const getResultDnsForwardZones = await fetchWithBQ(
+          dnsForwardZonesFind(dnsForwardZonesIdsParams, "dnsforwardzone_find")
+        );
+        // Return possible errors
+        if (getResultDnsForwardZones.error) {
+          return { error: getResultDnsForwardZones.error };
+        }
+        // If no error: cast and assign 'ids'
+        const responseDataDnsForwardZones =
+          getResultDnsForwardZones.data as FindRPCResponse;
+
+        const dnsZonesIds: string[] = [];
+        const dnsZonesItemsCount = responseDataDnsForwardZones.result.result
+          .length as number;
+
+        for (let i = startIdx; i < dnsZonesItemsCount && i < stopIdx; i++) {
+          const dnsZoneId = responseDataDnsForwardZones.result.result[
+            i
+          ] as dnsZoneType;
+          const dnsName = dnsZoneId.idnsname[0]["__dns_name__"];
+          if (dnsName) {
+            dnsZonesIds.push(dnsName as string);
+          }
+        }
+
+        // FETCH DNS ZONE DATA VIA "dnsforwardzone_show" COMMAND
+        const commands: Command[] = [];
+        dnsZonesIds.forEach((dnsZoneId) => {
+          commands.push({
+            method: "dnsforwardzone_show",
+            params: [[dnsZoneId], {}],
+          });
+        });
+
+        const dnsForwardZonesShowResult = await fetchWithBQ(
+          getBatchCommand(commands, apiVersion)
+        );
+
+        const response = dnsForwardZonesShowResult.data as BatchRPCResponse;
+        if (response) {
+          response.result.totalCount = dnsZonesItemsCount;
+        }
+
+        // Handle the '__dns_name__' fields
+        const dnsForwardZones: DNSForwardZone[] = [];
+        const count = response.result.totalCount;
+        for (let i = 0; i < count; i++) {
+          const dnsZone = response.result.results[i].result as Record<
+            string,
+            unknown
+          >;
+          // Convert API object to DNSForwardZone type
+          const convertedDnsForwardZone: DNSForwardZone =
+            apiToDnsForwardZone(dnsZone);
+          dnsForwardZones.push(convertedDnsForwardZone);
+        }
+
+        // Return results
+        return {
+          data: {
+            ...response,
+            result: dnsForwardZones,
+          },
+        };
+      },
+    }),
+  }),
+  overrideExisting: false,
+});
+
+export const {
+  useDnsForwardZonesFindQuery,
+  useGetDnsForwardZonesFullDataQuery,
+  useSearchDnsForwardZonesEntriesMutation,
+} = extendedApi;

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -842,6 +842,16 @@ export type DnsRecordType =
   | "TXT"
   | "URI";
 
+export interface DNSForwardZone {
+  dn: string;
+  idnsname: string;
+  idnsforwarders: string[];
+  idnsforwardpolicy: IDNSForwardPolicy;
+  idnszoneactive: boolean;
+  name_from_ip?: string;
+  managedby?: string;
+}
+
 export interface Automember {
   cn: string;
   description: string;

--- a/src/utils/dnsForwardZonesUtils.tsx
+++ b/src/utils/dnsForwardZonesUtils.tsx
@@ -1,0 +1,58 @@
+// Data types
+import { DNSForwardZone } from "./datatypes/globalDataTypes";
+import { convertApiObj } from "src/utils/ipaObjectUtils";
+
+export const dnsForwardZoneAsRecord = (
+  element: Partial<DNSForwardZone>,
+  onElementChange: (element: Partial<DNSForwardZone>) => void
+) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ipaObject = element as Record<string, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const recordOnChange = (ipaObject: Record<string, any>) => {
+    onElementChange(ipaObject as DNSForwardZone);
+  };
+
+  return { ipaObject, recordOnChange };
+};
+
+const simpleValues = new Set<keyof DNSForwardZone>([
+  "dn",
+  "idnsforwardpolicy",
+  "idnszoneactive",
+  "name_from_ip",
+  "managedby",
+]);
+const dateValues = new Set<keyof DNSForwardZone>([]);
+const complexValues = new Map<keyof DNSForwardZone, string>([
+  ["idnsname", "__dns_name__"],
+]);
+
+export function apiToDnsForwardZone(apiRecord: unknown): DNSForwardZone {
+  const converted = convertApiObj(
+    apiRecord as Record<string, unknown>,
+    simpleValues,
+    dateValues,
+    complexValues
+  ) as Partial<DNSForwardZone>;
+  return partialDnsForwardZoneToDnsForwardZone(converted);
+}
+
+export function partialDnsForwardZoneToDnsForwardZone(
+  partialDnsZone: Partial<DNSForwardZone>
+): DNSForwardZone {
+  return {
+    ...createEmptyDnsForwardZone(),
+    ...partialDnsZone,
+  };
+}
+
+export function createEmptyDnsForwardZone(): DNSForwardZone {
+  return {
+    dn: "",
+    idnsname: "",
+    idnsforwarders: [],
+    idnsforwardpolicy: "first",
+    idnszoneactive: false,
+  };
+}

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -24,6 +24,7 @@ import {
   CertificateMapping,
   DNSZone,
   DNSRecord,
+  DNSForwardZone,
 } from "./datatypes/globalDataTypes";
 // Errors
 import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
@@ -205,6 +206,9 @@ export const isDnsZoneSelectable = (dnsZone: DNSZone) =>
 
 export const isDnsRecordSelectable = (dnsRecord: DNSRecord) =>
   dnsRecord.idnsname !== "";
+
+export const isDnsForwardZoneSelectable = (dnsForwardZone: DNSForwardZone) =>
+  dnsForwardZone.idnsname !== "";
 
 /**
  * Write JSX error messages into 'apiErrorsJsx' array


### PR DESCRIPTION
Adds a new page.
I also wanted to experiment a little bit with typing, so this code contains PoC of typed responses. We can revert those, as they duplicate the code a bit as of right now.

## Summary by Sourcery

Add support for DNS forward zones end-to-end by defining data models, RPC endpoints, conversion utilities, and a new React page with routing, navigation, and interactive UI for managing forward zones.

New Features:
- Add DNS Forward Zones page with UI components for listing, searching, pagination, and bulk actions
- Introduce new RTK Query endpoints for DNS forward zones (find, full data, search)

Enhancements:
- Define DNSForwardZone type and IDNSForwardPolicy enum in data types
- Provide utilities for converting API records to DNSForwardZone instances
- Extend RPC layer with PoC typed response interfaces (MaybePromise, ValidRPCResponse, etc.)