### PR TITLE
Add data-cy

### DIFF
--- a/cypress/README.md
+++ b/cypress/README.md
@@ -1,0 +1,324 @@
+# Cypress rules
+
+## Attribute Usage
+
+**PatternFly components**: Use `data-cy` directly
+**Custom components**: Use `dataCy` prop (passed through to `data-cy`)
+
+All values use kebab-case formatting.
+
+## General Naming Convention
+
+Follow this hierarchy for naming:
+
+```
+{page-name}-{component-type}-{action/identifier}
+```
+
+## Toolbar
+
+Toolbar is prefixed with `toolbar` instead of a page name.
+Otherwise follows same rules as all components below
+
+```
+toolbar-button-about
+toolbar-button-logout
+```
+
+## Navigation
+
+Navigation elements follow this pattern:
+
+```
+nav-{section}
+nav-button-{action}
+nav-link-{page-name}
+```
+
+Examples:
+
+```
+nav-identity
+nav-policy
+nav-authentication
+nav-link-active-users
+nav-link-user-groups
+```
+
+## Breadcrumbs
+
+TODO
+
+## Pages
+
+Most pages consist of search bar, table and buttons.
+
+### Search Bar
+
+Each page has a search bar, that is always identified simply as
+
+```
+search
+```
+
+### Page Buttons
+
+Page toolbar buttons follow this pattern:
+
+```
+{page-name}-button-{action}
+```
+
+Examples:
+
+```
+active-users-button-add
+active-users-button-delete
+active-users-button-refresh
+host-groups-button-add
+```
+
+### Kebab Menus
+
+Kebab menus have `-kebab` postfix:
+
+```
+{page-name}-kebab
+```
+
+Kebab items follow this pattern:
+
+```
+{page-name}-kebab-{action}
+```
+
+Examples:
+
+```
+active-users-kebab
+active-users-kebab-rebuild-auto-membership
+```
+
+## Tables
+
+Tables and their components follow these patterns:
+
+```
+{page-name}-table
+```
+
+Examples:
+
+```
+active-users-table
+```
+
+## Tabs
+
+Follow similar naming fashion as pages:
+
+```
+{page-name}-tab-{tab-name}
+```
+
+Examples:
+
+```
+active-users-tab-memberof
+host-groups-tab-settings
+```
+
+## Settings Pages
+
+When clicking on an entry, we get to its settings page.
+Components in the tabs follow similar naming rules, prefixed with the whole tab name.
+
+### Inputs
+
+```
+{page-name}-tab-{tab-name}-textbox-{field-name}
+{page-name}-tab-{tab-name}-select-{field-name}
+{page-name}-tab-{tab-name}-checkbox-{field-name}
+```
+
+Examples:
+
+```
+active-users-tab-settings-textbox-first-name
+active-users-tab-settings-textbox-last-name
+```
+
+### Buttons
+
+```
+{page-name}-tab-{tab-name}-button-{action}
+```
+
+Examples:
+
+```
+active-users-tab-settings-button-refresh
+active-users-tab-settings-button-save
+```
+
+### Kebab
+
+Kebab for the actions simply has `-kebab` postfix
+
+```
+{page-name}-tab-{tab-name}-kebab
+{page-name}-tab-{tab-name}-kebab-{action}
+```
+
+Examples:
+
+```
+active-users-tab-settings-kebab
+active-users-tab-settings-kebab-new-certificate
+```
+
+## Other pages
+
+There are pages without tabs, these just omit the tab part.
+
+```
+{page-name}-button-{action}
+```
+
+Examples:
+
+```
+certificate-identity-mapping-match-textbox-issuer
+certificate-identity-mapping-match-textbox-subject
+```
+
+## Modals
+
+Modals follow this naming scheme:
+
+```
+{component-name}-modal
+```
+
+Examples:
+
+```
+add-user-modal
+delete-users-modal
+add-hbac-rule-modal
+reset-password-modal
+```
+
+### Error Modals
+
+Error modals within other modals have `-error` postfix:
+
+```
+{component-name}-modal-error
+```
+
+Examples:
+
+```
+add-user-modal-error
+delete-users-modal-error
+add-hbac-rule-modal-error
+```
+
+### Modal Buttons
+
+Modal buttons are always prefixed with `modal-button-`, followed by their action:
+
+```
+modal-button-{action}
+```
+
+Common examples:
+
+```
+modal-button-add
+modal-button-delete
+modal-button-cancel
+modal-button-save
+modal-button-reset
+modal-button-ok
+modal-button-enable
+modal-button-disable
+```
+
+### Modal Form Elements
+
+Modal form controls are simply prefixed with `modal`, as opening more than one modal is considered a bad practice.
+
+```
+modal-textbox-{field-name}
+modal-select-{field-name}
+modal-checkbox-{field-name}
+```
+
+## Form Components
+
+Form components throughout the application follow these patterns:
+
+### Input Components
+
+We don't differentiate between `input type="text"` and `textarea`, both are `textbox`
+
+```
+{context}-textbox-{field-name}
+{context}-select-{field-name}
+{context}-checkbox-{field-name}
+{context}-radio-{field-name}
+```
+
+### Button Components
+
+```
+{context}-button-{action}
+```
+
+### Toggle groups
+
+```
+{context}-toggle-group-{field-name}
+```
+
+### Select
+
+```
+{context}-field-name
+```
+
+### Dropdown
+
+```
+{context}-field-name
+```
+
+## Special Cases
+
+### Login Pages
+
+```
+login-textbox-username
+login-textbox-password
+login-button-submit
+```
+
+## Best Practices
+
+1. **Consistency**: Always use kebab-case
+2. **Hierarchy**: Follow the naming hierarchy for clarity
+3. **Uniqueness**: Ensure each data-cy value is unique across the application
+4. **Descriptive**: Use clear, descriptive names that indicate purpose
+5. **Avoid Ambiguity**: Don't use generic terms like "button" or "input" alone
+6. **Component Reuse**: For reusable components, accept `dataCy` as a prop
+7. **Error Handling**: Always add data-cy to error modals and validation messages
+
+## Testing Notes
+
+- Use `cy.dataCy(value)` command for selecting elements
+- Prefer data-cy over other selectors for stability
+- Test both success and error scenarios
+- Verify modal opening/closing behavior
+- Test form validation and submission

--- a/src/AppLayout.tsx
+++ b/src/AppLayout.tsx
@@ -94,19 +94,36 @@ const AppLayout = (props: PropsToAppLayout) => {
   };
 
   const dropdownItems = [
-    <DropdownItem key="profile" component="button">
+    <DropdownItem
+      key="profile"
+      component="button"
+      data-cy="toolbar-button-profile"
+    >
       <UserIcon /> Profile
     </DropdownItem>,
-    <DropdownItem key="change-password" component="button">
+    <DropdownItem
+      key="change-password"
+      component="button"
+      data-cy="toolbar-button-change-password"
+    >
       <KeyIcon /> Change password
     </DropdownItem>,
-    <DropdownItem key="customization" component="button">
+    <DropdownItem
+      key="customization"
+      component="button"
+      data-cy="toolbar-button-customization"
+    >
       <CogIcon /> Customization
     </DropdownItem>,
-    <DropdownItem key="about" component="button">
+    <DropdownItem key="about" component="button" data-cy="toolbar-button-about">
       <UnknownIcon /> About
     </DropdownItem>,
-    <DropdownItem key="logout" component="button" onClick={onLogout}>
+    <DropdownItem
+      key="logout"
+      component="button"
+      onClick={onLogout}
+      data-cy="toolbar-button-logout"
+    >
       <ShareSquareIcon /> Log out
     </DropdownItem>,
   ];
@@ -114,9 +131,11 @@ const AppLayout = (props: PropsToAppLayout) => {
   // TODO: Show the proper user login
   const dropdown = (
     <Dropdown
+      data-cy="toolbar-dropdown"
       onSelect={onDropdownSelect}
       toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
         <MenuToggle
+          data-cy="toolbar-username"
           ref={toggleRef}
           id="toggle-plain-text"
           onClick={onDropdownToggle}
@@ -136,7 +155,11 @@ const AppLayout = (props: PropsToAppLayout) => {
   const Header = (
     <Masthead>
       <MastheadToggle>
-        <PageToggleButton variant="plain" aria-label="Global navigation">
+        <PageToggleButton
+          data-cy="toolbar-button-toggle"
+          variant="plain"
+          aria-label="Global navigation"
+        >
           <BarsIcon />
         </PageToggleButton>
       </MastheadToggle>

--- a/src/components/AutomemberSections/InclusiveExclusiveSection.tsx
+++ b/src/components/AutomemberSections/InclusiveExclusiveSection.tsx
@@ -317,10 +317,11 @@ const InclusiveExclusiveSection = (props: PropsToInclusiveExclusiveSection) => {
       name: "Attribute",
       pfComponent: (
         <SimpleSelector
+          dataCy="modal-attribute"
           id="attribute"
           selected={key}
           options={userAciAttrs.map((name) => ({
-            label: name,
+            key: name,
             value: name,
           }))}
           onSelectedChange={(selected: string) => setkey(selected)}
@@ -333,6 +334,7 @@ const InclusiveExclusiveSection = (props: PropsToInclusiveExclusiveSection) => {
       fieldRequired: true,
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-expression"
           id="expression"
           value={expression}
           onChange={(_event, value: string) => setExpression(value)}
@@ -343,6 +345,7 @@ const InclusiveExclusiveSection = (props: PropsToInclusiveExclusiveSection) => {
 
   const addModalActions: JSX.Element[] = [
     <Button
+      data-cy="modal-button-add"
       key="add-inclusive"
       variant="primary"
       form={"add-" + props.conditionType + "-option-modal"}
@@ -355,6 +358,7 @@ const InclusiveExclusiveSection = (props: PropsToInclusiveExclusiveSection) => {
       {spinningOnAdd ? "Adding" : "Add"}
     </Button>,
     <Button
+      data-cy="modal-button-add-and-add-another"
       key="add-another-inclusive"
       variant="primary"
       form={"add-another" + props.conditionType + "option-modal"}
@@ -367,6 +371,7 @@ const InclusiveExclusiveSection = (props: PropsToInclusiveExclusiveSection) => {
       {spinningOnAdd ? "Adding" : "Add and add another"}
     </Button>,
     <Button
+      data-cy="modal-button-cancel"
       key={"cancel-add-" + props.conditionType}
       variant="link"
       onClick={onChangeAddModalVisibility}
@@ -437,6 +442,7 @@ const InclusiveExclusiveSection = (props: PropsToInclusiveExclusiveSection) => {
       />
       {/* Add option modal */}
       <ModalWithFormLayout
+        dataCy="add-automember-condition-modal"
         variantType="medium"
         modalPosition="top"
         title={"Add " + props.conditionType + " conditions"}

--- a/src/components/BulkSelectorPrep/BulkSelectorPrep.tsx
+++ b/src/components/BulkSelectorPrep/BulkSelectorPrep.tsx
@@ -142,6 +142,7 @@ const BulkSelectorPrep = <Type,>(props: PropsToBulkSelectorPrep<Type>) => {
   // Menu toggle element with checkbox
   const toggle = (
     <MenuToggle
+      data-cy="bulk-selector-prep"
       ref={toggleRefMenu}
       onClick={onToggleClick}
       isExpanded={isOpenMenu}

--- a/src/components/CertificateMappingDataOption.tsx
+++ b/src/components/CertificateMappingDataOption.tsx
@@ -14,6 +14,7 @@ import PopoverWithIconLayout from "./layouts/PopoverWithIconLayout";
 import SecondaryButton from "./layouts/SecondaryButton";
 
 interface PropsToCertificateMappingDataOption {
+  dataCy: string;
   isCertMappingDataChecked: boolean;
   onChangeCertMappingDataCheck: (value: boolean) => void;
   setIsAddButtonDisabled: (value: boolean) => void;
@@ -94,6 +95,7 @@ const CertificateMappingDataOption = (
               name={"flexitem-ipacertmapdata-" + idx + "-div"}
             >
               <TextInput
+                data-cy="modal-textbox-cert-map-data"
                 id="cert-map-data"
                 value={certMap}
                 type="text"
@@ -106,6 +108,7 @@ const CertificateMappingDataOption = (
             </FlexItem>
             <FlexItem key={"ipacertmapdata-" + idx + "-delete-button"}>
               <SecondaryButton
+                dataCy={"modal-button-delete-ipacertmapdata-" + certMap}
                 name="remove"
                 onClickHandler={() =>
                   onRemoveCertificateMappingDataHandler(idx)
@@ -118,6 +121,7 @@ const CertificateMappingDataOption = (
         ))}
       </Flex>
       <SecondaryButton
+        dataCy="modal-button-add-ipacertmapdata"
         name={"add-ipacertmapdata"}
         classname="pf-v5-u-mt-sm pf-v5-u-mb-0"
         isDisabled={!props.isCertMappingDataChecked}
@@ -167,6 +171,7 @@ const CertificateMappingDataOption = (
               flex={{ default: "flex_1" }}
             >
               <TextArea
+                data-cy="modal-textbox-cert"
                 id="cert-map-data"
                 value={certificate}
                 type="text"
@@ -184,6 +189,7 @@ const CertificateMappingDataOption = (
               name={"certificate-" + idx + "-delete-button"}
             >
               <SecondaryButton
+                dataCy={"modal-button-delete-certificate-" + certificate}
                 name="remove"
                 onClickHandler={() => onRemoveCertificateHandler(idx)}
               >
@@ -194,6 +200,7 @@ const CertificateMappingDataOption = (
         ))}
       </Flex>
       <SecondaryButton
+        dataCy="modal-button-add-certificate"
         name={"add-certificate"}
         classname="pf-v5-u-mt-sm"
         isDisabled={!props.isCertMappingDataChecked}
@@ -214,6 +221,7 @@ const CertificateMappingDataOption = (
   return (
     <>
       <Radio
+        data-cy="modal-radio-cert-mapping-data"
         isChecked={props.isCertMappingDataChecked}
         name="cert-mapping-data-radio"
         onChange={(_event, value) => props.onChangeCertMappingDataCheck(value)}

--- a/src/components/Form/DateTimeSelector/DateTimeSelector.test.tsx
+++ b/src/components/Form/DateTimeSelector/DateTimeSelector.test.tsx
@@ -14,6 +14,7 @@ describe("DateTimeSelector Component", () => {
   const mockOnChange = vi.fn();
 
   const defaultProps = {
+    dataCy: "date-time-selector",
     datetime: null,
     onChange: mockOnChange,
     name: "krbpasswordexpiration",

--- a/src/components/Form/DateTimeSelector/DateTimeSelector.tsx
+++ b/src/components/Form/DateTimeSelector/DateTimeSelector.tsx
@@ -8,6 +8,7 @@ import {
 } from "@patternfly/react-core";
 
 interface PropsToDateTimeSelector {
+  dataCy: string;
   datetime: Date | null;
   onChange?: (timeValue: Date | null) => void;
   name: string;
@@ -109,6 +110,9 @@ const DateTimeSelector = (props: PropsToDateTimeSelector) => {
   return (
     <InputGroup>
       <DatePicker
+        inputProps={{
+          "data-cy": props.dataCy + "-date",
+        }}
         name={props.name}
         value={dateText}
         onChange={onDateChange}
@@ -117,6 +121,9 @@ const DateTimeSelector = (props: PropsToDateTimeSelector) => {
         isDisabled={props.isDisabled || false}
       />
       <TimePicker
+        inputProps={{
+          "data-cy": props.dataCy + "-time",
+        }}
         name={props.name}
         time={timeText}
         aria-label={props.ariaLabel || props.name}

--- a/src/components/Form/IpaCalendar/IpaCalendar.test.tsx
+++ b/src/components/Form/IpaCalendar/IpaCalendar.test.tsx
@@ -2,9 +2,9 @@ import React from "react";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { vi, describe, it, expect, afterEach } from "vitest";
 // Component
-import IpaCalendar from "./IpaCalendar";
+import IpaCalendar, { IpaCalendarProps } from "./IpaCalendar";
 // Utils
-import { IPAParamDefinition, updateIpaObject } from "src/utils/ipaObjectUtils";
+import { updateIpaObject } from "src/utils/ipaObjectUtils";
 
 // Mock of util function: updateIpaObject
 vi.mock("src/utils/ipaObjectUtils", async () => ({
@@ -51,7 +51,8 @@ describe("IpaCalendar Component", () => {
     },
   };
 
-  const defaultProps: IPAParamDefinition = {
+  const defaultProps: IpaCalendarProps = {
+    dataCy: "ipa-calendar",
     name: "krbpasswordexpiration2",
     ariaLabel: "Kerberos password expiration date 2",
     ipaObject: {},

--- a/src/components/Form/IpaCalendar/IpaCalendar.tsx
+++ b/src/components/Form/IpaCalendar/IpaCalendar.tsx
@@ -25,6 +25,10 @@ export interface ParamPropertiesDateTime {
   paramMetadata: ParamMetadata;
 }
 
+export interface IpaCalendarProps extends IPAParamDefinition {
+  dataCy: string;
+}
+
 function getParamPropertiesDateTime(
   parDef: IPAParamDefinition
 ): ParamPropertiesDateTime {
@@ -48,7 +52,7 @@ function getParamPropertiesDateTime(
   };
 }
 
-const IpaCalendar = (props: IPAParamDefinition) => {
+const IpaCalendar = (props: IpaCalendarProps) => {
   const { readOnly, value } = getParamPropertiesDateTime(props);
 
   const onDateChange = (date: Date | null) => {
@@ -59,6 +63,7 @@ const IpaCalendar = (props: IPAParamDefinition) => {
 
   return (
     <DateTimeSelector
+      dataCy={props.dataCy}
       datetime={value}
       onChange={onDateChange}
       name={props.name}

--- a/src/components/Form/IpaCertificateMappingData/IpaCertificateMappingData.tsx
+++ b/src/components/Form/IpaCertificateMappingData/IpaCertificateMappingData.tsx
@@ -104,6 +104,7 @@ const IpaCertificateMappingData = (props: PropsToIpaCertificateMappingData) => {
 
   const deletionModalActions = [
     <Button
+      data-cy="modal-button-delete"
       key="del-certificate-mapping-data"
       variant="danger"
       onClick={() => onRemoveCertificateMappingData(idxToDelete)}
@@ -115,7 +116,12 @@ const IpaCertificateMappingData = (props: PropsToIpaCertificateMappingData) => {
     >
       {modalSpinning ? "Deleting" : "Delete"}
     </Button>,
-    <Button key="cancel" variant="link" onClick={onCloseDeletionModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel"
+      variant="link"
+      onClick={onCloseDeletionModal}
+    >
       Cancel
     </Button>,
   ];
@@ -269,6 +275,7 @@ const IpaCertificateMappingData = (props: PropsToIpaCertificateMappingData) => {
 
   const actions = [
     <SecondaryButton
+      dataCy="modal-button-add"
       key="add"
       onClickHandler={onAddCertificateMappingData}
       isDisabled={isAddButtonDisabled}
@@ -281,6 +288,7 @@ const IpaCertificateMappingData = (props: PropsToIpaCertificateMappingData) => {
       {modalSpinning ? "Adding" : "Add"}
     </SecondaryButton>,
     <Button
+      data-cy="modal-button-cancel"
       key="cancel"
       variant="link"
       onClick={onClose}
@@ -309,6 +317,7 @@ const IpaCertificateMappingData = (props: PropsToIpaCertificateMappingData) => {
                 </FlexItem>
                 <FlexItem>
                   <SecondaryButton
+                    dataCy="user-tab-settings-button-delete-certificate-mapping-data"
                     onClickHandler={() => onDeleteCertMapData(idx)}
                     name={"remove-certificate-mapping-data-" + idx}
                   >
@@ -321,12 +330,14 @@ const IpaCertificateMappingData = (props: PropsToIpaCertificateMappingData) => {
         : null}
 
       <SecondaryButton
+        dataCy="user-tab-settings-button-add-certificate-mapping-data"
         name={"add-certificate-mapping-data"}
         onClickHandler={() => setIsOpen(true)}
       >
         Add
       </SecondaryButton>
       <Modal
+        data-cy={"add-certificate-mapping-data-modal"}
         variant="small"
         title="Add certificate mapping data"
         isOpen={isOpen}
@@ -335,6 +346,7 @@ const IpaCertificateMappingData = (props: PropsToIpaCertificateMappingData) => {
       >
         <>
           <CertificateMappingDataOption
+            dataCy="modal-cert-map-data"
             isCertMappingDataChecked={isCertMappingDataChecked}
             onChangeCertMappingDataCheck={onChangeCertMappingDataCheck}
             setIsAddButtonDisabled={setIsAddButtonDisabled}
@@ -355,6 +367,7 @@ const IpaCertificateMappingData = (props: PropsToIpaCertificateMappingData) => {
         </>
       </Modal>
       <ConfirmationModal
+        dataCy={"remove-certificate-mapping-data-modal"}
         title={"Remove certificate mapping data"}
         isOpen={isDeletionModalOpen}
         onClose={onCloseDeletionModal}

--- a/src/components/Form/IpaCertificates/IpaCertificates.test.tsx
+++ b/src/components/Form/IpaCertificates/IpaCertificates.test.tsx
@@ -152,6 +152,7 @@ describe("IpaCertificates Component", () => {
   };
 
   const defaultProps: PropsToIpaCertificates = {
+    dataCy: "ipa-certificates",
     ipaObject: {},
     onChange: mockOnChange,
     metadata: mockMetadata,

--- a/src/components/Form/IpaCertificates/IpaCertificates.tsx
+++ b/src/components/Form/IpaCertificates/IpaCertificates.tsx
@@ -33,6 +33,7 @@ import useAlerts from "src/hooks/useAlerts";
 import { parseDn } from "src/utils/utils";
 
 export interface PropsToIpaCertificates {
+  dataCy: string;
   ipaObject: Record<string, unknown>;
   onChange: (ipaObject: Record<string, unknown>) => void;
   metadata: Metadata;
@@ -204,6 +205,7 @@ const IpaCertificates = (props: PropsToIpaCertificates) => {
   const getDropdownItems = (idx: number) => {
     return [
       <DropdownItem
+        data-cy="ipa-certificates-dropdown-view"
         key="view"
         component="button"
         onClick={() => onViewCertificate(idx)}
@@ -211,6 +213,7 @@ const IpaCertificates = (props: PropsToIpaCertificates) => {
         View
       </DropdownItem>,
       <DropdownItem
+        data-cy="ipa-certificates-dropdown-get"
         key="get"
         component="button"
         onClick={() => onGetCertificate(idx)}
@@ -218,6 +221,7 @@ const IpaCertificates = (props: PropsToIpaCertificates) => {
         Get
       </DropdownItem>,
       <DropdownItem
+        data-cy="ipa-certificates-dropdown-download"
         key="download"
         component="button"
         onClick={() => onDownloadCertificate(idx)}
@@ -225,6 +229,7 @@ const IpaCertificates = (props: PropsToIpaCertificates) => {
         Download
       </DropdownItem>,
       <DropdownItem
+        data-cy="ipa-certificates-dropdown-revoke"
         key="revoke"
         component="button"
         isDisabled={!canBeRevoked(idx)}
@@ -233,6 +238,7 @@ const IpaCertificates = (props: PropsToIpaCertificates) => {
         Revoke
       </DropdownItem>,
       <DropdownItem
+        data-cy="ipa-certificates-dropdown-remove-hold"
         key="remove-hold"
         component="button"
         isDisabled={!canHoldBeRemoved(idx)}
@@ -242,6 +248,7 @@ const IpaCertificates = (props: PropsToIpaCertificates) => {
       </DropdownItem>,
       <Divider component="li" key="separator" />,
       <DropdownItem
+        data-cy="ipa-certificates-dropdown-delete"
         key="delete"
         component="button"
         onClick={() => onRemoveCert(idx)}
@@ -437,6 +444,7 @@ const IpaCertificates = (props: PropsToIpaCertificates) => {
 
   const deletionConfModalActions = [
     <Button
+      data-cy="modal-button-delete"
       key="del-certificate-conf"
       variant="danger"
       onClick={() => onDeleteCertificate(idxToDelete)}
@@ -448,7 +456,12 @@ const IpaCertificates = (props: PropsToIpaCertificates) => {
     >
       {modalSpinning ? "Deleting" : "Delete"}
     </Button>,
-    <Button key="cancel" variant="link" onClick={onCloseDeletionConfModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel"
+      variant="link"
+      onClick={onCloseDeletionConfModal}
+    >
       Cancel
     </Button>,
   ];
@@ -579,6 +592,7 @@ const IpaCertificates = (props: PropsToIpaCertificates) => {
           })
         : null}
       <SecondaryButton
+        dataCy="modal-button-add"
         name={"add-certificate"}
         onClickHandler={onOpenModal}
         isDisabled={readOnly}
@@ -586,6 +600,7 @@ const IpaCertificates = (props: PropsToIpaCertificates) => {
         Add
       </SecondaryButton>
       <ModalWithTextAreaLayout
+        dataCy="ipa-certificates-modal"
         id="certificate-textarea"
         value={textAreaValue}
         onChange={onChangeTextAreaValue}
@@ -595,6 +610,7 @@ const IpaCertificates = (props: PropsToIpaCertificates) => {
           textareaModalOption === "add"
             ? [
                 <SecondaryButton
+                  dataCy="modal-button-add"
                   key="add-certificate"
                   onClickHandler={onAddCertificate}
                   isDisabled={modalSpinning}
@@ -605,12 +621,22 @@ const IpaCertificates = (props: PropsToIpaCertificates) => {
                 >
                   {modalSpinning ? "Adding" : "Add"}
                 </SecondaryButton>,
-                <Button key="cancel" variant="link" onClick={onClickCancel}>
+                <Button
+                  data-cy="modal-button-cancel"
+                  key="cancel"
+                  variant="link"
+                  onClick={onClickCancel}
+                >
                   Cancel
                 </Button>,
               ]
             : [
-                <Button key="close" variant="link" onClick={onClickCancel}>
+                <Button
+                  data-cy="modal-button-close"
+                  key="close"
+                  variant="link"
+                  onClick={onClickCancel}
+                >
                   Close
                 </Button>,
               ]
@@ -640,6 +666,7 @@ const IpaCertificates = (props: PropsToIpaCertificates) => {
         isTextareaDisabled={textareaModalOption === "get"}
       />
       <ConfirmationModal
+        dataCy="remove-certificate-modal"
         title={"Remove certificate"}
         isOpen={isDeleteConfModalOpen}
         onClose={onCloseDeletionConfModal}

--- a/src/components/Form/IpaCheckbox/IpaCheckbox.test.tsx
+++ b/src/components/Form/IpaCheckbox/IpaCheckbox.test.tsx
@@ -52,6 +52,7 @@ describe("IpaCheckbox Component", () => {
   };
 
   const defaultProps: CheckboxOption = {
+    dataCy: "ipa-checkbox",
     name: "ipakrbokasdelegate2",
     ariaLabel: "ipakrbokasdelegate2",
     ipaObject: {},

--- a/src/components/Form/IpaCheckbox/IpaCheckbox.tsx
+++ b/src/components/Form/IpaCheckbox/IpaCheckbox.tsx
@@ -10,6 +10,7 @@ import {
 } from "../../../utils/ipaObjectUtils";
 
 export interface CheckboxOption extends IPAParamDefinition {
+  dataCy: string;
   value: string;
   text: string;
   textNode?: React.ReactNode;
@@ -52,6 +53,7 @@ const IpaCheckbox = (props: CheckboxOption) => {
 
   return (
     <Checkbox
+      data-cy={props.dataCy}
       id={props.name + "-" + props.value}
       className={props.className}
       name={props.name}

--- a/src/components/Form/IpaCheckboxes/IpaCheckboxes.test.tsx
+++ b/src/components/Form/IpaCheckboxes/IpaCheckboxes.test.tsx
@@ -66,6 +66,7 @@ describe("IpaCheckboxes Component", () => {
   };
 
   const defaultProps: IPAParamDefinitionCheckboxes = {
+    dataCy: "ipa-checkboxes",
     name: "ipauserauthtype2",
     ariaLabel: "ipauserauthtype2",
     ipaObject: {},

--- a/src/components/Form/IpaCheckboxes/IpaCheckboxes.tsx
+++ b/src/components/Form/IpaCheckboxes/IpaCheckboxes.tsx
@@ -15,6 +15,7 @@ interface CheckboxOption {
 }
 
 export interface IPAParamDefinitionCheckboxes extends IPAParamDefinition {
+  dataCy: string;
   options: CheckboxOption[];
 }
 
@@ -45,6 +46,7 @@ const IpaCheckboxes = (props: IPAParamDefinitionCheckboxes) => {
     <>
       {props.options.map((option, idx) => (
         <Checkbox
+          data-cy={props.dataCy + "-" + option.value}
           key={props.name + "-" + option.value}
           id={props.name + "-" + option.value} // Mandatory
           name={props.name}

--- a/src/components/Form/IpaDropdownSearch/IpaDropdownSearch.test.tsx
+++ b/src/components/Form/IpaDropdownSearch/IpaDropdownSearch.test.tsx
@@ -85,6 +85,7 @@ describe("IpaDropdownSearch Component", () => {
   };
 
   const defaultProps: IPAParamDefinitionDropdown = {
+    dataCy: "ipa-dropdown-search",
     name: "ca_renewal_master_server",
     ariaLabel: "IPA CA renewal master",
     ipaObject: mockIpaObject,

--- a/src/components/Form/IpaDropdownSearch/IpaDropdownSearch.tsx
+++ b/src/components/Form/IpaDropdownSearch/IpaDropdownSearch.tsx
@@ -19,6 +19,7 @@ import {
 import { updateIpaObject } from "src/utils/ipaObjectUtils";
 
 export interface IPAParamDefinitionDropdown extends IPAParamDefinition {
+  dataCy: string;
   id?: string;
   setIpaObject?: (ipaObject: Record<string, unknown>) => void;
   onSelect?: (username: string) => void; // For non-ipaObjects
@@ -59,11 +60,13 @@ const IpaDropdownSearch = (props: IPAParamDefinitionDropdown) => {
 
   return (
     <Dropdown
+      data-cy={props.dataCy + "-dropdown"}
       isOpen={isOpen}
       onSelect={onSelect}
       onOpenChange={(isOpen: boolean) => setIsOpen(isOpen)}
       toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
         <MenuToggle
+          data-cy={props.dataCy + "-dropdown-toggle"}
           id={props.id || "dropdown-search"}
           ref={toggleRef}
           isFullWidth
@@ -80,6 +83,7 @@ const IpaDropdownSearch = (props: IPAParamDefinitionDropdown) => {
       <MenuSearch>
         <MenuSearchInput>
           <SearchInput
+            data-cy={props.dataCy + "-dropdown-search"}
             id={"search-" + props.id || "dropdown-search"}
             value={searchValue}
             placeholder="Search"
@@ -96,7 +100,11 @@ const IpaDropdownSearch = (props: IPAParamDefinitionDropdown) => {
       <Divider />
       <DropdownList>
         {options.map((option, index) => (
-          <DropdownItem value={option} key={index}>
+          <DropdownItem
+            data-cy={props.dataCy + "-dropdown-" + option}
+            value={option}
+            key={index}
+          >
             {option}
           </DropdownItem>
         ))}

--- a/src/components/Form/IpaForwardPolicy.tsx
+++ b/src/components/Form/IpaForwardPolicy.tsx
@@ -30,6 +30,7 @@ const IpaForwardPolicy = (props: IPAParamDefinition) => {
     <Flex>
       <FlexItem>
         <Radio
+          data-cy="dns-zone-tab-settings-radio-forward-first"
           id={"forward-first"}
           key={"forward-first"}
           name={props.name}
@@ -42,6 +43,7 @@ const IpaForwardPolicy = (props: IPAParamDefinition) => {
       </FlexItem>
       <FlexItem>
         <Radio
+          data-cy="dns-zone-tab-settings-radio-forward-only"
           id={"forward-only"}
           key={"forward-only"}
           name={props.name}
@@ -54,6 +56,7 @@ const IpaForwardPolicy = (props: IPAParamDefinition) => {
       </FlexItem>
       <FlexItem>
         <Radio
+          data-cy="dns-zone-tab-settings-radio-forwarding-disabled"
           id={"forwarding-disabled"}
           key={"forwarding-disabled"}
           name={props.name}

--- a/src/components/Form/IpaNumberInput/IpaNumberInput.test.tsx
+++ b/src/components/Form/IpaNumberInput/IpaNumberInput.test.tsx
@@ -54,6 +54,7 @@ describe("IpaNumberInput Component", () => {
   };
 
   const defaultProps: IPAParamDefinitionNumberInput = {
+    dataCy: "ipa-number-input",
     ariaLabel: "sudoorder2",
     ipaObject: { sudoorder2: "" }, // Default value
     maxValue: 2147483647,

--- a/src/components/Form/IpaNumberInput/IpaNumberInput.tsx
+++ b/src/components/Form/IpaNumberInput/IpaNumberInput.tsx
@@ -20,6 +20,7 @@ import {
  */
 
 export interface IPAParamDefinitionNumberInput extends IPAParamDefinition {
+  dataCy: string;
   id?: string;
   className?: string;
   numCharsShown?: number;
@@ -100,7 +101,7 @@ const IpaNumberInput = (props: IPAParamDefinitionNumberInput) => {
       isDisabled={isDisabled}
       widthChars={props.numCharsShown || 1}
       className={props.className || ""}
-      inputProps={{ id: props.id }}
+      inputProps={{ id: props.id, "data-cy": props.dataCy }}
     />
   );
 };

--- a/src/components/Form/IpaPACType/IpaPACType.test.tsx
+++ b/src/components/Form/IpaPACType/IpaPACType.test.tsx
@@ -2,8 +2,7 @@ import React from "react";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { vi, describe, it, expect, afterEach } from "vitest";
 // Component
-import IpaPACType from "./IpaPACType";
-import { IPAParamDefinition } from "src/utils/ipaObjectUtils";
+import IpaPACType, { IpaPACTypeProps } from "./IpaPACType";
 import { updateIpaObject } from "src/utils/ipaObjectUtils";
 
 // Mock of util function: updateIpaObject
@@ -82,7 +81,8 @@ describe("IpaPACType Component", () => {
     ipakrboktoauthasdelegate: false,
   };
 
-  const defaultProps: IPAParamDefinition = {
+  const defaultProps: IpaPACTypeProps = {
+    dataCy: "ipa-pac-type",
     name: "ipakrbauthzdata",
     required: false,
     readOnly: false,

--- a/src/components/Form/IpaPACType/IpaPACType.tsx
+++ b/src/components/Form/IpaPACType/IpaPACType.tsx
@@ -10,7 +10,11 @@ import {
   updateIpaObject,
 } from "src/utils/ipaObjectUtils";
 
-const IpaPACType = (props: IPAParamDefinition) => {
+export interface IpaPACTypeProps extends IPAParamDefinition {
+  dataCy: string;
+}
+
+const IpaPACType = (props: IpaPACTypeProps) => {
   const { readOnly, value } = getParamProperties(props);
 
   // States
@@ -106,6 +110,7 @@ const IpaPACType = (props: IPAParamDefinition) => {
   return (
     <>
       <Radio
+        data-cy={props.dataCy + "-inherited"}
         isChecked={isInheritedChecked}
         name="inherited"
         onChange={(_event, value) => updateList(value, "inherited")}
@@ -114,6 +119,7 @@ const IpaPACType = (props: IPAParamDefinition) => {
         isDisabled={readOnly}
       />
       <Radio
+        data-cy={props.dataCy + "-override"}
         isChecked={isOverrideChecked}
         name="override"
         onChange={(_event, value) => updateList(value, "override")}
@@ -122,6 +128,7 @@ const IpaPACType = (props: IPAParamDefinition) => {
         isDisabled={readOnly}
       />
       <Checkbox
+        data-cy={props.dataCy + "-ms-pac"}
         label="MS-PAC"
         isChecked={isMsPacChecked}
         onChange={(_event, value) => updateList(value, "MS-PAC")}
@@ -131,6 +138,7 @@ const IpaPACType = (props: IPAParamDefinition) => {
         className="pf-v5-u-ml-lg"
       />
       <Checkbox
+        data-cy={props.dataCy + "-pad"}
         label="PAD"
         isChecked={isPadChecked}
         onChange={(_event, value) => updateList(value, "PAD")}

--- a/src/components/Form/IpaPasswordInput/IpaPasswordInput.test.tsx
+++ b/src/components/Form/IpaPasswordInput/IpaPasswordInput.test.tsx
@@ -2,9 +2,8 @@ import React from "react";
 import { render, screen, cleanup, waitFor } from "@testing-library/react";
 import { describe, expect, it, afterEach } from "vitest";
 // Component
-import IpaPasswordInput from "./IpaPasswordInput";
+import IpaPasswordInput, { IpaPasswordInputProps } from "./IpaPasswordInput";
 import { HIDDEN_PASSWORD } from "src/utils/utils";
-import { IPAParamDefinition } from "src/utils/ipaObjectUtils";
 
 describe("IpaPasswordInput Component", () => {
   const mockMetadata = {
@@ -41,7 +40,8 @@ describe("IpaPasswordInput Component", () => {
     },
   };
 
-  const defaultProps: IPAParamDefinition = {
+  const defaultProps: IpaPasswordInputProps = {
+    dataCy: "ipa-password-input",
     ariaLabel: "Secret",
     name: "ipaidpclientsecret",
     objectName: "idp",
@@ -52,7 +52,7 @@ describe("IpaPasswordInput Component", () => {
   afterEach(cleanup);
 
   it("renders IpaPasswordInput correctly with password", async () => {
-    const props: IPAParamDefinition = {
+    const props: IpaPasswordInputProps = {
       ...defaultProps,
       ipaObject: {
         ipaidpclientsecret: ["Password"],
@@ -77,7 +77,7 @@ describe("IpaPasswordInput Component", () => {
   });
 
   it("renders IpaPasswordInput correctly with encrypted password", async () => {
-    const props: IPAParamDefinition = {
+    const props: IpaPasswordInputProps = {
       ...defaultProps,
       ipaObject: {
         ipaidpclientsecret: [{ __base64__: "YWF3cmV3YQ==" } /* Secret123 */],

--- a/src/components/Form/IpaPasswordInput/IpaPasswordInput.tsx
+++ b/src/components/Form/IpaPasswordInput/IpaPasswordInput.tsx
@@ -9,7 +9,11 @@ import {
 } from "src/utils/ipaObjectUtils";
 import { HIDDEN_PASSWORD } from "src/utils/utils";
 
-const IpaPasswordInput = (props: IPAParamDefinition) => {
+export interface IpaPasswordInputProps extends IPAParamDefinition {
+  dataCy: string;
+}
+
+const IpaPasswordInput = (props: IpaPasswordInputProps) => {
   const { required, readOnly, value, onChange } = getParamProperties(props);
 
   const [textInputValue, setTextInputValue] = React.useState<string>(
@@ -31,6 +35,7 @@ const IpaPasswordInput = (props: IPAParamDefinition) => {
 
   return (
     <TextInput
+      data-cy={props.dataCy}
       type="password"
       id={props.name}
       name={props.name}

--- a/src/components/Form/IpaSelect/IpaSelect.test.tsx
+++ b/src/components/Form/IpaSelect/IpaSelect.test.tsx
@@ -59,6 +59,7 @@ describe("IpaSelect Component", () => {
   };
 
   const defaultProps: IPAParamDefinitionSelect = {
+    dataCy: "ipa-select",
     id: "customipaselect",
     name: "customipaselect",
     ariaLabel: "customipaselect",

--- a/src/components/Form/IpaSelect/IpaSelect.tsx
+++ b/src/components/Form/IpaSelect/IpaSelect.tsx
@@ -15,6 +15,7 @@ import { updateIpaObject } from "src/utils/ipaObjectUtils";
 import { NO_SELECTION_OPTION } from "src/utils/constUtils";
 
 export interface IPAParamDefinitionSelect extends IPAParamDefinition {
+  dataCy: string;
   id?: string;
   setIpaObject?: (ipaObject: Record<string, unknown>) => void;
   variant?:
@@ -77,6 +78,7 @@ const IpaSelect = (props: IPAParamDefinitionSelect) => {
   // Toggle
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
+      data-cy={props.dataCy}
       id={props.id}
       ref={toggleRef}
       onClick={onToggle}
@@ -112,6 +114,7 @@ const IpaSelect = (props: IPAParamDefinitionSelect) => {
 
   return (
     <Select
+      data-cy={props.dataCy + "-select"}
       aria-label={props.name}
       onOpenChange={(isOpen) => setIsOpen(isOpen)}
       toggle={toggle}
@@ -122,7 +125,11 @@ const IpaSelect = (props: IPAParamDefinitionSelect) => {
     >
       {optionsToSelect.map((option, index) => {
         return (
-          <SelectOption key={index} value={option}>
+          <SelectOption
+            data-cy={props.dataCy + "-select-" + option}
+            key={index}
+            value={option}
+          >
             {option}
           </SelectOption>
         );

--- a/src/components/Form/IpaSshPublicKeys/IpaSshPublicKeys.test.tsx
+++ b/src/components/Form/IpaSshPublicKeys/IpaSshPublicKeys.test.tsx
@@ -103,6 +103,7 @@ describe("IpaSshPublicKeys Component", () => {
   };
 
   const defaultProps: PropsToSshPublicKeysModal = {
+    dataCy: "ipa-ssh-public-keys",
     ipaObject: {},
     onChange: mockOnChange,
     metadata: mockMetadata,

--- a/src/components/Form/IpaSshPublicKeys/IpaSshPublicKeys.tsx
+++ b/src/components/Form/IpaSshPublicKeys/IpaSshPublicKeys.tsx
@@ -28,6 +28,7 @@ import {
 } from "src/services/rpc";
 
 export interface PropsToSshPublicKeysModal {
+  dataCy: string;
   ipaObject: Record<string, unknown>;
   onChange: (ipaObject: Record<string, unknown>) => void;
   metadata: Metadata;
@@ -80,6 +81,7 @@ const IpaSshPublicKeys = (props: PropsToSshPublicKeysModal) => {
 
   const deletionModalActions = [
     <Button
+      data-cy="modal-button-delete"
       key="del-ssh-key"
       variant="danger"
       onClick={() => onRemoveSSHKey(idxToDelete)}
@@ -91,7 +93,12 @@ const IpaSshPublicKeys = (props: PropsToSshPublicKeysModal) => {
     >
       {modalSpinning ? "Deleting" : "Delete"}
     </Button>,
-    <Button key="cancel" variant="link" onClick={onCloseDeletionModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel"
+      variant="link"
+      onClick={onCloseDeletionModal}
+    >
       Cancel
     </Button>,
   ];
@@ -264,6 +271,7 @@ const IpaSshPublicKeys = (props: PropsToSshPublicKeysModal) => {
 
   const modal_actions = [
     <SecondaryButton
+      dataCy="modal-button-set"
       key="set"
       onClickHandler={onClickSetTextAreaSshPublicKeys}
       isDisabled={isSetButtonDisabled || modalSpinning}
@@ -275,6 +283,7 @@ const IpaSshPublicKeys = (props: PropsToSshPublicKeysModal) => {
       {modalSpinning ? "Setting" : "Set"}
     </SecondaryButton>,
     <Button
+      data-cy="modal-button-cancel"
       key="cancel"
       variant="link"
       onClick={onClickCancelTextAreaSshPublicKeys}
@@ -306,6 +315,7 @@ const IpaSshPublicKeys = (props: PropsToSshPublicKeysModal) => {
                       </FlexItem>
                       <FlexItem>
                         <SecondaryButton
+                          dataCy={props.dataCy + "-show-ssh-public-key"}
                           onClickHandler={() => onShowSetSshKey(idx, publicKey)}
                           name={"show-ssh-public-key-" + idx}
                           isDisabled={readOnly}
@@ -316,6 +326,7 @@ const IpaSshPublicKeys = (props: PropsToSshPublicKeysModal) => {
                       </FlexItem>
                       <FlexItem className="pf-v5-u-mb-md">
                         <SecondaryButton
+                          dataCy={props.dataCy + "-remove-ssh-public-key"}
                           onClickHandler={() => onDeleteSshKey(idx)}
                           name={"remove-ssh-public-key-" + idx}
                           isDisabled={readOnly}
@@ -332,6 +343,7 @@ const IpaSshPublicKeys = (props: PropsToSshPublicKeysModal) => {
           })
         : null}
       <Modal
+        data-cy="ssh-public-key-modal"
         variant="small"
         title={idxSelected !== null ? "SSH Key" : "Set SSH key"}
         isOpen={isTextAreaSshPublicKeysOpen}
@@ -345,6 +357,7 @@ const IpaSshPublicKeys = (props: PropsToSshPublicKeysModal) => {
             fieldId="ipasshpubkey"
           >
             <TextArea
+              data-cy="modal-textbox-ssh-public-key"
               id="ipasshpubkey"
               value={textAreaSshPublicKeysValue}
               name="ipasshpubkey"
@@ -360,6 +373,7 @@ const IpaSshPublicKeys = (props: PropsToSshPublicKeysModal) => {
         </Form>
       </Modal>
       <SecondaryButton
+        dataCy="modal-button-add"
         onClickHandler={openSshPublicKeysModal}
         name={"add-ssh-public-key"}
         isDisabled={readOnly}
@@ -368,6 +382,7 @@ const IpaSshPublicKeys = (props: PropsToSshPublicKeysModal) => {
         Add Key
       </SecondaryButton>
       <ConfirmationModal
+        dataCy="remove-ssh-public-key-modal"
         title={"Remove SSH Public Key"}
         isOpen={isDeletionModalOpen}
         onClose={onCloseDeletionModal}

--- a/src/components/Form/IpaTextArea/IpaTextArea.test.tsx
+++ b/src/components/Form/IpaTextArea/IpaTextArea.test.tsx
@@ -8,9 +8,7 @@ import {
 } from "@testing-library/react";
 import { describe, afterEach, it, expect, vi } from "vitest";
 // Component
-import IpaTextArea from "./IpaTextArea";
-// Utils
-import { IPAParamDefinition } from "src/utils/ipaObjectUtils";
+import IpaTextArea, { IpaTextAreaProps } from "./IpaTextArea";
 
 describe("IpaTextArea Component", () => {
   const mockOnChange = vi.fn();
@@ -87,7 +85,8 @@ describe("IpaTextArea Component", () => {
     },
   };
 
-  const defaultProps: IPAParamDefinition = {
+  const defaultProps: IpaTextAreaProps = {
+    dataCy: "ipa-text-area",
     name: "customipatextarea",
     ariaLabel: "customipatextarea",
     ipaObject: mockIpaObject,

--- a/src/components/Form/IpaTextArea/IpaTextArea.tsx
+++ b/src/components/Form/IpaTextArea/IpaTextArea.tsx
@@ -7,7 +7,11 @@ import {
   convertToString,
 } from "src/utils/ipaObjectUtils";
 
-const IpaTextArea = (props: IPAParamDefinition) => {
+export interface IpaTextAreaProps extends IPAParamDefinition {
+  dataCy: string;
+}
+
+const IpaTextArea = (props: IpaTextAreaProps) => {
   const { required, readOnly, value, onChange } = getParamProperties(props);
 
   const [textareaValue, setTextareaValue] = React.useState<string>(
@@ -20,6 +24,7 @@ const IpaTextArea = (props: IPAParamDefinition) => {
 
   return (
     <TextArea
+      data-cy={props.dataCy}
       id={props.name}
       name={props.name}
       value={textareaValue}

--- a/src/components/Form/IpaTextContent/IpaTextContent.test.tsx
+++ b/src/components/Form/IpaTextContent/IpaTextContent.test.tsx
@@ -44,6 +44,7 @@ describe("IpaTextContent Component", () => {
 
   const mockCn = "TEST VALUE";
   const defaultProps: IpaTextContentProps = {
+    dataCy: "ipa-text-content",
     ariaLabel: "test",
     name: "cn",
     objectName: "pwpolicy",

--- a/src/components/Form/IpaTextContent/IpaTextContent.tsx
+++ b/src/components/Form/IpaTextContent/IpaTextContent.tsx
@@ -11,6 +11,7 @@ import {
 import { Link } from "react-router-dom";
 
 export interface IpaTextContentProps extends IPAParamDefinition {
+  dataCy: string;
   linkTo?: string;
 }
 
@@ -29,6 +30,7 @@ const IpaTextContent = (props: IpaTextContentProps) => {
     <>
       {props.linkTo ? (
         <TextContent
+          data-cy={props.dataCy}
           readOnly={readOnly}
           required={required}
           aria-label={props.ariaLabel}
@@ -38,6 +40,7 @@ const IpaTextContent = (props: IpaTextContentProps) => {
         </TextContent>
       ) : (
         <TextContent
+          data-cy={props.dataCy}
           readOnly={readOnly}
           required={required}
           aria-label={props.ariaLabel}

--- a/src/components/Form/IpaTextInput/IpaTextInput.test.tsx
+++ b/src/components/Form/IpaTextInput/IpaTextInput.test.tsx
@@ -8,9 +8,7 @@ import {
 } from "@testing-library/react";
 import { describe, vi, afterEach, it, expect } from "vitest";
 // Component
-import IpaTextInput from "./IpaTextInput";
-// Utils
-import { IPAParamDefinition } from "src/utils/ipaObjectUtils";
+import IpaTextInput, { IpaTextInputProps } from "./IpaTextInput";
 
 describe("IpaTextInput Component", () => {
   const mockOnChange = vi.fn();
@@ -87,7 +85,8 @@ describe("IpaTextInput Component", () => {
     objectclass: [],
   };
 
-  const defaultProps: IPAParamDefinition = {
+  const defaultProps: IpaTextInputProps = {
+    dataCy: "ipa-text-input",
     name: "customipatextinput",
     ariaLabel: "Custom IpaTextInput",
     ipaObject: mockIpaObject,

--- a/src/components/Form/IpaTextInput/IpaTextInput.tsx
+++ b/src/components/Form/IpaTextInput/IpaTextInput.tsx
@@ -7,7 +7,11 @@ import {
   convertToString,
 } from "src/utils/ipaObjectUtils";
 
-const IpaTextInput = (props: IPAParamDefinition) => {
+export interface IpaTextInputProps extends IPAParamDefinition {
+  dataCy: string;
+}
+
+const IpaTextInput = (props: IpaTextInputProps) => {
   const { required, readOnly, value, onChange } = getParamProperties(props);
 
   const [textInputValue, setTextInputValue] = React.useState<string>(
@@ -20,6 +24,7 @@ const IpaTextInput = (props: IPAParamDefinition) => {
 
   return (
     <TextInput
+      data-cy={props.dataCy}
       id={props.name}
       name={props.name}
       value={textInputValue}

--- a/src/components/Form/IpaTextInputFromList/IpaTextInputFromList.test.tsx
+++ b/src/components/Form/IpaTextInputFromList/IpaTextInputFromList.test.tsx
@@ -50,6 +50,7 @@ describe("IpaTextInputFromList Component", () => {
   afterEach(cleanup);
 
   const defaultProps: PropsToTextInputFromList = {
+    dataCy: "ipa-text-input-from-list",
     name: "krbprincipalname",
     elementsList: ["test1", "test2"],
     ipaObject: { krbprincipalname: ["test1", "test2"] },

--- a/src/components/Form/IpaTextInputFromList/IpaTextInputFromList.tsx
+++ b/src/components/Form/IpaTextInputFromList/IpaTextInputFromList.tsx
@@ -11,6 +11,7 @@ import useAlerts from "src/hooks/useAlerts";
 import { getParamProperties } from "src/utils/ipaObjectUtils";
 
 export interface PropsToTextInputFromList {
+  dataCy: string;
   name: string;
   elementsList: string[];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -59,6 +60,7 @@ const IpaTextInputFromList = (props: PropsToTextInputFromList) => {
                 className="pf-v5-u-ml-lg"
               >
                 <TextInput
+                  data-cy={props.dataCy + "-textbox-" + element}
                   key={idx}
                   name={props.name}
                   value={element}
@@ -78,6 +80,7 @@ const IpaTextInputFromList = (props: PropsToTextInputFromList) => {
                 }
               >
                 <SecondaryButton
+                  dataCy={props.dataCy + "-button-remove-" + element}
                   name={"remove-principal-alias-" + idx}
                   onClickHandler={() => props.onRemove(idx)}
                   isDisabled={readOnly || isDisabled(idx)}
@@ -89,6 +92,7 @@ const IpaTextInputFromList = (props: PropsToTextInputFromList) => {
           ))}
       </Flex>
       <SecondaryButton
+        dataCy={props.dataCy + "-button-add"}
         classname="pf-v5-u-mt-md"
         name="add-principal-alias"
         onClickHandler={props.onOpenModal}

--- a/src/components/Form/IpaTextboxList/IpaTextboxList.test.tsx
+++ b/src/components/Form/IpaTextboxList/IpaTextboxList.test.tsx
@@ -8,6 +8,7 @@ describe("IpaTextboxList Component", () => {
   const mockSetIpaObject = vi.fn();
 
   const defaultProps: PropsToIpaTextboxList = {
+    dataCy: "ipa-textbox-list",
     ipaObject: {},
     setIpaObject: mockSetIpaObject,
     name: "customipatextboxlist",

--- a/src/components/Form/IpaTextboxList/IpaTextboxList.tsx
+++ b/src/components/Form/IpaTextboxList/IpaTextboxList.tsx
@@ -12,6 +12,7 @@ import SecondaryButton from "../../layouts/SecondaryButton";
 import { updateIpaObject } from "src/utils/ipaObjectUtils";
 
 export interface PropsToIpaTextboxList {
+  dataCy: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ipaObject: Record<string, any>;
   setIpaObject: (value: Record<string, unknown>) => void;
@@ -113,6 +114,7 @@ const IpaTextboxList = (props: PropsToIpaTextboxList) => {
               flex={{ default: "flex_1" }}
             >
               <TextInput
+                data-cy={props.dataCy + "-textbox-" + idx}
                 id={props.name + "-" + idx}
                 value={item}
                 type="text"
@@ -128,6 +130,7 @@ const IpaTextboxList = (props: PropsToIpaTextboxList) => {
             </FlexItem>
             <FlexItem key={props.name + "-" + idx + "-delete-button"}>
               <SecondaryButton
+                dataCy={props.dataCy + "-button-delete-" + idx}
                 name={"remove-" + props.name + "-" + idx}
                 onClickHandler={() => onRemoveHandler(idx)}
               >
@@ -138,6 +141,7 @@ const IpaTextboxList = (props: PropsToIpaTextboxList) => {
         ))}
       </Flex>
       <SecondaryButton
+        dataCy={props.dataCy + "-button-add"}
         classname="pf-v5-u-mt-sm"
         name={"add-" + props.name}
         onClickHandler={onAddHandler}

--- a/src/components/Form/IpaToggleGroup/IpaToggleGroup.test.tsx
+++ b/src/components/Form/IpaToggleGroup/IpaToggleGroup.test.tsx
@@ -61,6 +61,7 @@ describe("IpaToggleGroup Component", () => {
   };
 
   const defaultProps: ToggleOptionProps = {
+    dataCy: "ipa-toggle-group",
     name: "usercategory2",
     ariaLabel: "User Category",
     ipaObject: {},

--- a/src/components/Form/IpaToggleGroup/IpaToggleGroup.tsx
+++ b/src/components/Form/IpaToggleGroup/IpaToggleGroup.tsx
@@ -20,6 +20,7 @@ interface ToggleOptions {
 }
 
 export interface ToggleOptionProps extends IPAParamDefinition {
+  dataCy: string;
   options: ToggleOptions[];
   optionSelected: string;
   setOptionSelected: (value: string) => void;
@@ -64,6 +65,7 @@ const IpaToggleGroup = (props: ToggleOptionProps) => {
     <ToggleGroup isCompact={props.isCompact} className={props.className}>
       {props.options.map((option) => (
         <ToggleGroupItem
+          data-cy={props.dataCy + "-" + option.value}
           key={option.label}
           text={option.label}
           buttonId={option.label}

--- a/src/components/Form/NumberInput.tsx
+++ b/src/components/Form/NumberInput.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { NumberInput } from "@patternfly/react-core";
 
 export interface NumberSelectorProps {
+  dataCy: string;
   id: string;
   name: string;
   value: number | "";
@@ -79,7 +80,7 @@ const NumberSelector = (props: NumberSelectorProps) => {
       isDisabled={props.isDisabled || false}
       widthChars={props.numCharsShown || 1}
       className={props.className || ""}
-      inputProps={{ id: props.id }}
+      inputProps={{ id: props.id, "data-cy": props.dataCy }}
     />
   );
 };

--- a/src/components/Form/PrincipalAliasMultiTextBox/PrincipalAliasMultiTextBox.test.tsx
+++ b/src/components/Form/PrincipalAliasMultiTextBox/PrincipalAliasMultiTextBox.test.tsx
@@ -88,6 +88,7 @@ describe("PrincipalAliasMultiTextBox Component", () => {
   };
 
   const defaultProps: PrincipalAliasMultiTextBoxProps = {
+    dataCy: "principal-alias-multi-textbox",
     ipaObject: mockIpaObject,
     metadata: mockMetadata,
     onRefresh: mockOnRefresh,

--- a/src/components/Form/PrincipalAliasMultiTextBox/PrincipalAliasMultiTextBox.tsx
+++ b/src/components/Form/PrincipalAliasMultiTextBox/PrincipalAliasMultiTextBox.tsx
@@ -33,6 +33,7 @@ import { getRealmFromKrbPolicy } from "src/utils/utils";
 import { IPAObject } from "src/utils/ipaObjectUtils";
 
 export interface PrincipalAliasMultiTextBoxProps {
+  dataCy: string;
   ipaObject: Record<string, unknown>;
   metadata: Metadata;
   onRefresh: () => void;
@@ -145,6 +146,7 @@ const PrincipalAliasMultiTextBox = (props: PrincipalAliasMultiTextBoxProps) => {
 
   const deletionConfModalActions = [
     <Button
+      data-cy="modal-button-delete"
       key="del-principal-alias"
       variant="danger"
       onClick={() => onRemovePrincipalAlias(aliasIdxToDelete)}
@@ -156,7 +158,12 @@ const PrincipalAliasMultiTextBox = (props: PrincipalAliasMultiTextBoxProps) => {
     >
       {modalSpinning ? " Deleting" : "Delete"}
     </Button>,
-    <Button key="cancel" variant="link" onClick={onCloseDeletionConfModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel"
+      variant="link"
+      onClick={onCloseDeletionConfModal}
+    >
       Cancel
     </Button>,
   ];
@@ -223,6 +230,7 @@ const PrincipalAliasMultiTextBox = (props: PrincipalAliasMultiTextBoxProps) => {
 
   const textInputModalActions = [
     <SecondaryButton
+      dataCy="modal-button-add"
       key="add-principal-alias"
       onClickHandler={onAddPrincipalAlias}
       // isDisabled={newAliasValue === "" ? true : false}
@@ -240,7 +248,12 @@ const PrincipalAliasMultiTextBox = (props: PrincipalAliasMultiTextBoxProps) => {
     >
       {modalSpinning ? "Adding" : "Add"}
     </SecondaryButton>,
-    <Button key="cancel" variant="link" onClick={onCloseTextInputModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel"
+      variant="link"
+      onClick={onCloseTextInputModal}
+    >
       Cancel
     </Button>,
   ];
@@ -249,6 +262,7 @@ const PrincipalAliasMultiTextBox = (props: PrincipalAliasMultiTextBoxProps) => {
     <>
       <alerts.ManagedAlerts />
       <IpaTextInputFromList
+        dataCy={props.dataCy}
         name="krbprincipalname"
         elementsList={krbprincipalname}
         ipaObject={props.ipaObject}
@@ -259,6 +273,7 @@ const PrincipalAliasMultiTextBox = (props: PrincipalAliasMultiTextBoxProps) => {
         isPrincipalAlias
       />
       <AddTextInputFromListModal
+        dataCy={props.dataCy}
         id="kerberos-principal-textinput"
         newValue={newAliasValue}
         setNewValue={setNewAliasValue}
@@ -271,6 +286,7 @@ const PrincipalAliasMultiTextBox = (props: PrincipalAliasMultiTextBoxProps) => {
         textInputValidator={areRealmsMatching}
       />
       <ConfirmationModal
+        dataCy="remove-kerberos-alias-modal"
         title={"Remove kerberos alias"}
         isOpen={isDeleteConfModalOpen}
         onClose={onCloseDeletionConfModal}

--- a/src/components/Form/TextInputList.tsx
+++ b/src/components/Form/TextInputList.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { TextInput, Button, Flex, FlexItem } from "@patternfly/react-core";
 
 interface TextInputListProps {
+  dataCy: string;
   name: string;
   ariaLabel: string;
   list: string[];
@@ -52,6 +53,7 @@ const TextInputList = (props: TextInputListProps) => {
               flex={{ default: "flex_1" }}
             >
               <TextInput
+                data-cy={props.dataCy + "-" + item}
                 id={props.name + "-" + idx}
                 value={item}
                 type="text"
@@ -62,6 +64,7 @@ const TextInputList = (props: TextInputListProps) => {
             </FlexItem>
             <FlexItem key={props.name + "-" + idx + "-delete-button"}>
               <Button
+                data-cy={props.dataCy + "-" + item + "-delete-button"}
                 variant="secondary"
                 name={"remove-" + props.name + "-" + idx}
                 onClick={() => onRemoveHandler(idx)}
@@ -73,6 +76,7 @@ const TextInputList = (props: TextInputListProps) => {
         ))}
       </Flex>
       <Button
+        data-cy={props.dataCy + "-add-button"}
         variant="secondary"
         className="pf-v5-u-mt-sm"
         name={"add-" + props.name}

--- a/src/components/HostsSections/HostCertificate.tsx
+++ b/src/components/HostsSections/HostCertificate.tsx
@@ -35,6 +35,7 @@ const HostCertificate = (props: PropsToHostSettings) => {
             role="group"
           >
             <IpaCertificates
+              dataCy="host-certificate"
               ipaObject={ipaObject}
               onChange={recordOnChange}
               metadata={props.metadata}

--- a/src/components/HostsSections/HostSettings.tsx
+++ b/src/components/HostsSections/HostSettings.tsx
@@ -95,6 +95,7 @@ const HostSettings = (props: PropsToHostSettings) => {
           <Form className="pf-v5-u-mb-lg">
             <FormGroup label="Host name" fieldId="host-name">
               <TextInput
+                data-cy="hosts-tab-settings-textbox-host-name"
                 id="host-name"
                 name="hostname"
                 value={hostName}
@@ -109,6 +110,7 @@ const HostSettings = (props: PropsToHostSettings) => {
               role="group"
             >
               <PrincipalAliasMultiTextBox
+                dataCy="host-tab-settings-principal-alias"
                 ipaObject={ipaObject}
                 metadata={props.metadata}
                 onRefresh={props.onRefresh}
@@ -117,6 +119,7 @@ const HostSettings = (props: PropsToHostSettings) => {
             </FormGroup>
             <FormGroup label="Description" fieldId="description">
               <IpaTextArea
+                dataCy="host-tab-settings-textbox-description"
                 name="description"
                 ipaObject={ipaObject}
                 onChange={recordOnChange}
@@ -126,6 +129,7 @@ const HostSettings = (props: PropsToHostSettings) => {
             </FormGroup>
             <FormGroup label="Class" fieldId="userclass">
               <IpaTextInput
+                dataCy="host-tab-settings-textbox-userclass"
                 name={"userclass"}
                 ariaLabel={"User class"}
                 ipaObject={ipaObject}
@@ -136,6 +140,7 @@ const HostSettings = (props: PropsToHostSettings) => {
             </FormGroup>
             <FormGroup label="Locality" fieldId="l">
               <IpaTextInput
+                dataCy="host-tab-settings-textbox-locality"
                 name={"l"}
                 ariaLabel={"Locality"}
                 ipaObject={ipaObject}
@@ -146,6 +151,7 @@ const HostSettings = (props: PropsToHostSettings) => {
             </FormGroup>
             <FormGroup label="Location" fieldId="nshostlocation">
               <IpaTextInput
+                dataCy="host-tab-settings-textbox-location"
                 name={"nshostlocation"}
                 ariaLabel={"Location"}
                 ipaObject={ipaObject}
@@ -156,6 +162,7 @@ const HostSettings = (props: PropsToHostSettings) => {
             </FormGroup>
             <FormGroup label="Platform" fieldId="nshardwareplatform">
               <IpaTextInput
+                dataCy="host-tab-settings-textbox-platform"
                 name={"nshardwareplatform"}
                 ariaLabel={"Platform"}
                 ipaObject={ipaObject}
@@ -166,6 +173,7 @@ const HostSettings = (props: PropsToHostSettings) => {
             </FormGroup>
             <FormGroup label="Operating system" fieldId="nsosversion">
               <IpaTextInput
+                dataCy="host-tab-settings-textbox-os-version"
                 name={"nsosversion"}
                 ariaLabel={"Operating system"}
                 ipaObject={ipaObject}
@@ -184,6 +192,7 @@ const HostSettings = (props: PropsToHostSettings) => {
               role="group"
             >
               <IpaSshPublicKeys
+                dataCy="host-tab-settings-ssh-public-keys"
                 ipaObject={ipaObject}
                 onChange={recordOnChange}
                 metadata={props.metadata}
@@ -193,6 +202,7 @@ const HostSettings = (props: PropsToHostSettings) => {
             </FormGroup>
             <FormGroup label="MAC address" fieldId="macaddress" role="group">
               <IpaTextboxList
+                dataCy="host-tab-settings-textbox-mac-address"
                 ipaObject={ipaObject}
                 setIpaObject={recordOnChange}
                 name={"macaddress"}
@@ -209,6 +219,7 @@ const HostSettings = (props: PropsToHostSettings) => {
               }
             >
               <IpaCheckboxes
+                dataCy="host-tab-settings-checkbox-auth-indicators"
                 name="krbprincipalauthind"
                 options={[
                   {
@@ -245,6 +256,7 @@ const HostSettings = (props: PropsToHostSettings) => {
               role="group"
             >
               <IpaCheckbox
+                dataCy="host-tab-settings-checkbox-trusted-for-delegation"
                 name="ipakrbokasdelegate"
                 value="trustedForDelegation"
                 text="Trusted for delegation"
@@ -260,6 +272,7 @@ const HostSettings = (props: PropsToHostSettings) => {
               role="group"
             >
               <IpaCheckbox
+                dataCy="host-tab-settings-checkbox-trusted-auth-as-user"
                 name="ipakrboktoauthasdelegate"
                 value="trustedAuthAsUser"
                 text="Trusted to authenticate as a user"
@@ -271,6 +284,7 @@ const HostSettings = (props: PropsToHostSettings) => {
             </FormGroup>
             <FormGroup label="Assigned ID view" fieldId="assigned-id-view">
               <TextInput
+                data-cy="host-tab-settings-textbox-assigned-id-view"
                 id="assigned-id-view"
                 name="ipaassignedidview"
                 value={assignedIDView}

--- a/src/components/IssuerAndSubjectOption.tsx
+++ b/src/components/IssuerAndSubjectOption.tsx
@@ -51,6 +51,7 @@ const IssuerAndSubjectOption = (props: PropsToIssuerAndSubjectOption) => {
   return (
     <>
       <Radio
+        data-cy="modal-radio-issuer-and-subject"
         isChecked={props.isIssuerAndSubjectChecked}
         name="issuer-and-subject-radio"
         onChange={(_event, value) => props.onChangeIssuerAndSubjectCheck(value)}
@@ -73,6 +74,7 @@ const IssuerAndSubjectOption = (props: PropsToIssuerAndSubjectOption) => {
             name="issuer-formgroup"
           >
             <TextInput
+              data-cy="modal-textbox-issuer"
               id="issuer"
               value={props.issuerValue}
               type="text"
@@ -96,6 +98,7 @@ const IssuerAndSubjectOption = (props: PropsToIssuerAndSubjectOption) => {
             name="subject-formgroup"
           >
             <TextInput
+              data-cy="modal-textbox-subject"
               id="subject-textbox"
               value={props.subjectValue}
               type="text"

--- a/src/components/ManagedBy/ManagedByAddModal.tsx
+++ b/src/components/ManagedBy/ManagedByAddModal.tsx
@@ -119,6 +119,7 @@ const ManagedByAddModal = (props: PropsToAddModal) => {
   // Buttons that will be shown at the end of the form
   const modalActions = [
     <SecondaryButton
+      dataCy="modal-button-add"
       key={"add-new-" + convertedTabName}
       isDisabled={buttonDisabled || props.spinning}
       form="modal-form"
@@ -130,6 +131,7 @@ const ManagedByAddModal = (props: PropsToAddModal) => {
       {props.spinning ? "Adding" : "Add"}
     </SecondaryButton>,
     <Button
+      data-cy="modal-button-cancel"
       key={"cancel-add-new-" + convertedTabName}
       variant="link"
       onClick={cleanAndCloseModal}
@@ -141,6 +143,7 @@ const ManagedByAddModal = (props: PropsToAddModal) => {
   // Render component
   return (
     <ModalWithFormLayout
+      dataCy="add-managed-by-modal"
       variantType="medium"
       modalPosition="top"
       offPosition="76px"

--- a/src/components/ManagedBy/ManagedByDeleteModal.tsx
+++ b/src/components/ManagedBy/ManagedByDeleteModal.tsx
@@ -92,6 +92,7 @@ const ManagedByDeleteModal = (props: PropsToDeleteModal) => {
   // Set the Modal and Action buttons for 'Delete' option
   const modalActionsDelete: JSX.Element[] = [
     <Button
+      data-cy="modal-button-delete"
       key="delete-groups"
       variant="danger"
       onClick={deleteGroups}
@@ -103,7 +104,12 @@ const ManagedByDeleteModal = (props: PropsToDeleteModal) => {
     >
       {props.spinning ? "Deleting" : "Delete"}
     </Button>,
-    <Button key="cancel-remove-group" variant="link" onClick={closeModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-remove-group"
+      variant="link"
+      onClick={closeModal}
+    >
       Cancel
     </Button>,
   ];
@@ -115,6 +121,7 @@ const ManagedByDeleteModal = (props: PropsToDeleteModal) => {
   // Render component
   return (
     <ModalWithFormLayout
+      dataCy="managed-by-delete-modal"
       variantType="medium"
       modalPosition="top"
       offPosition="76px"

--- a/src/components/ManagedBy/ManagedByTable.tsx
+++ b/src/components/ManagedBy/ManagedByTable.tsx
@@ -196,7 +196,9 @@ const ManagedByTable = (props: PropsToTable) => {
             />
             <EmptyStateBody>Clear all filters and try again.</EmptyStateBody>
             <EmptyStateFooter>
-              <Button variant="link">Clear all filters</Button>
+              <Button data-cy="clear-all-filters" variant="link">
+                Clear all filters
+              </Button>
             </EmptyStateFooter>
           </EmptyState>
         </Bullseye>

--- a/src/components/ManagedBy/ManagedByToolbar.tsx
+++ b/src/components/ManagedBy/ManagedByToolbar.tsx
@@ -97,13 +97,21 @@ const ManagedByToolbar = (props: PropsToToolbar) => {
     {
       id: hostsToolbarData.refreshButton.id,
       key: 0,
-      element: <SecondaryButton name="refresh">Refresh</SecondaryButton>,
+      element: (
+        <SecondaryButton
+          dataCy="hosts-tab-managed-by-button-refresh"
+          name="refresh"
+        >
+          Refresh
+        </SecondaryButton>
+      ),
     },
     {
       id: hostsToolbarData.deleteButton.id,
       key: 1,
       element: (
         <SecondaryButton
+          dataCy="hosts-tab-managed-by-button-delete"
           name="remove"
           isDisabled={hostsToolbarData.deleteButton.isDisabledHandler}
           onClickHandler={hostsToolbarData.deleteButton.onClickHandler}
@@ -117,6 +125,7 @@ const ManagedByToolbar = (props: PropsToToolbar) => {
       key: 2,
       element: (
         <SecondaryButton
+          dataCy="hosts-tab-managed-by-button-add"
           name="add"
           onClickHandler={hostsToolbarData.addButton.onClickHandler}
         >

--- a/src/components/MemberOf/MemberOfAddModal.tsx
+++ b/src/components/MemberOf/MemberOfAddModal.tsx
@@ -108,6 +108,7 @@ const MemberOfAddModal = (props: PropsToAdd) => {
   // Buttons that will be shown at the end of the form
   const modalActions = [
     <Button
+      data-cy="modal-button-add"
       key="add-new-user"
       variant="secondary"
       isDisabled={buttonDisabled || props.spinning}
@@ -119,13 +120,19 @@ const MemberOfAddModal = (props: PropsToAdd) => {
     >
       {props.spinning ? "Adding" : "Add"}
     </Button>,
-    <Button key="cancel-new-user" variant="link" onClick={props.onCloseModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-new-user"
+      variant="link"
+      onClick={props.onCloseModal}
+    >
       Cancel
     </Button>,
   ];
 
   return (
     <Modal
+      data-cy="member-of-add-modal"
       variant={"medium"}
       position={"top"}
       positionOffset={"76px"}

--- a/src/components/MemberOf/MemberOfAddModalOld.tsx
+++ b/src/components/MemberOf/MemberOfAddModalOld.tsx
@@ -208,6 +208,7 @@ const MemberOfAddModal = (props: PropsToAdd) => {
   // Buttons that will be shown at the end of the form
   const modalActions = [
     <Button
+      data-cy="modal-button-add"
       key="add-new-user"
       variant="secondary"
       isDisabled={buttonDisabled}
@@ -216,7 +217,12 @@ const MemberOfAddModal = (props: PropsToAdd) => {
     >
       Add
     </Button>,
-    <Button key="cancel-new-user" variant="link" onClick={cleanAndCloseModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-new-user"
+      variant="link"
+      onClick={cleanAndCloseModal}
+    >
       Cancel
     </Button>,
   ];
@@ -224,6 +230,7 @@ const MemberOfAddModal = (props: PropsToAdd) => {
   // Render 'MemberOfaddModal'
   return (
     <ModalWithFormLayout
+      dataCy="member-of-add-modal"
       variantType="medium"
       modalPosition="top"
       offPosition="76px"

--- a/src/components/MemberOf/MemberOfDeleteModal.tsx
+++ b/src/components/MemberOf/MemberOfDeleteModal.tsx
@@ -25,6 +25,7 @@ const MemberOfDeleteModal = (props: React.PropsWithChildren<PropsToDelete>) => {
 
   const modalActionsDelete: JSX.Element[] = [
     <Button
+      data-cy="modal-button-delete"
       key="delete-groups"
       variant="danger"
       onClick={onDelete}
@@ -37,6 +38,7 @@ const MemberOfDeleteModal = (props: React.PropsWithChildren<PropsToDelete>) => {
       {props.spinning ? "Deleting" : "Delete"}
     </Button>,
     <Button
+      data-cy="modal-button-cancel"
       key="cancel-remove-group"
       variant="link"
       onClick={props.onCloseModal}
@@ -47,6 +49,7 @@ const MemberOfDeleteModal = (props: React.PropsWithChildren<PropsToDelete>) => {
 
   return (
     <Modal
+      data-cy="member-of-delete-modal"
       variant={"medium"}
       position={"top"}
       positionOffset={"76px"}

--- a/src/components/MemberOf/MemberOfDeleteModalOld.tsx
+++ b/src/components/MemberOf/MemberOfDeleteModalOld.tsx
@@ -117,6 +117,7 @@ const MemberOfDeleteModal = (props: PropsToDelete) => {
   // Set the Modal and Action buttons for 'Delete' option
   const modalActionsDelete: JSX.Element[] = [
     <Button
+      data-cy="modal-button-delete"
       key="delete-groups"
       variant="danger"
       onClick={deleteGroups}
@@ -124,7 +125,12 @@ const MemberOfDeleteModal = (props: PropsToDelete) => {
     >
       Delete
     </Button>,
-    <Button key="cancel-remove-group" variant="link" onClick={closeModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-remove-group"
+      variant="link"
+      onClick={closeModal}
+    >
       Cancel
     </Button>,
   ];
@@ -132,6 +138,7 @@ const MemberOfDeleteModal = (props: PropsToDelete) => {
   // Render 'MemberOfDeleteModal'
   return (
     <ModalWithFormLayout
+      dataCy="member-of-delete-modal"
       variantType="medium"
       modalPosition="top"
       offPosition="76px"

--- a/src/components/MemberOf/MemberOfSubIdToolbar.tsx
+++ b/src/components/MemberOf/MemberOfSubIdToolbar.tsx
@@ -39,6 +39,7 @@ const MemberOfSubIdToolbar = (props: MemberOfSubIdToolbarProps) => {
       <ToolbarContent>
         <ToolbarItem id="refresh-button">
           <Button
+            data-cy="member-of-sub-id-button-refresh"
             variant="secondary"
             name="refresh"
             isDisabled={!props.refreshButtonEnabled}
@@ -49,6 +50,7 @@ const MemberOfSubIdToolbar = (props: MemberOfSubIdToolbarProps) => {
         </ToolbarItem>
         <ToolbarItem id="auto-assign-button">
           <Button
+            data-cy="member-of-sub-id-button-auto-assign"
             variant="secondary"
             name="auto-assign"
             isDisabled={!props.autoAssignButtonEnabled}

--- a/src/components/MemberOf/MemberOfToolbar.tsx
+++ b/src/components/MemberOf/MemberOfToolbar.tsx
@@ -71,6 +71,7 @@ const MemberOfToolbar = (props: MemberOfToolbarProps) => {
           spacer={{ default: "spacerMd" }}
         >
           <SearchInputLayout
+            dataCy="search"
             name="search"
             ariaLabel="Search user"
             placeholder="Search"
@@ -87,6 +88,7 @@ const MemberOfToolbar = (props: MemberOfToolbarProps) => {
         />
         <ToolbarItem id="refresh-button">
           <Button
+            data-cy="member-of-button-refresh"
             variant="secondary"
             name="refresh"
             isDisabled={!props.refreshButtonEnabled}
@@ -97,6 +99,7 @@ const MemberOfToolbar = (props: MemberOfToolbarProps) => {
         </ToolbarItem>
         <ToolbarItem id="delete-button">
           <Button
+            data-cy="member-of-button-delete"
             variant="secondary"
             name="remove"
             isDisabled={!props.deleteButtonEnabled}
@@ -107,6 +110,7 @@ const MemberOfToolbar = (props: MemberOfToolbarProps) => {
         </ToolbarItem>
         <ToolbarItem id="add-button">
           <Button
+            data-cy="member-of-button-add"
             variant="secondary"
             name="add"
             isDisabled={!props.addButtonEnabled}

--- a/src/components/MemberOf/MemberOfToolbarOld.tsx
+++ b/src/components/MemberOf/MemberOfToolbarOld.tsx
@@ -494,6 +494,7 @@ const MemberOfToolbar = (props: PropsToToolbar) => {
       key: 0,
       element: (
         <SearchInputLayout
+          dataCy="search"
           name="search"
           ariaLabel="Search user"
           placeholder="Search"
@@ -514,7 +515,11 @@ const MemberOfToolbar = (props: PropsToToolbar) => {
       id: toolbarData().refreshButton.id,
       key: 2,
       element: (
-        <Button variant="secondary" name="refresh">
+        <Button
+          data-cy="member-of-button-refresh"
+          variant="secondary"
+          name="refresh"
+        >
           Refresh
         </Button>
       ),
@@ -524,6 +529,7 @@ const MemberOfToolbar = (props: PropsToToolbar) => {
       key: 3,
       element: (
         <Button
+          data-cy="member-of-button-delete"
           variant="secondary"
           name="remove"
           isDisabled={toolbarData().deleteButton.isDisabledHandler}
@@ -538,6 +544,7 @@ const MemberOfToolbar = (props: PropsToToolbar) => {
       key: 4,
       element: (
         <Button
+          data-cy="member-of-button-add"
           variant="secondary"
           name="add"
           onClick={toolbarData().addButton.onClickHandler}

--- a/src/components/Members/MembersExternal.tsx
+++ b/src/components/Members/MembersExternal.tsx
@@ -93,6 +93,7 @@ const MembersExternal = (props: PropsToMembersExternal) => {
       name: "External member",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-new-external-member"
           id="new-external-member"
           name="ipaexternalmember"
           value={newMember}
@@ -114,6 +115,7 @@ const MembersExternal = (props: PropsToMembersExternal) => {
   // - Actions
   const actionsToAddModal = [
     <Button
+      data-cy="add-new-external"
       key="add-new-external"
       variant="secondary"
       isDisabled={newMember.length === 0}
@@ -123,6 +125,7 @@ const MembersExternal = (props: PropsToMembersExternal) => {
       Add
     </Button>,
     <Button
+      data-cy="cancel-new-external"
       key="cancel-new-external"
       variant="link"
       onClick={() => setShowAddModal(false)}
@@ -249,6 +252,7 @@ const MembersExternal = (props: PropsToMembersExternal) => {
       />
       {showAddModal && (
         <ModalWithFormLayout
+          dataCy="add-external-member-modal"
           variantType="small"
           modalPosition="top"
           title={"Add external member"}

--- a/src/components/ResetIdpPassword.tsx
+++ b/src/components/ResetIdpPassword.tsx
@@ -87,6 +87,7 @@ const ResetIdpPassword = (props: PropsToResetIdpPassword) => {
           onChange={setNewPassword}
           onRevealHandler={setPasswordHidden}
           passwordHidden={passwordHidden}
+          dataCy="modal-textbox-new-password"
         />
       ),
     },
@@ -105,6 +106,7 @@ const ResetIdpPassword = (props: PropsToResetIdpPassword) => {
             onRevealHandler={setVerifyPasswordHidden}
             passwordHidden={verifyPasswordHidden}
             validated={passwordValidationResult.pfError}
+            dataCy="modal-textbox-verify-password"
           />
           <HelperText>
             <HelperTextItem variant="error">
@@ -163,6 +165,7 @@ const ResetIdpPassword = (props: PropsToResetIdpPassword) => {
 
   const actions = [
     <Button
+      data-cy="modal-button-reset-password"
       key={"reset-password"}
       variant="primary"
       onClick={onResetPassword}
@@ -175,6 +178,7 @@ const ResetIdpPassword = (props: PropsToResetIdpPassword) => {
       Reset password
     </Button>,
     <Button
+      data-cy="modal-button-cancel-reset-password"
       key={"cancel-reset-password"}
       variant="link"
       onClick={resetFieldsAndCloseModal}
@@ -188,6 +192,7 @@ const ResetIdpPassword = (props: PropsToResetIdpPassword) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="reset-password-modal"
         variantType="small"
         modalPosition="top"
         title="Reset password"

--- a/src/components/ServicesSections/ServiceCertificate.tsx
+++ b/src/components/ServicesSections/ServiceCertificate.tsx
@@ -32,6 +32,7 @@ const ServiceCertificate = (props: PropsToServiceSettings) => {
         <Form className="pf-v5-u-mb-lg">
           <FormGroup label="Certificates" fieldId="certificates" role="group">
             <IpaCertificates
+              dataCy="service-tab-certificates"
               ipaObject={ipaObject}
               onChange={recordOnChange}
               metadata={props.metadata}

--- a/src/components/ServicesSections/ServiceSettings.tsx
+++ b/src/components/ServicesSections/ServiceSettings.tsx
@@ -73,6 +73,7 @@ const ServiceSettings = (props: PropsToServiceSettings) => {
               role="group"
             >
               <PrincipalAliasMultiTextBox
+                dataCy="service-tab-settings-principal-alias"
                 ipaObject={ipaObject}
                 metadata={props.metadata}
                 onRefresh={props.onRefresh}
@@ -81,6 +82,7 @@ const ServiceSettings = (props: PropsToServiceSettings) => {
             </FormGroup>
             <FormGroup label="Service" fieldId="service">
               <TextInput
+                data-cy="services-tab-settings-textbox-service"
                 id="service"
                 name="service"
                 value={service}
@@ -91,6 +93,7 @@ const ServiceSettings = (props: PropsToServiceSettings) => {
             </FormGroup>
             <FormGroup label="Host name" fieldId="host-name">
               <TextInput
+                data-cy="services-tab-settings-textbox-host"
                 id="host-name"
                 name="host"
                 value={host}
@@ -101,6 +104,7 @@ const ServiceSettings = (props: PropsToServiceSettings) => {
             </FormGroup>
             <FormGroup label="PAC type" fieldId="pac-type" role="group">
               <IpaPACType
+                dataCy="service-tab-settings-pac-type"
                 name="ipakrbauthzdata"
                 ipaObject={ipaObject}
                 onChange={recordOnChange}
@@ -121,6 +125,7 @@ const ServiceSettings = (props: PropsToServiceSettings) => {
               }
             >
               <IpaCheckboxes
+                dataCy="service-tab-settings-checkbox-authentication-indicators"
                 name="krbprincipalauthind"
                 options={[
                   {
@@ -157,6 +162,7 @@ const ServiceSettings = (props: PropsToServiceSettings) => {
               role="group"
             >
               <IpaCheckbox
+                dataCy="service-tab-settings-checkbox-trusted-delegation"
                 name="ipakrbokasdelegate"
                 value="trustedForDelegation"
                 text="Trusted for delegation"
@@ -172,6 +178,7 @@ const ServiceSettings = (props: PropsToServiceSettings) => {
               role="group"
             >
               <IpaCheckbox
+                dataCy="service-tab-settings-checkbox-trusted-auth-as-user"
                 name="ipakrboktoauthasdelegate"
                 value="trustedAuthAsUser"
                 text="Trusted to authenticate as a user"
@@ -187,6 +194,7 @@ const ServiceSettings = (props: PropsToServiceSettings) => {
               role="group"
             >
               <IpaCheckbox
+                dataCy="service-tab-settings-checkbox-requires-pre-authentication"
                 name="ipakrbrequirespreauth"
                 value="requiresPreAuth"
                 text="Requires pre-authentication"

--- a/src/components/SudoRuleSections/RunCommands.tsx
+++ b/src/components/SudoRuleSections/RunCommands.tsx
@@ -506,6 +506,7 @@ const RunCommands = (props: PropsToRunCommands) => {
       <FlexItem>Command category the rule applies to: </FlexItem>
       <FlexItem>
         <IpaToggleGroup
+          dataCy="sudo-rule-toggle-group-cmd-category"
           ipaObject={props.ipaObject}
           name="cmdcategory"
           options={options}

--- a/src/components/SudoRuleSections/SudoRuleAsWhom.tsx
+++ b/src/components/SudoRuleSections/SudoRuleAsWhom.tsx
@@ -517,6 +517,7 @@ const SudoRuleAsWhom = (props: SudoRuleAsWhomProps) => {
       <FlexItem>RunAs User category the rule applies to: </FlexItem>
       <FlexItem>
         <IpaToggleGroup
+          dataCy="sudo-rule-toggle-group-sudo-run-as-user-category"
           ipaObject={props.ipaObject}
           name="ipasudorunasusercategory"
           options={userOptions}
@@ -549,6 +550,7 @@ const SudoRuleAsWhom = (props: SudoRuleAsWhomProps) => {
       <FlexItem>RunAs Group category the rule applies to: </FlexItem>
       <FlexItem>
         <IpaToggleGroup
+          dataCy="sudo-rule-toggle-group-sudo-run-as-group-category"
           ipaObject={props.ipaObject}
           name="ipasudorunasgroupcategory"
           options={groupOptions}

--- a/src/components/SudoRuleSections/SudoRuleGeneral.tsx
+++ b/src/components/SudoRuleSections/SudoRuleGeneral.tsx
@@ -21,6 +21,7 @@ const SudoRuleGeneral = (props: PropsToSudoRuleGeneral) => {
     <Form className="pf-v5-u-mt-sm pf-v5-u-mb-lg pf-v5-u-mr-md" isHorizontal>
       <FormGroup label="Rule name" fieldId="cn">
         <IpaTextInput
+          dataCy="sudo-rule-textbox-rule-name"
           name="cn"
           aria-label="rule name"
           ipaObject={props.ipaObject}
@@ -31,6 +32,7 @@ const SudoRuleGeneral = (props: PropsToSudoRuleGeneral) => {
       </FormGroup>
       <FormGroup label="Sudo order" fieldId="sudo-order">
         <IpaNumberInput
+          dataCy="sudo-rule-textbox-sudo-order"
           id="sudo-order"
           name="sudoorder"
           aria-label="sudo order"
@@ -45,6 +47,7 @@ const SudoRuleGeneral = (props: PropsToSudoRuleGeneral) => {
       </FormGroup>
       <FormGroup label="Description" fieldId="description">
         <IpaTextArea
+          dataCy="sudo-rule-textbox-description"
           name="description"
           ipaObject={props.ipaObject}
           onChange={props.recordOnChange}

--- a/src/components/SudoRuleSections/SudoRuleOptions.tsx
+++ b/src/components/SudoRuleSections/SudoRuleOptions.tsx
@@ -265,6 +265,7 @@ const SudoRuleOptions = (props: PropsToSudoRuleOptions) => {
       name: "Sudo option",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-sudo-option"
           type="text"
           id="sudo-option"
           name="ipasudoopt"
@@ -279,6 +280,7 @@ const SudoRuleOptions = (props: PropsToSudoRuleOptions) => {
 
   const addModalActions: JSX.Element[] = [
     <Button
+      data-cy="modal-button-add"
       key="delete-groups"
       variant="primary"
       form={"add-sudo-option-modal"}
@@ -291,6 +293,7 @@ const SudoRuleOptions = (props: PropsToSudoRuleOptions) => {
       {spinningOnAdd ? "Adding" : "Add"}
     </Button>,
     <Button
+      data-cy="modal-button-cancel"
       key="cancel-remove-group"
       variant="link"
       onClick={onChangeAddModalVisibility}
@@ -365,6 +368,7 @@ const SudoRuleOptions = (props: PropsToSudoRuleOptions) => {
       />
       {/* Add option modal */}
       <ModalWithFormLayout
+        dataCy="add-sudo-option-modal"
         variantType="medium"
         modalPosition="top"
         title={"Add sudo option"}

--- a/src/components/SudoRuleSections/SudoRulesWho.tsx
+++ b/src/components/SudoRuleSections/SudoRulesWho.tsx
@@ -339,6 +339,7 @@ const SudoRulesWho = (props: PropsToSudoRulesWho) => {
       <FlexItem>User category the rule applies to: </FlexItem>
       <FlexItem>
         <IpaToggleGroup
+          dataCy="sudo-rule-toggle-group-user-category"
           ipaObject={props.ipaObject}
           name="usercategory"
           options={options}

--- a/src/components/TypeAheadSelect.tsx
+++ b/src/components/TypeAheadSelect.tsx
@@ -60,6 +60,7 @@ const TypeAheadSelect = (props: PropsToTypeAheadSelect) => {
       if (!newSelectOptions.length) {
         newSelectOptions = [
           {
+            "data-cy": "typeahead-select-no-results",
             isAriaDisabled: true,
             children: `No results found for "${filterValue}"`,
             value: NO_RESULTS,
@@ -233,6 +234,7 @@ const TypeAheadSelect = (props: PropsToTypeAheadSelect) => {
       onClick={onToggleClick}
       isExpanded={isOpen}
       isFullWidth
+      data-cy="typeahead-select-toggle"
     >
       <TextInputGroup isPlain>
         <TextInputGroupMain
@@ -259,6 +261,7 @@ const TypeAheadSelect = (props: PropsToTypeAheadSelect) => {
 
   return (
     <Select
+      data-cy={props.id + "-typeahead-select"}
       id={props.id + "-typeahead-select"}
       isOpen={isOpen}
       selected={props.selected}

--- a/src/components/TypeAheadSelectWithCreate.tsx
+++ b/src/components/TypeAheadSelectWithCreate.tsx
@@ -54,6 +54,7 @@ const TypeAheadSelectWithCreate = (props: PropsToTypeAheadSelectWithCreate) => {
       if (!newSelectOptions.length) {
         newSelectOptions = [
           {
+            "data-cy": "typeahead-select-create-option",
             isDisabled: false,
             children: `Create new option "${filterValue}"`,
             value: "create",
@@ -179,6 +180,7 @@ const TypeAheadSelectWithCreate = (props: PropsToTypeAheadSelectWithCreate) => {
 
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
+      data-cy={props.id + "-select-toggle"}
       ref={toggleRef}
       variant="typeahead"
       onClick={onToggleClick}
@@ -203,6 +205,7 @@ const TypeAheadSelectWithCreate = (props: PropsToTypeAheadSelectWithCreate) => {
         <TextInputGroupUtilities>
           {!!inputValue && (
             <Button
+              data-cy={props.id + "-select-clear-input"}
               variant="plain"
               onClick={() => {
                 props.onSelectedChange("");
@@ -222,6 +225,7 @@ const TypeAheadSelectWithCreate = (props: PropsToTypeAheadSelectWithCreate) => {
 
   return (
     <Select
+      data-cy={props.id + "-select"}
       id={props.id + "-select"}
       isOpen={isOpen}
       selected={props.selected}

--- a/src/components/UsersSections/UserSettings.tsx
+++ b/src/components/UsersSections/UserSettings.tsx
@@ -279,12 +279,14 @@ const UserSettings = (props: PropsToUserSettings) => {
 
   const activeDropdownItems = [
     <DropdownItem
+      data-cy="user-tab-settings-kebab-reset-password"
       key="reset password"
       onClick={() => setIsResetPasswordModalOpen(true)}
     >
       Reset password
     </DropdownItem>,
     <DropdownItem
+      data-cy="user-tab-settings-kebab-enable"
       key="enable"
       isDisabled={!props.user.nsaccountlock}
       onClick={() => setIsDisableEnableModalOpen(true)}
@@ -292,16 +294,22 @@ const UserSettings = (props: PropsToUserSettings) => {
       Enable
     </DropdownItem>,
     <DropdownItem
+      data-cy="user-tab-settings-kebab-disable"
       key="disable"
       isDisabled={props.user.nsaccountlock}
       onClick={() => setIsDisableEnableModalOpen(true)}
     >
       Disable
     </DropdownItem>,
-    <DropdownItem key="delete" onClick={() => setIsDeleteModalOpen(true)}>
+    <DropdownItem
+      data-cy="user-tab-settings-kebab-delete"
+      key="delete"
+      onClick={() => setIsDeleteModalOpen(true)}
+    >
       Delete
     </DropdownItem>,
     <DropdownItem
+      data-cy="user-tab-settings-kebab-unlock"
       key="unlock"
       isDisabled={!getUnlockStatus()}
       onClick={() => setIsUnlockModalOpen(true)}
@@ -309,24 +317,28 @@ const UserSettings = (props: PropsToUserSettings) => {
       Unlock
     </DropdownItem>,
     <DropdownItem
+      data-cy="user-tab-settings-kebab-add-otp-token"
       key="add otp token"
       onClick={() => setIsAddOtpTokenModalOpen(true)}
     >
       Add OTP token
     </DropdownItem>,
     <DropdownItem
+      data-cy="user-tab-settings-kebab-rebuild-auto-membership"
       key="rebuild auto membership"
       onClick={() => setIsRebuildAutoMembershipModalOpen(true)}
     >
       Rebuild auto membership
     </DropdownItem>,
     <DropdownItem
+      data-cy="user-tab-settings-kebab-new-certificate"
       key="new certificate"
       onClick={() => setIsNewCertificateModalOpen(true)}
     >
       New certificate
     </DropdownItem>,
     <DropdownItem
+      data-cy="user-tab-settings-kebab-auto-assign-subordinate-ids"
       key="auto assign subordinate ids"
       isDisabled={isDisabledAutoAssignSubIds}
       onClick={onClickAutoAssignSubIds}
@@ -336,22 +348,42 @@ const UserSettings = (props: PropsToUserSettings) => {
   ];
 
   const stageDropdownItems = [
-    <DropdownItem key="activate" onClick={() => setIsActivateModalOpen(true)}>
+    <DropdownItem
+      data-cy="user-tab-settings-kebab-activate"
+      key="activate"
+      onClick={() => setIsActivateModalOpen(true)}
+    >
       Activate
     </DropdownItem>,
-    <DropdownItem key="delete" onClick={() => setIsDeleteModalOpen(true)}>
+    <DropdownItem
+      data-cy="user-tab-settings-kebab-delete"
+      key="delete"
+      onClick={() => setIsDeleteModalOpen(true)}
+    >
       Delete
     </DropdownItem>,
   ];
 
   const preservedDropdownItems = [
-    <DropdownItem key="stage" onClick={() => setIsStageModalOpen(true)}>
+    <DropdownItem
+      data-cy="user-tab-settings-kebab-stage"
+      key="stage"
+      onClick={() => setIsStageModalOpen(true)}
+    >
       Stage
     </DropdownItem>,
-    <DropdownItem key="restore" onClick={() => setIsRestoreModalOpen(true)}>
+    <DropdownItem
+      data-cy="user-tab-settings-kebab-restore"
+      key="restore"
+      onClick={() => setIsRestoreModalOpen(true)}
+    >
       Restore
     </DropdownItem>,
-    <DropdownItem key="delete" onClick={() => setIsDeleteModalOpen(true)}>
+    <DropdownItem
+      data-cy="user-tab-settings-kebab-delete"
+      key="delete"
+      onClick={() => setIsDeleteModalOpen(true)}
+    >
       Delete
     </DropdownItem>,
   ];
@@ -401,7 +433,10 @@ const UserSettings = (props: PropsToUserSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton onClickHandler={props.onRefresh}>
+        <SecondaryButton
+          dataCy="user-tab-settings-button-refresh"
+          onClickHandler={props.onRefresh}
+        >
           Refresh
         </SecondaryButton>
       ),
@@ -410,6 +445,7 @@ const UserSettings = (props: PropsToUserSettings) => {
       key: 1,
       element: (
         <SecondaryButton
+          dataCy="user-tab-settings-button-revert"
           isDisabled={!props.isModified}
           onClickHandler={onRevert}
         >
@@ -420,7 +456,11 @@ const UserSettings = (props: PropsToUserSettings) => {
     {
       key: 2,
       element: (
-        <SecondaryButton isDisabled={!props.isModified} onClickHandler={onSave}>
+        <SecondaryButton
+          dataCy="user-tab-settings-button-save"
+          isDisabled={!props.isModified}
+          onClickHandler={onSave}
+        >
           Save
         </SecondaryButton>
       ),
@@ -441,6 +481,7 @@ const UserSettings = (props: PropsToUserSettings) => {
                 ? stageDropdownItems
                 : preservedDropdownItems
           }
+          dataCy="user-tab-settings-kebab"
         />
       ),
     },

--- a/src/components/UsersSections/UsersAccountSettings.tsx
+++ b/src/components/UsersSections/UsersAccountSettings.tsx
@@ -84,10 +84,15 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
   };
 
   const certificatesOptions = [
-    <SecondaryButton key="add" onClickHandler={onClickAddTextAreaCertificates}>
+    <SecondaryButton
+      dataCy="modal-button-add"
+      key="add"
+      onClickHandler={onClickAddTextAreaCertificates}
+    >
       Add
     </SecondaryButton>,
     <Button
+      data-cy="modal-button-cancel"
       key="cancel"
       variant="link"
       onClick={onClickCancelTextAreaCertificates}
@@ -130,6 +135,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
           <Form className="pf-v5-u-mb-lg">
             <FormGroup label="User login" fieldId="uid">
               <IpaTextInput
+                dataCy="user-tab-settings-textbox-uid"
                 name={"uid"}
                 ariaLabel={"User login"}
                 ipaObject={ipaObject}
@@ -140,6 +146,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
             </FormGroup>
             <FormGroup label="Password" fieldId="password">
               <TextInput
+                data-cy="user-tab-settings-textbox-password"
                 id="password"
                 name="has_password"
                 value={password}
@@ -160,10 +167,12 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
                 onChange={recordOnChange}
                 objectName="user"
                 metadata={props.metadata}
+                dataCy="user-tab-settings-calendar-krbpasswordexpiration"
               />
             </FormGroup>
             <FormGroup label="UID" fieldId="uidnumber">
               <IpaTextInput
+                dataCy="user-tab-settings-textbox-uidnumber"
                 name={"uidnumber"}
                 ariaLabel={"UID number"}
                 ipaObject={ipaObject}
@@ -174,6 +183,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
             </FormGroup>
             <FormGroup label="GID" fieldId="gidnumber">
               <IpaTextInput
+                dataCy="user-tab-settings-textbox-gidnumber"
                 name={"gidnumber"}
                 ariaLabel={"GID number"}
                 ipaObject={ipaObject}
@@ -188,6 +198,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
               role="group"
             >
               <PrincipalAliasMultiTextBox
+                dataCy="user-tab-settings-kerberos-principal-alias"
                 ipaObject={ipaObject}
                 metadata={props.metadata}
                 onRefresh={props.onRefresh}
@@ -200,6 +211,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
               role="group"
             >
               <IpaCalendar
+                dataCy="user-tab-settings-calendar-krbprincipalexpiration"
                 name={"krbprincipalexpiration"}
                 ariaLabel={"Kerberos principal expiration date"}
                 ipaObject={ipaObject}
@@ -210,6 +222,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
             </FormGroup>
             <FormGroup label="Login shell" fieldId="loginshell">
               <IpaTextInput
+                dataCy="user-tab-settings-textbox-loginshell"
                 name={"loginshell"}
                 ariaLabel={"Login shell"}
                 ipaObject={ipaObject}
@@ -224,6 +237,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
           <Form className="pf-v5-u-mb-lg">
             <FormGroup label="Home directory" fieldId="homedirectory">
               <IpaTextInput
+                dataCy="user-tab-settings-textbox-homedirectory"
                 name={"homedirectory"}
                 ariaLabel={"Home directory"}
                 ipaObject={ipaObject}
@@ -238,6 +252,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
               role="group"
             >
               <IpaSshPublicKeys
+                dataCy="user-tab-settings-ssh-public-keys"
                 ipaObject={ipaObject}
                 onChange={recordOnChange}
                 metadata={props.metadata}
@@ -251,6 +266,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
               role="group"
             >
               <IpaCertificates
+                dataCy="user-tab-settings-certificates"
                 ipaObject={ipaObject}
                 objectType="user"
                 onChange={recordOnChange}
@@ -291,6 +307,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
               }
             >
               <IpaCheckboxes
+                dataCy="user-tab-settings-checkbox-ipauserauthtype"
                 name="ipauserauthtype"
                 options={[
                   {
@@ -329,6 +346,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
               fieldId="ipatokenradiusconfiglink"
             >
               <IpaSelect
+                dataCy="user-tab-settings-ipatokenradiusconfiglink"
                 id="ipatokenradiusconfiglink"
                 name="ipatokenradiusconfiglink"
                 options={radiusProxyList}
@@ -343,6 +361,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
               fieldId="ipatokenradiususername"
             >
               <IpaTextInput
+                dataCy="user-tab-settings-textbox-ipatokenradiususername"
                 name={"ipatokenradiususername"}
                 ariaLabel={"Radius proxy username"}
                 ipaObject={ipaObject}
@@ -356,6 +375,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
               fieldId="ipaidpconfiglink"
             >
               <IpaSelect
+                dataCy="user-tab-settings-ipaidpconfiglink"
                 id="ipaidpconfiglink"
                 name="ipaidpconfiglink"
                 options={idpConfOptions}
@@ -367,6 +387,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
             </FormGroup>
             <FormGroup label="External IdP user identifier" fieldId="ipaidpsub">
               <IpaTextInput
+                dataCy="user-tab-settings-textbox-ipaidpsub"
                 name={"ipaidpsub"}
                 ariaLabel={"External IdP user identifier"}
                 ipaObject={ipaObject}
@@ -379,6 +400,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
         </FlexItem>
       </Flex>
       <ModalWithTextAreaLayout
+        dataCy="usercertificate-modal"
         id="certificate-textarea"
         value={textAreaCertificatesValue}
         onChange={onChangeTextAreaCertificatesValue}

--- a/src/components/UsersSections/UsersAttributesSMB.tsx
+++ b/src/components/UsersSections/UsersAttributesSMB.tsx
@@ -81,6 +81,7 @@ const UsersAttributesSMB = (props: PropsToSmbServices) => {
             }
           >
             <IpaTextInput
+              dataCy="user-tab-settings-textbox-smb-logon-script-path"
               name={"ipantlogonscript"}
               ariaLabel={"SMB logon script path"}
               ipaObject={ipaObject}
@@ -97,6 +98,7 @@ const UsersAttributesSMB = (props: PropsToSmbServices) => {
             }
           >
             <IpaTextInput
+              dataCy="user-tab-settings-textbox-smb-profile-path"
               name={"ipantprofilepath"}
               ariaLabel={"SMB profile path"}
               ipaObject={ipaObject}
@@ -120,6 +122,7 @@ const UsersAttributesSMB = (props: PropsToSmbServices) => {
             }
           >
             <IpaTextInput
+              dataCy="user-tab-settings-textbox-smb-home-directory"
               name={"ipanthomedirectory"}
               ariaLabel={"SMB home directory"}
               ipaObject={ipaObject}
@@ -139,6 +142,7 @@ const UsersAttributesSMB = (props: PropsToSmbServices) => {
             }
           >
             <IpaSelect
+              dataCy="user-tab-settings-smb-home-directory-drive"
               id="ipanthomedirectorydrive"
               name="ipanthomedirectorydrive"
               options={SMBHomeDirectoryDriveOptions}

--- a/src/components/UsersSections/UsersContactSettings.tsx
+++ b/src/components/UsersSections/UsersContactSettings.tsx
@@ -27,6 +27,7 @@ const UsersContactSettings = (props: PropsToUsersContactSettings) => {
         <Form className="pf-v5-u-mb-lg">
           <FormGroup label="Mail address" fieldId="mail" role="group">
             <IpaTextboxList
+              dataCy="user-tab-settings-mail"
               ipaObject={ipaObject}
               setIpaObject={recordOnChange}
               name={"mail"}
@@ -39,6 +40,7 @@ const UsersContactSettings = (props: PropsToUsersContactSettings) => {
             role="group"
           >
             <IpaTextboxList
+              dataCy="user-tab-settings-telephonenumber"
               ipaObject={ipaObject}
               setIpaObject={recordOnChange}
               name={"telephonenumber"}
@@ -47,6 +49,7 @@ const UsersContactSettings = (props: PropsToUsersContactSettings) => {
           </FormGroup>
           <FormGroup label="Pager number" fieldId="pager" role="group">
             <IpaTextboxList
+              dataCy="user-tab-settings-pager"
               ipaObject={ipaObject}
               setIpaObject={recordOnChange}
               name={"pager"}
@@ -59,6 +62,7 @@ const UsersContactSettings = (props: PropsToUsersContactSettings) => {
         <Form className="pf-v5-u-mb-lg">
           <FormGroup label="Mobile phone number" fieldId="mobile" role="group">
             <IpaTextboxList
+              dataCy="user-tab-settings-mobile"
               ipaObject={ipaObject}
               setIpaObject={recordOnChange}
               name={"mobile"}

--- a/src/components/UsersSections/UsersEmployeeInfo.tsx
+++ b/src/components/UsersSections/UsersEmployeeInfo.tsx
@@ -35,6 +35,7 @@ const UsersEmployeeInfo = (props: PropsToEmployeeInfo) => {
         <Form className="pf-v5-u-mb-lg">
           <FormGroup label="Org. unit" fieldId="ou">
             <IpaTextInput
+              dataCy="user-tab-settings-textbox-ou"
               name={"ou"}
               ariaLabel={"Org. unit"}
               ipaObject={ipaObject}
@@ -45,6 +46,7 @@ const UsersEmployeeInfo = (props: PropsToEmployeeInfo) => {
           </FormGroup>
           <FormGroup label="Manager" fieldId="manager">
             <IpaSelect
+              dataCy="user-tab-settings-select-manager"
               id="manager"
               name="manager"
               options={managerOptions}
@@ -60,6 +62,7 @@ const UsersEmployeeInfo = (props: PropsToEmployeeInfo) => {
             role="group"
           >
             <IpaTextboxList
+              dataCy="user-tab-settings-textbox-departmentnumber"
               ipaObject={ipaObject}
               setIpaObject={recordOnChange}
               name={"departmentnumber"}
@@ -70,8 +73,9 @@ const UsersEmployeeInfo = (props: PropsToEmployeeInfo) => {
       </FlexItem>
       <FlexItem flex={{ default: "flex_1" }}>
         <Form className="pf-v5-u-mb-lg">
-          <FormGroup label="Employee number" fieldId="employeenumber">
+          <FormGroup label="Employee number" fieldId="employee-number">
             <IpaTextInput
+              dataCy="user-tab-settings-textbox-employeenumber"
               name={"employeenumber"}
               ariaLabel={"Employee number"}
               ipaObject={ipaObject}
@@ -82,6 +86,7 @@ const UsersEmployeeInfo = (props: PropsToEmployeeInfo) => {
           </FormGroup>
           <FormGroup label="Employee type" fieldId="employeetype">
             <IpaTextInput
+              dataCy="user-tab-settings-textbox-employee-type"
               name={"employeetype"}
               ariaLabel={"Employee type"}
               ipaObject={ipaObject}
@@ -92,6 +97,7 @@ const UsersEmployeeInfo = (props: PropsToEmployeeInfo) => {
           </FormGroup>
           <FormGroup label="Preferred language" fieldId="preferredlanguage">
             <IpaTextInput
+              dataCy="user-tab-settings-textbox-preferred-language"
               name={"preferredlanguage"}
               ariaLabel={"Preferred language"}
               ipaObject={ipaObject}

--- a/src/components/UsersSections/UsersIdentity.tsx
+++ b/src/components/UsersSections/UsersIdentity.tsx
@@ -23,6 +23,7 @@ const UsersIdentity = (props: PropsToUsersIdentity) => {
 
   const firstNameTextInput = (
     <IpaTextInput
+      dataCy="user-tab-settings-textbox-givenname"
       name={"givenname"}
       ariaLabel={"Given name"}
       ipaObject={ipaObject}
@@ -35,6 +36,7 @@ const UsersIdentity = (props: PropsToUsersIdentity) => {
   // - Last name
   const lastNameTextInput = (
     <IpaTextInput
+      dataCy="user-tab-settings-textbox-lastname"
       name={"sn"}
       ariaLabel={"Last name"}
       ipaObject={ipaObject}
@@ -47,6 +49,7 @@ const UsersIdentity = (props: PropsToUsersIdentity) => {
   // - Full name
   const fullNameTextInput = (
     <IpaTextInput
+      dataCy="user-tab-settings-textbox-fullname"
       name={"cn"}
       ariaLabel={"Full name"}
       ipaObject={ipaObject}
@@ -59,6 +62,7 @@ const UsersIdentity = (props: PropsToUsersIdentity) => {
   // - Job title
   const jobTitleTextInput = (
     <IpaTextInput
+      dataCy="user-tab-settings-textbox-jobtitle"
       name={"title"}
       ariaLabel={"Job title"}
       ipaObject={ipaObject}
@@ -71,6 +75,7 @@ const UsersIdentity = (props: PropsToUsersIdentity) => {
   // - GECOS
   const gecosTextInput = (
     <IpaTextInput
+      dataCy="user-tab-settings-textbox-gecos"
       name={"gecos"}
       ariaLabel={"GECOS"}
       ipaObject={ipaObject}
@@ -83,6 +88,7 @@ const UsersIdentity = (props: PropsToUsersIdentity) => {
   // - User class
   const userClassTextInput = (
     <IpaTextInput
+      dataCy="user-tab-settings-textbox-userclass"
       name={"userclass"}
       ariaLabel={"User Class"}
       ipaObject={ipaObject}

--- a/src/components/UsersSections/UsersKerberosTicket.tsx
+++ b/src/components/UsersSections/UsersKerberosTicket.tsx
@@ -20,6 +20,7 @@ const UsersKerberosTicket = (props: PropsToKrbTicket) => {
         <Form className="pf-v5-u-mb-lg">
           <FormGroup label="Max renew (seconds)" fieldId="max-renew">
             <TextInput
+              data-cy="user-tab-settings-textbox-max-renew"
               id="max-renew"
               name="krbmaxrenewableage"
               value={props.krbPolicyData.krbmaxrenewableage}
@@ -34,6 +35,7 @@ const UsersKerberosTicket = (props: PropsToKrbTicket) => {
         <Form className="pf-v5-u-mb-lg">
           <FormGroup label="Max life (seconds)" fieldId="max-life">
             <TextInput
+              data-cy="user-tab-settings-textbox-max-life"
               id="max-life"
               name="krbmaxticketlife"
               value={props.krbPolicyData.krbmaxticketlife}

--- a/src/components/UsersSections/UsersMailingAddress.tsx
+++ b/src/components/UsersSections/UsersMailingAddress.tsx
@@ -27,6 +27,7 @@ const UsersMailingAddress = (props: PropsToUsersMailingAddress) => {
         <Form className="pf-v5-u-mb-lg">
           <FormGroup label="Street address" fieldId="street">
             <IpaTextInput
+              dataCy="user-tab-settings-textbox-street"
               name={"street"}
               ariaLabel={"Street address"}
               ipaObject={ipaObject}
@@ -37,6 +38,7 @@ const UsersMailingAddress = (props: PropsToUsersMailingAddress) => {
           </FormGroup>
           <FormGroup label="City" fieldId="l">
             <IpaTextInput
+              dataCy="user-tab-settings-textbox-city"
               name={"l"}
               ariaLabel={"City"}
               ipaObject={ipaObject}
@@ -51,6 +53,7 @@ const UsersMailingAddress = (props: PropsToUsersMailingAddress) => {
         <Form className="pf-v5-u-mb-lg">
           <FormGroup label="State/province" fieldId="st">
             <IpaTextInput
+              dataCy="user-tab-settings-textbox-state"
               name={"st"}
               ariaLabel={"State/province"}
               ipaObject={ipaObject}
@@ -61,6 +64,7 @@ const UsersMailingAddress = (props: PropsToUsersMailingAddress) => {
           </FormGroup>
           <FormGroup label="ZIP" fieldId="postalcode">
             <IpaTextInput
+              dataCy="user-tab-settings-textbox-postalcode"
               name={"postalcode"}
               ariaLabel={"Postal code"}
               ipaObject={ipaObject}

--- a/src/components/UsersSections/UsersPasswordPolicy.tsx
+++ b/src/components/UsersSections/UsersPasswordPolicy.tsx
@@ -20,6 +20,7 @@ const UsersPasswordPolicy = (props: PropsToPasswordPolicy) => {
         <Form className="pf-v5-u-mb-lg">
           <FormGroup label="Max lifetime (days)" fieldId="max-lifetime-days">
             <TextInput
+              data-cy="user-tab-settings-textbox-max-lifetime-days"
               id="max-lifetime-days"
               name="krbmaxpwdlife"
               value={props.pwdPolicyData.krbmaxpwdlife}
@@ -30,6 +31,7 @@ const UsersPasswordPolicy = (props: PropsToPasswordPolicy) => {
           </FormGroup>
           <FormGroup label="Min lifetime (hours)" fieldId="min-lifetime-hours">
             <TextInput
+              data-cy="user-tab-settings-textbox-min-lifetime-hours"
               id="min-lifetime-hours"
               name="krbminpwdlife"
               value={props.pwdPolicyData.krbminpwdlife}
@@ -43,6 +45,7 @@ const UsersPasswordPolicy = (props: PropsToPasswordPolicy) => {
             fieldId="history-size"
           >
             <TextInput
+              data-cy="user-tab-settings-textbox-history-size"
               id="history-size"
               name="krbpwdhistorylength"
               value={props.pwdPolicyData.krbpwdhistorylength}
@@ -53,6 +56,7 @@ const UsersPasswordPolicy = (props: PropsToPasswordPolicy) => {
           </FormGroup>
           <FormGroup label="Character classes" fieldId="character-classes">
             <TextInput
+              data-cy="user-tab-settings-textbox-character-classes"
               id="character-classes"
               name="krbpwdmindiffchars"
               value={props.pwdPolicyData.krbpwdmindiffchars}
@@ -63,6 +67,7 @@ const UsersPasswordPolicy = (props: PropsToPasswordPolicy) => {
           </FormGroup>
           <FormGroup label="Min length" fieldId="min-length">
             <TextInput
+              data-cy="user-tab-settings-textbox-min-length"
               id="min-length"
               name="krbpwdminlength"
               value={props.pwdPolicyData.krbpwdminlength}
@@ -77,6 +82,7 @@ const UsersPasswordPolicy = (props: PropsToPasswordPolicy) => {
         <Form className="pf-v5-u-mb-lg">
           <FormGroup label="Max failures" fieldId="max-failures">
             <TextInput
+              data-cy="user-tab-settings-textbox-max-failures"
               id="max-failures"
               name="krbpwdmaxfailure"
               value={props.pwdPolicyData.krbpwdmaxfailure}
@@ -90,6 +96,7 @@ const UsersPasswordPolicy = (props: PropsToPasswordPolicy) => {
             fieldId="future-reset-interval"
           >
             <TextInput
+              data-cy="user-tab-settings-textbox-future-reset-interval"
               id="future-reset-interval"
               name="krbpwdfailurecountinterval"
               value={props.pwdPolicyData.krbpwdfailurecountinterval}
@@ -103,6 +110,7 @@ const UsersPasswordPolicy = (props: PropsToPasswordPolicy) => {
             fieldId="lockout-duration"
           >
             <TextInput
+              data-cy="user-tab-settings-textbox-lockout-duration"
               id="lockout-duration"
               name="krbpwdlockoutduration"
               value={props.pwdPolicyData.krbpwdlockoutduration}
@@ -113,6 +121,7 @@ const UsersPasswordPolicy = (props: PropsToPasswordPolicy) => {
           </FormGroup>
           <FormGroup label="Grace login limit" fieldId="grace-login-limit">
             <TextInput
+              data-cy="user-tab-settings-textbox-grace-login-limit"
               id="grace-login-limit"
               name="passwordgracelimit"
               value={props.pwdPolicyData.passwordgracelimit}

--- a/src/components/errors/ModalErrors.tsx
+++ b/src/components/errors/ModalErrors.tsx
@@ -6,10 +6,11 @@ import { ApiError } from "src/hooks/useApiError";
 import ErrorModal from "../modals/ErrorModal";
 
 interface ModalErrorProps {
+  dataCy: string;
   errors: ApiError[];
 }
 
-const ModalErrors = ({ errors }: ModalErrorProps) => {
+const ModalErrors = ({ errors, dataCy }: ModalErrorProps) => {
   const [isModalErrorOpen, setIsModalErrorOpen] = React.useState(false);
   const [errorTitle, setErrorTitle] = React.useState("");
   const [errorMessage, setErrorMessage] = React.useState("");
@@ -33,7 +34,12 @@ const ModalErrors = ({ errors }: ModalErrorProps) => {
   };
 
   const errorModalActions = [
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+    >
       Cancel
     </Button>,
   ];
@@ -42,6 +48,7 @@ const ModalErrors = ({ errors }: ModalErrorProps) => {
     <>
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy={dataCy}
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/layouts/DropdownSearch/DropdownSearch.test.tsx
+++ b/src/components/layouts/DropdownSearch/DropdownSearch.test.tsx
@@ -32,6 +32,7 @@ describe("DropdownSearch Component", () => {
   it("renders the DropdownSearch component with items", async () => {
     render(
       <DropdownSearch
+        dataCy="dropdown-search"
         id="test"
         onSelect={mockOnSelect}
         options={mockList}
@@ -57,6 +58,7 @@ describe("DropdownSearch Component", () => {
   it("select in DropdownSearch Component works", async () => {
     render(
       <DropdownSearch
+        dataCy="dropdown-search"
         id="test"
         onSelect={mockOnSelect}
         options={mockList}
@@ -85,6 +87,7 @@ describe("DropdownSearch Component", () => {
   it("search in DropdownSearch Component works", async () => {
     render(
       <DropdownSearch
+        dataCy="dropdown-search"
         id="test"
         onSelect={mockOnSelect}
         options={mockList}
@@ -137,6 +140,7 @@ describe("DropdownSearch Component", () => {
   it("failing search in DropdownSearch Component works", async () => {
     render(
       <DropdownSearch
+        dataCy="dropdown-search"
         id="test"
         onSelect={mockOnSelect}
         options={mockList}

--- a/src/components/layouts/DropdownSearch/DropdownSearch.tsx
+++ b/src/components/layouts/DropdownSearch/DropdownSearch.tsx
@@ -14,6 +14,7 @@ import {
 import { useGetIDListMutation, GenericPayload } from "src/services/rpc";
 
 interface DropdownProps {
+  dataCy: string;
   id?: string;
   onSelect: (value: string) => void;
   options: string[];
@@ -74,12 +75,14 @@ const DropdownSearch = (props: DropdownProps) => {
 
   return (
     <Dropdown
+      data-cy={props.dataCy + "-dropdown"}
       id={props.id || "dropdown-search"}
       isOpen={isOpen}
       onSelect={onSelect}
       onOpenChange={(isOpen: boolean) => setIsOpen(isOpen)}
       toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
         <MenuToggle
+          data-cy={props.dataCy + "-dropdown-toggle"}
           ref={toggleRef}
           isFullWidth
           onClick={onToggleClick}
@@ -95,6 +98,7 @@ const DropdownSearch = (props: DropdownProps) => {
       <MenuSearch>
         <MenuSearchInput>
           <SearchInput
+            data-cy={props.dataCy + "-dropdown-search"}
             value={searchValue}
             placeholder="Search"
             onChange={(_event, value) => setSearchValue(value)}
@@ -108,7 +112,11 @@ const DropdownSearch = (props: DropdownProps) => {
       <Divider />
       <DropdownList>
         {filteredOptions.map((option, index) => (
-          <DropdownItem value={option} key={index}>
+          <DropdownItem
+            data-cy={props.dataCy + "-dropdown-" + option}
+            value={option}
+            key={index}
+          >
             {option}
           </DropdownItem>
         ))}

--- a/src/components/layouts/DualListLayout/DualListLayout.tsx
+++ b/src/components/layouts/DualListLayout/DualListLayout.tsx
@@ -204,6 +204,7 @@ const DualListTableLayout = (props: DualListProps) => {
       id: "dual-list-search",
       pfComponent: (
         <SearchInputLayout
+          dataCy="modal-search"
           name="search"
           ariaLabel="Search dual select list"
           placeholder="Search for entries"
@@ -253,6 +254,7 @@ const DualListTableLayout = (props: DualListProps) => {
             <Flex>
               <FlexItem>
                 <TextInput
+                  data-cy="modal-textbox-external"
                   type="text"
                   id="dual-list-external"
                   name="dual-list-external"
@@ -263,6 +265,7 @@ const DualListTableLayout = (props: DualListProps) => {
               </FlexItem>
               <FlexItem>
                 <Button
+                  data-cy="modal-button-external-add"
                   title="Add external item to the chosen list"
                   size="sm"
                   variant="secondary"
@@ -319,6 +322,7 @@ const DualListTableLayout = (props: DualListProps) => {
   // Buttons that will be shown at the end of the form
   const modalActions = [
     <SecondaryButton
+      dataCy="modal-button-add"
       key={"dual-list-" + props.target}
       isDisabled={buttonDisabled || props.spinning}
       form="modal-form"
@@ -330,6 +334,7 @@ const DualListTableLayout = (props: DualListProps) => {
       {props.spinning ? props.addSpinningBtnName : props.addBtnName}
     </SecondaryButton>,
     <Button
+      data-cy="modal-button-cancel"
       key={"cancel-new-" + props.target}
       variant="link"
       onClick={closeModal}
@@ -341,6 +346,7 @@ const DualListTableLayout = (props: DualListProps) => {
   // Render component
   return (
     <ModalWithFormLayout
+      dataCy="dual-list-modal"
       variantType="medium"
       modalPosition="top"
       title={props.title}

--- a/src/components/layouts/ExpandableCardLayout.tsx
+++ b/src/components/layouts/ExpandableCardLayout.tsx
@@ -43,6 +43,7 @@ const ExpandableCardLayout = (props: PropsToCardLayout) => {
   // Toggle
   const KebabToggleWithRef = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
+      data-cy={props.id + "-kebab"}
       ref={toggleRef}
       id={props.id}
       aria-label="kebab dropdown toggle"
@@ -57,7 +58,11 @@ const ExpandableCardLayout = (props: PropsToCardLayout) => {
   const getDropdownItems = () => {
     if (props.dropdownItems !== undefined && props.dropdownItems.length > 0) {
       return (
-        <Dropdown toggle={KebabToggleWithRef} isOpen={isOpen}>
+        <Dropdown
+          data-cy={props.id + "-kebab-dropdown"}
+          toggle={KebabToggleWithRef}
+          isOpen={isOpen}
+        >
           <DropdownList>{props.dropdownItems}</DropdownList>
         </Dropdown>
       );

--- a/src/components/layouts/HelpTextWithIconLayout.tsx
+++ b/src/components/layouts/HelpTextWithIconLayout.tsx
@@ -13,6 +13,7 @@ interface PropsToHelpTextLayout {
 const HelpTextWithIconLayout = (props: PropsToHelpTextLayout) => {
   return (
     <Button
+      data-cy="help-text-with-icon-button"
       variant="link"
       icon={props.icon || <OutlinedQuestionCircleIcon />}
       onClick={props.onClick}

--- a/src/components/layouts/InformationModalLayout.tsx
+++ b/src/components/layouts/InformationModalLayout.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { Modal } from "@patternfly/react-core";
 
 interface PropsToModalLayout {
+  dataCy: string;
   isOpen: boolean;
   onClose: () => void;
   actions: JSX.Element[];
@@ -14,6 +15,7 @@ interface PropsToModalLayout {
 const InformationModalLayout = (props: PropsToModalLayout) => {
   return (
     <Modal
+      data-cy={props.dataCy}
       variant={props.variant || "small"}
       title={props.title}
       isOpen={props.isOpen}

--- a/src/components/layouts/KebabLayout.tsx
+++ b/src/components/layouts/KebabLayout.tsx
@@ -10,6 +10,7 @@ import {
 import { EllipsisVIcon } from "@patternfly/react-icons";
 
 interface PropsToKebab {
+  dataCy: string;
   // Dropdown
   onDropdownSelect?:
     | ((event?: React.MouseEvent<Element, MouseEvent> | undefined) => void)
@@ -28,6 +29,7 @@ const KebabLayout = (props: PropsToKebab) => {
   // Toggle
   const toggleKebab = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
+      data-cy={props.dataCy}
       ref={toggleRef}
       id={props.idKebab}
       aria-label="kebab dropdown toggle"
@@ -41,6 +43,7 @@ const KebabLayout = (props: PropsToKebab) => {
 
   return (
     <Dropdown
+      data-cy={props.dataCy + "-kebab"}
       onSelect={props.onDropdownSelect}
       className={props.className}
       toggle={toggleKebab}

--- a/src/components/layouts/ModalWithFormLayout.tsx
+++ b/src/components/layouts/ModalWithFormLayout.tsx
@@ -3,6 +3,8 @@ import React from "react";
 import { Form, FormGroup, Modal, ModalVariant } from "@patternfly/react-core";
 
 export interface PropsToModal {
+  // Data cypress
+  dataCy: string;
   // Modal variant
   variantType: "small" | "medium" | "large" | "default";
   // Position
@@ -66,6 +68,7 @@ const ModalWithFormLayout = (props: PropsToModal) => {
   // Render 'ModalWithFormLayout'
   return (
     <Modal
+      data-cy={props.dataCy}
       variant={variant}
       title={props.title}
       description={props.description}

--- a/src/components/layouts/ModalWithTextAreaLayout.tsx
+++ b/src/components/layouts/ModalWithTextAreaLayout.tsx
@@ -5,6 +5,7 @@ import { Form, FormGroup, Modal, TextArea } from "@patternfly/react-core";
 import { Metadata } from "src/utils/datatypes/globalDataTypes";
 
 interface PropsToPKModal {
+  dataCy: string;
   id: string;
   value: string;
   onChange: (value: string) => void;
@@ -28,6 +29,7 @@ interface PropsToPKModal {
 const ModalWithTextAreaLayout = (props: PropsToPKModal) => {
   return (
     <Modal
+      data-cy={props.dataCy + "-modal"}
       variant={props.variant || "small"}
       title={props.title}
       isOpen={props.isOpen}
@@ -42,6 +44,7 @@ const ModalWithTextAreaLayout = (props: PropsToPKModal) => {
           isRequired={props.isRequired}
         >
           <TextArea
+            data-cy={"modal-textbox-" + props.dataCy}
             id={props.id}
             value={props.value}
             name={props.name}

--- a/src/components/layouts/PasswordInput/PasswordInput.test.tsx
+++ b/src/components/layouts/PasswordInput/PasswordInput.test.tsx
@@ -8,6 +8,7 @@ const mockOnChange = vi.fn();
 const mockOnRevealHandler = vi.fn();
 
 const initialProps: PropsToPasswordInput = {
+  dataCy: "password-input",
   name: "Password",
   onChange: mockOnChange,
   onRevealHandler: mockOnRevealHandler,

--- a/src/components/layouts/PasswordInput/PasswordInput.tsx
+++ b/src/components/layouts/PasswordInput/PasswordInput.tsx
@@ -10,6 +10,7 @@ import { EyeSlashIcon } from "@patternfly/react-icons";
 import { EyeIcon } from "@patternfly/react-icons";
 
 export interface PropsToPasswordInput {
+  dataCy: string;
   ariaLabel?: string;
   name?: string;
   id?: string;
@@ -30,6 +31,7 @@ const PasswordInput = (props: PropsToPasswordInput) => {
     <InputGroup>
       <InputGroupItem isFill>
         <TextInput
+          data-cy={props.dataCy}
           aria-label={props.ariaLabel ?? props.name}
           type={props.passwordHidden ? "password" : "text"}
           id={props.id}
@@ -44,6 +46,7 @@ const PasswordInput = (props: PropsToPasswordInput) => {
       </InputGroupItem>
       <InputGroupItem>
         <Button
+          data-cy={props.dataCy + "-reveal-button"}
           variant="control"
           onClick={() => props.onRevealHandler(!props.passwordHidden)}
           aria-label={props.passwordHidden ? "Show password" : "Hide password"}

--- a/src/components/layouts/SearchInputLayout.tsx
+++ b/src/components/layouts/SearchInputLayout.tsx
@@ -11,6 +11,7 @@ interface SearchValueData {
 
 interface PropsToSearchInput {
   name?: string;
+  dataCy: string;
   ariaLabel?: string;
   placeholder?: string;
   searchValueData: SearchValueData;
@@ -31,6 +32,7 @@ const SearchInputLayout = (props: PropsToSearchInput) => {
 
   return (
     <SearchInput
+      data-cy={props.dataCy}
       name={props.name}
       aria-label={props.ariaLabel}
       placeholder={props.placeholder}

--- a/src/components/layouts/SecondaryButton.tsx
+++ b/src/components/layouts/SecondaryButton.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { Button } from "@patternfly/react-core";
 
 interface PropsToSecondaryButton {
+  dataCy: string;
   id?: string;
   classname?: string;
   name?: string;
@@ -27,6 +28,7 @@ interface PropsToSecondaryButton {
 const SecondaryButton = (props: PropsToSecondaryButton) => {
   return (
     <Button
+      data-cy={props.dataCy}
       id={props.id}
       className={props.classname}
       name={props.name}

--- a/src/components/layouts/SettingsTableLayout.tsx
+++ b/src/components/layouts/SettingsTableLayout.tsx
@@ -71,6 +71,7 @@ const SettingsTableLayout = (props: PropsToSettingsTableLayout) => {
         <FlexItem>
           {props.entryCount > 0 && props.onSearchChange !== undefined && (
             <SearchInput
+              data-cy="search"
               placeholder={"Filter by ..."}
               value={props.searchValue}
               onChange={(_event, value: string) =>
@@ -84,6 +85,7 @@ const SettingsTableLayout = (props: PropsToSettingsTableLayout) => {
           <>
             <FlexItem>
               <SecondaryButton
+                dataCy="settings-button-delete"
                 classname="pf-v5-u-mr-sm"
                 isDisabled={props.isDeleteDisabled || false}
                 onClickHandler={props.onDeleteModal}
@@ -91,6 +93,7 @@ const SettingsTableLayout = (props: PropsToSettingsTableLayout) => {
                 Delete
               </SecondaryButton>
               <SecondaryButton
+                dataCy="settings-button-add"
                 classname="pf-v5-u-mr-sm"
                 isDisabled={props.isAddDisabled || false}
                 onClickHandler={props.onAddModal}
@@ -139,6 +142,7 @@ const SettingsTableLayout = (props: PropsToSettingsTableLayout) => {
           <EmptyStateBody>
             <EmptyStateActions>
               <SecondaryButton
+                dataCy="settings-button-add"
                 onClickHandler={props.onAddModal}
                 isDisabled={props.isAddDisabled || false}
                 id={addButtonId}

--- a/src/components/layouts/SimpleSelector.tsx
+++ b/src/components/layouts/SimpleSelector.tsx
@@ -6,10 +6,15 @@ import {
   Select,
   SelectList,
   SelectOption,
-  SelectOptionProps,
 } from "@patternfly/react-core";
 
+export interface SelectOptionProps {
+  key: string;
+  value: string;
+}
+
 interface PropsToSimpleSelector {
+  dataCy: string;
   id: string;
   selected: string;
   options: SelectOptionProps[];
@@ -36,6 +41,7 @@ const SimpleSelector = (props: PropsToSimpleSelector) => {
 
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
+      data-cy={props.dataCy + "-select-toggle"}
       id={props.id}
       ref={toggleRef}
       aria-label={
@@ -51,6 +57,7 @@ const SimpleSelector = (props: PropsToSimpleSelector) => {
 
   return (
     <Select
+      data-cy={props.dataCy + "-select"}
       id={props.id + "-select"}
       isOpen={isOpen}
       selected={props.selected}
@@ -62,6 +69,7 @@ const SimpleSelector = (props: PropsToSimpleSelector) => {
       <SelectList id={props.id + "-selector-list"}>
         {props.options.map((option, idx) => (
           <SelectOption
+            data-cy={props.dataCy + "-select-" + option.key}
             id={option.key + "-" + idx}
             key={option.key + "-" + idx}
             tabIndex={idx}

--- a/src/components/layouts/TableWithButtonsLayout.tsx
+++ b/src/components/layouts/TableWithButtonsLayout.tsx
@@ -31,6 +31,7 @@ const TableWithButtonsLayout = (props: PropsToTableWithButtons) => {
       <Flex>
         <FlexItem>
           <SecondaryButton
+            dataCy="table-button-delete"
             classname={props.deleteButtonClasses}
             isDisabled={props.isDeleteDisabled}
             onClickHandler={props.onDeleteModal}
@@ -38,6 +39,7 @@ const TableWithButtonsLayout = (props: PropsToTableWithButtons) => {
             Delete
           </SecondaryButton>
           <SecondaryButton
+            dataCy="table-button-add"
             classname={props.addButtonClasses}
             onClickHandler={props.onAddModal}
           >

--- a/src/components/modals/AddHostGroup.tsx
+++ b/src/components/modals/AddHostGroup.tsx
@@ -71,6 +71,7 @@ const AddHostGroup = (props: PropsToAddGroup) => {
       pfComponent: (
         <>
           <TextInput
+            data-cy="modal-textbox-hostgroup-name"
             type="text"
             id="modal-form-hostgroup-name"
             name="modal-form-hostgroup-name"
@@ -95,6 +96,7 @@ const AddHostGroup = (props: PropsToAddGroup) => {
       name: "Description",
       pfComponent: (
         <TextArea
+          data-cy="modal-textbox-hostgroup-description"
           id="modal-form-hostgroup-desc"
           name="modal-form-hostgroup-desc"
           value={description}
@@ -239,10 +241,19 @@ const AddHostGroup = (props: PropsToAddGroup) => {
   };
 
   const errorModalActions = [
-    <SecondaryButton key="retry" onClickHandler={onRetry}>
+    <SecondaryButton
+      dataCy="modal-button-retry"
+      key="retry"
+      onClickHandler={onRetry}
+    >
       Retry
     </SecondaryButton>,
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+    >
       Cancel
     </Button>,
   ];
@@ -260,6 +271,7 @@ const AddHostGroup = (props: PropsToAddGroup) => {
   // Buttons that will be shown at the end of the form
   const modalActions = [
     <SecondaryButton
+      dataCy="modal-button-add"
       key="add-new-hostgroup"
       name="add"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
@@ -272,6 +284,7 @@ const AddHostGroup = (props: PropsToAddGroup) => {
       {addSpinning ? "Adding" : "Add"}
     </SecondaryButton>,
     <SecondaryButton
+      dataCy="modal-button-add-and-add-another"
       key="add-and-add-another-new-group"
       name="add_and_add_another"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
@@ -283,7 +296,12 @@ const AddHostGroup = (props: PropsToAddGroup) => {
     >
       {addAgainSpinning ? "Adding" : "Add and add another"}
     </SecondaryButton>,
-    <Button key="cancel-new-group" variant="link" onClick={cleanAndCloseModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-new-group"
+      variant="link"
+      onClick={cleanAndCloseModal}
+    >
       Cancel
     </Button>,
   ];
@@ -293,6 +311,7 @@ const AddHostGroup = (props: PropsToAddGroup) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="add-hostgroup-modal"
         variantType="small"
         modalPosition="top"
         offPosition="76px"
@@ -305,6 +324,7 @@ const AddHostGroup = (props: PropsToAddGroup) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="add-hostgroup-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/AddIDView.tsx
+++ b/src/components/modals/AddIDView.tsx
@@ -63,6 +63,7 @@ const AddIDViewModal = (props: PropsToAddIDView) => {
       pfComponent: (
         <>
           <TextInput
+            data-cy="modal-textbox-id-view-name"
             type="text"
             id="modal-form-id-view-name"
             name="modal-form-id-view-name"
@@ -85,6 +86,7 @@ const AddIDViewModal = (props: PropsToAddIDView) => {
       name: "Description",
       pfComponent: (
         <TextArea
+          data-cy="modal-textbox-id-view-description"
           id="modal-form-id-view-desc"
           name="modal-form-id-view-desc"
           value={description}
@@ -225,10 +227,19 @@ const AddIDViewModal = (props: PropsToAddIDView) => {
   };
 
   const errorModalActions = [
-    <SecondaryButton key="retry" onClickHandler={onRetry}>
+    <SecondaryButton
+      dataCy="modal-button-retry"
+      key="retry"
+      onClickHandler={onRetry}
+    >
       Retry
     </SecondaryButton>,
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+    >
       Cancel
     </Button>,
   ];
@@ -246,6 +257,7 @@ const AddIDViewModal = (props: PropsToAddIDView) => {
   // Buttons that will be shown at the end of the form
   const modalActions = [
     <SecondaryButton
+      dataCy="modal-button-add"
       key="add-new-id-view"
       name="add"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
@@ -258,6 +270,7 @@ const AddIDViewModal = (props: PropsToAddIDView) => {
       {addSpinning ? "Adding" : "Add"}
     </SecondaryButton>,
     <SecondaryButton
+      dataCy="modal-button-add-and-add-another"
       key="add-and-add-another-new-view"
       name="add_and_add_another"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
@@ -269,7 +282,12 @@ const AddIDViewModal = (props: PropsToAddIDView) => {
     >
       {addAgainSpinning ? "Adding" : "Add and add another"}
     </SecondaryButton>,
-    <Button key="cancel-new-view" variant="link" onClick={cleanAndCloseModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-new-view"
+      variant="link"
+      onClick={cleanAndCloseModal}
+    >
       Cancel
     </Button>,
   ];
@@ -279,6 +297,7 @@ const AddIDViewModal = (props: PropsToAddIDView) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="add-id-view-modal"
         variantType="small"
         modalPosition="top"
         offPosition="76px"
@@ -291,6 +310,7 @@ const AddIDViewModal = (props: PropsToAddIDView) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="add-id-view-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/AddNetgroup.tsx
+++ b/src/components/modals/AddNetgroup.tsx
@@ -71,6 +71,7 @@ const AddNetgroup = (props: PropsToAddGroup) => {
       pfComponent: (
         <>
           <TextInput
+            data-cy="modal-textbox-netgroup-name"
             type="text"
             id="modal-form-netgroup-name"
             name="modal-form-netgroup-name"
@@ -95,6 +96,7 @@ const AddNetgroup = (props: PropsToAddGroup) => {
       name: "Description",
       pfComponent: (
         <TextArea
+          data-cy="modal-textbox-netgroup-description"
           id="modal-form-netgroup-desc"
           name="modal-form-netgroup-desc"
           value={description}
@@ -239,10 +241,19 @@ const AddNetgroup = (props: PropsToAddGroup) => {
   };
 
   const errorModalActions = [
-    <SecondaryButton key="retry" onClickHandler={onRetry}>
+    <SecondaryButton
+      dataCy="modal-button-retry"
+      key="retry"
+      onClickHandler={onRetry}
+    >
       Retry
     </SecondaryButton>,
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+    >
       Cancel
     </Button>,
   ];
@@ -260,6 +271,7 @@ const AddNetgroup = (props: PropsToAddGroup) => {
   // Buttons that will be shown at the end of the form
   const modalActions = [
     <SecondaryButton
+      dataCy="modal-button-add"
       key="add-new-netgroup"
       name="add"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
@@ -272,6 +284,7 @@ const AddNetgroup = (props: PropsToAddGroup) => {
       {addSpinning ? "Adding" : "Add"}
     </SecondaryButton>,
     <SecondaryButton
+      dataCy="modal-button-add-and-add-another"
       key="add-and-add-another-new-netgroup"
       name="add_and_add_another"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
@@ -284,6 +297,7 @@ const AddNetgroup = (props: PropsToAddGroup) => {
       {addAgainSpinning ? "Adding" : "Add and add another"}
     </SecondaryButton>,
     <Button
+      data-cy="modal-button-cancel"
       key="cancel-new-netgroup"
       variant="link"
       onClick={cleanAndCloseModal}
@@ -297,6 +311,7 @@ const AddNetgroup = (props: PropsToAddGroup) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="add-netgroup-modal"
         variantType="small"
         modalPosition="top"
         offPosition="76px"
@@ -309,6 +324,7 @@ const AddNetgroup = (props: PropsToAddGroup) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="add-netgroup-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/AddService.tsx
+++ b/src/components/modals/AddService.tsx
@@ -79,6 +79,7 @@ const AddService = (props: PropsToAddService) => {
   // Toggle
   const toggleService = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
+      data-cy="modal-select-service-toggle"
       ref={toggleRef}
       onClick={serviceOnToggle}
       className="pf-v5-u-w-100"
@@ -125,6 +126,7 @@ const AddService = (props: PropsToAddService) => {
   // Toggle
   const toggleHost = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
+      data-cy="modal-select-host-name-toggle"
       ref={toggleRef}
       onClick={hostNameOnToggle}
       className="pf-v5-u-w-100"
@@ -236,6 +238,7 @@ const AddService = (props: PropsToAddService) => {
       pfComponent: (
         <>
           <Select
+            data-cy="modal-select-service"
             id="service"
             aria-label="Select service"
             toggle={toggleService}
@@ -245,7 +248,11 @@ const AddService = (props: PropsToAddService) => {
             aria-labelledby="service"
           >
             {serviceOptions.map((option, index) => (
-              <SelectOption key={index} value={option}>
+              <SelectOption
+                data-cy={"modal-select-service-" + option}
+                key={index}
+                value={option}
+              >
                 {option}
               </SelectOption>
             ))}
@@ -270,6 +277,7 @@ const AddService = (props: PropsToAddService) => {
       pfComponent: (
         <>
           <Select
+            data-cy="modal-select-host-name"
             id="host"
             aria-label="Select host name"
             toggle={toggleHost}
@@ -279,7 +287,11 @@ const AddService = (props: PropsToAddService) => {
             aria-labelledby="host name"
           >
             {props.hostsList.map((option, index) => (
-              <SelectOption key={index} value={option}>
+              <SelectOption
+                data-cy={"modal-select-host-name-" + option}
+                key={index}
+                value={option}
+              >
                 {option}
               </SelectOption>
             ))}
@@ -302,6 +314,7 @@ const AddService = (props: PropsToAddService) => {
       name: "",
       pfComponent: (
         <Checkbox
+          data-cy="modal-checkbox-force-service"
           label="Force"
           isChecked={forceCheckbox}
           aria-label="force service checkbox"
@@ -317,6 +330,7 @@ const AddService = (props: PropsToAddService) => {
       name: "",
       pfComponent: (
         <Checkbox
+          data-cy="modal-checkbox-skip-host-check-service"
           label="Skip host check"
           isChecked={skipHostCheckbox}
           aria-label="skip host check checkbox"
@@ -485,10 +499,19 @@ const AddService = (props: PropsToAddService) => {
   };
 
   const errorModalActions = [
-    <SecondaryButton key="retry" onClickHandler={onRetry}>
+    <SecondaryButton
+      dataCy="modal-button-retry"
+      key="retry"
+      onClickHandler={onRetry}
+    >
       Retry
     </SecondaryButton>,
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+    >
       Cancel
     </Button>,
   ];
@@ -506,6 +529,7 @@ const AddService = (props: PropsToAddService) => {
   // Buttons that will be shown at the end of the form
   const modalActions = [
     <SecondaryButton
+      dataCy="modal-button-add"
       key="add-new-service"
       name="add"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
@@ -518,6 +542,7 @@ const AddService = (props: PropsToAddService) => {
       {addSpinning ? "Adding" : "Add"}
     </SecondaryButton>,
     <SecondaryButton
+      dataCy="modal-button-add-and-add-another"
       key="add-and-add-another-new-service"
       name="add_and_add_another"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
@@ -530,6 +555,7 @@ const AddService = (props: PropsToAddService) => {
       {addAgainSpinning ? "Adding" : "Add and add another"}
     </SecondaryButton>,
     <Button
+      data-cy="modal-button-cancel"
       key="cancel-new-service"
       variant="link"
       onClick={cleanAndCloseModal}
@@ -543,6 +569,7 @@ const AddService = (props: PropsToAddService) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="add-service-modal"
         variantType="small"
         modalPosition="top"
         offPosition="76px"
@@ -555,6 +582,7 @@ const AddService = (props: PropsToAddService) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="add-service-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/AddTextInputFromListModal.tsx
+++ b/src/components/modals/AddTextInputFromListModal.tsx
@@ -9,6 +9,7 @@ import {
 } from "@patternfly/react-core";
 
 interface PropsToAddModal {
+  dataCy: string;
   id: string;
   newValue: string;
   setNewValue: (newValue: string) => void;
@@ -33,6 +34,7 @@ const AddTextInputFromListModal = (props: PropsToAddModal) => {
 
   return (
     <Modal
+      data-cy={props.dataCy}
       variant={props.variant || "small"}
       title={props.title}
       isOpen={props.isOpen}
@@ -46,6 +48,7 @@ const AddTextInputFromListModal = (props: PropsToAddModal) => {
           fieldId={props.id}
         >
           <TextInput
+            data-cy="modal-textbox-new-kerberos-principal-alias"
             id={props.id}
             name={props.textInputName}
             value={props.newValue}

--- a/src/components/modals/AddUserGroup.tsx
+++ b/src/components/modals/AddUserGroup.tsx
@@ -91,6 +91,7 @@ const AddUserGroup = (props: PropsToAddGroup) => {
       pfComponent: (
         <>
           <TextInput
+            data-cy="modal-textbox-group-name"
             type="text"
             id="modal-form-group-name"
             name="modal-form-group-name"
@@ -115,6 +116,7 @@ const AddUserGroup = (props: PropsToAddGroup) => {
       name: "Description",
       pfComponent: (
         <TextArea
+          data-cy="modal-textbox-group-desc"
           id="modal-form-group-desc"
           name="modal-form-group-desc"
           value={description}
@@ -147,6 +149,7 @@ const AddUserGroup = (props: PropsToAddGroup) => {
       pfComponent: (
         <>
           <TextInput
+            data-cy="modal-textbox-group-gid"
             type="text"
             id="modal-form-group-gid"
             name="modal-form-group-gid"
@@ -312,10 +315,19 @@ const AddUserGroup = (props: PropsToAddGroup) => {
   };
 
   const errorModalActions = [
-    <SecondaryButton key="retry" onClickHandler={onRetry}>
+    <SecondaryButton
+      dataCy="modal-button-retry"
+      key="retry"
+      onClickHandler={onRetry}
+    >
       Retry
     </SecondaryButton>,
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+    >
       Cancel
     </Button>,
   ];
@@ -333,6 +345,7 @@ const AddUserGroup = (props: PropsToAddGroup) => {
   // Buttons that will be shown at the end of the form
   const modalActions = [
     <SecondaryButton
+      dataCy="modal-button-add"
       key="add-new-group"
       name="add"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
@@ -345,6 +358,7 @@ const AddUserGroup = (props: PropsToAddGroup) => {
       {addSpinning ? "Adding" : "Add"}
     </SecondaryButton>,
     <SecondaryButton
+      dataCy="modal-button-add-and-add-another"
       key="add-and-add-another-new-group"
       name="add_and_add_another"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
@@ -356,7 +370,12 @@ const AddUserGroup = (props: PropsToAddGroup) => {
     >
       {addAgainSpinning ? "Adding" : "Add and add another"}
     </SecondaryButton>,
-    <Button key="cancel-new-group" variant="link" onClick={cleanAndCloseModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-new-group"
+      variant="link"
+      onClick={cleanAndCloseModal}
+    >
       Cancel
     </Button>,
   ];
@@ -366,6 +385,7 @@ const AddUserGroup = (props: PropsToAddGroup) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="add-user-group-modal"
         variantType="small"
         modalPosition="top"
         offPosition="76px"
@@ -378,6 +398,7 @@ const AddUserGroup = (props: PropsToAddGroup) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="add-user-group-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/Automember/AddRule.tsx
+++ b/src/components/modals/Automember/AddRule.tsx
@@ -88,6 +88,7 @@ const AddRule = (props: PropsToAddRule) => {
   // Toggle
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
+      data-cy="modal-select-automember-toggle"
       ref={toggleRef}
       onClick={() => setIsSelectOpen(!isSelectOpen)}
       className="pf-v5-u-w-100"
@@ -109,6 +110,7 @@ const AddRule = (props: PropsToAddRule) => {
       name: "Automember",
       pfComponent: (
         <Select
+          data-cy="modal-select-automember"
           id="automember"
           toggle={toggle}
           onSelect={onSelectGroup}
@@ -117,7 +119,11 @@ const AddRule = (props: PropsToAddRule) => {
           aria-labelledby="automember-group-add"
         >
           {props.groupsAvailableToAdd.map((option, index) => (
-            <SelectOption key={index} value={option}>
+            <SelectOption
+              data-cy={"modal-select-automember-" + option}
+              key={index}
+              value={option}
+            >
               {option}
             </SelectOption>
           ))}
@@ -214,6 +220,7 @@ const AddRule = (props: PropsToAddRule) => {
 
   const modalActions = [
     <SecondaryButton
+      dataCy="modal-button-add"
       key="add"
       onClickHandler={onAdd}
       isLoading={addSpinning}
@@ -224,6 +231,7 @@ const AddRule = (props: PropsToAddRule) => {
       Add
     </SecondaryButton>,
     <SecondaryButton
+      dataCy="modal-button-add-and-add-another"
       key="add-another"
       onClickHandler={onAddAndAddAnother}
       isLoading={addAgainSpinning}
@@ -233,7 +241,12 @@ const AddRule = (props: PropsToAddRule) => {
     >
       Add and add another
     </SecondaryButton>,
-    <Button key="cancel-new-rule" variant="link" onClick={cleanAndCloseModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-new-rule"
+      variant="link"
+      onClick={cleanAndCloseModal}
+    >
       Cancel
     </Button>,
   ];
@@ -243,6 +256,7 @@ const AddRule = (props: PropsToAddRule) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="add-rule-modal"
         variantType="small"
         modalPosition="top"
         offPosition="76px"

--- a/src/components/modals/Automember/DeleteRule.tsx
+++ b/src/components/modals/Automember/DeleteRule.tsx
@@ -134,6 +134,7 @@ const DeleteRule = (props: PropsToDeleteRule) => {
   // Set the Modal and Action buttons for 'Delete' option
   const modalActionsDelete: JSX.Element[] = [
     <Button
+      data-cy="modal-button-delete"
       key="delete-rules"
       variant="danger"
       onClick={onDelete}
@@ -145,7 +146,12 @@ const DeleteRule = (props: PropsToDeleteRule) => {
     >
       {spinning ? "Deleting" : "Delete"}
     </Button>,
-    <Button key="cancel-delete-rules" variant="link" onClick={closeModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-delete-rules"
+      variant="link"
+      onClick={closeModal}
+    >
       Cancel
     </Button>,
   ];
@@ -154,6 +160,7 @@ const DeleteRule = (props: PropsToDeleteRule) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="delete-rule-modal"
         variantType="medium"
         modalPosition="top"
         offPosition="76px"

--- a/src/components/modals/CertificateMapping/AddRuleModal.tsx
+++ b/src/components/modals/CertificateMapping/AddRuleModal.tsx
@@ -120,6 +120,7 @@ const AddRuleModal = (props: PropsToAddRuleModal) => {
       name: "Rule name",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-rule-name"
           type="text"
           id="rule-name"
           name="cn"
@@ -136,6 +137,7 @@ const AddRuleModal = (props: PropsToAddRuleModal) => {
       name: "Mapping rule",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-mapping-rule"
           type="text"
           id="mapping-rule"
           name="ipacertmapmaprule"
@@ -156,6 +158,7 @@ const AddRuleModal = (props: PropsToAddRuleModal) => {
       name: "Matching rule",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-matching-rule"
           type="text"
           id="matching-rule"
           name="ipacertmapmatchrule"
@@ -175,6 +178,7 @@ const AddRuleModal = (props: PropsToAddRuleModal) => {
       name: "Domain name",
       pfComponent: (
         <TextInputList
+          dataCy="modal-domain-name"
           name="associateddomain"
           ariaLabel="Domain name text input"
           list={domainName}
@@ -192,6 +196,7 @@ const AddRuleModal = (props: PropsToAddRuleModal) => {
       name: "Priority",
       pfComponent: (
         <NumberSelector
+          dataCy="modal-number-selector-priority"
           id="priority-number-selector"
           name="priority"
           value={priority}
@@ -211,6 +216,7 @@ const AddRuleModal = (props: PropsToAddRuleModal) => {
       name: "Description",
       pfComponent: (
         <TextArea
+          data-cy="modal-textbox-description"
           type="text"
           id="description"
           name="description"
@@ -225,6 +231,7 @@ const AddRuleModal = (props: PropsToAddRuleModal) => {
   // Actions
   const modalActions: JSX.Element[] = [
     <Button
+      data-cy="modal-button-add"
       key="add-new"
       variant="secondary"
       isDisabled={isAddButtonSpinning || ruleName === ""}
@@ -236,6 +243,7 @@ const AddRuleModal = (props: PropsToAddRuleModal) => {
       Add
     </Button>,
     <Button
+      data-cy="modal-button-add-and-add-another"
       key="add-new-again"
       variant="secondary"
       isDisabled={isAddAnotherButtonSpinning || ruleName === ""}
@@ -246,7 +254,12 @@ const AddRuleModal = (props: PropsToAddRuleModal) => {
     >
       Add and add again
     </Button>,
-    <Button key="cancel-new" variant="link" onClick={cleanAndCloseModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-new"
+      variant="link"
+      onClick={cleanAndCloseModal}
+    >
       Cancel
     </Button>,
   ];
@@ -255,6 +268,7 @@ const AddRuleModal = (props: PropsToAddRuleModal) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="add-rule-modal"
         variantType={"small"}
         modalPosition={"top"}
         offPosition={"76px"}

--- a/src/components/modals/CertificateMapping/DeleteMultipleRulesModal.tsx
+++ b/src/components/modals/CertificateMapping/DeleteMultipleRulesModal.tsx
@@ -57,7 +57,12 @@ const DeleteMultipleRulesModal = (props: DeleteMultipleRulesModalProps) => {
   };
 
   const errorModalActions = [
-    <Button key="cancel" variant="link" onClick={closeAndCleanErrorParameters}>
+    <Button
+      data-cy="modal-button-ok"
+      key="cancel"
+      variant="link"
+      onClick={closeAndCleanErrorParameters}
+    >
       OK
     </Button>,
   ];
@@ -158,6 +163,7 @@ const DeleteMultipleRulesModal = (props: DeleteMultipleRulesModalProps) => {
 
   const modalActions: JSX.Element[] = [
     <Button
+      data-cy="modal-button-delete"
       key="delete-certmaprules"
       variant="danger"
       onClick={onDelete}
@@ -170,6 +176,7 @@ const DeleteMultipleRulesModal = (props: DeleteMultipleRulesModalProps) => {
       {spinning ? "Deleting" : "Delete"}
     </Button>,
     <Button
+      data-cy="modal-button-cancel"
       key="cancel-delete-certmaprules"
       variant="link"
       onClick={props.onClose}
@@ -183,6 +190,7 @@ const DeleteMultipleRulesModal = (props: DeleteMultipleRulesModalProps) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="delete-multiple-rules-modal"
         variantType="medium"
         modalPosition="top"
         offPosition="76px"
@@ -195,6 +203,7 @@ const DeleteMultipleRulesModal = (props: DeleteMultipleRulesModalProps) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="delete-multiple-rules-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={closeAndCleanErrorParameters}

--- a/src/components/modals/CertificateMapping/DeleteRuleModal.tsx
+++ b/src/components/modals/CertificateMapping/DeleteRuleModal.tsx
@@ -52,10 +52,16 @@ const DeleteRuleModal = (props: DeleteRuleModalProps) => {
   };
 
   const modalActions: JSX.Element[] = [
-    <Button key={"delete-" + props.ruleId} variant="primary" onClick={onDelete}>
+    <Button
+      data-cy="modal-button-ok"
+      key={"delete-" + props.ruleId}
+      variant="primary"
+      onClick={onDelete}
+    >
       OK
     </Button>,
     <Button
+      data-cy="modal-button-cancel"
       key={"cancel-delete-" + props.ruleId}
       variant="secondary"
       onClick={onClose}
@@ -69,6 +75,7 @@ const DeleteRuleModal = (props: DeleteRuleModalProps) => {
     <>
       <alerts.ManagedAlerts />
       <ConfirmationModal
+        dataCy="delete-rule-modal"
         title={"Confirmation"}
         isOpen={props.isOpen}
         onClose={onClose}

--- a/src/components/modals/CertificateMapping/EnableDisableMultipleRules.tsx
+++ b/src/components/modals/CertificateMapping/EnableDisableMultipleRules.tsx
@@ -67,6 +67,7 @@ const EnableDisableMultipleRulesModal = (
 
   const modalActions: JSX.Element[] = [
     <Button
+      data-cy="modal-button-ok"
       key={props.operation + "-certmaprules"}
       variant="primary"
       onClick={onEnableDisable}
@@ -74,6 +75,7 @@ const EnableDisableMultipleRulesModal = (
       OK
     </Button>,
     <Button
+      data-cy="modal-button-cancel"
       key={"cancel-" + props.operation + "-certmaprules"}
       variant="secondary"
       onClick={onCloseWithoutClearingElements}
@@ -87,6 +89,7 @@ const EnableDisableMultipleRulesModal = (
     <>
       <alerts.ManagedAlerts />
       <ConfirmationModal
+        dataCy="enable-disable-multiple-rules-modal"
         title={capitalizeFirstLetter(props.operation) + " confirmation"}
         isOpen={props.isOpen}
         onClose={onClose}

--- a/src/components/modals/CertificateMapping/EnableDisableRuleModal.tsx
+++ b/src/components/modals/CertificateMapping/EnableDisableRuleModal.tsx
@@ -54,6 +54,7 @@ const EnableDisableRuleModal = (props: EnableDisableRuleModalProps) => {
 
   const modalActions: JSX.Element[] = [
     <Button
+      data-cy="modal-button-ok"
       key={props.operation + "-" + props.ruleId}
       variant="primary"
       onClick={onEnableDisable}
@@ -61,6 +62,7 @@ const EnableDisableRuleModal = (props: EnableDisableRuleModalProps) => {
       OK
     </Button>,
     <Button
+      data-cy="modal-button-cancel"
       key={"cancel-" + props.operation + "-" + props.ruleId}
       variant="secondary"
       onClick={onClose}
@@ -74,6 +76,7 @@ const EnableDisableRuleModal = (props: EnableDisableRuleModalProps) => {
     <>
       <alerts.ManagedAlerts />
       <ConfirmationModal
+        dataCy="enable-disable-rule-modal"
         title={"Confirmation"}
         isOpen={props.isOpen}
         onClose={onClose}

--- a/src/components/modals/CertificateModals/CertificatesInformationModal.tsx
+++ b/src/components/modals/CertificateModals/CertificatesInformationModal.tsx
@@ -31,7 +31,12 @@ const CertificatesInformationModal = (props: PropsToCertificatesInfoModal) => {
 
   // Actions
   const infoModalActions = [
-    <Button key="close" variant="primary" onClick={props.onClose}>
+    <Button
+      data-cy="modal-button-close"
+      key="close"
+      variant="primary"
+      onClick={props.onClose}
+    >
       Close
     </Button>,
   ];
@@ -112,6 +117,7 @@ const CertificatesInformationModal = (props: PropsToCertificatesInfoModal) => {
 
   return (
     <InformationModalLayout
+      dataCy="certificates-information-modal"
       title={"Certificate for " + certName}
       variant="medium"
       actions={infoModalActions}

--- a/src/components/modals/CertificateModals/IssueNewCertificate.tsx
+++ b/src/components/modals/CertificateModals/IssueNewCertificate.tsx
@@ -120,7 +120,12 @@ const IssueNewCertificate = (props: PropsToIssueNewCertificate) => {
   };
 
   const toggleCA = (toggleRef: React.Ref<MenuToggleElement>) => (
-    <MenuToggle ref={toggleRef} onClick={onCAToggle} className="pf-v5-u-w-100">
+    <MenuToggle
+      data-cy="modal-select-ca-toggle"
+      ref={toggleRef}
+      onClick={onCAToggle}
+      className="pf-v5-u-w-100"
+    >
       {selectedCA}
     </MenuToggle>
   );
@@ -143,6 +148,7 @@ const IssueNewCertificate = (props: PropsToIssueNewCertificate) => {
 
   const toggleProfile = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
+      data-cy="modal-select-profile-toggle"
       ref={toggleRef}
       onClick={onProfileToggle}
       className="pf-v5-u-w-100"
@@ -160,6 +166,7 @@ const IssueNewCertificate = (props: PropsToIssueNewCertificate) => {
     name: "Principal",
     pfComponent: (
       <TextInput
+        data-cy="modal-textbox-principal"
         id="principal"
         name="principal"
         type="text"
@@ -175,6 +182,7 @@ const IssueNewCertificate = (props: PropsToIssueNewCertificate) => {
     labelIcon: <PopoverWithIconLayout message={addPrincipalTooltipMessage} />,
     pfComponent: (
       <Checkbox
+        data-cy="modal-checkbox-add-principal"
         label="Add principal"
         id="add-principal"
         name="add-principal"
@@ -234,6 +242,7 @@ const IssueNewCertificate = (props: PropsToIssueNewCertificate) => {
       fieldRequired: true,
       pfComponent: (
         <Select
+          data-cy="modal-ca-select"
           id={"ca-selector"}
           aria-label={"Selector for certificate authority"}
           toggle={toggleCA}
@@ -243,7 +252,11 @@ const IssueNewCertificate = (props: PropsToIssueNewCertificate) => {
         >
           {certAuthList.map((option, index) => {
             return (
-              <SelectOption key={index} value={option.cn}>
+              <SelectOption
+                data-cy={"modal-ca-select-" + option.cn}
+                key={index}
+                value={option.cn}
+              >
                 {option.cn}
               </SelectOption>
             );
@@ -256,6 +269,7 @@ const IssueNewCertificate = (props: PropsToIssueNewCertificate) => {
       name: "Profile ID",
       pfComponent: (
         <Select
+          data-cy="modal-profile-select"
           id={"profile-selector"}
           aria-label={"Selector for profile ID"}
           toggle={toggleProfile}
@@ -265,7 +279,11 @@ const IssueNewCertificate = (props: PropsToIssueNewCertificate) => {
         >
           {certProfileList.map((option, index) => {
             return (
-              <SelectOption key={index} value={option.cn}>
+              <SelectOption
+                data-cy={"modal-profile-select-" + option.cn}
+                key={index}
+                value={option.cn}
+              >
                 {option.cn}
               </SelectOption>
             );
@@ -315,6 +333,7 @@ const IssueNewCertificate = (props: PropsToIssueNewCertificate) => {
       id: "certificate-textarea-field",
       pfComponent: (
         <TextArea
+          data-cy="modal-textbox-certificate"
           id="certificate-textarea"
           name="csr"
           aria-label="Text area for certificate"
@@ -345,6 +364,7 @@ const IssueNewCertificate = (props: PropsToIssueNewCertificate) => {
   // Actions
   const actions = [
     <Button
+      data-cy="modal-button-issue"
       key={"issue-new-certificate"}
       variant="primary"
       onClick={onAddCertificate}
@@ -353,6 +373,7 @@ const IssueNewCertificate = (props: PropsToIssueNewCertificate) => {
       Issue
     </Button>,
     <Button
+      data-cy="modal-button-cancel"
       key={"cancel-issue-new-certificate"}
       variant="link"
       onClick={resetFieldsAndClose}
@@ -365,6 +386,7 @@ const IssueNewCertificate = (props: PropsToIssueNewCertificate) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="issue-new-certificate-modal"
         variantType="medium"
         modalPosition="top"
         title={"Issue new certificate for '" + props.id + "'"}

--- a/src/components/modals/CertificateModals/RemoveHoldCertificate.tsx
+++ b/src/components/modals/CertificateModals/RemoveHoldCertificate.tsx
@@ -72,10 +72,20 @@ const RemoveHoldCertificate = (props: PropsToRemoveHoldCertificate) => {
   };
 
   const infoModalActions = [
-    <Button key="remove-hold" variant="danger" onClick={onRemoveHold}>
+    <Button
+      data-cy="modal-button-remove-hold"
+      key="remove-hold"
+      variant="danger"
+      onClick={onRemoveHold}
+    >
       Remove hold
     </Button>,
-    <Button key="close" variant="link" onClick={props.onClose}>
+    <Button
+      data-cy="modal-button-close"
+      key="close"
+      variant="link"
+      onClick={props.onClose}
+    >
       Close
     </Button>,
   ];
@@ -88,6 +98,7 @@ const RemoveHoldCertificate = (props: PropsToRemoveHoldCertificate) => {
     <>
       <alerts.ManagedAlerts />
       <InformationModalLayout
+        dataCy="remove-hold-certificate-modal"
         title={"Certificate for " + certName}
         variant="medium"
         actions={infoModalActions}

--- a/src/components/modals/CertificateModals/RevokeCertificate.tsx
+++ b/src/components/modals/CertificateModals/RevokeCertificate.tsx
@@ -84,6 +84,7 @@ const RevokeCertificate = (props: PropsToRevokeCertificate) => {
   // Toggle
   const toggleRevReason = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
+      data-cy="modal-select-rev-reason-toggle"
       ref={toggleRef}
       onClick={onToggleRevReason}
       className="pf-v5-u-w-100"
@@ -123,7 +124,12 @@ const RevokeCertificate = (props: PropsToRevokeCertificate) => {
 
   // Toggle
   const toggleCASelect = (toggleRef: React.Ref<MenuToggleElement>) => (
-    <MenuToggle ref={toggleRef} onClick={onCAToggle} className="pf-v5-u-w-100">
+    <MenuToggle
+      data-cy="modal-select-ca-toggle"
+      ref={toggleRef}
+      onClick={onCAToggle}
+      className="pf-v5-u-w-100"
+    >
       {CASelected}
     </MenuToggle>
   );
@@ -174,10 +180,19 @@ const RevokeCertificate = (props: PropsToRevokeCertificate) => {
   };
 
   const modalActions = [
-    <SecondaryButton key="revoke" onClickHandler={onRevokeCert}>
+    <SecondaryButton
+      dataCy="modal-button-revoke"
+      key="revoke"
+      onClickHandler={onRevokeCert}
+    >
       Revoke
     </SecondaryButton>,
-    <Button key="cancel" variant="link" onClick={onCancel}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel"
+      variant="link"
+      onClick={onCancel}
+    >
       Cancel
     </Button>,
   ];
@@ -188,6 +203,7 @@ const RevokeCertificate = (props: PropsToRevokeCertificate) => {
       name: "Revocation reason",
       pfComponent: (
         <Select
+          data-cy="modal-select-rev-reason"
           id="revocation-reasons"
           aria-label="Select a revocation reason"
           aria-labelledby="revocation-reasons"
@@ -197,7 +213,11 @@ const RevokeCertificate = (props: PropsToRevokeCertificate) => {
           onSelect={onSelectRevReason}
         >
           {Object.entries(REVOCATION_REASONS).map((value) => (
-            <SelectOption key={value[0]} value={value[1]}>
+            <SelectOption
+              data-cy={"modal-select-rev-reason-" + value[1]}
+              key={value[0]}
+              value={value[1]}
+            >
               {value[1]}
             </SelectOption>
           ))}
@@ -209,6 +229,7 @@ const RevokeCertificate = (props: PropsToRevokeCertificate) => {
       name: "CA",
       pfComponent: (
         <Select
+          data-cy="modal-select-rev-ca"
           id="revocation-certificate-authority"
           aria-label="Select a certificate authority for the revocation"
           aria-labelledby="revocation certificate authority"
@@ -218,7 +239,11 @@ const RevokeCertificate = (props: PropsToRevokeCertificate) => {
           onSelect={onCASelect}
         >
           {CAOptions.map((option, index) => (
-            <SelectOption key={index} value={option}>
+            <SelectOption
+              data-cy={"modal-select-rev-ca-option-" + option}
+              key={index}
+              value={option}
+            >
               {option}
             </SelectOption>
           ))}
@@ -231,6 +256,7 @@ const RevokeCertificate = (props: PropsToRevokeCertificate) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="revoke-certificate-modal"
         variantType="small"
         modalPosition="top"
         title={"Certificate for " + certName}

--- a/src/components/modals/ConfirmationModal.tsx
+++ b/src/components/modals/ConfirmationModal.tsx
@@ -5,6 +5,7 @@ import { Card, CardTitle, Modal } from "@patternfly/react-core";
 import TextLayout from "../layouts/TextLayout";
 
 interface PropsToConfModal {
+  dataCy: string;
   variant?: "default" | "small" | "medium" | "large";
   title: string;
   isOpen?: boolean;
@@ -17,6 +18,7 @@ interface PropsToConfModal {
 const ConfirmationModal = (props: PropsToConfModal) => {
   return (
     <Modal
+      data-cy={props.dataCy}
       variant={props.variant || "small"}
       title={props.title}
       isOpen={props.isOpen}

--- a/src/components/modals/DeleteHostGroups.tsx
+++ b/src/components/modals/DeleteHostGroups.tsx
@@ -106,7 +106,12 @@ const DeleteHostGroups = (props: PropsToDeleteGroups) => {
   };
 
   const errorModalActions = [
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      data-cy="modal-button-ok"
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+    >
       OK
     </Button>,
   ];
@@ -186,6 +191,7 @@ const DeleteHostGroups = (props: PropsToDeleteGroups) => {
   // Set the Modal and Action buttons for 'Delete' option
   const modalActionsDelete: JSX.Element[] = [
     <Button
+      data-cy="modal-button-delete"
       key="delete-hostgroups"
       variant="danger"
       onClick={deleteGroups}
@@ -197,7 +203,12 @@ const DeleteHostGroups = (props: PropsToDeleteGroups) => {
     >
       {spinning ? "Deleting" : "Delete"}
     </Button>,
-    <Button key="cancel-delete-hostgroups" variant="link" onClick={closeModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-delete-hostgroups"
+      variant="link"
+      onClick={closeModal}
+    >
       Cancel
     </Button>,
   ];
@@ -206,6 +217,7 @@ const DeleteHostGroups = (props: PropsToDeleteGroups) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="delete-hostgroups-modal"
         variantType="medium"
         modalPosition="top"
         offPosition="76px"
@@ -218,6 +230,7 @@ const DeleteHostGroups = (props: PropsToDeleteGroups) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="delete-hostgroups-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/DeleteIDViews.tsx
+++ b/src/components/modals/DeleteIDViews.tsx
@@ -99,7 +99,12 @@ const DeleteIDViewsModal = (props: PropsToDeleteViews) => {
   };
 
   const errorModalActions = [
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      data-cy="modal-button-ok"
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+    >
       OK
     </Button>,
   ];
@@ -174,6 +179,7 @@ const DeleteIDViewsModal = (props: PropsToDeleteViews) => {
   // Set the Modal and Action buttons for 'Delete' option
   const modalActionsDelete: JSX.Element[] = [
     <Button
+      data-cy="modal-button-delete"
       key="delete-id-views"
       variant="danger"
       onClick={deleteViews}
@@ -185,7 +191,12 @@ const DeleteIDViewsModal = (props: PropsToDeleteViews) => {
     >
       {spinning ? "Deleting" : "Delete"}
     </Button>,
-    <Button key="cancel-delete-id-views" variant="link" onClick={closeModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-delete-id-views"
+      variant="link"
+      onClick={closeModal}
+    >
       Cancel
     </Button>,
   ];
@@ -194,6 +205,7 @@ const DeleteIDViewsModal = (props: PropsToDeleteViews) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="delete-id-views-modal"
         variantType="medium"
         modalPosition="top"
         offPosition="76px"
@@ -206,6 +218,7 @@ const DeleteIDViewsModal = (props: PropsToDeleteViews) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="delete-id-views-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/DeleteNetgroups.tsx
+++ b/src/components/modals/DeleteNetgroups.tsx
@@ -105,7 +105,12 @@ const DeleteNetgroups = (props: PropsToDeleteGroups) => {
   };
 
   const errorModalActions = [
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      data-cy="modal-button-ok"
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+    >
       OK
     </Button>,
   ];
@@ -185,6 +190,7 @@ const DeleteNetgroups = (props: PropsToDeleteGroups) => {
   // Set the Modal and Action buttons for 'Delete' option
   const modalActionsDelete: JSX.Element[] = [
     <Button
+      data-cy="modal-button-delete"
       key="delete-netgroups"
       variant="danger"
       onClick={deleteGroups}
@@ -196,7 +202,12 @@ const DeleteNetgroups = (props: PropsToDeleteGroups) => {
     >
       {spinning ? "Deleting" : "Delete"}
     </Button>,
-    <Button key="cancel-delete-netgroups" variant="link" onClick={closeModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-delete-netgroups"
+      variant="link"
+      onClick={closeModal}
+    >
       Cancel
     </Button>,
   ];
@@ -205,6 +216,7 @@ const DeleteNetgroups = (props: PropsToDeleteGroups) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="delete-netgroups-modal"
         variantType="medium"
         modalPosition="top"
         offPosition="76px"
@@ -217,6 +229,7 @@ const DeleteNetgroups = (props: PropsToDeleteGroups) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="delete-netgroups-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/DeleteServices.tsx
+++ b/src/components/modals/DeleteServices.tsx
@@ -105,7 +105,12 @@ const DeleteServices = (props: PropsToDeleteServices) => {
   };
 
   const errorModalActions = [
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      data-cy="modal-button-ok"
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+    >
       OK
     </Button>,
   ];
@@ -185,6 +190,7 @@ const DeleteServices = (props: PropsToDeleteServices) => {
   // Set the Modal and Action buttons for 'Delete' option
   const modalActionsDelete: JSX.Element[] = [
     <Button
+      data-cy="modal-button-delete"
       key="delete-services"
       variant="danger"
       onClick={deleteServices}
@@ -196,7 +202,12 @@ const DeleteServices = (props: PropsToDeleteServices) => {
     >
       {spinning ? "Deleting" : "Delete"}
     </Button>,
-    <Button key="cancel-delete-services" variant="link" onClick={closeModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-delete-services"
+      variant="link"
+      onClick={closeModal}
+    >
       Cancel
     </Button>,
   ];
@@ -205,6 +216,7 @@ const DeleteServices = (props: PropsToDeleteServices) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="delete-services-modal"
         variantType="small"
         modalPosition="top"
         offPosition="76px"
@@ -217,6 +229,7 @@ const DeleteServices = (props: PropsToDeleteServices) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="delete-services-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/DeleteUserGroups.tsx
+++ b/src/components/modals/DeleteUserGroups.tsx
@@ -106,7 +106,12 @@ const DeleteUserGroups = (props: PropsToDeleteGroups) => {
   };
 
   const errorModalActions = [
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      data-cy="modal-button-ok"
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+    >
       OK
     </Button>,
   ];
@@ -186,6 +191,7 @@ const DeleteUserGroups = (props: PropsToDeleteGroups) => {
   // Set the Modal and Action buttons for 'Delete' option
   const modalActionsDelete: JSX.Element[] = [
     <Button
+      data-cy="modal-button-delete"
       key="delete-usergroups"
       variant="danger"
       onClick={deleteGroups}
@@ -197,7 +203,12 @@ const DeleteUserGroups = (props: PropsToDeleteGroups) => {
     >
       {spinning ? "Deleting" : "Delete"}
     </Button>,
-    <Button key="cancel-delete-usergroups" variant="link" onClick={closeModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-delete-usergroups"
+      variant="link"
+      onClick={closeModal}
+    >
       Cancel
     </Button>,
   ];
@@ -206,6 +217,7 @@ const DeleteUserGroups = (props: PropsToDeleteGroups) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="delete-usergroups-modal"
         variantType="medium"
         modalPosition="top"
         offPosition="76px"
@@ -218,6 +230,7 @@ const DeleteUserGroups = (props: PropsToDeleteGroups) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="delete-usergroups-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/DnsZones/AddDnsZoneModal.tsx
+++ b/src/components/modals/DnsZones/AddDnsZoneModal.tsx
@@ -147,6 +147,7 @@ const AddDnsZoneModal = (props: PropsToAddModal) => {
       <div className="pf-v5-u-ml-lg pf-v5-u-mb-md">
         <Form id="add-modal-form-zone-name">
           <Radio
+            data-cy="modal-radio-dns-zone-name"
             name="dnszone_name_type"
             id="dnszone_name_type"
             onChange={() => {
@@ -164,6 +165,7 @@ const AddDnsZoneModal = (props: PropsToAddModal) => {
             isRequired={isZoneNameRadioChecked}
           >
             <TextInput
+              data-cy="modal-textbox-dns-zone-name"
               type="text"
               id="dns-name"
               name="idnsname"
@@ -181,6 +183,7 @@ const AddDnsZoneModal = (props: PropsToAddModal) => {
       <div className="pf-v5-u-ml-lg pf-v5-u-mb-md">
         <Form id="add-modal-form-reverse-zone">
           <Radio
+            data-cy="modal-radio-reverse-zone-ip"
             name="reverse_zone_type"
             id="reverse_zone_type"
             onChange={() => {
@@ -200,6 +203,7 @@ const AddDnsZoneModal = (props: PropsToAddModal) => {
           >
             <>
               <TextInput
+                data-cy="modal-textbox-reverse-zone-ip"
                 type="text"
                 id="reverse-zone-ip"
                 name="name_from_ip"
@@ -261,6 +265,7 @@ const AddDnsZoneModal = (props: PropsToAddModal) => {
   // Actions
   const modalActions: JSX.Element[] = [
     <Button
+      data-cy="modal-button-ok"
       key="add-new"
       variant="secondary"
       isDisabled={
@@ -283,6 +288,7 @@ const AddDnsZoneModal = (props: PropsToAddModal) => {
       )}
     </Button>,
     <Button
+      data-cy="modal-button-ok"
       key="add-new-another"
       variant="secondary"
       isDisabled={
@@ -304,7 +310,12 @@ const AddDnsZoneModal = (props: PropsToAddModal) => {
         "Add and add another"
       )}
     </Button>,
-    <Button key="cancel-new" variant="link" onClick={cleanAndCloseModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-new"
+      variant="link"
+      onClick={cleanAndCloseModal}
+    >
       Cancel
     </Button>,
   ];

--- a/src/components/modals/DnsZones/AddRemovePermission.tsx
+++ b/src/components/modals/DnsZones/AddRemovePermission.tsx
@@ -56,6 +56,7 @@ const AddRemovePermission = (props: AddRemovePermissionProps) => {
 
   const modalActions: JSX.Element[] = [
     <Button
+      data-cy="modal-button-ok"
       key={"delete-" + props.dnsZoneId}
       variant="primary"
       onClick={onAddRemovePermission}
@@ -63,6 +64,7 @@ const AddRemovePermission = (props: AddRemovePermissionProps) => {
       OK
     </Button>,
     <Button
+      data-cy="modal-button-cancel"
       key={"cancel-delete-" + props.dnsZoneId}
       variant="secondary"
       onClick={props.onClose}
@@ -76,6 +78,7 @@ const AddRemovePermission = (props: AddRemovePermissionProps) => {
     <>
       <alerts.ManagedAlerts />
       <ConfirmationModal
+        dataCy="dns-zones-add-remove-permission-modal"
         title={"Confirmation"}
         isOpen={props.isOpen}
         onClose={props.onClose}

--- a/src/components/modals/DnsZones/DeleteDnsZonesModal.tsx
+++ b/src/components/modals/DnsZones/DeleteDnsZonesModal.tsx
@@ -60,7 +60,12 @@ const DeleteDnsZonesModal = (props: DeleteDnsZonesModalProps) => {
   };
 
   const errorModalActions = [
-    <Button key="cancel" variant="link" onClick={closeAndCleanErrorParameters}>
+    <Button
+      data-cy="modal-button-ok"
+      key="cancel"
+      variant="link"
+      onClick={closeAndCleanErrorParameters}
+    >
       OK
     </Button>,
   ];
@@ -168,6 +173,7 @@ const DeleteDnsZonesModal = (props: DeleteDnsZonesModalProps) => {
 
   const modalActions: JSX.Element[] = [
     <Button
+      data-cy="modal-button-ok"
       key="delete-dnszones"
       variant="danger"
       onClick={onDelete}
@@ -186,7 +192,12 @@ const DeleteDnsZonesModal = (props: DeleteDnsZonesModalProps) => {
         "Delete"
       )}
     </Button>,
-    <Button key="cancel-delete-dnszones" variant="link" onClick={props.onClose}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-delete-dnszones"
+      variant="link"
+      onClick={props.onClose}
+    >
       Cancel
     </Button>,
   ];
@@ -196,6 +207,7 @@ const DeleteDnsZonesModal = (props: DeleteDnsZonesModalProps) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="dns-zones-delete-modal"
         variantType="medium"
         modalPosition="top"
         offPosition="76px"
@@ -208,6 +220,7 @@ const DeleteDnsZonesModal = (props: DeleteDnsZonesModalProps) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="dns-zones-delete-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={closeAndCleanErrorParameters}

--- a/src/components/modals/DnsZones/EnableDisableDnsZonesModal.tsx
+++ b/src/components/modals/DnsZones/EnableDisableDnsZonesModal.tsx
@@ -68,6 +68,7 @@ const EnableDisableDnsZonesModal = (props: EnableDisableDnsZonesModalProps) => {
 
   const modalActions: JSX.Element[] = [
     <Button
+      data-cy="modal-button-ok"
       key={props.operation + "-dnszones"}
       variant="primary"
       onClick={onEnableDisable}
@@ -75,6 +76,7 @@ const EnableDisableDnsZonesModal = (props: EnableDisableDnsZonesModalProps) => {
       OK
     </Button>,
     <Button
+      data-cy="modal-button-cancel"
       key={"cancel-" + props.operation + "-dnszones"}
       variant="secondary"
       onClick={onCloseWithoutClearingElements}
@@ -88,6 +90,7 @@ const EnableDisableDnsZonesModal = (props: EnableDisableDnsZonesModalProps) => {
     <>
       <alerts.ManagedAlerts />
       <ConfirmationModal
+        dataCy="dns-zones-enable-disable-modal"
         title={capitalizeFirstLetter(props.operation) + " confirmation"}
         isOpen={props.isOpen}
         onClose={onClose}

--- a/src/components/modals/ErrorModal.tsx
+++ b/src/components/modals/ErrorModal.tsx
@@ -4,6 +4,7 @@ import { Modal } from "@patternfly/react-core";
 import TextLayout from "../layouts/TextLayout";
 
 interface PropsToErrorModal {
+  dataCy: string;
   title: string;
   isOpen: boolean;
   onClose: () => void;
@@ -15,6 +16,7 @@ const ErrorModal = (props: PropsToErrorModal) => {
   return (
     <Modal
       variant="small"
+      data-cy={props.dataCy}
       title={props.title}
       isOpen={props.isOpen}
       onClose={props.onClose}

--- a/src/components/modals/HbacModals/AddHBACRule.tsx
+++ b/src/components/modals/HbacModals/AddHBACRule.tsx
@@ -70,6 +70,7 @@ const AddHBACRule = (props: PropsToAddGroup) => {
                 ? ValidatedOptions.error
                 : ValidatedOptions.default
             }
+            data-cy="modal-textbox-rule-name"
           />
           <HelperText>
             {ruleName === "" && <HelperTextItem>Required value</HelperTextItem>}
@@ -88,6 +89,7 @@ const AddHBACRule = (props: PropsToAddGroup) => {
           onChange={(_event, value) => setDescription(value)}
           aria-label="Rule description"
           autoResize
+          data-cy="modal-textbox-description"
         />
       ),
     },
@@ -217,10 +219,19 @@ const AddHBACRule = (props: PropsToAddGroup) => {
   };
 
   const errorModalActions = [
-    <SecondaryButton key="retry" onClickHandler={onRetry}>
+    <SecondaryButton
+      dataCy="modal-button-retry"
+      key="retry"
+      onClickHandler={onRetry}
+    >
       Retry
     </SecondaryButton>,
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+    >
       Cancel
     </Button>,
   ];
@@ -238,6 +249,7 @@ const AddHBACRule = (props: PropsToAddGroup) => {
   // Buttons that will be shown at the end of the form
   const modalActions = [
     <SecondaryButton
+      dataCy="modal-button-add"
       key="add-new-rule"
       name="add"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
@@ -250,6 +262,7 @@ const AddHBACRule = (props: PropsToAddGroup) => {
       {addSpinning ? "Adding" : "Add"}
     </SecondaryButton>,
     <SecondaryButton
+      dataCy="modal-button-add-and-add-another"
       key="add-and-add-another-new-rule"
       name="add_and_add_another"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
@@ -261,7 +274,12 @@ const AddHBACRule = (props: PropsToAddGroup) => {
     >
       {addAgainSpinning ? "Adding" : "Add and add another"}
     </SecondaryButton>,
-    <Button key="cancel-new-rule" variant="link" onClick={cleanAndCloseModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-new-rule"
+      variant="link"
+      onClick={cleanAndCloseModal}
+    >
       Cancel
     </Button>,
   ];
@@ -271,6 +289,7 @@ const AddHBACRule = (props: PropsToAddGroup) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="add-hbac-rule-modal"
         variantType="small"
         modalPosition="top"
         offPosition="76px"
@@ -283,6 +302,7 @@ const AddHBACRule = (props: PropsToAddGroup) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="add-hbac-rule-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/HbacModals/AddHBACService.tsx
+++ b/src/components/modals/HbacModals/AddHBACService.tsx
@@ -70,6 +70,7 @@ const AddHBACService = (props: PropsToAddGroup) => {
                 ? ValidatedOptions.error
                 : ValidatedOptions.default
             }
+            data-cy="modal-textbox-service-name"
           />
           <HelperText>
             {serviceName === "" && (
@@ -88,6 +89,7 @@ const AddHBACService = (props: PropsToAddGroup) => {
           name="modal-form-service-desc"
           value={description}
           onChange={(_event, value) => setDescription(value)}
+          data-cy="modal-textbox-description"
           aria-label="Service description"
           autoResize
         />
@@ -221,10 +223,19 @@ const AddHBACService = (props: PropsToAddGroup) => {
   };
 
   const errorModalActions = [
-    <SecondaryButton key="retry" onClickHandler={onRetry}>
+    <SecondaryButton
+      key="retry"
+      onClickHandler={onRetry}
+      dataCy="modal-button-retry"
+    >
       Retry
     </SecondaryButton>,
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+      data-cy="modal-button-cancel"
+    >
       Cancel
     </Button>,
   ];
@@ -242,6 +253,7 @@ const AddHBACService = (props: PropsToAddGroup) => {
   // Buttons that will be shown at the end of the form
   const modalActions = [
     <SecondaryButton
+      dataCy="modal-button-add"
       key="add-new-service"
       name="add"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
@@ -254,6 +266,7 @@ const AddHBACService = (props: PropsToAddGroup) => {
       {addSpinning ? "Adding" : "Add"}
     </SecondaryButton>,
     <SecondaryButton
+      dataCy="modal-button-add-and-add-another"
       key="add-and-add-another-new-service"
       name="add_and_add_another"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
@@ -266,6 +279,7 @@ const AddHBACService = (props: PropsToAddGroup) => {
       {addAgainSpinning ? "Adding" : "Add and add another"}
     </SecondaryButton>,
     <Button
+      data-cy="modal-button-cancel"
       key="cancel-new-service"
       variant="link"
       onClick={cleanAndCloseModal}
@@ -279,6 +293,7 @@ const AddHBACService = (props: PropsToAddGroup) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="add-hbac-service-modal"
         variantType="small"
         modalPosition="top"
         offPosition="76px"
@@ -291,6 +306,7 @@ const AddHBACService = (props: PropsToAddGroup) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="add-hbac-service-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/HbacModals/AddHBACServiceGroup.tsx
+++ b/src/components/modals/HbacModals/AddHBACServiceGroup.tsx
@@ -70,6 +70,7 @@ const AddHBACServiceGroup = (props: PropsToAddGroup) => {
                 ? ValidatedOptions.error
                 : ValidatedOptions.default
             }
+            data-cy="modal-textbox-service-group-name"
           />
           <HelperText>
             {serviceName === "" && (
@@ -88,6 +89,7 @@ const AddHBACServiceGroup = (props: PropsToAddGroup) => {
           name="modal-form-service-group-desc"
           value={description}
           onChange={(_event, value) => setDescription(value)}
+          data-cy="modal-textbox-description"
           aria-label="Service group description"
           autoResize
         />
@@ -221,10 +223,19 @@ const AddHBACServiceGroup = (props: PropsToAddGroup) => {
   };
 
   const errorModalActions = [
-    <SecondaryButton key="retry" onClickHandler={onRetry}>
+    <SecondaryButton
+      key="retry"
+      onClickHandler={onRetry}
+      dataCy="modal-button-retry"
+    >
       Retry
     </SecondaryButton>,
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+      data-cy="modal-button-cancel"
+    >
       Cancel
     </Button>,
   ];
@@ -242,6 +253,7 @@ const AddHBACServiceGroup = (props: PropsToAddGroup) => {
   // Buttons that will be shown at the end of the form
   const modalActions = [
     <SecondaryButton
+      dataCy="modal-button-add"
       key="add-new-service-group"
       name="add"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
@@ -254,6 +266,7 @@ const AddHBACServiceGroup = (props: PropsToAddGroup) => {
       {addSpinning ? "Adding" : "Add"}
     </SecondaryButton>,
     <SecondaryButton
+      dataCy="modal-button-add-and-add-another"
       key="add-and-add-another-new-service-group"
       name="add_and_add_another"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
@@ -266,6 +279,7 @@ const AddHBACServiceGroup = (props: PropsToAddGroup) => {
       {addAgainSpinning ? "Adding" : "Add and add another"}
     </SecondaryButton>,
     <Button
+      data-cy="modal-button-cancel"
       key="cancel-new-service"
       variant="link"
       onClick={cleanAndCloseModal}
@@ -279,6 +293,7 @@ const AddHBACServiceGroup = (props: PropsToAddGroup) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="add-hbac-service-group-modal"
         variantType="small"
         modalPosition="top"
         offPosition="76px"
@@ -291,6 +306,7 @@ const AddHBACServiceGroup = (props: PropsToAddGroup) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="add-hbac-service-group-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/HbacModals/DeleteHBACRule.tsx
+++ b/src/components/modals/HbacModals/DeleteHBACRule.tsx
@@ -99,7 +99,12 @@ const DeleteHBACRule = (props: PropsToDeleteRules) => {
   };
 
   const errorModalActions = [
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+      data-cy="modal-button-ok"
+    >
       OK
     </Button>,
   ];
@@ -182,10 +187,16 @@ const DeleteHBACRule = (props: PropsToDeleteRules) => {
       spinnerAriaLabel="Deleting"
       isLoading={spinning}
       isDisabled={spinning}
+      data-cy="modal-button-delete"
     >
       {spinning ? "Deleting" : "Delete"}
     </Button>,
-    <Button key="cancel-delete-hbacrules" variant="link" onClick={closeModal}>
+    <Button
+      key="cancel-delete-hbacrules"
+      variant="link"
+      onClick={closeModal}
+      data-cy="modal-button-cancel"
+    >
       Cancel
     </Button>,
   ];
@@ -194,6 +205,7 @@ const DeleteHBACRule = (props: PropsToDeleteRules) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="delete-hbac-rules-modal"
         variantType="medium"
         modalPosition="top"
         offPosition="76px"
@@ -206,6 +218,7 @@ const DeleteHBACRule = (props: PropsToDeleteRules) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="delete-hbac-rules-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/HbacModals/DeleteHBACService.tsx
+++ b/src/components/modals/HbacModals/DeleteHBACService.tsx
@@ -99,7 +99,12 @@ const DeleteHBACService = (props: PropsToDeleteServices) => {
   };
 
   const errorModalActions = [
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+      data-cy="modal-button-ok"
+    >
       OK
     </Button>,
   ];
@@ -182,6 +187,7 @@ const DeleteHBACService = (props: PropsToDeleteServices) => {
       spinnerAriaLabel="Deleting"
       isLoading={spinning}
       isDisabled={spinning}
+      data-cy="modal-button-delete"
     >
       {spinning ? "Deleting" : "Delete"}
     </Button>,
@@ -189,6 +195,7 @@ const DeleteHBACService = (props: PropsToDeleteServices) => {
       key="cancel-delete-hbacservices"
       variant="link"
       onClick={closeModal}
+      data-cy="modal-button-cancel"
     >
       Cancel
     </Button>,
@@ -198,6 +205,7 @@ const DeleteHBACService = (props: PropsToDeleteServices) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="delete-hbac-services-modal"
         variantType="medium"
         modalPosition="top"
         offPosition="76px"
@@ -210,6 +218,7 @@ const DeleteHBACService = (props: PropsToDeleteServices) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="delete-hbac-services-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/HbacModals/DeleteHBACServiceGroup.tsx
+++ b/src/components/modals/HbacModals/DeleteHBACServiceGroup.tsx
@@ -102,7 +102,12 @@ const DeleteHBACServiceGroup = (props: PropsToDeleteServices) => {
   };
 
   const errorModalActions = [
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+      data-cy="modal-button-ok"
+    >
       OK
     </Button>,
   ];
@@ -185,6 +190,7 @@ const DeleteHBACServiceGroup = (props: PropsToDeleteServices) => {
       spinnerAriaLabel="Deleting"
       isLoading={spinning}
       isDisabled={spinning}
+      data-cy="modal-button-delete"
     >
       {spinning ? "Deleting" : "Delete"}
     </Button>,
@@ -192,6 +198,7 @@ const DeleteHBACServiceGroup = (props: PropsToDeleteServices) => {
       key="cancel-delete-hbacservicegroups"
       variant="link"
       onClick={closeModal}
+      data-cy="modal-button-cancel"
     >
       Cancel
     </Button>,
@@ -201,6 +208,7 @@ const DeleteHBACServiceGroup = (props: PropsToDeleteServices) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="delete-hbac-service-groups-modal"
         variantType="medium"
         modalPosition="top"
         offPosition="76px"
@@ -213,6 +221,7 @@ const DeleteHBACServiceGroup = (props: PropsToDeleteServices) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="delete-hbac-service-groups-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/HbacModals/DisableEnableHBACRules.tsx
+++ b/src/components/modals/HbacModals/DisableEnableHBACRules.tsx
@@ -102,7 +102,12 @@ const DisableEnableHBACRules = (props: PropsToDisableEnableHBACRules) => {
   };
 
   const errorModalActions = [
-    <Button key="ok" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      data-cy="modal-button-ok"
+      key="ok"
+      variant="link"
+      onClick={onCloseErrorModal}
+    >
       OK
     </Button>,
   ];
@@ -267,16 +272,23 @@ const DisableEnableHBACRules = (props: PropsToDisableEnableHBACRules) => {
         )
       }
       form="hbacrules-enable-disable-hbacrules-modal"
+      data-cy="modal-button-disable"
     >
       Disable
     </Button>,
-    <Button key="cancel-disable-hacbrule" variant="link" onClick={closeModal}>
+    <Button
+      key="cancel-disable-hacbrule"
+      variant="link"
+      onClick={closeModal}
+      data-cy="modal-button-cancel"
+    >
       Cancel
     </Button>,
   ];
 
   const modalDisable: JSX.Element = (
     <ModalWithFormLayout
+      dataCy="disable-hbac-rules-modal"
       variantType="medium"
       modalPosition="top"
       offPosition="76px"
@@ -301,16 +313,23 @@ const DisableEnableHBACRules = (props: PropsToDisableEnableHBACRules) => {
         )
       }
       form="hbacrules-enable-disable-hbacrules-modal"
+      data-cy="modal-button-enable"
     >
       Enable
     </Button>,
-    <Button key="cancel-enable-hbacrule" variant="link" onClick={closeModal}>
+    <Button
+      key="cancel-enable-hbacrule"
+      variant="link"
+      onClick={closeModal}
+      data-cy="modal-button-cancel"
+    >
       Cancel
     </Button>,
   ];
 
   const modalEnable: JSX.Element = (
     <ModalWithFormLayout
+      dataCy="enable-hbac-rules-modal"
       variantType="medium"
       modalPosition="top"
       offPosition="76px"
@@ -330,6 +349,7 @@ const DisableEnableHBACRules = (props: PropsToDisableEnableHBACRules) => {
       {!props.optionSelected ? modalEnable : modalDisable}
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="disable-enable-hbac-rules-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/HbacModals/RemoveHBACRuleMembers.tsx
+++ b/src/components/modals/HbacModals/RemoveHBACRuleMembers.tsx
@@ -54,6 +54,7 @@ const RemoveHBACRuleMembersModal = (props: PropsToDelete) => {
   // Buttons that will be shown at the end of the form
   const modalActions = [
     <SecondaryButton
+      dataCy="modal-button-delete"
       key={"delete-" + props.elementType}
       form="modal-form"
       onClickHandler={() => props.removeMembers(props.elementsToDelete)}
@@ -65,6 +66,7 @@ const RemoveHBACRuleMembersModal = (props: PropsToDelete) => {
       {props.spinning ? "Deleting" : "Delete"}
     </SecondaryButton>,
     <Button
+      data-cy="modal-button-cancel"
       key={"cancel-delete-" + props.elementType}
       variant="link"
       onClick={props.closeModal}
@@ -76,6 +78,7 @@ const RemoveHBACRuleMembersModal = (props: PropsToDelete) => {
   // Render component
   return (
     <ModalWithFormLayout
+      dataCy="remove-hbac-rule-members-modal"
       variantType="medium"
       modalPosition="top"
       title={"Remove " + label.toLowerCase() + "s from HBAC rule"}

--- a/src/components/modals/HostModals/AddHost.tsx
+++ b/src/components/modals/HostModals/AddHost.tsx
@@ -94,6 +94,7 @@ const AddHost = (props: PropsToAddHost) => {
   // Toggle
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
+      data-cy="modal-select-dns-zone-toggle"
       ref={toggleRef}
       onClick={dnsZoneOnToggle}
       className="pf-v5-u-w-100"
@@ -261,6 +262,7 @@ const AddHost = (props: PropsToAddHost) => {
       pfComponent: (
         <>
           <TextInput
+            data-cy="modal-textbox-host-name"
             type="text"
             id="modal-form-host-name"
             name="modal-form-host-name"
@@ -288,6 +290,7 @@ const AddHost = (props: PropsToAddHost) => {
       pfComponent: (
         <>
           <Select
+            data-cy="modal-select-dns-zone"
             id="dnszone"
             aria-label="Select DNS zone selector"
             toggle={toggle}
@@ -298,6 +301,7 @@ const AddHost = (props: PropsToAddHost) => {
           >
             {dnsZoneOptions.map((option, index) => (
               <SelectOption
+                data-cy={"modal-select-dns-zone-" + option.value}
                 isDisabled={option.disabled}
                 key={index}
                 value={option.value}
@@ -324,6 +328,7 @@ const AddHost = (props: PropsToAddHost) => {
       name: "Description",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-host-desc"
           type="text"
           id="modal-form-host-desc"
           name="modal-form-host-desc"
@@ -338,6 +343,7 @@ const AddHost = (props: PropsToAddHost) => {
       name: "Class",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-host-class"
           type="text"
           id="modal-form-host-class"
           name="modal-form-host-class"
@@ -353,6 +359,7 @@ const AddHost = (props: PropsToAddHost) => {
       pfComponent: (
         <>
           <TextInput
+            data-cy="modal-textbox-host-ip-address"
             type="text"
             id="modal-form-host-ip-address"
             name="modal-form-host-ip-address"
@@ -379,6 +386,7 @@ const AddHost = (props: PropsToAddHost) => {
       pfComponent: (
         <div title="Skip the DNS check, but requires a valid IP address">
           <Checkbox
+            data-cy="modal-checkbox-force-host"
             label="Force"
             isChecked={forceCheckbox}
             aria-label="force host name checkbox"
@@ -402,6 +410,7 @@ const AddHost = (props: PropsToAddHost) => {
       name: "",
       pfComponent: (
         <Checkbox
+          data-cy="modal-checkbox-generate-otp"
           label="Generate OTP"
           isChecked={generateOtpCheckbox}
           aria-label="Generate OTP checkbox"
@@ -417,6 +426,7 @@ const AddHost = (props: PropsToAddHost) => {
       name: "",
       pfComponent: (
         <Checkbox
+          data-cy="modal-checkbox-suppress-membership"
           label="Suppress processing of membership attributes"
           isChecked={noMembershipCheckbox}
           aria-label="Suppress membership attributes checkbox"
@@ -612,10 +622,19 @@ const AddHost = (props: PropsToAddHost) => {
   };
 
   const errorModalActions = [
-    <SecondaryButton key="retry" onClickHandler={onRetry}>
+    <SecondaryButton
+      dataCy="modal-button-retry"
+      key="retry"
+      onClickHandler={onRetry}
+    >
       Retry
     </SecondaryButton>,
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+    >
       Cancel
     </Button>,
   ];
@@ -633,6 +652,7 @@ const AddHost = (props: PropsToAddHost) => {
   // Buttons that will be shown at the end of the form
   const modalActions = [
     <SecondaryButton
+      dataCy="modal-button-add"
       key="add-new-host"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
       onClickHandler={addHostHandler}
@@ -644,6 +664,7 @@ const AddHost = (props: PropsToAddHost) => {
       {addSpinning ? "Adding" : "Add"}
     </SecondaryButton>,
     <SecondaryButton
+      dataCy="modal-button-add-and-add-another"
       key="add-and-add-another-host"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
       onClickHandler={addAndAddAnotherHandler}
@@ -653,7 +674,12 @@ const AddHost = (props: PropsToAddHost) => {
     >
       {addAgainSpinning ? "Adding" : "Add and add another"}
     </SecondaryButton>,
-    <Button key="cancel-new-host" variant="link" onClick={cleanAndCloseModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-new-host"
+      variant="link"
+      onClick={cleanAndCloseModal}
+    >
       Cancel
     </Button>,
   ];
@@ -663,6 +689,7 @@ const AddHost = (props: PropsToAddHost) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="add-host-modal"
         variantType="small"
         modalPosition="top"
         offPosition="76px"
@@ -675,6 +702,7 @@ const AddHost = (props: PropsToAddHost) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="add-host-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/HostModals/DeleteHosts.tsx
+++ b/src/components/modals/HostModals/DeleteHosts.tsx
@@ -105,7 +105,12 @@ const DeleteHosts = (props: PropsToDeleteHosts) => {
   };
 
   const errorModalActions = [
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      data-cy="modal-button-ok"
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+    >
       OK
     </Button>,
   ];
@@ -185,6 +190,7 @@ const DeleteHosts = (props: PropsToDeleteHosts) => {
   // Set the Modal and Action buttons for 'Delete' option
   const modalActionsDelete: JSX.Element[] = [
     <Button
+      data-cy="modal-button-delete"
       key="delete-hosts"
       variant="danger"
       onClick={deleteHosts}
@@ -196,7 +202,12 @@ const DeleteHosts = (props: PropsToDeleteHosts) => {
     >
       {spinning ? "Deleting" : "Delete"}
     </Button>,
-    <Button key="cancel-delete-hosts" variant="link" onClick={closeModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-delete-hosts"
+      variant="link"
+      onClick={closeModal}
+    >
       Cancel
     </Button>,
   ];
@@ -205,6 +216,7 @@ const DeleteHosts = (props: PropsToDeleteHosts) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="delete-hosts-modal"
         variantType="medium"
         modalPosition="top"
         offPosition="76px"
@@ -217,6 +229,7 @@ const DeleteHosts = (props: PropsToDeleteHosts) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="delete-hosts-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/HostModals/HostSetPassword.tsx
+++ b/src/components/modals/HostModals/HostSetPassword.tsx
@@ -59,6 +59,7 @@ const HostSetPassword = (props: PropsToResetPassword) => {
       name: "New Password",
       pfComponent: (
         <PasswordInput
+          dataCy="reset-password-new-password"
           id="reset-password-new-password"
           name="password"
           value={newPassword}
@@ -76,6 +77,7 @@ const HostSetPassword = (props: PropsToResetPassword) => {
       pfComponent: (
         <>
           <PasswordInput
+            dataCy="set-password-verify-password"
             id="set-password-verify-password"
             name="password2"
             value={verifyPassword}
@@ -153,6 +155,7 @@ const HostSetPassword = (props: PropsToResetPassword) => {
 
   const actions = [
     <Button
+      data-cy="modal-button-set-password"
       key={"set-password"}
       variant="primary"
       onClick={onSetPassword}
@@ -165,6 +168,7 @@ const HostSetPassword = (props: PropsToResetPassword) => {
       Reset password
     </Button>,
     <Button
+      data-cy="modal-button-cancel"
       key={"cancel-set-password"}
       variant="link"
       onClick={resetFieldsAndCloseModal}
@@ -176,6 +180,7 @@ const HostSetPassword = (props: PropsToResetPassword) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="host-set-password-modal"
         variantType="small"
         modalPosition="top"
         title="Set password"

--- a/src/components/modals/IdOverrideModals/AddIdOverrideGroup.tsx
+++ b/src/components/modals/IdOverrideModals/AddIdOverrideGroup.tsx
@@ -103,6 +103,7 @@ const AddIDOverrideGroupModal = (props: PropsToAddGroup) => {
       name: "Group to override",
       pfComponent: (
         <DropdownSearch
+          dataCy="modal-override-group"
           id="modal-form-override-group"
           options={groupNames}
           onSelect={(value: string) => setOverrideGroup(value)}
@@ -116,6 +117,7 @@ const AddIDOverrideGroupModal = (props: PropsToAddGroup) => {
       name: "Group name",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-group-name"
           type="text"
           id="modal-form-group-name"
           name="modal-form-group-name"
@@ -130,6 +132,7 @@ const AddIDOverrideGroupModal = (props: PropsToAddGroup) => {
       name: "GID",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-gidnumber"
           type="text"
           id="modal-form-gidnumber"
           name="modal-form-gidnumber"
@@ -149,6 +152,7 @@ const AddIDOverrideGroupModal = (props: PropsToAddGroup) => {
       name: "Description",
       pfComponent: (
         <TextArea
+          data-cy="modal-textbox-group-description"
           id="modal-form-group-desc"
           name="modal-form-group-desc"
           value={description}
@@ -287,10 +291,19 @@ const AddIDOverrideGroupModal = (props: PropsToAddGroup) => {
   };
 
   const errorModalActions = [
-    <SecondaryButton key="retry" onClickHandler={onRetry}>
+    <SecondaryButton
+      key="retry"
+      onClickHandler={onRetry}
+      dataCy="modal-button-retry"
+    >
       Retry
     </SecondaryButton>,
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+      data-cy="modal-button-cancel"
+    >
       Cancel
     </Button>,
   ];
@@ -320,6 +333,7 @@ const AddIDOverrideGroupModal = (props: PropsToAddGroup) => {
   // Buttons that will be shown at the end of the form
   const modalActions = [
     <SecondaryButton
+      dataCy="modal-button-add"
       key="add-new-group"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
       onClickHandler={addHandler}
@@ -331,6 +345,7 @@ const AddIDOverrideGroupModal = (props: PropsToAddGroup) => {
       {addSpinning ? "Adding" : "Add"}
     </SecondaryButton>,
     <SecondaryButton
+      dataCy="modal-button-add-and-add-another"
       key="add-and-add-another-group"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
       onClickHandler={addAndAddAnotherHandler}
@@ -340,7 +355,12 @@ const AddIDOverrideGroupModal = (props: PropsToAddGroup) => {
     >
       {addAgainSpinning ? "Adding" : "Add and add another"}
     </SecondaryButton>,
-    <Button key="cancel-new-group" variant="link" onClick={cleanAndCloseModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-new-group"
+      variant="link"
+      onClick={cleanAndCloseModal}
+    >
       Cancel
     </Button>,
   ];
@@ -365,6 +385,7 @@ const AddIDOverrideGroupModal = (props: PropsToAddGroup) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="add-id-override-group-modal"
         variantType="small"
         modalPosition="top"
         offPosition="76px"
@@ -378,6 +399,7 @@ const AddIDOverrideGroupModal = (props: PropsToAddGroup) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="add-id-override-group-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/IdOverrideModals/AddIdOverrideUser.tsx
+++ b/src/components/modals/IdOverrideModals/AddIdOverrideUser.tsx
@@ -113,6 +113,7 @@ const AddIDOverrideUserModal = (props: PropsToAddUser) => {
       name: "User to override",
       pfComponent: (
         <DropdownSearch
+          dataCy="modal-form-override-user"
           id="modal-form-override-user"
           options={userNames}
           onSelect={(value: string) => setOverrideUser(value)}
@@ -126,6 +127,7 @@ const AddIDOverrideUserModal = (props: PropsToAddUser) => {
       name: "User login",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-user-login"
           type="text"
           id="modal-form-user-login"
           name="modal-form-user-login"
@@ -140,6 +142,7 @@ const AddIDOverrideUserModal = (props: PropsToAddUser) => {
       name: "GECOS",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-user-gecos"
           type="text"
           id="modal-form-user-gecos"
           name="modal-form-user-gecos"
@@ -154,6 +157,7 @@ const AddIDOverrideUserModal = (props: PropsToAddUser) => {
       name: "UID",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-user-uidnumber"
           type="text"
           id="modal-form-user-uidnumber"
           name="modal-form-user-uidnumber"
@@ -173,6 +177,7 @@ const AddIDOverrideUserModal = (props: PropsToAddUser) => {
       name: "GID",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-user-gidnumber"
           type="text"
           id="modal-form-user-gidnumber"
           name="modal-form-user-gidnumber"
@@ -192,6 +197,7 @@ const AddIDOverrideUserModal = (props: PropsToAddUser) => {
       name: "Login shell",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-user-shell"
           type="text"
           id="modal-form-user-shell"
           name="modal-form-user-shell"
@@ -206,6 +212,7 @@ const AddIDOverrideUserModal = (props: PropsToAddUser) => {
       name: "Home directory",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-user-homedir"
           type="text"
           id="modal-form-user-homedir"
           name="modal-form-user-homedir"
@@ -220,6 +227,7 @@ const AddIDOverrideUserModal = (props: PropsToAddUser) => {
       name: "Certificate",
       pfComponent: (
         <TextArea
+          data-cy="modal-textbox-user-cert"
           id="modal-form-user-cert"
           name="modal-form-user-cert"
           value={usercertificate}
@@ -232,6 +240,7 @@ const AddIDOverrideUserModal = (props: PropsToAddUser) => {
       name: "SSH public key",
       pfComponent: (
         <TextArea
+          data-cy="modal-textbox-user-ssh"
           id="modal-form-user-ssh"
           name="modal-form-user-ssh"
           value={ipasshpubkey}
@@ -244,6 +253,7 @@ const AddIDOverrideUserModal = (props: PropsToAddUser) => {
       name: "Description",
       pfComponent: (
         <TextArea
+          data-cy="modal-textbox-user-desc"
           id="modal-form-user-desc"
           name="modal-form-user-desc"
           value={description}
@@ -394,10 +404,19 @@ const AddIDOverrideUserModal = (props: PropsToAddUser) => {
   };
 
   const errorModalActions = [
-    <SecondaryButton key="retry" onClickHandler={onRetry}>
+    <SecondaryButton
+      key="retry"
+      onClickHandler={onRetry}
+      dataCy="modal-button-retry"
+    >
       Retry
     </SecondaryButton>,
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+      data-cy="modal-button-cancel"
+    >
       Cancel
     </Button>,
   ];
@@ -428,6 +447,7 @@ const AddIDOverrideUserModal = (props: PropsToAddUser) => {
   // Buttons that will be shown at the end of the form
   const modalActions = [
     <SecondaryButton
+      dataCy="modal-button-add"
       key="add-new-user"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
       onClickHandler={addHandler}
@@ -439,6 +459,7 @@ const AddIDOverrideUserModal = (props: PropsToAddUser) => {
       {addSpinning ? "Adding" : "Add"}
     </SecondaryButton>,
     <SecondaryButton
+      dataCy="modal-button-add-and-add-another"
       key="add-and-add-another-user"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
       onClickHandler={addAndAddAnotherHandler}
@@ -448,7 +469,12 @@ const AddIDOverrideUserModal = (props: PropsToAddUser) => {
     >
       {addAgainSpinning ? "Adding" : "Add and add another"}
     </SecondaryButton>,
-    <Button key="cancel-new-user" variant="link" onClick={cleanAndCloseModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-new-user"
+      variant="link"
+      onClick={cleanAndCloseModal}
+    >
       Cancel
     </Button>,
   ];
@@ -473,6 +499,7 @@ const AddIDOverrideUserModal = (props: PropsToAddUser) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="add-id-override-user-modal"
         variantType="small"
         modalPosition="top"
         offPosition="76px"
@@ -486,6 +513,7 @@ const AddIDOverrideUserModal = (props: PropsToAddUser) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="add-id-override-user-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/IdOverrideModals/DeleteIdOverrideGroups.tsx
+++ b/src/components/modals/IdOverrideModals/DeleteIdOverrideGroups.tsx
@@ -96,7 +96,12 @@ const DeleteIdOverrideGroupsModal = (props: PropsToDelete) => {
   };
 
   const errorModalActions = [
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+      data-cy="modal-button-ok"
+    >
       OK
     </Button>,
   ];
@@ -170,6 +175,7 @@ const DeleteIdOverrideGroupsModal = (props: PropsToDelete) => {
   // Set the Modal and Action buttons for 'Delete' option
   const modalActionsDelete: JSX.Element[] = [
     <Button
+      data-cy="modal-button-delete"
       key="delete-id-override"
       variant="danger"
       onClick={deleteViews}
@@ -181,7 +187,12 @@ const DeleteIdOverrideGroupsModal = (props: PropsToDelete) => {
     >
       {spinning ? "Deleting" : "Delete"}
     </Button>,
-    <Button key="cancel-delete-id-override" variant="link" onClick={closeModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-delete-id-override"
+      variant="link"
+      onClick={closeModal}
+    >
       Cancel
     </Button>,
   ];
@@ -190,6 +201,7 @@ const DeleteIdOverrideGroupsModal = (props: PropsToDelete) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="delete-id-override-modal"
         variantType="medium"
         modalPosition="top"
         offPosition="76px"
@@ -202,6 +214,7 @@ const DeleteIdOverrideGroupsModal = (props: PropsToDelete) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="delete-id-override-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/IdOverrideModals/DeleteIdOverrideUsers.tsx
+++ b/src/components/modals/IdOverrideModals/DeleteIdOverrideUsers.tsx
@@ -96,7 +96,12 @@ const DeleteIdOverrideUsersModal = (props: PropsToDelete) => {
   };
 
   const errorModalActions = [
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      data-cy="modal-button-ok"
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+    >
       OK
     </Button>,
   ];
@@ -170,6 +175,7 @@ const DeleteIdOverrideUsersModal = (props: PropsToDelete) => {
   // Set the Modal and Action buttons for 'Delete' option
   const modalActionsDelete: JSX.Element[] = [
     <Button
+      data-cy="modal-button-delete"
       key="delete-id-override"
       variant="danger"
       onClick={deleteViews}
@@ -181,7 +187,12 @@ const DeleteIdOverrideUsersModal = (props: PropsToDelete) => {
     >
       {spinning ? "Deleting" : "Delete"}
     </Button>,
-    <Button key="cancel-delete-id-override" variant="link" onClick={closeModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-delete-id-override"
+      variant="link"
+      onClick={closeModal}
+    >
       Cancel
     </Button>,
   ];
@@ -190,6 +201,7 @@ const DeleteIdOverrideUsersModal = (props: PropsToDelete) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="delete-id-override-modal"
         variantType="medium"
         modalPosition="top"
         offPosition="76px"
@@ -202,6 +214,7 @@ const DeleteIdOverrideUsersModal = (props: PropsToDelete) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="delete-id-override-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/IdpReferences/AddModal.tsx
+++ b/src/components/modals/IdpReferences/AddModal.tsx
@@ -8,12 +8,13 @@ import {
   TextInput,
   ValidatedOptions,
 } from "@patternfly/react-core";
-import { SelectOptionProps } from "@patternfly/react-core";
 // Components
 import ModalWithFormLayout, {
   Field,
 } from "src/components/layouts/ModalWithFormLayout";
-import SimpleSelector from "src/components/layouts/SimpleSelector";
+import SimpleSelector, {
+  SelectOptionProps,
+} from "src/components/layouts/SimpleSelector";
 // RPC
 import {
   CustomIdpAddPayload,
@@ -62,23 +63,23 @@ const AddModal = (props: PropsToAddModal) => {
   );
   const providerOptions: SelectOptionProps[] = [
     {
-      label: "keycloak",
+      key: "keycloak",
       value: "Keycloak or Red Hat SSO",
     },
     {
-      label: "google",
+      key: "google",
       value: "Google",
     },
     {
-      label: "github",
+      key: "github",
       value: "Github",
     },
     {
-      label: "microsoft",
+      key: "microsoft",
       value: "Microsoft or Azure",
     },
     {
-      label: "okta",
+      key: "okta",
       value: "Okta",
     },
   ];
@@ -254,6 +255,7 @@ const AddModal = (props: PropsToAddModal) => {
       name: "Identity Provider reference name",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-idp-ref-name"
           type="text"
           id="identity-provider-reference-name"
           name="cn"
@@ -270,6 +272,7 @@ const AddModal = (props: PropsToAddModal) => {
       name: "Client identifier",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-client-id"
           type="text"
           id="client-id"
           name="ipaidpclientid"
@@ -286,6 +289,7 @@ const AddModal = (props: PropsToAddModal) => {
       name: "Secret",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-secret"
           type="text"
           id="secret"
           name="ipaidpclientsecret"
@@ -301,6 +305,7 @@ const AddModal = (props: PropsToAddModal) => {
       pfComponent: (
         <>
           <TextInput
+            data-cy="modal-textbox-verify-secret"
             type="text"
             id="verify-secret"
             name="ipaidpclientsecret_verify"
@@ -342,6 +347,7 @@ const AddModal = (props: PropsToAddModal) => {
       pfComponent: (
         <>
           <Radio
+            data-cy="modal-radio-predefined-idp"
             isChecked={isPreDefinedChecked}
             name="predefined-idp"
             onChange={(_event, isChecked) => onPreDefinedChange(isChecked)}
@@ -350,6 +356,7 @@ const AddModal = (props: PropsToAddModal) => {
             aria-label="Pre-defined IdP template"
           />
           <Radio
+            data-cy="modal-radio-custom-idp"
             isChecked={isCustomChecked}
             name="custom-idp"
             onChange={(_event, isChecked) => onCustomChange(isChecked)}
@@ -368,6 +375,7 @@ const AddModal = (props: PropsToAddModal) => {
       name: "Provider type",
       pfComponent: (
         <SimpleSelector
+          dataCy="modal-simple-provider-type"
           id="provider-type-selector"
           options={providerOptions}
           selected={selectedProvider}
@@ -388,6 +396,7 @@ const AddModal = (props: PropsToAddModal) => {
       name: "Organization",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-org"
           type="text"
           id="org"
           name="ipaidporg"
@@ -403,6 +412,7 @@ const AddModal = (props: PropsToAddModal) => {
       name: "Base URL",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-base-url"
           type="text"
           id="base-url"
           name="ipaidpbaseurl"
@@ -422,6 +432,7 @@ const AddModal = (props: PropsToAddModal) => {
       name: "Organization",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-org"
           type="text"
           id="org"
           name="ipaidporg"
@@ -440,6 +451,7 @@ const AddModal = (props: PropsToAddModal) => {
       name: "Authorization URI",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-auth-uri"
           type="text"
           id="auth-uri"
           name="ipaidpauthendpoint"
@@ -455,6 +467,7 @@ const AddModal = (props: PropsToAddModal) => {
       name: "Device authorization URI",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-dev-auth-uri"
           type="text"
           id="dev-auth-uri"
           name="ipaidpdevauthendpoint"
@@ -470,6 +483,7 @@ const AddModal = (props: PropsToAddModal) => {
       name: "Token URI",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-token-uri"
           type="text"
           id="token-uri"
           name="ipaidptokenendpoint"
@@ -485,6 +499,7 @@ const AddModal = (props: PropsToAddModal) => {
       name: "User info URI",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-user-info-uri"
           type="text"
           id="user-info-uri"
           name="ipaidpuserinfoendpoint"
@@ -500,6 +515,7 @@ const AddModal = (props: PropsToAddModal) => {
       name: "JWKS URI",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-jwks-uri"
           type="text"
           id="jwks-uri"
           name="ipaidpkeysendpoint"
@@ -518,6 +534,7 @@ const AddModal = (props: PropsToAddModal) => {
       name: "Scope",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-scope"
           type="text"
           id="scope"
           name="ipaidpscope"
@@ -532,6 +549,7 @@ const AddModal = (props: PropsToAddModal) => {
       name: "External IdP UID attribute",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-ext-idp-uid-attr"
           type="text"
           id="ext-idp-uid-attr"
           name="ipaidpsub"
@@ -624,6 +642,7 @@ const AddModal = (props: PropsToAddModal) => {
   // Actions
   const modalActions: JSX.Element[] = [
     <Button
+      data-cy="modal-button-add"
       key="add-new"
       variant="secondary"
       isDisabled={
@@ -639,6 +658,7 @@ const AddModal = (props: PropsToAddModal) => {
       Add
     </Button>,
     <Button
+      data-cy="modal-button-add-and-add-another"
       key="add-new-again"
       variant="secondary"
       isDisabled={
@@ -653,7 +673,12 @@ const AddModal = (props: PropsToAddModal) => {
     >
       Add and add again
     </Button>,
-    <Button key="cancel-new" variant="link" onClick={cleanAndCloseModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-new"
+      variant="link"
+      onClick={cleanAndCloseModal}
+    >
       Cancel
     </Button>,
   ];
@@ -662,6 +687,7 @@ const AddModal = (props: PropsToAddModal) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="add-idp-reference-modal"
         variantType={"small"}
         modalPosition={"top"}
         offPosition={"76px"}

--- a/src/components/modals/IdpReferences/DeleteModal.tsx
+++ b/src/components/modals/IdpReferences/DeleteModal.tsx
@@ -94,7 +94,12 @@ const DeleteModal = (props: PropsToDelete) => {
   };
 
   const errorModalActions = [
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      data-cy="modal-button-ok"
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+    >
       OK
     </Button>,
   ];
@@ -168,6 +173,7 @@ const DeleteModal = (props: PropsToDelete) => {
   // Set the Modal and Action buttons for 'Delete' option
   const modalActionsDelete: JSX.Element[] = [
     <Button
+      data-cy="modal-button-delete"
       key="delete-idpreferences"
       variant="danger"
       onClick={deleteIdpReferences}
@@ -180,6 +186,7 @@ const DeleteModal = (props: PropsToDelete) => {
       {spinning ? "Deleting" : "Delete"}
     </Button>,
     <Button
+      data-cy="modal-button-cancel"
       key="cancel-delete-idpreferences"
       variant="link"
       onClick={props.onClose}
@@ -192,6 +199,7 @@ const DeleteModal = (props: PropsToDelete) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="delete-idpreferences-modal"
         variantType="medium"
         modalPosition="top"
         offPosition="76px"
@@ -204,6 +212,7 @@ const DeleteModal = (props: PropsToDelete) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="delete-idpreferences-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/KeytabElementsDeleteModal.tsx
+++ b/src/components/modals/KeytabElementsDeleteModal.tsx
@@ -86,6 +86,7 @@ const KeytabElementsDeleteModal = (props: PropsToDelete) => {
   // Buttons that will be shown at the end of the form
   const modalActions = [
     <SecondaryButton
+      dataCy="modal-button-delete"
       key={"delete-" + props.elementType}
       form="modal-form"
       onClickHandler={removeElementFromList}
@@ -93,6 +94,7 @@ const KeytabElementsDeleteModal = (props: PropsToDelete) => {
       Delete
     </SecondaryButton>,
     <Button
+      data-cy="modal-button-cancel"
       key={"cancel-delete-" + props.elementType}
       variant="link"
       onClick={closeModal}
@@ -104,6 +106,7 @@ const KeytabElementsDeleteModal = (props: PropsToDelete) => {
   // Render component
   return (
     <ModalWithFormLayout
+      dataCy="keytab-elements-delete-modal"
       variantType="medium"
       modalPosition="top"
       title={

--- a/src/components/modals/PrincipalAliasAddModal.tsx
+++ b/src/components/modals/PrincipalAliasAddModal.tsx
@@ -20,6 +20,7 @@ const PrincipalAliasAddModal = (props: PropsToPrincipalAliasModal) => {
       name: "New kerberos principal alias",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-new-kerberos-principal-alias"
           id="new-kerberos-alias"
           name="krbprincalname"
           value={props.data.newKrbAlias}
@@ -33,6 +34,7 @@ const PrincipalAliasAddModal = (props: PropsToPrincipalAliasModal) => {
 
   return (
     <ModalWithFormLayout
+      dataCy="principal-alias-add-modal"
       variantType="small"
       modalPosition="top"
       title="Add Kerberos Principal Alias"

--- a/src/components/modals/PrincipalAliasDeleteModal.tsx
+++ b/src/components/modals/PrincipalAliasDeleteModal.tsx
@@ -25,6 +25,7 @@ const PrincipalAliasDeleteModal = (props: PropsToPrincipalAliasModal) => {
 
   return (
     <ModalWithFormLayout
+      dataCy="principal-alias-delete-modal"
       variantType="small"
       modalPosition="top"
       title="Remove Kerberos Principal Alias"

--- a/src/components/modals/PwPoliciesModals/AddModal.tsx
+++ b/src/components/modals/PwPoliciesModals/AddModal.tsx
@@ -165,9 +165,10 @@ const AddModal = (props: PropsToAddModal) => {
       name: "Group",
       pfComponent: (
         <SimpleSelector
+          dataCy="modal-simple-group"
           id="group"
           options={availableItems.map((name) => ({
-            label: name,
+            key: name,
             value: name,
           }))}
           selected={selectedItem}
@@ -181,6 +182,7 @@ const AddModal = (props: PropsToAddModal) => {
       name: "Priority",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-priority"
           id="modal-form-priority"
           name="cospriority"
           type="number"
@@ -196,6 +198,7 @@ const AddModal = (props: PropsToAddModal) => {
   // Actions
   const modalActions: JSX.Element[] = [
     <Button
+      data-cy="modal-button-add"
       key="add-new"
       variant="secondary"
       isDisabled={isAddButtonSpinning || selectedItem === ""}
@@ -207,6 +210,7 @@ const AddModal = (props: PropsToAddModal) => {
       Add
     </Button>,
     <Button
+      data-cy="modal-button-add-and-add-another"
       key="add-new-again"
       variant="secondary"
       isDisabled={isAddAnotherButtonSpinning || selectedItem === ""}
@@ -217,7 +221,12 @@ const AddModal = (props: PropsToAddModal) => {
     >
       Add and add again
     </Button>,
-    <Button key="cancel-new" variant="link" onClick={cleanAndCloseModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-new"
+      variant="link"
+      onClick={cleanAndCloseModal}
+    >
       Cancel
     </Button>,
   ];
@@ -227,6 +236,7 @@ const AddModal = (props: PropsToAddModal) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="add-pwpolicy-modal"
         variantType={"small"}
         modalPosition={"top"}
         offPosition={"76px"}

--- a/src/components/modals/PwPoliciesModals/DeleteModal.tsx
+++ b/src/components/modals/PwPoliciesModals/DeleteModal.tsx
@@ -94,7 +94,12 @@ const DeleteModal = (props: PropsToDelete) => {
   };
 
   const errorModalActions = [
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      data-cy="modal-button-ok"
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+    >
       OK
     </Button>,
   ];
@@ -168,6 +173,7 @@ const DeleteModal = (props: PropsToDelete) => {
   // Set the Modal and Action buttons for 'Delete' option
   const modalActionsDelete: JSX.Element[] = [
     <Button
+      data-cy="modal-button-delete"
       key="delete-pwpolicies"
       variant="danger"
       onClick={deletePasswordPolicies}
@@ -180,6 +186,7 @@ const DeleteModal = (props: PropsToDelete) => {
       {spinning ? "Deleting" : "Delete"}
     </Button>,
     <Button
+      data-cy="modal-button-cancel"
       key="cancel-delete-pwpolicies"
       variant="link"
       onClick={props.onClose}
@@ -192,6 +199,7 @@ const DeleteModal = (props: PropsToDelete) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="delete-pwpolicy-modal"
         variantType="medium"
         modalPosition="top"
         offPosition="76px"
@@ -204,6 +212,7 @@ const DeleteModal = (props: PropsToDelete) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="delete-pwpolicy-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/RebuildAutoMembership.tsx
+++ b/src/components/modals/RebuildAutoMembership.tsx
@@ -69,6 +69,7 @@ const RebuildAutoMembership = (props: PropsToRebuildAutoMembership) => {
   // Actions
   const membershipModalActions: JSX.Element[] = [
     <Button
+      data-cy="modal-button-ok"
       key="rebuild-auto-membership"
       variant="primary"
       onClick={onRebuildAutoMembership}
@@ -77,6 +78,7 @@ const RebuildAutoMembership = (props: PropsToRebuildAutoMembership) => {
       OK
     </Button>,
     <Button
+      data-cy="modal-button-cancel"
       key="cancel-rebuild-auto-membership"
       variant="link"
       onClick={props.onClose}
@@ -106,6 +108,7 @@ const RebuildAutoMembership = (props: PropsToRebuildAutoMembership) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="rebuild-auto-membership-modal"
         variantType="medium"
         modalPosition="top"
         offPosition="76px"

--- a/src/components/modals/RemoveNetgroupMembers.tsx
+++ b/src/components/modals/RemoveNetgroupMembers.tsx
@@ -54,6 +54,7 @@ const RemoveNetgroupMembersModal = (props: PropsToDelete) => {
   // Buttons that will be shown at the end of the form
   const modalActions = [
     <SecondaryButton
+      dataCy="modal-button-delete"
       key={"delete-" + props.elementType}
       form="modal-form"
       onClickHandler={() => props.removeMembers(props.elementsToDelete)}
@@ -65,6 +66,7 @@ const RemoveNetgroupMembersModal = (props: PropsToDelete) => {
       {props.spinning ? "Deleting" : "Delete"}
     </SecondaryButton>,
     <Button
+      data-cy="modal-button-cancel"
       key={"cancel-delete-" + props.elementType}
       variant="link"
       onClick={props.closeModal}
@@ -76,6 +78,7 @@ const RemoveNetgroupMembersModal = (props: PropsToDelete) => {
   // Render component
   return (
     <ModalWithFormLayout
+      dataCy="remove-netgroup-members-modal"
       variantType="medium"
       modalPosition="top"
       title={"Remove " + label.toLowerCase() + "s from Netgroup"}

--- a/src/components/modals/SubIdsModals/AddModal.tsx
+++ b/src/components/modals/SubIdsModals/AddModal.tsx
@@ -168,9 +168,10 @@ const AddModal = (props: PropsToAddModal) => {
       name: "Owner",
       pfComponent: (
         <SimpleSelector
+          dataCy="modal-simple-owner"
           id="owner"
           options={availableItems.map((name) => ({
-            label: name,
+            key: name,
             value: name,
           }))}
           selected={selectedItem}
@@ -184,6 +185,7 @@ const AddModal = (props: PropsToAddModal) => {
   // Actions
   const modalActions: JSX.Element[] = [
     <Button
+      data-cy="modal-button-add"
       key="add-new"
       variant="secondary"
       isDisabled={isAddButtonSpinning || selectedItem === ""}
@@ -195,6 +197,7 @@ const AddModal = (props: PropsToAddModal) => {
       Add
     </Button>,
     <Button
+      data-cy="modal-button-add-and-add-another"
       key="add-new-again"
       variant="secondary"
       isDisabled={isAddAnotherButtonSpinning || selectedItem === ""}
@@ -205,7 +208,12 @@ const AddModal = (props: PropsToAddModal) => {
     >
       Add and add again
     </Button>,
-    <Button key="cancel-new" variant="link" onClick={cleanAndCloseModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-new"
+      variant="link"
+      onClick={cleanAndCloseModal}
+    >
       Cancel
     </Button>,
   ];
@@ -215,6 +223,7 @@ const AddModal = (props: PropsToAddModal) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="add-subid-modal"
         variantType={"small"}
         modalPosition={"top"}
         offPosition={"76px"}

--- a/src/components/modals/SudoModals/AddSudoCmd.tsx
+++ b/src/components/modals/SudoModals/AddSudoCmd.tsx
@@ -67,6 +67,7 @@ const AddSudoCmd = (props: PropsToAddGroup) => {
             validated={
               cmdName === "" ? ValidatedOptions.error : ValidatedOptions.default
             }
+            data-cy="modal-textbox-command"
           />
           <HelperText>
             {cmdName === "" && <HelperTextItem>Required value</HelperTextItem>}
@@ -83,6 +84,7 @@ const AddSudoCmd = (props: PropsToAddGroup) => {
           name="modal-form-cmd-desc"
           value={description}
           onChange={(_event, value) => setDescription(value)}
+          data-cy="modal-textbox-description"
           aria-label="Sudo command description"
           autoResize
         />
@@ -214,10 +216,19 @@ const AddSudoCmd = (props: PropsToAddGroup) => {
   };
 
   const errorModalActions = [
-    <SecondaryButton key="retry" onClickHandler={onRetry}>
+    <SecondaryButton
+      key="retry"
+      onClickHandler={onRetry}
+      dataCy="modal-button-retry"
+    >
       Retry
     </SecondaryButton>,
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+      data-cy="modal-button-cancel"
+    >
       Cancel
     </Button>,
   ];
@@ -235,6 +246,7 @@ const AddSudoCmd = (props: PropsToAddGroup) => {
   // Buttons that will be shown at the end of the form
   const modalActions = [
     <SecondaryButton
+      dataCy="modal-button-add"
       key="add-new-cmd"
       name="add"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
@@ -247,6 +259,7 @@ const AddSudoCmd = (props: PropsToAddGroup) => {
       {addSpinning ? "Adding" : "Add"}
     </SecondaryButton>,
     <SecondaryButton
+      dataCy="modal-button-add-and-add-another"
       key="add-and-add-another-new-cmd"
       name="add_and_add_another"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
@@ -258,7 +271,12 @@ const AddSudoCmd = (props: PropsToAddGroup) => {
     >
       {addAgainSpinning ? "Adding" : "Add and add another"}
     </SecondaryButton>,
-    <Button key="cancel-new-cmd" variant="link" onClick={cleanAndCloseModal}>
+    <Button
+      key="cancel-new-cmd"
+      variant="link"
+      onClick={cleanAndCloseModal}
+      data-cy="modal-button-cancel"
+    >
       Cancel
     </Button>,
   ];
@@ -268,6 +286,7 @@ const AddSudoCmd = (props: PropsToAddGroup) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="add-sudo-cmd-modal"
         variantType="small"
         modalPosition="top"
         offPosition="76px"
@@ -280,6 +299,7 @@ const AddSudoCmd = (props: PropsToAddGroup) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="add-sudo-cmd-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/SudoModals/AddSudoCmdGroup.tsx
+++ b/src/components/modals/SudoModals/AddSudoCmdGroup.tsx
@@ -60,6 +60,7 @@ const AddSudoCmdGroup = (props: PropsToAddGroup) => {
       pfComponent: (
         <>
           <TextInput
+            data-cy="modal-textbox-cmd-grp-name"
             type="text"
             id="modal-form-cmd-grp-name"
             name="modal-form-cmd-grp-name"
@@ -84,6 +85,7 @@ const AddSudoCmdGroup = (props: PropsToAddGroup) => {
       name: "Description",
       pfComponent: (
         <TextArea
+          data-cy="modal-textbox-cmd-grp-desc"
           id="modal-form-cmd-grp-desc"
           name="modal-form-cmd-grp-desc"
           value={description}
@@ -219,10 +221,19 @@ const AddSudoCmdGroup = (props: PropsToAddGroup) => {
   };
 
   const errorModalActions = [
-    <SecondaryButton key="retry" onClickHandler={onRetry}>
+    <SecondaryButton
+      key="retry"
+      onClickHandler={onRetry}
+      dataCy="modal-button-retry"
+    >
       Retry
     </SecondaryButton>,
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+      data-cy="modal-button-cancel"
+    >
       Cancel
     </Button>,
   ];
@@ -240,6 +251,7 @@ const AddSudoCmdGroup = (props: PropsToAddGroup) => {
   // Buttons that will be shown at the end of the form
   const modalActions = [
     <SecondaryButton
+      dataCy="modal-button-add"
       key="add-new-cmd"
       name="add"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
@@ -252,6 +264,7 @@ const AddSudoCmdGroup = (props: PropsToAddGroup) => {
       {addSpinning ? "Adding" : "Add"}
     </SecondaryButton>,
     <SecondaryButton
+      dataCy="modal-button-add-and-add-another"
       key="add-and-add-another-new-cmd"
       name="add_and_add_another"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
@@ -263,7 +276,12 @@ const AddSudoCmdGroup = (props: PropsToAddGroup) => {
     >
       {addAgainSpinning ? "Adding" : "Add and add another"}
     </SecondaryButton>,
-    <Button key="cancel-new-cmd" variant="link" onClick={cleanAndCloseModal}>
+    <Button
+      key="cancel-new-cmd"
+      variant="link"
+      onClick={cleanAndCloseModal}
+      data-cy="modal-button-cancel"
+    >
       Cancel
     </Button>,
   ];
@@ -273,6 +291,7 @@ const AddSudoCmdGroup = (props: PropsToAddGroup) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="add-sudo-cmd-group-modal"
         variantType="small"
         modalPosition="top"
         offPosition="76px"
@@ -285,6 +304,7 @@ const AddSudoCmdGroup = (props: PropsToAddGroup) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="add-sudo-cmd-group-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/SudoModals/AddSudoRule.tsx
+++ b/src/components/modals/SudoModals/AddSudoRule.tsx
@@ -70,6 +70,7 @@ const AddSudoRule = (props: PropsToAddGroup) => {
                 ? ValidatedOptions.error
                 : ValidatedOptions.default
             }
+            data-cy="modal-textbox-rule-name"
           />
           <HelperText>
             {ruleName === "" && <HelperTextItem>Required value</HelperTextItem>}
@@ -86,6 +87,7 @@ const AddSudoRule = (props: PropsToAddGroup) => {
           name="modal-form-rule-desc"
           value={description}
           onChange={(_event, value) => setDescription(value)}
+          data-cy="modal-textbox-description"
           aria-label="Rule description"
           autoResize
         />
@@ -217,10 +219,19 @@ const AddSudoRule = (props: PropsToAddGroup) => {
   };
 
   const errorModalActions = [
-    <SecondaryButton key="retry" onClickHandler={onRetry}>
+    <SecondaryButton
+      key="retry"
+      onClickHandler={onRetry}
+      dataCy="modal-button-retry"
+    >
       Retry
     </SecondaryButton>,
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+      data-cy="modal-button-cancel"
+    >
       Cancel
     </Button>,
   ];
@@ -238,6 +249,7 @@ const AddSudoRule = (props: PropsToAddGroup) => {
   // Buttons that will be shown at the end of the form
   const modalActions = [
     <SecondaryButton
+      dataCy="modal-button-add"
       key="add-new-rule"
       name="add"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
@@ -250,6 +262,7 @@ const AddSudoRule = (props: PropsToAddGroup) => {
       {addSpinning ? "Adding" : "Add"}
     </SecondaryButton>,
     <SecondaryButton
+      dataCy="modal-button-add-and-add-another"
       key="add-and-add-another-new-rule"
       name="add_and_add_another"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
@@ -261,7 +274,12 @@ const AddSudoRule = (props: PropsToAddGroup) => {
     >
       {addAgainSpinning ? "Adding" : "Add and add another"}
     </SecondaryButton>,
-    <Button key="cancel-new-rule" variant="link" onClick={cleanAndCloseModal}>
+    <Button
+      key="cancel-new-rule"
+      variant="link"
+      onClick={cleanAndCloseModal}
+      data-cy="modal-button-cancel"
+    >
       Cancel
     </Button>,
   ];
@@ -271,6 +289,7 @@ const AddSudoRule = (props: PropsToAddGroup) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="add-sudo-rule-modal"
         variantType="small"
         modalPosition="top"
         offPosition="76px"
@@ -283,6 +302,7 @@ const AddSudoRule = (props: PropsToAddGroup) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="add-sudo-rule-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/SudoModals/DeleteSudoCmd.tsx
+++ b/src/components/modals/SudoModals/DeleteSudoCmd.tsx
@@ -99,7 +99,12 @@ const DeleteSudoCmd = (props: PropsToDeleteRules) => {
   };
 
   const errorModalActions = [
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+      data-cy="modal-button-ok"
+    >
       OK
     </Button>,
   ];
@@ -182,6 +187,7 @@ const DeleteSudoCmd = (props: PropsToDeleteRules) => {
       spinnerAriaLabel="Deleting"
       isLoading={spinning}
       isDisabled={spinning}
+      data-cy="modal-button-delete"
     >
       {spinning ? "Deleting" : "Delete"}
     </Button>,
@@ -189,6 +195,7 @@ const DeleteSudoCmd = (props: PropsToDeleteRules) => {
       key="cancel-delete-sudo-commands"
       variant="link"
       onClick={closeModal}
+      data-cy="modal-button-cancel"
     >
       Cancel
     </Button>,
@@ -198,6 +205,7 @@ const DeleteSudoCmd = (props: PropsToDeleteRules) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="delete-sudo-commands-modal"
         variantType="medium"
         modalPosition="top"
         offPosition="76px"
@@ -210,6 +218,7 @@ const DeleteSudoCmd = (props: PropsToDeleteRules) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="delete-sudo-commands-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/SudoModals/DeleteSudoCmdGroups.tsx
+++ b/src/components/modals/SudoModals/DeleteSudoCmdGroups.tsx
@@ -99,7 +99,12 @@ const DeleteSudoCmdGroups = (props: PropsToDeleteRules) => {
   };
 
   const errorModalActions = [
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      data-cy="modal-button-ok"
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+    >
       OK
     </Button>,
   ];
@@ -174,6 +179,7 @@ const DeleteSudoCmdGroups = (props: PropsToDeleteRules) => {
   // Set the Modal and Action buttons for 'Delete' option
   const modalActionsDelete: JSX.Element[] = [
     <Button
+      data-cy="modal-button-delete"
       key="delete-sudo-command-groups"
       variant="danger"
       onClick={deleteRules}
@@ -186,6 +192,7 @@ const DeleteSudoCmdGroups = (props: PropsToDeleteRules) => {
       {spinning ? "Deleting" : "Delete"}
     </Button>,
     <Button
+      data-cy="modal-button-cancel"
       key="cancel-delete-sudo-command-groups"
       variant="link"
       onClick={closeModal}
@@ -198,6 +205,7 @@ const DeleteSudoCmdGroups = (props: PropsToDeleteRules) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="delete-sudo-command-groups-modal"
         variantType="medium"
         modalPosition="top"
         offPosition="76px"
@@ -210,6 +218,7 @@ const DeleteSudoCmdGroups = (props: PropsToDeleteRules) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="delete-sudo-command-groups-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/SudoModals/DeleteSudoRule.tsx
+++ b/src/components/modals/SudoModals/DeleteSudoRule.tsx
@@ -99,7 +99,12 @@ const DeleteSudoRule = (props: PropsToDeleteRules) => {
   };
 
   const errorModalActions = [
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      data-cy="modal-button-ok"
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+    >
       OK
     </Button>,
   ];
@@ -174,6 +179,7 @@ const DeleteSudoRule = (props: PropsToDeleteRules) => {
   // Set the Modal and Action buttons for 'Delete' option
   const modalActionsDelete: JSX.Element[] = [
     <Button
+      data-cy="modal-button-delete"
       key="delete-sudorules"
       variant="danger"
       onClick={deleteRules}
@@ -185,7 +191,12 @@ const DeleteSudoRule = (props: PropsToDeleteRules) => {
     >
       {spinning ? "Deleting" : "Delete"}
     </Button>,
-    <Button key="cancel-delete-sudorules" variant="link" onClick={closeModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-delete-sudorules"
+      variant="link"
+      onClick={closeModal}
+    >
       Cancel
     </Button>,
   ];
@@ -194,6 +205,7 @@ const DeleteSudoRule = (props: PropsToDeleteRules) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="delete-sudo-rules-modal"
         variantType="medium"
         modalPosition="top"
         offPosition="76px"
@@ -206,6 +218,7 @@ const DeleteSudoRule = (props: PropsToDeleteRules) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="delete-sudo-rules-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/SudoModals/DisableEnableSudoRules.tsx
+++ b/src/components/modals/SudoModals/DisableEnableSudoRules.tsx
@@ -102,7 +102,12 @@ const DisableEnableSudoRules = (props: PropsToDisableEnableRules) => {
   };
 
   const errorModalActions = [
-    <Button key="ok" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      data-cy="modal-button-ok"
+      key="ok"
+      variant="link"
+      onClick={onCloseErrorModal}
+    >
       OK
     </Button>,
   ];
@@ -258,6 +263,7 @@ const DisableEnableSudoRules = (props: PropsToDisableEnableRules) => {
   // Set the Modal and Action buttons for 'Disable' option
   const modalActionsDisable: JSX.Element[] = [
     <Button
+      data-cy="modal-button-disable"
       key="disable-sudorules"
       variant="primary"
       onClick={() =>
@@ -270,13 +276,19 @@ const DisableEnableSudoRules = (props: PropsToDisableEnableRules) => {
     >
       Disable
     </Button>,
-    <Button key="cancel-disable-sudorule" variant="link" onClick={closeModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-disable-sudorule"
+      variant="link"
+      onClick={closeModal}
+    >
       Cancel
     </Button>,
   ];
 
   const modalDisable: JSX.Element = (
     <ModalWithFormLayout
+      dataCy="disable-enable-sudo-rules-modal"
       variantType="medium"
       modalPosition="top"
       offPosition="76px"
@@ -292,6 +304,7 @@ const DisableEnableSudoRules = (props: PropsToDisableEnableRules) => {
   // Set the Modal and Action buttons for 'Enable' option
   const modalActionsEnable: JSX.Element[] = [
     <Button
+      data-cy="modal-button-enable"
       key="enable-sudorules"
       variant="primary"
       onClick={() =>
@@ -304,13 +317,19 @@ const DisableEnableSudoRules = (props: PropsToDisableEnableRules) => {
     >
       Enable
     </Button>,
-    <Button key="cancel-enable-sudorule" variant="link" onClick={closeModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-enable-sudorule"
+      variant="link"
+      onClick={closeModal}
+    >
       Cancel
     </Button>,
   ];
 
   const modalEnable: JSX.Element = (
     <ModalWithFormLayout
+      dataCy="disable-enable-sudo-rules-modal"
       variantType="medium"
       modalPosition="top"
       offPosition="76px"
@@ -329,6 +348,7 @@ const DisableEnableSudoRules = (props: PropsToDisableEnableRules) => {
       {!props.optionSelected ? modalEnable : modalDisable}
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="disable-enable-sudo-rules-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/UserModals/ActivateStageUsers.tsx
+++ b/src/components/modals/UserModals/ActivateStageUsers.tsx
@@ -61,6 +61,7 @@ const ActivateStageUsers = (props: PropsToActivateUsers) => {
       id: "no-members",
       pfComponent: (
         <Checkbox
+          data-cy="modal-checkbox-suppress-membership"
           label="Suppress processing of membership attributes"
           isChecked={noMembersChecked}
           onChange={() => {
@@ -121,10 +122,16 @@ const ActivateStageUsers = (props: PropsToActivateUsers) => {
       variant="primary"
       onClick={activateUsers}
       form="stage-users-modal"
+      data-cy="modal-button-activate"
     >
       Activate
     </Button>,
-    <Button key="cancel-stage-user" variant="link" onClick={closeModal}>
+    <Button
+      key="cancel-stage-user"
+      variant="link"
+      onClick={closeModal}
+      data-cy="modal-button-cancel"
+    >
       Cancel
     </Button>,
   ];
@@ -134,6 +141,7 @@ const ActivateStageUsers = (props: PropsToActivateUsers) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="activate-stage-users-modal"
         variantType="medium"
         modalPosition="top"
         offPosition="76px"

--- a/src/components/modals/UserModals/AddOtpToken.tsx
+++ b/src/components/modals/UserModals/AddOtpToken.tsx
@@ -111,6 +111,7 @@ const AddOtpToken = (props: PropsToAddOtpToken) => {
     <Flex>
       <FlexItem>
         <Radio
+          data-cy="modal-radio-totp"
           isChecked={tokenType === "totp"}
           name="totp"
           onChange={(_event, checked) => onTokenTypeChange(checked, "totp")}
@@ -120,6 +121,7 @@ const AddOtpToken = (props: PropsToAddOtpToken) => {
       </FlexItem>
       <FlexItem>
         <Radio
+          data-cy="modal-radio-hotp"
           isChecked={tokenType === "hotp"}
           name="hotp"
           onChange={(_event, checked) => onTokenTypeChange(checked, "hotp")}
@@ -134,6 +136,7 @@ const AddOtpToken = (props: PropsToAddOtpToken) => {
     <Flex>
       <FlexItem>
         <Radio
+          data-cy="modal-radio-sha1"
           isChecked={tokenAlgorithm === "sha1"}
           name="sha1"
           onChange={(_event, checked) =>
@@ -145,6 +148,7 @@ const AddOtpToken = (props: PropsToAddOtpToken) => {
       </FlexItem>
       <FlexItem>
         <Radio
+          data-cy="modal-radio-sha256"
           isChecked={tokenAlgorithm === "sha256"}
           name="sha256"
           onChange={(_event, checked) =>
@@ -156,6 +160,7 @@ const AddOtpToken = (props: PropsToAddOtpToken) => {
       </FlexItem>
       <FlexItem>
         <Radio
+          data-cy="modal-radio-sha384"
           isChecked={tokenAlgorithm === "sha384"}
           name="sha384"
           onChange={(_event, checked) =>
@@ -167,6 +172,7 @@ const AddOtpToken = (props: PropsToAddOtpToken) => {
       </FlexItem>
       <FlexItem>
         <Radio
+          data-cy="modal-radio-sha512"
           isChecked={tokenAlgorithm === "sha512"}
           name="sha512"
           onChange={(_event, checked) =>
@@ -183,6 +189,7 @@ const AddOtpToken = (props: PropsToAddOtpToken) => {
     <Flex>
       <FlexItem>
         <Radio
+          data-cy="modal-radio-6"
           isChecked={tokenDigits === "6"}
           name="6"
           onChange={(_event, checked) => onTokenDigitsChange(checked, "6")}
@@ -192,6 +199,7 @@ const AddOtpToken = (props: PropsToAddOtpToken) => {
       </FlexItem>
       <FlexItem>
         <Radio
+          data-cy="modal-radio-8"
           isChecked={tokenDigits === "8"}
           name="8"
           onChange={(_event, checked) => onTokenDigitsChange(checked, "8")}
@@ -244,6 +252,7 @@ const AddOtpToken = (props: PropsToAddOtpToken) => {
   // Toggle
   const toggleOwnersToSelect = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
+      data-cy="modal-select-owner-toggle"
       ref={toggleRef}
       onClick={onToggle}
       isExpanded={isOwnerOpen}
@@ -256,6 +265,7 @@ const AddOtpToken = (props: PropsToAddOtpToken) => {
 
   const ownerComponent: JSX.Element = (
     <Select
+      data-cy="modal-select-owner"
       id={"owner"}
       aria-label={"Selector for owner"}
       toggle={toggleOwnersToSelect}
@@ -265,7 +275,11 @@ const AddOtpToken = (props: PropsToAddOtpToken) => {
     >
       {ownersToSelect.map((option, index) => {
         return (
-          <SelectOption key={index} value={option}>
+          <SelectOption
+            data-cy={"modal-select-owner-" + option}
+            key={index}
+            value={option}
+          >
             {option}
           </SelectOption>
         );
@@ -294,6 +308,7 @@ const AddOtpToken = (props: PropsToAddOtpToken) => {
       name: "Unique ID",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-unique-id"
           id="unique-id"
           type="text"
           aria-label="text input for unique-id"
@@ -307,6 +322,7 @@ const AddOtpToken = (props: PropsToAddOtpToken) => {
       name: "Description",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-description"
           id="description"
           type="text"
           aria-label="text input for description"
@@ -325,6 +341,7 @@ const AddOtpToken = (props: PropsToAddOtpToken) => {
       name: "Validity start",
       pfComponent: (
         <DateTimeSelector
+          dataCy="modal-textbox-validity-start"
           datetime={validityStart}
           onChange={setValidityStart}
           name="ipatokennotbefore"
@@ -337,6 +354,7 @@ const AddOtpToken = (props: PropsToAddOtpToken) => {
       name: "Validity end",
       pfComponent: (
         <DateTimeSelector
+          dataCy="modal-textbox-validity-end"
           datetime={validityEnd}
           onChange={setValidityEnd}
           name="ipatokennotafter"
@@ -349,6 +367,7 @@ const AddOtpToken = (props: PropsToAddOtpToken) => {
       name: "Vendor",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-vendor"
           id="vendor"
           name="ipatokenvendor"
           type="text"
@@ -363,6 +382,7 @@ const AddOtpToken = (props: PropsToAddOtpToken) => {
       name: "Model",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-model"
           id="model"
           name="ipatokenmodel"
           type="text"
@@ -377,6 +397,7 @@ const AddOtpToken = (props: PropsToAddOtpToken) => {
       name: "Serial",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-serial"
           id="serial"
           name="ipatokenserial"
           type="text"
@@ -391,6 +412,7 @@ const AddOtpToken = (props: PropsToAddOtpToken) => {
       name: "Key",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-key"
           id="key"
           name="ipatokenotpkey"
           type="text"
@@ -415,6 +437,7 @@ const AddOtpToken = (props: PropsToAddOtpToken) => {
       name: "Clock interval (seconds)",
       pfComponent: (
         <TextInput
+          data-cy="modal-textbox-clock-interval"
           id="clock-interval"
           name="ipatokentotptimestep"
           type="text"
@@ -549,6 +572,7 @@ const AddOtpToken = (props: PropsToAddOtpToken) => {
 
   const actions = [
     <Button
+      data-cy="modal-button-add"
       key={"add-otp-token"}
       variant="primary"
       onClick={() => onAddOtpToken(false)}
@@ -556,6 +580,7 @@ const AddOtpToken = (props: PropsToAddOtpToken) => {
       Add
     </Button>,
     <Button
+      data-cy="modal-button-add-and-add-another"
       key={"add-and-add-another-otp-token"}
       variant="primary"
       onClick={() => onAddOtpToken(true)}
@@ -563,6 +588,7 @@ const AddOtpToken = (props: PropsToAddOtpToken) => {
       Add and add another
     </Button>,
     <Button
+      data-cy="modal-button-cancel"
       key={"cancel-reset-password"}
       variant="link"
       onClick={onResetFieldsAndCloseModal}
@@ -576,6 +602,7 @@ const AddOtpToken = (props: PropsToAddOtpToken) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="add-otp-token-modal"
         variantType="small"
         modalPosition="top"
         title="Add OTP token"

--- a/src/components/modals/UserModals/AddUser.tsx
+++ b/src/components/modals/UserModals/AddUser.tsx
@@ -298,6 +298,7 @@ const AddUser = (props: PropsToAddUser) => {
     });
 
     newGidOptions.unshift({
+      "data-cy": "modal-useradd-gid-select",
       value: "",
       children: NO_SELECTION_OPTION,
     });
@@ -351,6 +352,7 @@ const AddUser = (props: PropsToAddUser) => {
         <>
           <TextInput
             type="text"
+            data-cy="modal-textbox-login"
             id="modal-form-user-login"
             name="modal-form-user-login"
             onFocus={resetUserLoginError}
@@ -381,6 +383,7 @@ const AddUser = (props: PropsToAddUser) => {
           <TextInput
             isRequired
             type="text"
+            data-cy="modal-textbox-first-name"
             id="modal-form-first-name"
             name="modal-form-first-name"
             onFocus={resetFirstNameError}
@@ -407,6 +410,7 @@ const AddUser = (props: PropsToAddUser) => {
           <TextInput
             isRequired
             type="text"
+            data-cy="modal-textbox-last-name"
             id="modal-form-last-name"
             name="modal-form-last-name"
             onFocus={resetLastNameError}
@@ -431,6 +435,7 @@ const AddUser = (props: PropsToAddUser) => {
       pfComponent: (
         <TextInput
           type="text"
+          data-cy="modal-textbox-user-class"
           id="modal-form-user-class"
           name="modal-form-user-class"
           value={userClass}
@@ -450,6 +455,7 @@ const AddUser = (props: PropsToAddUser) => {
       pfComponent: (
         <Flex>
           <Checkbox
+            data-cy="modal-checkbox-no-private-group"
             label="No private group"
             id="no-private-group"
             isChecked={isNoPrivateGroupChecked}
@@ -463,6 +469,7 @@ const AddUser = (props: PropsToAddUser) => {
       name: "GID",
       pfComponent: (
         <TypeAheadSelectWithCreate
+          data-cy="modal-useradd-gid"
           id={"modal-form-gid"}
           options={gidOptions}
           selected={gidSelected}
@@ -475,6 +482,7 @@ const AddUser = (props: PropsToAddUser) => {
       name: "New password",
       pfComponent: (
         <PasswordInput
+          dataCy="modal-textbox-new-password"
           id="modal-form-new-password"
           name="modal-form-new-password"
           value={newPassword}
@@ -491,6 +499,7 @@ const AddUser = (props: PropsToAddUser) => {
       pfComponent: (
         <>
           <PasswordInput
+            dataCy="modal-textbox-verify-password"
             id="modal-form-verify-password"
             name="modal-form-verify-password"
             value={verifyNewPassword}
@@ -720,10 +729,19 @@ const AddUser = (props: PropsToAddUser) => {
   };
 
   const errorModalActions = [
-    <SecondaryButton key="retry" onClickHandler={onRetry}>
+    <SecondaryButton
+      key="retry"
+      onClickHandler={onRetry}
+      dataCy="modal-button-retry"
+    >
       Retry
     </SecondaryButton>,
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+    >
       Cancel
     </Button>,
   ];
@@ -741,6 +759,7 @@ const AddUser = (props: PropsToAddUser) => {
   // Buttons that will be shown at the end of the form
   const modalActions = [
     <Button
+      data-cy="modal-button-add"
       key="add-new-user"
       variant="secondary"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
@@ -753,6 +772,7 @@ const AddUser = (props: PropsToAddUser) => {
       {addSpinning ? "Adding" : "Add"}
     </Button>,
     <Button
+      data-cy="modal-button-add-and-add-another"
       key="add-and-add-another-user"
       variant="secondary"
       isDisabled={buttonDisabled || addAgainSpinning || addSpinning}
@@ -763,7 +783,12 @@ const AddUser = (props: PropsToAddUser) => {
     >
       {addAgainSpinning ? "Adding" : "Add and add another"}
     </Button>,
-    <Button key="cancel-new-user" variant="link" onClick={cleanAndCloseModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-new-user"
+      variant="link"
+      onClick={cleanAndCloseModal}
+    >
       Cancel
     </Button>,
   ];
@@ -773,6 +798,7 @@ const AddUser = (props: PropsToAddUser) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="add-user-modal"
         variantType="small"
         modalPosition="top"
         offPosition="76px"
@@ -785,6 +811,7 @@ const AddUser = (props: PropsToAddUser) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="add-user-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/UserModals/DeleteUsers.tsx
+++ b/src/components/modals/UserModals/DeleteUsers.tsx
@@ -113,6 +113,7 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
             <Text component={TextVariants.p}>Remove mode</Text>
           </TextContent>
           <Radio
+            data-cy="modal-radio-delete"
             id="radio-delete"
             label="Delete"
             name="radio-delete"
@@ -120,6 +121,7 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
             onChange={manageRadioButtons}
           />
           <Radio
+            data-cy="modal-radio-preserve"
             id="radio-preserve"
             label="Preserve"
             name="radio-preserve"
@@ -166,7 +168,12 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
   };
 
   const errorModalActions = [
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      data-cy="modal-button-ok"
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+    >
       OK
     </Button>,
   ];
@@ -298,6 +305,7 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
   // Set the Modal and Action buttons for 'Delete' option
   const modalActionsDelete: JSX.Element[] = [
     <Button
+      data-cy="modal-button-delete"
       key="delete-users"
       variant="danger"
       onClick={() => {
@@ -311,7 +319,12 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
     >
       {spinning ? "Deleting" : "Delete"}
     </Button>,
-    <Button key="cancel-new-user" variant="link" onClick={closeModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-new-user"
+      variant="link"
+      onClick={closeModal}
+    >
       Cancel
     </Button>,
   ];
@@ -329,6 +342,7 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
 
   const modalDelete: JSX.Element = (
     <ModalWithFormLayout
+      dataCy="delete-users-modal"
       variantType="medium"
       modalPosition="top"
       offPosition="76px"
@@ -344,6 +358,7 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
   // Set the Modal and Action buttons for 'Preserve' option
   const modalActionsPreserve: JSX.Element[] = [
     <Button
+      data-cy="modal-button-preserve"
       key="preserve-users"
       variant="primary"
       onClick={() => {
@@ -357,13 +372,19 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
     >
       {spinning ? "Preserving" : "Preserve"}
     </Button>,
-    <Button key="cancel-new-user" variant="link" onClick={closeModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-new-user"
+      variant="link"
+      onClick={closeModal}
+    >
       Cancel
     </Button>,
   ];
 
   const modalPreserve: JSX.Element = (
     <ModalWithFormLayout
+      dataCy="preserve-users-modal"
       variantType="medium"
       modalPosition="top"
       offPosition="76px"
@@ -383,6 +404,7 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
       {isDeleteChecked ? modalDelete : modalPreserve}
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="delete-users-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/UserModals/DisableEnableUsers.tsx
+++ b/src/components/modals/UserModals/DisableEnableUsers.tsx
@@ -142,7 +142,12 @@ const DisableEnableUsers = (props: PropsToDisableEnableUsers) => {
   };
 
   const errorModalActions = [
-    <Button key="ok" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      data-cy="modal-button-ok"
+      key="ok"
+      variant="link"
+      onClick={onCloseErrorModal}
+    >
       OK
     </Button>,
   ];
@@ -340,16 +345,23 @@ const DisableEnableUsers = (props: PropsToDisableEnableUsers) => {
         )
       }
       form="users-enable-disable-users-modal"
+      data-cy="modal-button-disable"
     >
       Disable
     </Button>,
-    <Button key="cancel-disable-user" variant="link" onClick={closeModal}>
+    <Button
+      key="cancel-disable-user"
+      variant="link"
+      onClick={closeModal}
+      data-cy="modal-button-cancel"
+    >
       Cancel
     </Button>,
   ];
 
   const modalDisable: JSX.Element = (
     <ModalWithFormLayout
+      dataCy="disable-users-modal"
       variantType="medium"
       modalPosition="top"
       offPosition="76px"
@@ -379,16 +391,23 @@ const DisableEnableUsers = (props: PropsToDisableEnableUsers) => {
             )
       }
       form="active-users-enable-disable-users-modal"
+      data-cy="modal-button-enable"
     >
       Enable
     </Button>,
-    <Button key="cancel-enable-user" variant="link" onClick={closeModal}>
+    <Button
+      key="cancel-enable-user"
+      variant="link"
+      onClick={closeModal}
+      data-cy="modal-button-cancel"
+    >
       Cancel
     </Button>,
   ];
 
   const modalEnable: JSX.Element = (
     <ModalWithFormLayout
+      dataCy="enable-users-modal"
       variantType="medium"
       modalPosition="top"
       offPosition="76px"
@@ -408,6 +427,7 @@ const DisableEnableUsers = (props: PropsToDisableEnableUsers) => {
       {!props.optionSelected ? modalEnable : modalDisable}
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="disable-enable-users-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/UserModals/QrCodeModal.tsx
+++ b/src/components/modals/UserModals/QrCodeModal.tsx
@@ -37,7 +37,12 @@ const QrCodeModal = (props: PropsToQrCodeModal) => {
   // Generate QR code
   const qrCode = (
     <>
-      <a href={props.QrUri} target="_blank" rel="noreferrer">
+      <a
+        href={props.QrUri}
+        target="_blank"
+        rel="noreferrer"
+        data-cy="qr-code-link"
+      >
         <QRCodeCanvas
           id="qrCode"
           value={props.QrUri}
@@ -73,7 +78,12 @@ const QrCodeModal = (props: PropsToQrCodeModal) => {
 
   // Actions
   const actions = [
-    <Button key="ok" variant="link" onClick={props.onClose}>
+    <Button
+      data-cy="modal-button-ok"
+      key="ok"
+      variant="link"
+      onClick={props.onClose}
+    >
       Ok
     </Button>,
   ];
@@ -81,6 +91,7 @@ const QrCodeModal = (props: PropsToQrCodeModal) => {
   // Render component
   return (
     <ModalWithFormLayout
+      dataCy="configure-your-token-modal"
       variantType="small"
       modalPosition="top"
       title="Configure your token"

--- a/src/components/modals/UserModals/ResetPassword.tsx
+++ b/src/components/modals/UserModals/ResetPassword.tsx
@@ -82,6 +82,7 @@ const ResetPassword = (props: PropsToResetPassword) => {
           onChange={setNewPassword}
           onRevealHandler={setPasswordHidden}
           passwordHidden={passwordHidden}
+          dataCy="modal-textbox-new-password"
         />
       ),
     },
@@ -100,6 +101,7 @@ const ResetPassword = (props: PropsToResetPassword) => {
             onRevealHandler={setVerifyPasswordHidden}
             passwordHidden={verifyPasswordHidden}
             validated={passwordValidationResult.pfError}
+            dataCy="modal-textbox-verify-password"
           />
           <HelperText>
             <HelperTextItem variant="error">
@@ -125,6 +127,7 @@ const ResetPassword = (props: PropsToResetPassword) => {
           onChange={setCurrentPassword}
           onRevealHandler={setCurrentPasswordHidden}
           passwordHidden={currentPasswordHidden}
+          dataCy="modal-textbox-current-password"
         />
       ),
     },
@@ -141,6 +144,7 @@ const ResetPassword = (props: PropsToResetPassword) => {
           onChange={setNewPassword}
           onRevealHandler={setPasswordHidden}
           passwordHidden={passwordHidden}
+          dataCy="modal-textbox-new-password"
         />
       ),
     },
@@ -159,6 +163,7 @@ const ResetPassword = (props: PropsToResetPassword) => {
             onRevealHandler={setVerifyPasswordHidden}
             passwordHidden={verifyPasswordHidden}
             validated={passwordValidationResult.pfError}
+            dataCy="modal-textbox-verify-password"
           />
           <HelperText>
             <HelperTextItem variant="error">
@@ -178,6 +183,7 @@ const ResetPassword = (props: PropsToResetPassword) => {
           value={otp}
           aria-label="otp text input"
           onChange={(_event, newValue) => setOtp(newValue)}
+          data-cy="modal-textbox-reset-password-otp"
         />
       ),
     },
@@ -280,6 +286,7 @@ const ResetPassword = (props: PropsToResetPassword) => {
         newPassword === "" ||
         verifyPassword === ""
       }
+      data-cy="modal-button-reset-password"
     >
       Reset password
     </Button>,
@@ -287,6 +294,7 @@ const ResetPassword = (props: PropsToResetPassword) => {
       key={"cancel-reset-password"}
       variant="link"
       onClick={resetFieldsAndCloseModal}
+      data-cy="modal-button-cancel"
     >
       Cancel
     </Button>,
@@ -295,6 +303,7 @@ const ResetPassword = (props: PropsToResetPassword) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="reset-password-modal"
         variantType="small"
         modalPosition="top"
         title="Reset password"

--- a/src/components/modals/UserModals/RestorePreservedUsers.tsx
+++ b/src/components/modals/UserModals/RestorePreservedUsers.tsx
@@ -121,10 +121,16 @@ const RestorePreservedUsers = (props: PropsToPreservedUsers) => {
       spinnerAriaLabel="Restoring"
       isLoading={spinning}
       isDisabled={spinning}
+      data-cy="modal-button-restore"
     >
       {spinning ? "Restoring" : "Restore"}
     </Button>,
-    <Button key="cancel-restore-user" variant="link" onClick={closeModal}>
+    <Button
+      key="cancel-restore-user"
+      variant="link"
+      onClick={closeModal}
+      data-cy="modal-button-cancel"
+    >
       Cancel
     </Button>,
   ];
@@ -133,6 +139,7 @@ const RestorePreservedUsers = (props: PropsToPreservedUsers) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="restore-preserved-users-modal"
         variantType="medium"
         modalPosition="top"
         offPosition="76px"

--- a/src/components/modals/UserModals/StagePreservedUsers.tsx
+++ b/src/components/modals/UserModals/StagePreservedUsers.tsx
@@ -87,7 +87,12 @@ const StagePreservedUsers = (props: PropsToStagePreservedUsers) => {
   };
 
   const errorModalActions = [
-    <Button key="cancel" variant="link" onClick={onCloseErrorModal}>
+    <Button
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+      data-cy="modal-button-ok"
+    >
       OK
     </Button>,
   ];
@@ -187,16 +192,23 @@ const StagePreservedUsers = (props: PropsToStagePreservedUsers) => {
       spinnerAriaLabel="Staging"
       isLoading={spinning}
       isDisabled={spinning}
+      data-cy="modal-button-stage"
     >
       {spinning ? "Staging" : "Stage"}
     </Button>,
-    <Button key="cancel-stage-user" variant="link" onClick={closeModal}>
+    <Button
+      key="cancel-stage-user"
+      variant="link"
+      onClick={closeModal}
+      data-cy="modal-button-cancel"
+    >
       Cancel
     </Button>,
   ];
 
   const modalStage: JSX.Element = (
     <ModalWithFormLayout
+      dataCy="stage-preserved-users-modal"
       variantType="medium"
       modalPosition="top"
       offPosition="76px"
@@ -215,6 +227,7 @@ const StagePreservedUsers = (props: PropsToStagePreservedUsers) => {
       {modalStage}
       {isModalErrorOpen && (
         <ErrorModal
+          dataCy="stage-preserved-users-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/components/modals/UserModals/UnlockUser.tsx
+++ b/src/components/modals/UserModals/UnlockUser.tsx
@@ -87,10 +87,16 @@ const UnlockUser = (props: propsToUnlockUser) => {
       variant="primary"
       onClick={onUnlockUser}
       form="unlock-user-modal"
+      data-cy="modal-button-ok"
     >
       Ok
     </Button>,
-    <Button key="cancel-unlock-user" variant="link" onClick={props.onClose}>
+    <Button
+      key="cancel-unlock-user"
+      variant="link"
+      onClick={props.onClose}
+      data-cy="modal-button-cancel"
+    >
       Cancel
     </Button>,
   ];
@@ -99,6 +105,7 @@ const UnlockUser = (props: propsToUnlockUser) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
+        dataCy="unlock-user-modal"
         variantType="small"
         modalPosition="top"
         title="Unlock user"

--- a/src/components/tables/EmptyBodyTable.tsx
+++ b/src/components/tables/EmptyBodyTable.tsx
@@ -33,7 +33,11 @@ const EmptyBodyTable = (props: EmptyBodyTableProps) => {
             <EmptyStateBody>Clear all filters and try again.</EmptyStateBody>
             {props.onClickFilter && (
               <EmptyStateFooter>
-                <Button variant="link" onClick={props.onClickFilter}>
+                <Button
+                  data-cy="button-clear-all-filters"
+                  variant="link"
+                  onClick={props.onClickFilter}
+                >
                   Clear all filters
                 </Button>
               </EmptyStateFooter>

--- a/src/hooks/useAlerts.tsx
+++ b/src/hooks/useAlerts.tsx
@@ -46,6 +46,7 @@ export function useAlerts() {
     return alerts.map((alert) => (
       <Alert
         key={alert.name}
+        data-cy={alert.name}
         variant={alert.variant}
         title={alert.title}
         role="alert"
@@ -54,6 +55,7 @@ export function useAlerts() {
         onTimeout={() => removeAlert(alert.name)}
         actionClose={
           <AlertActionCloseButton
+            data-cy={"alert-button-close"}
             variantLabel={`${alert.variant} alert`}
             onClose={() => removeAlert(alert.name)}
           />

--- a/src/login/LoginMainPage.tsx
+++ b/src/login/LoginMainPage.tsx
@@ -134,12 +134,14 @@ const LoginMainPage = () => {
     if (errorMessage !== "") {
       return (
         <Modal
+          data-cy="authentication-modal-error"
           variant={ModalVariant.small}
           title="Authentication error"
           isOpen={showErrorModal}
           onClose={() => setShowErrorModal(false)}
           actions={[
             <Button
+              data-cy="modal-button-ok"
               key="confirm"
               variant="primary"
               onClick={() => setShowErrorModal(false)}

--- a/src/login/ResetPasswordPage.tsx
+++ b/src/login/ResetPasswordPage.tsx
@@ -178,6 +178,7 @@ const ResetPasswordPage = () => {
     <Form isHorizontal>
       <FormGroup label="username" fieldId="username">
         <TextInput
+          data-cy="reset-password-textbox-username"
           id="username"
           name="username"
           type="text"
@@ -187,6 +188,7 @@ const ResetPasswordPage = () => {
       </FormGroup>
       <FormGroup label="Current password" fieldId="current-password">
         <PasswordInput
+          dataCy="reset-password-textbox-current-password"
           id="current-password"
           name="current_password"
           value={currentPassword}
@@ -198,6 +200,7 @@ const ResetPasswordPage = () => {
       </FormGroup>
       <FormGroup label="New password" fieldId="new-password">
         <PasswordInput
+          dataCy="reset-password-textbox-new-password"
           id="new-password"
           name="new_password"
           value={newPassword}
@@ -210,6 +213,7 @@ const ResetPasswordPage = () => {
       </FormGroup>
       <FormGroup label="Verify password" fieldId="verify-password">
         <PasswordInput
+          dataCy="reset-password-textbox-verify-password"
           id="verify-password"
           name="verify_password"
           value={verifyPassword}
@@ -228,6 +232,7 @@ const ResetPasswordPage = () => {
       </FormGroup>
       <FormGroup label="OTP" fieldId="otp">
         <PasswordInput
+          dataCy="reset-password-textbox-otp"
           id="otp"
           name="otp"
           value={otp}
@@ -238,10 +243,15 @@ const ResetPasswordPage = () => {
         />
       </FormGroup>
       <ActionGroup>
-        <Button variant="link" onClick={() => navigate(-1)}>
+        <Button
+          data-cy="reset-password-button-cancel"
+          variant="link"
+          onClick={() => navigate(-1)}
+        >
           Cancel
         </Button>
         <Button
+          data-cy="reset-password-button-reset"
           variant="primary"
           isDisabled={isResetButtonDisabled || spinning}
           onClick={onResetPwd}

--- a/src/login/SyncOtpPage.tsx
+++ b/src/login/SyncOtpPage.tsx
@@ -122,6 +122,7 @@ const SyncOtpPage = () => {
     <Form isHorizontal>
       <FormGroup label="Username" fieldId="username" required>
         <TextInput
+          data-cy="sync-otp-textbox-username"
           id="username"
           name="user"
           type="text"
@@ -132,6 +133,7 @@ const SyncOtpPage = () => {
       </FormGroup>
       <FormGroup label="Password" fieldId="password" required>
         <PasswordInput
+          dataCy="sync-otp-textbox-password"
           id="form-password"
           name="password"
           value={password}
@@ -143,6 +145,7 @@ const SyncOtpPage = () => {
       </FormGroup>
       <FormGroup label="First OTP" fieldId="firstotp" required>
         <PasswordInput
+          dataCy="sync-otp-textbox-first-otp"
           id="form-first-otp"
           name="first_code"
           value={firstOtp}
@@ -154,6 +157,7 @@ const SyncOtpPage = () => {
       </FormGroup>
       <FormGroup label="Second OTP" fieldId="secondotp" required>
         <PasswordInput
+          dataCy="sync-otp-textbox-second-otp"
           id="form-second-otp"
           name="second_code"
           value={secondOtp}
@@ -165,6 +169,7 @@ const SyncOtpPage = () => {
       </FormGroup>
       <FormGroup label="Token ID" fieldId="tokenid">
         <TextInput
+          data-cy="sync-otp-textbox-token-id"
           id="form-token-id"
           name="token"
           value={tokenId}
@@ -172,10 +177,15 @@ const SyncOtpPage = () => {
         />
       </FormGroup>
       <ActionGroup>
-        <Button variant="link" onClick={() => navigate(-1)}>
+        <Button
+          data-cy="sync-otp-button-cancel"
+          variant="link"
+          onClick={() => navigate(-1)}
+        >
           Cancel
         </Button>
         <Button
+          data-cy="sync-otp-button-sync"
           variant="primary"
           isDisabled={isSyncButtonDisabled || btnSpinning}
           onClick={onSyncOtp}

--- a/src/navigation/Nav.tsx
+++ b/src/navigation/Nav.tsx
@@ -33,7 +33,9 @@ const renderNavItem = (
         dispatch(updateBreadCrumbPath([{ name: item.label, url: item.path }]));
       }}
     >
-      <NavLink to={item.path}>{item.label}</NavLink>
+      <NavLink to={item.path} data-cy={`nav-link-${item.group}`}>
+        {item.label}
+      </NavLink>
     </NavItem>
   );
 };
@@ -59,6 +61,7 @@ const Navigation = () => {
               isExpanded={section.items.some(
                 (route) => route.group === activeFirstLevel
               )}
+              data-cy={`nav-${section.label.toLowerCase()}`}
             >
               {section.items.map((subsection, sid) => {
                 if (subsection.items && subsection.items.length > 0) {
@@ -68,6 +71,7 @@ const Navigation = () => {
                       title={subsection.label}
                       isActive={activeFirstLevel === subsection.group}
                       isExpanded={activeFirstLevel === subsection.group}
+                      data-cy={`nav-${subsection.group}`}
                     >
                       {subsection.items.map(
                         (linkItem, lid) =>

--- a/src/pages/ActiveUsers/ActiveUsers.tsx
+++ b/src/pages/ActiveUsers/ActiveUsers.tsx
@@ -368,6 +368,7 @@ const ActiveUsers = () => {
 
   const membershipModalActions: JSX.Element[] = [
     <Button
+      data-cy="modal-button-ok"
       key="rebuild-auto-membership"
       variant="primary"
       onClick={onRebuildAutoMembership}
@@ -376,6 +377,7 @@ const ActiveUsers = () => {
       OK
     </Button>,
     <Button
+      data-cy="modal-button-cancel"
       key="cancel-rebuild-auto-membership"
       variant="link"
       onClick={() => setIsMembershipModalOpen(!isMembershipModalOpen)}
@@ -405,6 +407,7 @@ const ActiveUsers = () => {
 
   const dropdownItems = [
     <DropdownItem
+      data-cy="active-users-kebab-rebuild-auto-membership"
       key="action"
       component="button"
       onClick={() => setIsMembershipModalOpen(!isMembershipModalOpen)}
@@ -626,6 +629,7 @@ const ActiveUsers = () => {
       key: 1,
       element: (
         <SearchInputLayout
+          dataCy="search"
           name="search"
           ariaLabel="Search user"
           placeholder="Search"
@@ -644,6 +648,7 @@ const ActiveUsers = () => {
       key: 3,
       element: (
         <SecondaryButton
+          dataCy="active-users-button-refresh"
           onClickHandler={refreshUsersData}
           isDisabled={!showTableRows}
         >
@@ -655,6 +660,7 @@ const ActiveUsers = () => {
       key: 4,
       element: (
         <SecondaryButton
+          dataCy="active-users-button-delete"
           isDisabled={isDeleteButtonDisabled || !showTableRows}
           onClickHandler={onDeleteHandler}
         >
@@ -666,6 +672,7 @@ const ActiveUsers = () => {
       key: 5,
       element: (
         <SecondaryButton
+          dataCy="active-users-button-add"
           onClickHandler={onAddClickHandler}
           isDisabled={!showTableRows}
         >
@@ -677,6 +684,7 @@ const ActiveUsers = () => {
       key: 6,
       element: (
         <SecondaryButton
+          dataCy="active-users-button-disable"
           isDisabled={isDisableButtonDisabled || !showTableRows}
           onClickHandler={() => onEnableDisableHandler(true)}
         >
@@ -688,6 +696,7 @@ const ActiveUsers = () => {
       key: 7,
       element: (
         <SecondaryButton
+          dataCy="active-users-button-enable"
           isDisabled={isEnableButtonDisabled || !showTableRows}
           onClickHandler={() => onEnableDisableHandler(false)}
         >
@@ -699,6 +708,7 @@ const ActiveUsers = () => {
       key: 8,
       element: (
         <KebabLayout
+          dataCy="active-users-kebab"
           onDropdownSelect={onDropdownSelect}
           onKebabToggle={onKebabToggle}
           idKebab="main-dropdown-kebab"
@@ -814,9 +824,13 @@ const ActiveUsers = () => {
           buttonsData={disableEnableButtonsData}
           onRefresh={refreshUsersData}
         />
-        <ModalErrors errors={modalErrors.getAll()} />
+        <ModalErrors
+          errors={modalErrors.getAll()}
+          dataCy="active-users-modal-error"
+        />
         {isMembershipModalOpen && (
           <ModalWithFormLayout
+            dataCy="modal-rebuild-auto-membership"
             variantType="medium"
             modalPosition="top"
             offPosition="76px"

--- a/src/pages/ActiveUsers/ActiveUsersTabs.tsx
+++ b/src/pages/ActiveUsers/ActiveUsersTabs.tsx
@@ -170,6 +170,7 @@ const ActiveUsersTabs = ({ memberof }) => {
             unmountOnExit
           >
             <Tab
+              data-cy="active-users-tab-settings"
               eventKey={"settings"}
               name="details"
               title={<TabTitleText>Settings</TabTitleText>}
@@ -196,6 +197,7 @@ const ActiveUsersTabs = ({ memberof }) => {
               />
             </Tab>
             <Tab
+              data-cy="active-users-tab-memberof"
               eventKey={"memberof"}
               name="memberof-details"
               title={<TabTitleText>Is a member of</TabTitleText>}

--- a/src/pages/AutoMemHostRules/AutoMemHostRules.tsx
+++ b/src/pages/AutoMemHostRules/AutoMemHostRules.tsx
@@ -185,6 +185,7 @@ const AutoMemHostRules = () => {
       // Add empty entry as an option
       const groupsToSelector = [
         {
+          "data-cy": "typeahead-select-no-selection",
           value: NO_SELECTION,
           children: NO_SELECTION,
         },
@@ -192,6 +193,7 @@ const AutoMemHostRules = () => {
 
       // Add the rest of the data from hostgroups
       const tempGroupsToSelector = hostGroups.map((group) => ({
+        "data-cy": "typeahead-select-" + group,
         value: group,
         children: group,
       }));
@@ -510,6 +512,7 @@ const AutoMemHostRules = () => {
       key: 1,
       element: (
         <SearchInputLayout
+          dataCy="search"
           name="search"
           ariaLabel="Search rules"
           placeholder="Search"
@@ -540,6 +543,7 @@ const AutoMemHostRules = () => {
       key: 4,
       element: (
         <SecondaryButton
+          dataCy="auto-member-host-rules-button-refresh"
           onClickHandler={refreshData}
           isDisabled={!showTableRows}
         >
@@ -551,6 +555,7 @@ const AutoMemHostRules = () => {
       key: 5,
       element: (
         <SecondaryButton
+          dataCy="auto-member-host-rules-button-delete"
           isDisabled={isDeleteButtonDisabled || !showTableRows}
           onClickHandler={onOpenDeleteModal}
         >
@@ -562,6 +567,7 @@ const AutoMemHostRules = () => {
       key: 6,
       element: (
         <SecondaryButton
+          dataCy="auto-member-host-rules-button-add"
           isDisabled={!showTableRows}
           onClickHandler={onOpenAddModal}
         >
@@ -656,11 +662,13 @@ const AutoMemHostRules = () => {
         ruleType="hostgroup"
       />
       <ConfirmationModal
+        dataCy="auto-member-default-host-rules-modal"
         title="Default hostgroup"
         isOpen={showChangeConfirmationModal}
         onClose={onCloseConfirmationModal}
         actions={[
           <Button
+            data-cy="modal-button-ok"
             variant="primary"
             key="change-default"
             onClick={() => {
@@ -669,7 +677,11 @@ const AutoMemHostRules = () => {
           >
             OK
           </Button>,
-          <SecondaryButton key="cancel" onClickHandler={onCancelDefaultGroup}>
+          <SecondaryButton
+            key="cancel"
+            onClickHandler={onCancelDefaultGroup}
+            dataCy="modal-button-cancel"
+          >
             Cancel
           </SecondaryButton>,
         ]}

--- a/src/pages/AutoMemUserRules/AutoMemSettings.tsx
+++ b/src/pages/AutoMemUserRules/AutoMemSettings.tsx
@@ -155,7 +155,10 @@ const AutoMemSettings = (props: PropsToSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton onClickHandler={props.onRefresh}>
+        <SecondaryButton
+          dataCy="auto-member-tab-settings-button-refresh"
+          onClickHandler={props.onRefresh}
+        >
           Refresh
         </SecondaryButton>
       ),
@@ -164,6 +167,7 @@ const AutoMemSettings = (props: PropsToSettings) => {
       key: 1,
       element: (
         <SecondaryButton
+          dataCy="auto-member-tab-settings-button-revert"
           isDisabled={!props.isModified}
           onClickHandler={onRevert}
         >
@@ -175,6 +179,7 @@ const AutoMemSettings = (props: PropsToSettings) => {
       key: 2,
       element: (
         <SecondaryButton
+          dataCy="auto-member-tab-settings-button-save"
           isDisabled={!props.isModified || isSaving}
           onClickHandler={onSave}
           isLoading={isSaving}
@@ -229,6 +234,7 @@ const AutoMemSettings = (props: PropsToSettings) => {
             <Form className="pf-v5-u-mt-sm pf-v5-u-mb-lg pf-v5-u-mr-md">
               <FormGroup label="Description" fieldId="description" role="group">
                 <IpaTextArea
+                  dataCy="auto-member-tab-settings-textbox-description"
                   name="description"
                   ipaObject={ipaObject}
                   onChange={recordOnChange}

--- a/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
+++ b/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
@@ -185,6 +185,7 @@ const AutoMemUserRules = () => {
       // Add empty entry as an option
       const groupsToSelector = [
         {
+          "data-cy": "typeahead-select-no-selection",
           value: NO_SELECTION,
           children: NO_SELECTION,
         },
@@ -192,6 +193,7 @@ const AutoMemUserRules = () => {
 
       // Add the rest of the data from usergroups
       const tempGroupsToSelector = userGroups.map((group) => ({
+        "data-cy": "typeahead-select-" + group,
         value: group,
         children: group,
       }));
@@ -510,6 +512,7 @@ const AutoMemUserRules = () => {
       key: 1,
       element: (
         <SearchInputLayout
+          dataCy="search"
           name="search"
           ariaLabel="Search rules"
           placeholder="Search"
@@ -540,6 +543,7 @@ const AutoMemUserRules = () => {
       key: 4,
       element: (
         <SecondaryButton
+          dataCy="auto-member-user-rules-button-refresh"
           onClickHandler={refreshData}
           isDisabled={!showTableRows}
         >
@@ -551,6 +555,7 @@ const AutoMemUserRules = () => {
       key: 5,
       element: (
         <SecondaryButton
+          dataCy="auto-member-user-rules-button-delete"
           isDisabled={isDeleteButtonDisabled || !showTableRows}
           onClickHandler={onOpenDeleteModal}
         >
@@ -562,6 +567,7 @@ const AutoMemUserRules = () => {
       key: 6,
       element: (
         <SecondaryButton
+          dataCy="auto-member-user-rules-button-add"
           isDisabled={!showTableRows}
           onClickHandler={onOpenAddModal}
         >
@@ -656,11 +662,13 @@ const AutoMemUserRules = () => {
         ruleType="group"
       />
       <ConfirmationModal
+        dataCy="auto-member-default-user-rules-modal"
         title="Default user group"
         isOpen={showChangeConfirmationModal}
         onClose={onCloseConfirmationModal}
         actions={[
           <Button
+            data-cy="modal-button-ok"
             variant="primary"
             key="change-default"
             onClick={() => {
@@ -669,7 +677,11 @@ const AutoMemUserRules = () => {
           >
             OK
           </Button>,
-          <SecondaryButton key="cancel" onClickHandler={onCancelDefaultGroup}>
+          <SecondaryButton
+            dataCy="modal-button-cancel"
+            key="cancel"
+            onClickHandler={onCancelDefaultGroup}
+          >
             Cancel
           </SecondaryButton>,
         ]}

--- a/src/pages/CertificateMapping/CertificateMapping.tsx
+++ b/src/pages/CertificateMapping/CertificateMapping.tsx
@@ -367,6 +367,7 @@ const CertificateMappingPage = () => {
       key: 1,
       element: (
         <SearchInputLayout
+          dataCy="search"
           name="search"
           ariaLabel="Search certificate mapping rules"
           placeholder="Search"
@@ -385,6 +386,7 @@ const CertificateMappingPage = () => {
       key: 3,
       element: (
         <SecondaryButton
+          dataCy="certificate-mapping-button-refresh"
           onClickHandler={refreshData}
           isDisabled={!showTableRows}
         >
@@ -396,6 +398,7 @@ const CertificateMappingPage = () => {
       key: 4,
       element: (
         <SecondaryButton
+          dataCy="certificate-mapping-button-delete"
           isDisabled={isDeleteButtonDisabled || !showTableRows}
           onClickHandler={() => setShowDeleteModal(true)}
         >
@@ -407,6 +410,7 @@ const CertificateMappingPage = () => {
       key: 5,
       element: (
         <SecondaryButton
+          dataCy="certificate-mapping-button-add"
           isDisabled={!showTableRows}
           onClickHandler={() => setShowAddModal(true)}
         >
@@ -418,6 +422,7 @@ const CertificateMappingPage = () => {
       key: 6,
       element: (
         <SecondaryButton
+          dataCy="certificate-mapping-button-disable"
           isDisabled={isDisableButtonDisabled || !showTableRows}
           onClickHandler={onDisableOperation}
         >
@@ -429,6 +434,7 @@ const CertificateMappingPage = () => {
       key: 7,
       element: (
         <SecondaryButton
+          dataCy="certificate-mapping-button-enable"
           isDisabled={isEnableButtonDisabled || !showTableRows}
           onClickHandler={onEnableOperation}
         >

--- a/src/pages/CertificateMapping/CertificateMappingGlobalConfig.tsx
+++ b/src/pages/CertificateMapping/CertificateMappingGlobalConfig.tsx
@@ -104,7 +104,10 @@ const CertificateMappingGlobalConfig = () => {
     {
       key: 0,
       element: (
-        <SecondaryButton onClickHandler={certMapConfigData.refetch}>
+        <SecondaryButton
+          dataCy="certificate-mapping-global-config-button-refresh"
+          onClickHandler={certMapConfigData.refetch}
+        >
           Refresh
         </SecondaryButton>
       ),
@@ -113,6 +116,7 @@ const CertificateMappingGlobalConfig = () => {
       key: 1,
       element: (
         <SecondaryButton
+          dataCy="certificate-mapping-global-config-button-revert"
           isDisabled={!certMapConfigData.modified || isDataLoading}
           onClickHandler={onRevert}
         >
@@ -124,6 +128,7 @@ const CertificateMappingGlobalConfig = () => {
       key: 2,
       element: (
         <SecondaryButton
+          dataCy="certificate-mapping-global-config-button-save"
           isDisabled={!certMapConfigData.modified || isDataLoading}
           onClickHandler={onSave}
         >
@@ -174,6 +179,7 @@ const CertificateMappingGlobalConfig = () => {
                 <Form className="pf-v5-u-mb-lg">
                   <FormGroup fieldId="ipacertmappromptusername" role="group">
                     <IpaCheckbox
+                      dataCy="certificate-mapping-global-config-checkbox-ipacertmappromptusername"
                       name="ipacertmappromptusername"
                       value={String(
                         certMapConfigData.certMapConfig.ipacertmappromptusername

--- a/src/pages/CertificateMapping/CertificateMappingMatch.tsx
+++ b/src/pages/CertificateMapping/CertificateMappingMatch.tsx
@@ -159,12 +159,23 @@ const CertificateMappingMatch = () => {
   const toolbarFields = [
     {
       key: 0,
-      element: <Button onClick={onMatchCertificate}>Match</Button>,
+      element: (
+        <Button
+          data-cy="certificate-identity-mapping-match-button-match"
+          onClick={onMatchCertificate}
+        >
+          Match
+        </Button>
+      ),
     },
     {
       key: 1,
       element: (
-        <Button variant="secondary" onClick={onClearCertificate}>
+        <Button
+          data-cy="certificate-identity-mapping-match-button-clear"
+          variant="secondary"
+          onClick={onClearCertificate}
+        >
           Clear
         </Button>
       ),
@@ -223,6 +234,7 @@ const CertificateMappingMatch = () => {
                 <Form className="pf-v5-u-mb-lg">
                   <FormGroup label="Certificate" fieldId="cert_textarea">
                     <TextArea
+                      data-cy="certificate-identity-mapping-match-textbox-certificate"
                       name="cert_textarea"
                       aria-label="Certificate"
                       value={certificateText}
@@ -244,6 +256,7 @@ const CertificateMappingMatch = () => {
                 <Form className="pf-v5-u-mb-lg">
                   <FormGroup label="Issued by" fieldId="issuer">
                     <TextInput
+                      data-cy="certificate-identity-mapping-match-textbox-issuer"
                       name="issuer"
                       aria-label="Issued by text input"
                       type="text"
@@ -253,6 +266,7 @@ const CertificateMappingMatch = () => {
                   </FormGroup>
                   <FormGroup label="Issued to" fieldId="subject">
                     <TextInput
+                      data-cy="certificate-identity-mapping-match-textbox-subject"
                       name="subject"
                       aria-label="Issued to text input"
                       type="text"
@@ -262,6 +276,7 @@ const CertificateMappingMatch = () => {
                   </FormGroup>
                   <FormGroup label="Serial number" fieldId="serial_number">
                     <TextInput
+                      data-cy="certificate-identity-mapping-match-textbox-serial-number"
                       name="serial_number"
                       aria-label="Serial number text input"
                       type="text"
@@ -274,6 +289,7 @@ const CertificateMappingMatch = () => {
                     fieldId="serial_number_hex"
                   >
                     <TextInput
+                      data-cy="certificate-identity-mapping-match-textbox-serial-number-hex"
                       name="serial_number_hex"
                       aria-label="Serial number in hexadecimal text input"
                       type="text"
@@ -283,6 +299,7 @@ const CertificateMappingMatch = () => {
                   </FormGroup>
                   <FormGroup label="Valid from" fieldId="valid_not_before">
                     <TextInput
+                      data-cy="certificate-identity-mapping-match-textbox-valid-from"
                       name="valid_not_before"
                       aria-label="Valid from text input"
                       type="text"
@@ -292,6 +309,7 @@ const CertificateMappingMatch = () => {
                   </FormGroup>
                   <FormGroup label="Valid to" fieldId="valid_not_after">
                     <TextInput
+                      data-cy="certificate-identity-mapping-match-textbox-valid-to"
                       name="valid_not_after"
                       aria-label="Valid to text input"
                       type="text"
@@ -304,6 +322,7 @@ const CertificateMappingMatch = () => {
                     fieldId="sha1_fingerprint"
                   >
                     <TextArea
+                      data-cy="certificate-identity-mapping-match-textbox-sha1-fingerprint"
                       name="sha1_fingerprint"
                       aria-label="SHA1 Fingerprint text input"
                       value={fingerprintSha1}
@@ -317,6 +336,7 @@ const CertificateMappingMatch = () => {
                     fieldId="sha256_fingerprint"
                   >
                     <TextArea
+                      data-cy="certificate-identity-mapping-match-textbox-sha256-fingerprint"
                       name="sha256_fingerprint"
                       aria-label="SHA256 Fingerprint text input"
                       value={fingerprintSha256}

--- a/src/pages/CertificateMapping/CertificateMappingSettings.tsx
+++ b/src/pages/CertificateMapping/CertificateMappingSettings.tsx
@@ -151,6 +151,7 @@ const CertificateMappingSettings = (props: CertificateMappingSettingsProps) => {
 
   const kebabItems = [
     <DropdownItem
+      data-cy="certificate-mapping-tab-settings-kebab-enable"
       key="enable"
       isDisabled={isRuleEnabled}
       onClick={() => setIsEnableDisableOpen(true)}
@@ -158,13 +159,18 @@ const CertificateMappingSettings = (props: CertificateMappingSettingsProps) => {
       Enable
     </DropdownItem>,
     <DropdownItem
+      data-cy="certificate-mapping-tab-settings-kebab-disable"
       key="disable"
       isDisabled={!isRuleEnabled}
       onClick={() => setIsEnableDisableOpen(true)}
     >
       Disable
     </DropdownItem>,
-    <DropdownItem key="delete" onClick={() => setIsDeleteOpen(true)}>
+    <DropdownItem
+      data-cy="certificate-mapping-tab-settings-kebab-delete"
+      key="delete"
+      onClick={() => setIsDeleteOpen(true)}
+    >
       Delete
     </DropdownItem>,
   ];
@@ -174,7 +180,10 @@ const CertificateMappingSettings = (props: CertificateMappingSettingsProps) => {
     {
       key: 0,
       element: (
-        <SecondaryButton onClickHandler={props.onRefresh}>
+        <SecondaryButton
+          dataCy="certificate-mapping-tab-settings-button-refresh"
+          onClickHandler={props.onRefresh}
+        >
           Refresh
         </SecondaryButton>
       ),
@@ -183,6 +192,7 @@ const CertificateMappingSettings = (props: CertificateMappingSettingsProps) => {
       key: 1,
       element: (
         <SecondaryButton
+          dataCy="certificate-mapping-tab-settings-button-revert"
           isDisabled={!props.isModified || isDataLoading}
           onClickHandler={onRevert}
         >
@@ -194,6 +204,7 @@ const CertificateMappingSettings = (props: CertificateMappingSettingsProps) => {
       key: 2,
       element: (
         <SecondaryButton
+          dataCy="certificate-mapping-tab-settings-button-save"
           isDisabled={!props.isModified || isDataLoading}
           onClickHandler={onSave}
         >
@@ -205,6 +216,7 @@ const CertificateMappingSettings = (props: CertificateMappingSettingsProps) => {
       key: 3,
       element: (
         <KebabLayout
+          dataCy="certificate-mapping-tab-settings-kebab"
           direction={"up"}
           onDropdownSelect={() => setIsKebabOpen(!isKebabOpen)}
           onKebabToggle={() => setIsKebabOpen(!isKebabOpen)}
@@ -252,6 +264,7 @@ const CertificateMappingSettings = (props: CertificateMappingSettingsProps) => {
                 <Form className="pf-v5-u-mb-lg">
                   <FormGroup label="Rule name" role="group">
                     <IpaTextInput
+                      dataCy="certificate-mapping-tab-settings-textbox-cn"
                       name={"cn"}
                       ariaLabel={"Rule name"}
                       ipaObject={ipaObject}
@@ -261,6 +274,7 @@ const CertificateMappingSettings = (props: CertificateMappingSettingsProps) => {
                   </FormGroup>
                   <FormGroup label="Description" fieldId="description">
                     <IpaTextArea
+                      dataCy="certificate-mapping-tab-settings-textbox-description"
                       name={"description"}
                       ariaLabel={"Description"}
                       ipaObject={ipaObject}
@@ -277,6 +291,7 @@ const CertificateMappingSettings = (props: CertificateMappingSettingsProps) => {
                     }
                   >
                     <IpaTextInput
+                      dataCy="certificate-mapping-tab-settings-textbox-ipacertmapmaprule"
                       name={"ipacertmapmaprule"}
                       ariaLabel={"Mapping rule"}
                       ipaObject={ipaObject}
@@ -293,6 +308,7 @@ const CertificateMappingSettings = (props: CertificateMappingSettingsProps) => {
                     }
                   >
                     <IpaTextInput
+                      dataCy="certificate-mapping-tab-settings-textbox-ipacertmapmatchrule"
                       name={"ipacertmapmatchrule"}
                       ariaLabel={"Matching rule"}
                       ipaObject={ipaObject}
@@ -309,6 +325,7 @@ const CertificateMappingSettings = (props: CertificateMappingSettingsProps) => {
                     }
                   >
                     <IpaTextboxList
+                      dataCy="certificate-mapping-tab-settings-textbox-associateddomain"
                       ipaObject={ipaObject}
                       setIpaObject={recordOnChange}
                       name={"associateddomain"}
@@ -323,6 +340,7 @@ const CertificateMappingSettings = (props: CertificateMappingSettingsProps) => {
                     }
                   >
                     <IpaNumberInput
+                      dataCy="certificate-mapping-tab-settings-textbox-ipacertmappriority"
                       id={"ipacertmappriority"}
                       name={"ipacertmappriority"}
                       aria-label={"Priority number"}

--- a/src/pages/Configuration/ConfigGroupOptions.tsx
+++ b/src/pages/Configuration/ConfigGroupOptions.tsx
@@ -26,6 +26,7 @@ const ConfigGroupOptions = (props: PropsToGroupOptions) => {
             isRequired
           >
             <IpaTextArea
+              dataCy="configuration-textbox-ipagroupsearchfields"
               name="ipagroupsearchfields"
               ipaObject={props.ipaObject}
               onChange={props.recordOnChange}

--- a/src/pages/Configuration/ConfigObjectclassTable.tsx
+++ b/src/pages/Configuration/ConfigObjectclassTable.tsx
@@ -51,6 +51,7 @@ const ConfigObjectclassTable = (props: PropsToTable) => {
             const removeButton = (
               <TableText>
                 <Button
+                  data-cy="configuration-table-button-remove"
                   id={props.name + "-" + item}
                   onClick={() => removeOC(item)}
                   variant="secondary"
@@ -72,6 +73,7 @@ const ConfigObjectclassTable = (props: PropsToTable) => {
         </Tbody>
       </Table>
       <Button
+        data-cy="configuration-table-button-add"
         id={props.name + "-" + "addoc"}
         onClick={() => {
           setNewOC("");
@@ -83,12 +85,14 @@ const ConfigObjectclassTable = (props: PropsToTable) => {
         Add objectclass
       </Button>
       <Modal
+        data-cy="add-objectclass-modal"
         variant="small"
         title={"Add objectclass"}
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}
         actions={[
           <Button
+            data-cy="modal-button-add"
             key="add-new-oc"
             isDisabled={
               newOC === "" || values.indexOf(newOC.toLowerCase()) !== -1
@@ -98,6 +102,7 @@ const ConfigObjectclassTable = (props: PropsToTable) => {
             Add
           </Button>,
           <Button
+            data-cy="modal-button-cancel"
             key="cancel-new-host"
             variant="link"
             onClick={() => setIsOpen(false)}
@@ -114,6 +119,7 @@ const ConfigObjectclassTable = (props: PropsToTable) => {
             isRequired
           >
             <TextInput
+              data-cy="modal-textbox-objectclass"
               id="oc"
               type="text"
               value={newOC}

--- a/src/pages/Configuration/ConfigSELinuxOptions.tsx
+++ b/src/pages/Configuration/ConfigSELinuxOptions.tsx
@@ -24,6 +24,7 @@ const ConfigSELinuxOptions = (props: PropsToSELinuxOptions) => {
         isRequired
       >
         <IpaTextArea
+          dataCy="configuration-textbox-ipaselinuxusermaporder"
           name={"ipaselinuxusermaporder"}
           ariaLabel={"SELinux user map order"}
           ipaObject={props.ipaObject}
@@ -37,6 +38,7 @@ const ConfigSELinuxOptions = (props: PropsToSELinuxOptions) => {
         fieldId="ipaselinuxusermapdefault"
       >
         <IpaTextInput
+          dataCy="configuration-textbox-ipaselinuxusermapdefault"
           name={"ipaselinuxusermapdefault"}
           ariaLabel={"Default SELinux user"}
           ipaObject={props.ipaObject}

--- a/src/pages/Configuration/ConfigSearchOptions.tsx
+++ b/src/pages/Configuration/ConfigSearchOptions.tsx
@@ -19,6 +19,7 @@ const ConfigSearchOptions = (props: PropsToSearchOPtions) => {
     <Form className="pf-v5-u-mb-lg pf-v5-u-mt-lg" isHorizontal>
       <FormGroup label="Search size limit" fieldId="ipasearchrecordslimit">
         <IpaNumberInput
+          dataCy="configuration-textbox-ipasearchrecordslimit"
           id="ipasearchrecordslimit"
           name="ipasearchrecordslimit"
           aria-label="search size limit"
@@ -33,6 +34,7 @@ const ConfigSearchOptions = (props: PropsToSearchOPtions) => {
       </FormGroup>
       <FormGroup label="Search time limit" fieldId="ipasearchtimelimit">
         <IpaNumberInput
+          dataCy="configuration-textbox-ipasearchtimelimit"
           id="ipasearchtimelimit"
           name="ipasearchtimelimit"
           aria-label="search time limit"

--- a/src/pages/Configuration/ConfigServerOptions.tsx
+++ b/src/pages/Configuration/ConfigServerOptions.tsx
@@ -35,6 +35,7 @@ const ConfigServerOptions = (props: PropsToServerOptions) => {
         fieldId="ca_renewal_master_server"
       >
         <IpaDropdownSearch
+          dataCy="configuration-dropdown-renewal-master"
           id="ca_renewal_master_server"
           name="ca_renewal_master_server"
           options={options}
@@ -50,6 +51,7 @@ const ConfigServerOptions = (props: PropsToServerOptions) => {
         fieldId="pkinit_server_server"
       >
         <TextArea
+          data-cy="configuration-textbox-pkinit-server"
           id="pkinit_server_server"
           name="pkinit_server_server"
           aria-label="master capable of PKINIT"

--- a/src/pages/Configuration/ConfigServiceOptions.tsx
+++ b/src/pages/Configuration/ConfigServiceOptions.tsx
@@ -23,6 +23,7 @@ const ConfigServiceOptions = (props: PropsToServiceOptions) => {
         role="group"
       >
         <IpaCheckboxes
+          dataCy="configuration-checkbox-ipakrbauthzdata"
           name="ipakrbauthzdata"
           options={[
             {

--- a/src/pages/Configuration/ConfigUserOptions.tsx
+++ b/src/pages/Configuration/ConfigUserOptions.tsx
@@ -60,6 +60,7 @@ const ConfigUserOptions = (props: PropsToSearchOptions) => {
             isRequired
           >
             <IpaTextArea
+              dataCy="configuration-textbox-ipausersearchfields"
               name="ipausersearchfields"
               ipaObject={props.ipaObject}
               onChange={props.recordOnChange}
@@ -72,6 +73,7 @@ const ConfigUserOptions = (props: PropsToSearchOptions) => {
             fieldId="ipadefaultemaildomain"
           >
             <IpaTextInput
+              dataCy="configuration-textbox-ipadefaultemaildomain"
               name={"ipadefaultemaildomain"}
               ariaLabel={"Default e-mail domain"}
               ipaObject={props.ipaObject}
@@ -88,6 +90,7 @@ const ConfigUserOptions = (props: PropsToSearchOptions) => {
             }
           >
             <IpaTextArea
+              dataCy="configuration-textbox-ipadomainresolutionorder"
               name={"ipadomainresolutionorder"}
               ariaLabel={"Domain resolution order"}
               ipaObject={props.ipaObject}
@@ -101,6 +104,7 @@ const ConfigUserOptions = (props: PropsToSearchOptions) => {
             fieldId="ipadefaultprimarygroup"
           >
             <IpaDropdownSearch
+              dataCy="configuration-dropdown-ipadefaultprimarygroup"
               id="ipadefaultprimarygroup"
               name="ipadefaultprimarygroup"
               options={props.groups}
@@ -117,6 +121,7 @@ const ConfigUserOptions = (props: PropsToSearchOptions) => {
             isRequired
           >
             <IpaTextInput
+              dataCy="configuration-textbox-ipahomesrootdir"
               name={"ipahomesrootdir"}
               ariaLabel={"Home directory base"}
               ipaObject={props.ipaObject}
@@ -131,6 +136,7 @@ const ConfigUserOptions = (props: PropsToSearchOptions) => {
             isRequired
           >
             <IpaTextInput
+              dataCy="configuration-textbox-ipadefaultloginshell"
               name={"ipadefaultloginshell"}
               ariaLabel={"Default shell"}
               ipaObject={props.ipaObject}
@@ -145,6 +151,7 @@ const ConfigUserOptions = (props: PropsToSearchOptions) => {
             isRequired
           >
             <IpaNumberInput
+              dataCy="configuration-textbox-ipamaxusernamelength"
               id="ipamaxusernamelength"
               name="ipamaxusernamelength"
               aria-label="Maximum username length"
@@ -163,6 +170,7 @@ const ConfigUserOptions = (props: PropsToSearchOptions) => {
             isRequired
           >
             <IpaNumberInput
+              dataCy="configuration-textbox-ipapwdexpadvnotify"
               id="ipapwdexpadvnotify"
               name="ipapwdexpadvnotify"
               aria-label="Password Expiration Notification (days)"
@@ -181,6 +189,7 @@ const ConfigUserOptions = (props: PropsToSearchOptions) => {
             role="group"
           >
             <IpaCheckboxes
+              dataCy="configuration-checkboxes-ipaconfigstring"
               name="ipaconfigstring"
               options={[
                 {
@@ -212,6 +221,7 @@ const ConfigUserOptions = (props: PropsToSearchOptions) => {
             }
           >
             <IpaCheckboxes
+              dataCy="configuration-checkboxes-ipauserauthtype"
               name="ipauserauthtype"
               options={[
                 {
@@ -258,6 +268,7 @@ const ConfigUserOptions = (props: PropsToSearchOptions) => {
             fieldId="ipamigrationenabled-ipamigrationenabled"
           >
             <IpaCheckbox
+              dataCy="configuration-checkbox-ipamigrationenabled"
               name="ipamigrationenabled"
               value="ipamigrationenabled"
               text=""
@@ -273,6 +284,7 @@ const ConfigUserOptions = (props: PropsToSearchOptions) => {
             fieldId="ipauserdefaultsubordinateid-ipauserdefaultsubordinateid"
           >
             <IpaCheckbox
+              dataCy="configuration-checkbox-ipauserdefaultsubordinateid"
               name="ipauserdefaultsubordinateid"
               value="ipauserdefaultsubordinateid"
               text=""

--- a/src/pages/Configuration/Configuration.tsx
+++ b/src/pages/Configuration/Configuration.tsx
@@ -188,13 +188,19 @@ const Configuration = () => {
     {
       key: 0,
       element: (
-        <SecondaryButton onClickHandler={onRefresh}>Refresh</SecondaryButton>
+        <SecondaryButton
+          dataCy="configuration-button-refresh"
+          onClickHandler={onRefresh}
+        >
+          Refresh
+        </SecondaryButton>
       ),
     },
     {
       key: 1,
       element: (
         <SecondaryButton
+          dataCy="configuration-button-revert"
           isDisabled={!configData.modified}
           onClickHandler={onRevert}
         >
@@ -206,6 +212,7 @@ const Configuration = () => {
       key: 2,
       element: (
         <SecondaryButton
+          dataCy="configuration-button-save"
           isDisabled={!configData.modified || isSaving}
           onClickHandler={onSave}
           isLoading={isSaving}

--- a/src/pages/DNSZones/DnsZones.tsx
+++ b/src/pages/DNSZones/DnsZones.tsx
@@ -352,6 +352,7 @@ const DnsZones = () => {
       key: 1,
       element: (
         <SearchInputLayout
+          dataCy="search"
           name="search"
           ariaLabel="Search dns zones"
           placeholder="Search"
@@ -370,6 +371,7 @@ const DnsZones = () => {
       key: 3,
       element: (
         <SecondaryButton
+          dataCy="dns-zones-button-refresh"
           onClickHandler={refreshData}
           isDisabled={!showTableRows}
         >
@@ -383,6 +385,7 @@ const DnsZones = () => {
         <SecondaryButton
           isDisabled={isDeleteButtonDisabled || !showTableRows}
           onClickHandler={() => setShowDeleteModal(true)}
+          dataCy="dns-zones-button-delete"
         >
           Delete
         </SecondaryButton>
@@ -394,6 +397,7 @@ const DnsZones = () => {
         <SecondaryButton
           isDisabled={!showTableRows}
           onClickHandler={() => setShowAddModal(true)}
+          dataCy="dns-zones-button-add"
         >
           Add
         </SecondaryButton>
@@ -405,6 +409,7 @@ const DnsZones = () => {
         <SecondaryButton
           isDisabled={isDisableButtonDisabled || !showTableRows}
           onClickHandler={onDisableOperation}
+          dataCy="dns-zones-button-disable"
         >
           Disable
         </SecondaryButton>
@@ -416,6 +421,7 @@ const DnsZones = () => {
         <SecondaryButton
           isDisabled={isEnableButtonDisabled || !showTableRows}
           onClickHandler={onEnableOperation}
+          dataCy="dns-zones-button-enable"
         >
           Enable
         </SecondaryButton>

--- a/src/pages/DNSZones/DnsZonesSettings.tsx
+++ b/src/pages/DNSZones/DnsZonesSettings.tsx
@@ -191,6 +191,7 @@ const DnsZonesSettings = (props: DnsZonesSettingsProps) => {
 
   const kebabItems = [
     <DropdownItem
+      data-cy="dns-zones-tab-settings-kebab-enable"
       key="enable"
       isDisabled={isDnsZoneEnabled}
       onClick={() => setIsEnableDisableOpen(true)}
@@ -198,16 +199,22 @@ const DnsZonesSettings = (props: DnsZonesSettingsProps) => {
       Enable
     </DropdownItem>,
     <DropdownItem
+      data-cy="dns-zones-tab-settings-kebab-disable"
       key="disable"
       isDisabled={!isDnsZoneEnabled}
       onClick={() => setIsEnableDisableOpen(true)}
     >
       Disable
     </DropdownItem>,
-    <DropdownItem key="delete" onClick={() => setIsDeleteOpen(true)}>
+    <DropdownItem
+      data-cy="dns-zones-tab-settings-kebab-delete"
+      key="delete"
+      onClick={() => setIsDeleteOpen(true)}
+    >
       Delete
     </DropdownItem>,
     <DropdownItem
+      data-cy="dns-zones-tab-settings-kebab-add-permission"
       key="add-permission"
       isDisabled={operation !== "add"}
       onClick={() => {
@@ -218,6 +225,7 @@ const DnsZonesSettings = (props: DnsZonesSettingsProps) => {
       Add permission
     </DropdownItem>,
     <DropdownItem
+      data-cy="dns-zones-tab-settings-kebab-remove-permission"
       key="remove-permission"
       isDisabled={operation !== "remove"}
       onClick={() => {
@@ -234,7 +242,10 @@ const DnsZonesSettings = (props: DnsZonesSettingsProps) => {
     {
       key: 0,
       element: (
-        <SecondaryButton onClickHandler={props.onRefresh}>
+        <SecondaryButton
+          dataCy="dns-zones-tab-settings-button-refresh"
+          onClickHandler={props.onRefresh}
+        >
           Refresh
         </SecondaryButton>
       ),
@@ -243,6 +254,7 @@ const DnsZonesSettings = (props: DnsZonesSettingsProps) => {
       key: 1,
       element: (
         <SecondaryButton
+          dataCy="dns-zones-tab-settings-button-revert"
           isDisabled={!props.isModified || isDataLoading}
           onClickHandler={onRevert}
         >
@@ -254,6 +266,7 @@ const DnsZonesSettings = (props: DnsZonesSettingsProps) => {
       key: 2,
       element: (
         <SecondaryButton
+          dataCy="dns-zones-tab-settings-button-save"
           isDisabled={!props.isModified || isDataLoading}
           onClickHandler={onSave}
         >
@@ -265,6 +278,7 @@ const DnsZonesSettings = (props: DnsZonesSettingsProps) => {
       key: 3,
       element: (
         <KebabLayout
+          dataCy="dns-zones-tab-settings-kebab"
           direction={"up"}
           onDropdownSelect={() => setIsKebabOpen(!isKebabOpen)}
           onKebabToggle={() => setIsKebabOpen(!isKebabOpen)}
@@ -302,6 +316,7 @@ const DnsZonesSettings = (props: DnsZonesSettingsProps) => {
                 <Form className="pf-v5-u-mb-lg">
                   <FormGroup label="Zone name" role="idnsname">
                     <IpaTextInput
+                      dataCy="dns-zones-tab-settings-textbox-idnsname"
                       name={"idnsname"}
                       ariaLabel={"Zone name text input"}
                       ipaObject={ipaObject}
@@ -316,6 +331,7 @@ const DnsZonesSettings = (props: DnsZonesSettingsProps) => {
                     isRequired
                   >
                     <IpaTextInput
+                      dataCy="dns-zones-tab-settings-textbox-idnssoamname"
                       name={"idnssoamname"}
                       ariaLabel={"Authoritative nameserver text input"}
                       ipaObject={ipaObject}
@@ -330,6 +346,7 @@ const DnsZonesSettings = (props: DnsZonesSettingsProps) => {
                     isRequired
                   >
                     <IpaTextInput
+                      dataCy="dns-zones-tab-settings-textbox-idnssoarname"
                       name={"idnssoarname"}
                       ariaLabel={"Administrator e-mail address text input"}
                       ipaObject={ipaObject}
@@ -340,6 +357,7 @@ const DnsZonesSettings = (props: DnsZonesSettingsProps) => {
                   </FormGroup>
                   <FormGroup label="SOA serial" role="idnssoaserial">
                     <IpaNumberInput
+                      dataCy="dns-zones-tab-settings-textbox-idnssoaserial"
                       name={"idnssoaserial"}
                       ariaLabel={"SOA serial number input"}
                       ipaObject={ipaObject}
@@ -357,6 +375,7 @@ const DnsZonesSettings = (props: DnsZonesSettingsProps) => {
                     isRequired
                   >
                     <IpaNumberInput
+                      dataCy="dns-zones-tab-settings-textbox-idnssoarefresh"
                       name={"idnssoarefresh"}
                       ariaLabel={"SOA refresh in seconds number input"}
                       ipaObject={ipaObject}
@@ -373,6 +392,7 @@ const DnsZonesSettings = (props: DnsZonesSettingsProps) => {
                     isRequired
                   >
                     <IpaNumberInput
+                      dataCy="dns-zones-tab-settings-textbox-idnssoaretry"
                       name={"idnssoaretry"}
                       ariaLabel={"SOA retry  in seconds number input"}
                       ipaObject={ipaObject}
@@ -385,6 +405,7 @@ const DnsZonesSettings = (props: DnsZonesSettingsProps) => {
                   </FormGroup>
                   <FormGroup label="SOA expire (seconds)" role="idnssoaexpire">
                     <IpaNumberInput
+                      dataCy="dns-zones-tab-settings-textbox-idnssoaexpire"
                       name={"idnssoaexpire"}
                       ariaLabel={"SOA expire in seconds number input"}
                       ipaObject={ipaObject}
@@ -401,6 +422,7 @@ const DnsZonesSettings = (props: DnsZonesSettingsProps) => {
                     isRequired
                   >
                     <IpaNumberInput
+                      dataCy="dns-zones-tab-settings-textbox-idnssoaminimum"
                       name={"idnssoaminimum"}
                       ariaLabel={"SOA minimum in seconds number input"}
                       ipaObject={ipaObject}
@@ -416,6 +438,7 @@ const DnsZonesSettings = (props: DnsZonesSettingsProps) => {
                     role="dnsdefaultttl"
                   >
                     <IpaNumberInput
+                      dataCy="dns-zones-tab-settings-textbox-dnsdefaultttl"
                       name={"dnsdefaultttl"}
                       ariaLabel={"Default time to live in seconds number input"}
                       ipaObject={ipaObject}
@@ -428,6 +451,7 @@ const DnsZonesSettings = (props: DnsZonesSettingsProps) => {
                   </FormGroup>
                   <FormGroup label="Time to live (seconds)" role="dnsttl">
                     <IpaNumberInput
+                      dataCy="dns-zones-tab-settings-textbox-dnsttl"
                       name={"dnsttl"}
                       ariaLabel={"Time to live in seconds number input"}
                       ipaObject={ipaObject}
@@ -440,6 +464,7 @@ const DnsZonesSettings = (props: DnsZonesSettingsProps) => {
                   </FormGroup>
                   <FormGroup label="Dynamic update" role="idnsallowdynupdate">
                     <IpaCheckbox
+                      dataCy="dns-zones-tab-settings-checkbox-idnsallowdynupdate"
                       name={"idnsallowdynupdate"}
                       value={"dynamic-update"}
                       text={"Dynamic update"}
@@ -452,6 +477,7 @@ const DnsZonesSettings = (props: DnsZonesSettingsProps) => {
                   </FormGroup>
                   <FormGroup label="BIND update policy" role="idnsupdatepolicy">
                     <IpaTextArea
+                      dataCy="dns-zones-tab-settings-textbox-idnsupdatepolicy"
                       name={"idnsupdatepolicy"}
                       ariaLabel={"BIND update policy"}
                       ipaObject={ipaObject}
@@ -462,6 +488,7 @@ const DnsZonesSettings = (props: DnsZonesSettingsProps) => {
                   </FormGroup>
                   <FormGroup label="Allow query" role="idnsallowquery">
                     <IpaTextboxList
+                      dataCy="dns-zones-tab-settings-textbox-idnsallowquery"
                       name={"idnsallowquery"}
                       ariaLabel={"Allow query textbox list"}
                       ipaObject={ipaObject}
@@ -470,6 +497,7 @@ const DnsZonesSettings = (props: DnsZonesSettingsProps) => {
                   </FormGroup>
                   <FormGroup label="Allow transfer" role="idnsallowtransfer">
                     <IpaTextboxList
+                      dataCy="dns-zones-tab-settings-textbox-idnsallowtransfer"
                       name={"idnsallowtransfer"}
                       ariaLabel={"Allow transfer textbox list"}
                       ipaObject={ipaObject}
@@ -478,6 +506,7 @@ const DnsZonesSettings = (props: DnsZonesSettingsProps) => {
                   </FormGroup>
                   <FormGroup label="Zone forwarders" role="idnsforwarders">
                     <IpaTextboxList
+                      dataCy="dns-zones-tab-settings-textbox-idnsforwarders"
                       name={"idnsforwarders"}
                       ariaLabel={"Zone forwarders textbox list"}
                       ipaObject={ipaObject}
@@ -496,6 +525,7 @@ const DnsZonesSettings = (props: DnsZonesSettingsProps) => {
                   </FormGroup>
                   <FormGroup label="Allow PTR sync" role="idnsallowsyncptr">
                     <IpaCheckbox
+                      dataCy="dns-zones-tab-settings-checkbox-idnsallowsyncptr"
                       name={"idnsallowsyncptr"}
                       value={"allow-sync-ptr"}
                       text={"Allow PTR sync"}
@@ -511,6 +541,7 @@ const DnsZonesSettings = (props: DnsZonesSettingsProps) => {
                     role="idnssecinlinesigning"
                   >
                     <IpaCheckbox
+                      dataCy="dns-zones-tab-settings-checkbox-idnssecinlinesigning"
                       name={"idnssecinlinesigning"}
                       value={"inline-signing"}
                       text={"Allow in-line DNSSEC signing"}
@@ -523,6 +554,7 @@ const DnsZonesSettings = (props: DnsZonesSettingsProps) => {
                   </FormGroup>
                   <FormGroup label="NSEC3PARAM record" role="nsec3paramrecord">
                     <IpaTextInput
+                      dataCy="dns-zones-tab-settings-textbox-nsec3paramrecord"
                       name={"nsec3paramrecord"}
                       ariaLabel={"NSEC3PARAM record text input"}
                       ipaObject={ipaObject}

--- a/src/pages/HBACRules/HBACRules.tsx
+++ b/src/pages/HBACRules/HBACRules.tsx
@@ -476,6 +476,7 @@ const HBACRules = () => {
       key: 1,
       element: (
         <SearchInputLayout
+          dataCy="search"
           name="search"
           ariaLabel="Search user"
           placeholder="Search"
@@ -496,6 +497,7 @@ const HBACRules = () => {
         <SecondaryButton
           onClickHandler={refreshRulesData}
           isDisabled={!showTableRows}
+          dataCy="hbac-rules-button-refresh"
         >
           Refresh
         </SecondaryButton>
@@ -507,6 +509,7 @@ const HBACRules = () => {
         <SecondaryButton
           isDisabled={isDeleteButtonDisabled || !showTableRows}
           onClickHandler={onDeleteHandler}
+          dataCy="hbac-rules-button-delete"
         >
           Delete
         </SecondaryButton>
@@ -518,6 +521,7 @@ const HBACRules = () => {
         <SecondaryButton
           onClickHandler={onAddClickHandler}
           isDisabled={!showTableRows}
+          dataCy="hbac-rules-button-add"
         >
           Add
         </SecondaryButton>
@@ -529,6 +533,7 @@ const HBACRules = () => {
         <SecondaryButton
           isDisabled={isDisableButtonDisabled || !showTableRows}
           onClickHandler={() => onEnableDisableHandler(true)}
+          dataCy="hbac-rules-button-disable"
         >
           Disable
         </SecondaryButton>
@@ -540,6 +545,7 @@ const HBACRules = () => {
         <SecondaryButton
           isDisabled={isEnableButtonDisabled || !showTableRows}
           onClickHandler={() => onEnableDisableHandler(false)}
+          dataCy="hbac-rules-button-enable"
         >
           Enable
         </SecondaryButton>
@@ -632,7 +638,10 @@ const HBACRules = () => {
         buttonsData={disableEnableButtonsData}
         onRefresh={refreshRulesData}
       />
-      <ModalErrors errors={modalErrors.getAll()} />
+      <ModalErrors
+        errors={modalErrors.getAll()}
+        dataCy="hbac-rules-modal-error"
+      />
     </Page>
   );
 };

--- a/src/pages/HBACRules/HBACRulesSettings.tsx
+++ b/src/pages/HBACRules/HBACRulesSettings.tsx
@@ -174,7 +174,10 @@ const HBACRulesSettings = (props: PropsToSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton onClickHandler={props.onRefresh}>
+        <SecondaryButton
+          dataCy="hbac-rules-tab-settings-button-refresh"
+          onClickHandler={props.onRefresh}
+        >
           Refresh
         </SecondaryButton>
       ),
@@ -183,6 +186,7 @@ const HBACRulesSettings = (props: PropsToSettings) => {
       key: 1,
       element: (
         <SecondaryButton
+          dataCy="hbac-rules-tab-settings-button-revert"
           isDisabled={!props.isModified}
           onClickHandler={onRevert}
         >
@@ -194,6 +198,7 @@ const HBACRulesSettings = (props: PropsToSettings) => {
       key: 2,
       element: (
         <SecondaryButton
+          dataCy="hbac-rules-tab-settings-button-save"
           isDisabled={!props.isModified || isSaving}
           onClickHandler={onSave}
           isLoading={isSaving}
@@ -255,6 +260,7 @@ const HBACRulesSettings = (props: PropsToSettings) => {
             <Form className="pf-v5-u-mt-sm pf-v5-u-mb-lg pf-v5-u-mr-md">
               <FormGroup label="Description" fieldId="description">
                 <IpaTextArea
+                  dataCy="hbac-rules-tab-settings-textbox-description"
                   name="description"
                   ipaObject={ipaObject}
                   onChange={recordOnChange}
@@ -271,6 +277,7 @@ const HBACRulesSettings = (props: PropsToSettings) => {
               >
                 Who the rule applies to
                 <IpaCheckbox
+                  dataCy="hbac-rules-tab-settings-checkbox-usercategory"
                   name="usercategory"
                   value="usercategory"
                   text="Allow anyone"
@@ -343,6 +350,7 @@ const HBACRulesSettings = (props: PropsToSettings) => {
               >
                 Gives access to
                 <IpaCheckbox
+                  dataCy="hbac-rules-tab-settings-checkbox-hostcategory"
                   name="hostcategory"
                   value="hostcategory"
                   text="Any host"
@@ -417,6 +425,7 @@ const HBACRulesSettings = (props: PropsToSettings) => {
               >
                 Via the following services
                 <IpaCheckbox
+                  dataCy="hbac-rules-tab-settings-checkbox-servicecategory"
                   name="servicecategory"
                   value="servicecategory"
                   text="Any service"

--- a/src/pages/HBACServiceGroups/HBACServiceGroups.tsx
+++ b/src/pages/HBACServiceGroups/HBACServiceGroups.tsx
@@ -429,6 +429,7 @@ const HBACServiceGroups = () => {
       key: 1,
       element: (
         <SearchInputLayout
+          dataCy="search"
           name="search"
           ariaLabel="Search services"
           placeholder="Search"
@@ -449,6 +450,7 @@ const HBACServiceGroups = () => {
         <SecondaryButton
           onClickHandler={refreshServicesData}
           isDisabled={!showTableRows}
+          dataCy="hbac-service-groups-button-refresh"
         >
           Refresh
         </SecondaryButton>
@@ -460,6 +462,7 @@ const HBACServiceGroups = () => {
         <SecondaryButton
           isDisabled={isDeleteButtonDisabled || !showTableRows}
           onClickHandler={onDeleteHandler}
+          dataCy="hbac-service-groups-button-delete"
         >
           Delete
         </SecondaryButton>
@@ -471,6 +474,7 @@ const HBACServiceGroups = () => {
         <SecondaryButton
           onClickHandler={onAddClickHandler}
           isDisabled={!showTableRows}
+          dataCy="hbac-service-groups-button-add"
         >
           Add
         </SecondaryButton>
@@ -558,7 +562,10 @@ const HBACServiceGroups = () => {
         buttonsData={deleteServicesButtonsData}
         onRefresh={refreshServicesData}
       />
-      <ModalErrors errors={modalErrors.getAll()} />
+      <ModalErrors
+        errors={modalErrors.getAll()}
+        dataCy="hbac-service-groups-modal-error"
+      />
     </Page>
   );
 };

--- a/src/pages/HBACServiceGroups/HBACServiceGroupsSettings.tsx
+++ b/src/pages/HBACServiceGroups/HBACServiceGroupsSettings.tsx
@@ -93,7 +93,10 @@ const HBACServiceGroupsSettings = (props: PropsToSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton onClickHandler={props.onRefresh}>
+        <SecondaryButton
+          dataCy="hbac-service-groups-tab-settings-button-refresh"
+          onClickHandler={props.onRefresh}
+        >
           Refresh
         </SecondaryButton>
       ),
@@ -102,6 +105,7 @@ const HBACServiceGroupsSettings = (props: PropsToSettings) => {
       key: 1,
       element: (
         <SecondaryButton
+          dataCy="hbac-service-groups-tab-settings-button-revert"
           isDisabled={!props.isModified}
           onClickHandler={onRevert}
         >
@@ -113,6 +117,7 @@ const HBACServiceGroupsSettings = (props: PropsToSettings) => {
       key: 2,
       element: (
         <SecondaryButton
+          dataCy="hbac-service-groups-tab-settings-button-save"
           isDisabled={!props.isModified || isSaving}
           onClickHandler={onSave}
           isLoading={isSaving}
@@ -140,6 +145,7 @@ const HBACServiceGroupsSettings = (props: PropsToSettings) => {
         <Form className="pf-v5-u-mt-sm pf-v5-u-mb-lg pf-v5-u-mr-md">
           <FormGroup label="Description" fieldId="description">
             <IpaTextArea
+              dataCy="hbac-service-groups-tab-settings-textbox-description"
               name="description"
               ipaObject={ipaObject}
               onChange={recordOnChange}

--- a/src/pages/HBACServices/HBACServices.tsx
+++ b/src/pages/HBACServices/HBACServices.tsx
@@ -425,6 +425,7 @@ const HBACServices = () => {
       key: 1,
       element: (
         <SearchInputLayout
+          dataCy="search"
           name="search"
           ariaLabel="Search services"
           placeholder="Search"
@@ -445,6 +446,7 @@ const HBACServices = () => {
         <SecondaryButton
           onClickHandler={refreshServicesData}
           isDisabled={!showTableRows}
+          dataCy="hbac-services-button-refresh"
         >
           Refresh
         </SecondaryButton>
@@ -456,6 +458,7 @@ const HBACServices = () => {
         <SecondaryButton
           isDisabled={isDeleteButtonDisabled || !showTableRows}
           onClickHandler={onDeleteHandler}
+          dataCy="hbac-services-button-delete"
         >
           Delete
         </SecondaryButton>
@@ -467,6 +470,7 @@ const HBACServices = () => {
         <SecondaryButton
           onClickHandler={onAddClickHandler}
           isDisabled={!showTableRows}
+          dataCy="hbac-services-button-add"
         >
           Add
         </SecondaryButton>
@@ -554,7 +558,10 @@ const HBACServices = () => {
         buttonsData={deleteServicesButtonsData}
         onRefresh={refreshServicesData}
       />
-      <ModalErrors errors={modalErrors.getAll()} />
+      <ModalErrors
+        errors={modalErrors.getAll()}
+        dataCy="hbac-services-modal-error"
+      />
     </Page>
   );
 };

--- a/src/pages/HBACServices/HBACServicesSettings.tsx
+++ b/src/pages/HBACServices/HBACServicesSettings.tsx
@@ -82,7 +82,10 @@ const HBACServicesSettings = (props: PropsToSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton onClickHandler={props.onRefresh}>
+        <SecondaryButton
+          dataCy="hbac-services-tab-settings-button-refresh"
+          onClickHandler={props.onRefresh}
+        >
           Refresh
         </SecondaryButton>
       ),
@@ -91,6 +94,7 @@ const HBACServicesSettings = (props: PropsToSettings) => {
       key: 1,
       element: (
         <SecondaryButton
+          dataCy="hbac-services-tab-settings-button-revert"
           isDisabled={!props.isModified}
           onClickHandler={onRevert}
         >
@@ -102,6 +106,7 @@ const HBACServicesSettings = (props: PropsToSettings) => {
       key: 2,
       element: (
         <SecondaryButton
+          dataCy="hbac-services-tab-settings-button-save"
           isDisabled={!props.isModified || isSaving}
           onClickHandler={onSave}
           isLoading={isSaving}
@@ -129,6 +134,7 @@ const HBACServicesSettings = (props: PropsToSettings) => {
         <Form className="pf-v5-u-mt-sm pf-v5-u-mb-lg pf-v5-u-mr-md">
           <FormGroup label="Description" fieldId="description">
             <IpaTextArea
+              dataCy="hbac-services-tab-settings-textbox-description"
               name="description"
               ipaObject={ipaObject}
               onChange={recordOnChange}

--- a/src/pages/HostGroups/HostGroups.tsx
+++ b/src/pages/HostGroups/HostGroups.tsx
@@ -430,6 +430,7 @@ const HostGroups = () => {
       key: 1,
       element: (
         <SearchInputLayout
+          dataCy="search"
           name="search"
           ariaLabel="Search host groups"
           placeholder="Search"
@@ -450,6 +451,7 @@ const HostGroups = () => {
         <SecondaryButton
           onClickHandler={refreshGroupsData}
           isDisabled={!showTableRows}
+          dataCy="host-groups-button-refresh"
         >
           Refresh
         </SecondaryButton>
@@ -461,6 +463,7 @@ const HostGroups = () => {
         <SecondaryButton
           isDisabled={isDeleteButtonDisabled || !showTableRows}
           onClickHandler={onDeleteHandler}
+          dataCy="host-groups-button-delete"
         >
           Delete
         </SecondaryButton>
@@ -472,6 +475,7 @@ const HostGroups = () => {
         <SecondaryButton
           onClickHandler={onAddClickHandler}
           isDisabled={!showTableRows || isDisabledDueError}
+          dataCy="host-groups-button-add"
         >
           Add
         </SecondaryButton>
@@ -542,7 +546,10 @@ const HostGroups = () => {
           className="pf-v5-u-pb-0 pf-v5-u-pr-md"
         />
       </PageSection>
-      <ModalErrors errors={modalErrors.getAll()} />
+      <ModalErrors
+        errors={modalErrors.getAll()}
+        dataCy="host-groups-modal-error"
+      />
       <AddHostGroup
         show={showAddModal}
         handleModalToggle={onAddModalToggle}

--- a/src/pages/HostGroups/HostGroupsSettings.tsx
+++ b/src/pages/HostGroups/HostGroupsSettings.tsx
@@ -81,7 +81,10 @@ const HostGroupsSettings = (props: PropsToGroupsSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton onClickHandler={props.onRefresh}>
+        <SecondaryButton
+          dataCy="host-groups-tab-settings-button-refresh"
+          onClickHandler={props.onRefresh}
+        >
           Refresh
         </SecondaryButton>
       ),
@@ -90,6 +93,7 @@ const HostGroupsSettings = (props: PropsToGroupsSettings) => {
       key: 1,
       element: (
         <SecondaryButton
+          dataCy="host-groups-tab-settings-button-revert"
           isDisabled={!props.isModified}
           onClickHandler={onRevert}
         >
@@ -101,6 +105,7 @@ const HostGroupsSettings = (props: PropsToGroupsSettings) => {
       key: 2,
       element: (
         <SecondaryButton
+          dataCy="host-groups-tab-settings-button-save"
           isDisabled={!props.isModified || isSaving}
           onClickHandler={onSave}
           isLoading={isSaving}
@@ -131,6 +136,7 @@ const HostGroupsSettings = (props: PropsToGroupsSettings) => {
         >
           <FormGroup label="Description" fieldId="description">
             <IpaTextArea
+              dataCy="host-groups-tab-settings-textbox-description"
               name="description"
               ipaObject={ipaObject}
               onChange={recordOnChange}

--- a/src/pages/Hosts/Hosts.tsx
+++ b/src/pages/Hosts/Hosts.tsx
@@ -423,6 +423,7 @@ const Hosts = () => {
 
   const membershipModalActions: JSX.Element[] = [
     <Button
+      data-cy="modal-button-ok"
       key="rebuild-auto-membership"
       variant="primary"
       onClick={onRebuildAutoMembership}
@@ -431,6 +432,7 @@ const Hosts = () => {
       OK
     </Button>,
     <Button
+      data-cy="modal-button-cancel"
       key="cancel-rebuild-auto-membership"
       variant="link"
       onClick={() => setIsMembershipModalOpen(!isMembershipModalOpen)}
@@ -457,6 +459,7 @@ const Hosts = () => {
 
   const dropdownItems = [
     <DropdownItem
+      data-cy="hosts-kebab-rebuild-auto-membership"
       key="rebuild auto membership"
       component="button"
       onClick={() => setIsMembershipModalOpen(!isMembershipModalOpen)}
@@ -599,6 +602,7 @@ const Hosts = () => {
       key: 1,
       element: (
         <SearchInputLayout
+          dataCy="search"
           name="search"
           ariaLabel="Search hosts"
           placeholder="Search"
@@ -619,6 +623,7 @@ const Hosts = () => {
         <SecondaryButton
           onClickHandler={refreshHostsData}
           isDisabled={!showTableRows}
+          dataCy="hosts-button-refresh"
         >
           Refresh
         </SecondaryButton>
@@ -630,6 +635,7 @@ const Hosts = () => {
         <SecondaryButton
           isDisabled={isDeleteButtonDisabled || !showTableRows}
           onClickHandler={onDeleteHandler}
+          dataCy="hosts-button-delete"
         >
           Delete
         </SecondaryButton>
@@ -641,6 +647,7 @@ const Hosts = () => {
         <SecondaryButton
           onClickHandler={onAddClickHandler}
           isDisabled={!showTableRows || isDisabledDueError}
+          dataCy="hosts-button-add"
         >
           Add
         </SecondaryButton>
@@ -655,6 +662,7 @@ const Hosts = () => {
           idKebab="main-dropdown-kebab"
           isKebabOpen={kebabIsOpen}
           dropdownItems={!showTableRows ? [] : dropdownItems}
+          dataCy="hosts-kebab"
         />
       ),
     },
@@ -733,7 +741,7 @@ const Hosts = () => {
             className="pf-v5-u-pb-0 pf-v5-u-pr-md"
           />
         </PageSection>
-        <ModalErrors errors={modalErrors.getAll()} />
+        <ModalErrors errors={modalErrors.getAll()} dataCy="hosts-modal-error" />
         {isMembershipModalOpen && (
           <ModalWithFormLayout
             variantType="medium"
@@ -745,6 +753,7 @@ const Hosts = () => {
             show={isMembershipModalOpen}
             onClose={() => setIsMembershipModalOpen(!isMembershipModalOpen)}
             actions={membershipModalActions}
+            dataCy="hosts-rebuild-auto-membership-modal"
           />
         )}
         <AddHost

--- a/src/pages/Hosts/HostsSettings.tsx
+++ b/src/pages/Hosts/HostsSettings.tsx
@@ -106,6 +106,7 @@ const HostsSettings = (props: PropsToHostsSettings) => {
 
   const unprovisionHostModalActions = [
     <Button
+      data-cy="modal-button-unprovision"
       key="unprov-host"
       variant="danger"
       onClick={() => onUnprovisionHost(props.host.fqdn ? props.host.fqdn : "")}
@@ -117,7 +118,12 @@ const HostsSettings = (props: PropsToHostsSettings) => {
     >
       {modalSpinning ? "Unprovisioning" : "Unprovision"}
     </Button>,
-    <Button key="cancel" variant="link" onClick={onCloseUnprovisionHostModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel"
+      variant="link"
+      onClick={onCloseUnprovisionHostModal}
+    >
       Cancel
     </Button>,
   ];
@@ -209,6 +215,7 @@ const HostsSettings = (props: PropsToHostsSettings) => {
 
   const membershipModalActions: JSX.Element[] = [
     <Button
+      data-cy="modal-button-ok"
       key="rebuild-auto-membership"
       variant="primary"
       onClick={onRebuildAutoMembership}
@@ -217,6 +224,7 @@ const HostsSettings = (props: PropsToHostsSettings) => {
       OK
     </Button>,
     <Button
+      data-cy="modal-button-cancel"
       key="cancel-rebuild-auto-membership"
       variant="link"
       onClick={() => setIsMembershipModalOpen(!isMembershipModalOpen)}
@@ -228,6 +236,7 @@ const HostsSettings = (props: PropsToHostsSettings) => {
   const dropdownItems = [
     <DropdownItem
       key="rebuild auto membership"
+      data-cy="hosts-tab-settings-kebab-rebuild-auto-membership"
       component="button"
       onClick={() => setIsMembershipModalOpen(!isMembershipModalOpen)}
     >
@@ -235,6 +244,7 @@ const HostsSettings = (props: PropsToHostsSettings) => {
     </DropdownItem>,
     <DropdownItem
       key="unprovision"
+      data-cy="hosts-tab-settings-kebab-unprovision"
       onClick={() => setIsUnprovisionHostModalOpen(true)}
       component="button"
       isDisabled={!props.host.has_keytab}
@@ -243,6 +253,7 @@ const HostsSettings = (props: PropsToHostsSettings) => {
     </DropdownItem>,
     <DropdownItem
       key="set-one-time-password"
+      data-cy="hosts-tab-settings-kebab-set-one-time-password"
       onClick={() => setIsPasswordModalOpen(true)}
       component="button"
     >
@@ -251,6 +262,7 @@ const HostsSettings = (props: PropsToHostsSettings) => {
     <DropdownItem
       key="new certificate"
       component="button"
+      data-cy="hosts-tab-settings-kebab-new-certificate"
       onClick={() => setIsCertModalOpen(true)}
     >
       New certificate
@@ -318,7 +330,10 @@ const HostsSettings = (props: PropsToHostsSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton onClickHandler={props.onRefresh}>
+        <SecondaryButton
+          dataCy="hosts-tab-settings-button-refresh"
+          onClickHandler={props.onRefresh}
+        >
           Refresh
         </SecondaryButton>
       ),
@@ -327,6 +342,7 @@ const HostsSettings = (props: PropsToHostsSettings) => {
       key: 1,
       element: (
         <SecondaryButton
+          dataCy="hosts-tab-settings-button-revert"
           isDisabled={!props.isModified}
           onClickHandler={onRevert}
         >
@@ -338,6 +354,7 @@ const HostsSettings = (props: PropsToHostsSettings) => {
       key: 2,
       element: (
         <SecondaryButton
+          dataCy="hosts-tab-settings-button-save"
           isDisabled={!props.isModified || isSaving}
           onClickHandler={onSave}
           isLoading={isSaving}
@@ -353,6 +370,7 @@ const HostsSettings = (props: PropsToHostsSettings) => {
       key: 3,
       element: (
         <KebabLayout
+          dataCy="hosts-tab-settings-kebab"
           direction={"up"}
           onDropdownSelect={onKebabSelect}
           onKebabToggle={onKebabToggle}
@@ -454,9 +472,10 @@ const HostsSettings = (props: PropsToHostsSettings) => {
           </Flex>
         </SidebarContent>
       </Sidebar>
-      <ModalErrors errors={modalErrors.getAll()} />
+      <ModalErrors errors={modalErrors.getAll()} dataCy="hosts-modal-error" />
       {isMembershipModalOpen && (
         <ModalWithFormLayout
+          dataCy="rebuild-auto-membership-modal"
           variantType="medium"
           modalPosition="top"
           offPosition="76px"
@@ -485,6 +504,7 @@ const HostsSettings = (props: PropsToHostsSettings) => {
         }
       />
       <ConfirmationModal
+        dataCy="unprovision-host-modal"
         title={"Unprovision host"}
         isOpen={isUnprovisionHostModalOpen}
         onClose={onCloseUnprovisionHostModal}

--- a/src/pages/IDViews/IDViews.tsx
+++ b/src/pages/IDViews/IDViews.tsx
@@ -508,6 +508,7 @@ const IDViews = () => {
   };
   const dropdownItems = [
     <DropdownItem
+      data-cy="id-views-kebab-unapply-hosts"
       key="unapply-hosts"
       onClick={openUnapplyHostModal}
       isDisabled={!showTableRows || totalCount === 0}
@@ -515,6 +516,7 @@ const IDViews = () => {
       Unapply from hosts
     </DropdownItem>,
     <DropdownItem
+      data-cy="id-views-kebab-unapply-hostgroups"
       key="unapply-hostgroups"
       onClick={openUnapplyHostgroupModal}
       isDisabled={!showTableRows || totalCount === 0}
@@ -541,6 +543,7 @@ const IDViews = () => {
       key: 1,
       element: (
         <SearchInputLayout
+          dataCy="search"
           name="search"
           ariaLabel="Search ID views"
           placeholder="Search"
@@ -559,6 +562,7 @@ const IDViews = () => {
       key: 3,
       element: (
         <SecondaryButton
+          dataCy="id-views-button-refresh"
           onClickHandler={refreshViewsData}
           isDisabled={!showTableRows}
         >
@@ -570,6 +574,7 @@ const IDViews = () => {
       key: 4,
       element: (
         <SecondaryButton
+          dataCy="id-views-button-delete"
           isDisabled={isDeleteButtonDisabled || !showTableRows}
           onClickHandler={onDeleteHandler}
         >
@@ -581,6 +586,7 @@ const IDViews = () => {
       key: 5,
       element: (
         <SecondaryButton
+          dataCy="id-views-button-add"
           onClickHandler={onAddClickHandler}
           isDisabled={!showTableRows}
         >
@@ -592,6 +598,7 @@ const IDViews = () => {
       key: 6,
       element: (
         <KebabLayout
+          dataCy="id-views-kebab"
           onDropdownSelect={onKebabSelect}
           onKebabToggle={onKebabToggle}
           idKebab="toggle-action-buttons"
@@ -665,7 +672,10 @@ const IDViews = () => {
           className="pf-v5-u-pb-0 pf-v5-u-pr-md"
         />
       </PageSection>
-      <ModalErrors errors={modalErrors.getAll()} />
+      <ModalErrors
+        errors={modalErrors.getAll()}
+        dataCy="id-views-modal-error"
+      />
       <AddIDViewModal
         show={showAddModal}
         handleModalToggle={onAddModalToggle}

--- a/src/pages/IDViews/IDViewsAppliedTo.tsx
+++ b/src/pages/IDViews/IDViewsAppliedTo.tsx
@@ -495,6 +495,7 @@ const IDViewsAppliedTo = (props: AppliesToProps) => {
       key: 1,
       element: (
         <SearchInput
+          data-cy="search"
           name="search"
           placeholder="Search hosts"
           value={searchValue}
@@ -512,7 +513,11 @@ const IDViewsAppliedTo = (props: AppliesToProps) => {
     {
       key: 3,
       element: (
-        <Button variant="secondary" onClick={refreshViewsData}>
+        <Button
+          data-cy="id-views-tab-applied-to-refresh"
+          variant="secondary"
+          onClick={refreshViewsData}
+        >
           Refresh
         </Button>
       ),
@@ -521,11 +526,13 @@ const IDViewsAppliedTo = (props: AppliesToProps) => {
       key: 4,
       element: (
         <Dropdown
+          data-cy="id-views-tab-applied-to-kebab"
           isOpen={isApplyOpen}
           onSelect={onSelectApply}
           onOpenChange={(isApplyOpen: boolean) => setIsApplyOpen(isApplyOpen)}
           toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
             <MenuToggle
+              data-cy="id-views-tab-applied-to-kebab-apply-toggle"
               className="pf-m-small"
               ref={toggleRef}
               onClick={onToggleClickApply}
@@ -541,6 +548,7 @@ const IDViewsAppliedTo = (props: AppliesToProps) => {
         >
           <DropdownList>
             <DropdownItem
+              data-cy="id-views-tab-applied-to-kebab-apply-hosts"
               value={1}
               key="apply-hosts"
               onClick={() => setShowApplyHostModal(true)}
@@ -548,6 +556,7 @@ const IDViewsAppliedTo = (props: AppliesToProps) => {
               Apply hosts
             </DropdownItem>
             <DropdownItem
+              data-cy="id-views-tab-applied-to-kebab-apply-host-groups"
               value={2}
               key="apply-host-groups"
               onClick={() => setShowApplyHostGroupModal(true)}
@@ -562,6 +571,7 @@ const IDViewsAppliedTo = (props: AppliesToProps) => {
       key: 5,
       element: (
         <Dropdown
+          data-cy="id-views-tab-applied-to-kebab-unapply"
           isOpen={isUnapplyOpen}
           onSelect={onSelectUnapply}
           onOpenChange={(isUnapplyOpen: boolean) =>
@@ -569,6 +579,7 @@ const IDViewsAppliedTo = (props: AppliesToProps) => {
           }
           toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
             <MenuToggle
+              data-cy="id-views-tab-applied-to-kebab-unapply-toggle"
               ref={toggleRef}
               onClick={onToggleClickUnapply}
               isExpanded={isUnapplyOpen}
@@ -582,6 +593,7 @@ const IDViewsAppliedTo = (props: AppliesToProps) => {
         >
           <DropdownList>
             <DropdownItem
+              data-cy="id-views-tab-applied-to-kebab-unapply-hosts"
               value={1}
               key="unapply-hosts"
               onClick={() => setShowUnapplyHostsModal(true)}
@@ -590,6 +602,7 @@ const IDViewsAppliedTo = (props: AppliesToProps) => {
               Unapply hosts
             </DropdownItem>
             <DropdownItem
+              data-cy="id-views-tab-applied-to-kebab-unapply-host-groups"
               value={2}
               key="unapply-host-groups"
               onClick={() => setShowUnapplyHostGroupModal(true)}
@@ -656,7 +669,10 @@ const IDViewsAppliedTo = (props: AppliesToProps) => {
           className="pf-v5-u-pb-0 pf-v5-u-pr-md pf-v5-u-mt-md"
         />
       </PageSection>
-      <ModalErrors errors={modalErrors.getAll()} />
+      <ModalErrors
+        errors={modalErrors.getAll()}
+        dataCy="id-views-tab-applied-to-modal-error"
+      />
       <DualListLayout
         entry={""}
         target={"hostgroup"}

--- a/src/pages/IDViews/IDViewsOverrideGroups.tsx
+++ b/src/pages/IDViews/IDViewsOverrideGroups.tsx
@@ -307,7 +307,12 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
       key: 0,
       element: (
         <Tooltip aria="none" aria-live="polite" content={tooltipMsg}>
-          <Button aria-label="Search tips" variant="plain" id="search_tip">
+          <Button
+            data-cy="search"
+            aria-label="Search tips"
+            variant="plain"
+            id="search_tip"
+          >
             <OutlinedQuestionCircleIcon />
           </Button>
         </Tooltip>
@@ -318,6 +323,7 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
       key: 1,
       element: (
         <SearchInputLayout
+          dataCy="search"
           name="search"
           ariaLabel="Search groups"
           placeholder="Search"
@@ -335,7 +341,10 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
     {
       key: 3,
       element: (
-        <SecondaryButton onClickHandler={props.onRefresh}>
+        <SecondaryButton
+          dataCy="id-views-tab-override-groups-button-refresh"
+          onClickHandler={props.onRefresh}
+        >
           Refresh
         </SecondaryButton>
       ),
@@ -344,6 +353,7 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
       key: 4,
       element: (
         <SecondaryButton
+          dataCy="id-views-tab-override-groups-button-delete"
           isDisabled={isDeleteButtonDisabled || !showTableRows}
           onClickHandler={onDeleteHandler}
         >
@@ -355,6 +365,7 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
       key: 5,
       element: (
         <SecondaryButton
+          dataCy="id-views-tab-override-groups-button-add"
           onClickHandler={onAddClickHandler}
           isDisabled={!showTableRows}
         >

--- a/src/pages/IDViews/IDViewsOverrideUsers.tsx
+++ b/src/pages/IDViews/IDViewsOverrideUsers.tsx
@@ -295,6 +295,7 @@ const IDViewsOverrideUsers = (props: PropsToOverrides) => {
       key: 1,
       element: (
         <SearchInputLayout
+          dataCy="search"
           name="search"
           ariaLabel="Search users"
           placeholder="Search"
@@ -312,7 +313,10 @@ const IDViewsOverrideUsers = (props: PropsToOverrides) => {
     {
       key: 3,
       element: (
-        <SecondaryButton onClickHandler={props.onRefresh}>
+        <SecondaryButton
+          dataCy="id-views-tab-override-users-button-refresh"
+          onClickHandler={props.onRefresh}
+        >
           Refresh
         </SecondaryButton>
       ),
@@ -321,6 +325,7 @@ const IDViewsOverrideUsers = (props: PropsToOverrides) => {
       key: 4,
       element: (
         <SecondaryButton
+          dataCy="id-views-tab-override-users-button-delete"
           isDisabled={isDeleteButtonDisabled || !showTableRows}
           onClickHandler={onDeleteHandler}
         >
@@ -332,6 +337,7 @@ const IDViewsOverrideUsers = (props: PropsToOverrides) => {
       key: 5,
       element: (
         <SecondaryButton
+          dataCy="id-views-tab-override-users-button-add"
           onClickHandler={onAddClickHandler}
           isDisabled={!showTableRows}
         >

--- a/src/pages/IDViews/IDViewsSettings.tsx
+++ b/src/pages/IDViews/IDViewsSettings.tsx
@@ -86,7 +86,10 @@ const IDViewSettings = (props: PropsToIDViewSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton onClickHandler={props.onRefresh}>
+        <SecondaryButton
+          dataCy="id-views-tab-settings-button-refresh"
+          onClickHandler={props.onRefresh}
+        >
           Refresh
         </SecondaryButton>
       ),
@@ -95,6 +98,7 @@ const IDViewSettings = (props: PropsToIDViewSettings) => {
       key: 1,
       element: (
         <SecondaryButton
+          dataCy="id-views-tab-settings-button-revert"
           isDisabled={!props.isModified}
           onClickHandler={onRevert}
         >
@@ -106,6 +110,7 @@ const IDViewSettings = (props: PropsToIDViewSettings) => {
       key: 2,
       element: (
         <SecondaryButton
+          dataCy="id-views-tab-settings-button-save"
           isDisabled={!props.isModified || isSaving}
           onClickHandler={onSave}
           isLoading={isSaving}
@@ -153,6 +158,7 @@ const IDViewSettings = (props: PropsToIDViewSettings) => {
             }
           >
             <IpaTextInput
+              dataCy="id-views-tab-settings-textbox-ipadomainresolutionorder"
               name="ipadomainresolutionorder"
               ariaLabel={"Domain resolution order"}
               ipaObject={ipaObject}
@@ -163,6 +169,7 @@ const IDViewSettings = (props: PropsToIDViewSettings) => {
           </FormGroup>
           <FormGroup label="Description" fieldId="description">
             <IpaTextArea
+              dataCy="id-views-tab-settings-textbox-description"
               name="description"
               ipaObject={ipaObject}
               onChange={recordOnChange}

--- a/src/pages/IdPReferences/IdpReferences.tsx
+++ b/src/pages/IdPReferences/IdpReferences.tsx
@@ -346,6 +346,7 @@ const IdpReferences = () => {
       key: 1,
       element: (
         <SearchInputLayout
+          dataCy="search"
           name="search"
           ariaLabel="Search subIds"
           placeholder="Search"
@@ -364,6 +365,7 @@ const IdpReferences = () => {
       key: 3,
       element: (
         <SecondaryButton
+          dataCy="idp-references-button-refresh"
           onClickHandler={refreshData}
           isDisabled={!showTableRows}
         >
@@ -375,6 +377,7 @@ const IdpReferences = () => {
       key: 4,
       element: (
         <SecondaryButton
+          dataCy="idp-references-button-delete"
           isDisabled={isDeleteButtonDisabled || !showTableRows}
           onClickHandler={onOpenDeleteModal}
         >
@@ -386,6 +389,7 @@ const IdpReferences = () => {
       key: 5,
       element: (
         <SecondaryButton
+          dataCy="idp-references-button-add"
           isDisabled={!showTableRows}
           onClickHandler={onOpenAddModal}
         >

--- a/src/pages/IdPReferences/IdpReferencesSettings.tsx
+++ b/src/pages/IdPReferences/IdpReferencesSettings.tsx
@@ -148,6 +148,7 @@ const IdpRefSettings = (props: PropsToIdpRefSettings) => {
 
   const kebabItems = [
     <DropdownItem
+      data-cy="idp-references-tab-settings-kebab-reset-password"
       key="reset password"
       onClick={() => setIsResetPasswordModalOpen(true)}
     >
@@ -160,7 +161,10 @@ const IdpRefSettings = (props: PropsToIdpRefSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton onClickHandler={props.onRefresh}>
+        <SecondaryButton
+          dataCy="idp-references-tab-settings-button-refresh"
+          onClickHandler={props.onRefresh}
+        >
           Refresh
         </SecondaryButton>
       ),
@@ -169,6 +173,7 @@ const IdpRefSettings = (props: PropsToIdpRefSettings) => {
       key: 1,
       element: (
         <SecondaryButton
+          dataCy="idp-references-tab-settings-button-revert"
           isDisabled={!props.isModified || isDataLoading}
           onClickHandler={onRevert}
         >
@@ -180,6 +185,7 @@ const IdpRefSettings = (props: PropsToIdpRefSettings) => {
       key: 2,
       element: (
         <SecondaryButton
+          dataCy="idp-references-tab-settings-button-save"
           isDisabled={!props.isModified || isDataLoading}
           onClickHandler={onSave}
         >
@@ -191,6 +197,7 @@ const IdpRefSettings = (props: PropsToIdpRefSettings) => {
       key: 3,
       element: (
         <KebabLayout
+          dataCy="idp-references-tab-settings-kebab"
           direction={"up"}
           onDropdownSelect={() => setIsKebabOpen(!isKebabOpen)}
           onKebabToggle={() => setIsKebabOpen(!isKebabOpen)}
@@ -247,6 +254,7 @@ const IdpRefSettings = (props: PropsToIdpRefSettings) => {
                     role="group"
                   >
                     <IpaTextContent
+                      dataCy="idp-references-tab-settings-textbox-cn"
                       name={"cn"}
                       ariaLabel={"Identity Provider reference name"}
                       ipaObject={ipaObject}
@@ -260,6 +268,7 @@ const IdpRefSettings = (props: PropsToIdpRefSettings) => {
                     isRequired
                   >
                     <IpaTextInput
+                      dataCy="idp-references-tab-settings-textbox-ipaidpclientid"
                       name={"ipaidpclientid"}
                       ariaLabel={"Client identifier"}
                       ipaObject={ipaObject}
@@ -270,6 +279,7 @@ const IdpRefSettings = (props: PropsToIdpRefSettings) => {
                   </FormGroup>
                   <FormGroup label="Secret" fieldId="ipaidpclientsecret">
                     <IpaPasswordInput
+                      dataCy="idp-references-tab-settings-textbox-ipaidpclientsecret"
                       name={"ipaidpclientsecret"}
                       ariaLabel={"Secret"}
                       ipaObject={ipaObject}
@@ -293,6 +303,7 @@ const IdpRefSettings = (props: PropsToIdpRefSettings) => {
                 <Form className="pf-v5-u-mb-lg">
                   <FormGroup label="Scope" fieldId="ipaidpscope">
                     <IpaTextInput
+                      dataCy="idp-references-tab-settings-textbox-ipaidpscope"
                       name={"ipaidpscope"}
                       ariaLabel={"Scope"}
                       ipaObject={ipaObject}
@@ -306,6 +317,7 @@ const IdpRefSettings = (props: PropsToIdpRefSettings) => {
                     fieldId="ipaidpsub"
                   >
                     <IpaTextInput
+                      dataCy="idp-references-tab-settings-textbox-ipaidpsub"
                       name={"ipaidpsub"}
                       ariaLabel={"External IdP user identifier attribute"}
                       ipaObject={ipaObject}
@@ -319,6 +331,7 @@ const IdpRefSettings = (props: PropsToIdpRefSettings) => {
                     fieldId="ipaidpauthendpoint"
                   >
                     <IpaTextInput
+                      dataCy="idp-references-tab-settings-textbox-ipaidpauthendpoint"
                       name={"ipaidpauthendpoint"}
                       ariaLabel={"Authorization URI"}
                       ipaObject={ipaObject}
@@ -332,6 +345,7 @@ const IdpRefSettings = (props: PropsToIdpRefSettings) => {
                     fieldId="ipaidpdevauthendpoint"
                   >
                     <IpaTextInput
+                      dataCy="idp-references-tab-settings-textbox-ipaidpdevauthendpoint"
                       name={"ipaidpdevauthendpoint"}
                       ariaLabel={"Device authorization URI"}
                       ipaObject={ipaObject}
@@ -342,6 +356,7 @@ const IdpRefSettings = (props: PropsToIdpRefSettings) => {
                   </FormGroup>
                   <FormGroup label="Token URI" fieldId="ipaidptokenendpoint">
                     <IpaTextInput
+                      dataCy="idp-references-tab-settings-textbox-ipaidptokenendpoint"
                       name={"ipaidptokenendpoint"}
                       ariaLabel={"Token URI"}
                       ipaObject={ipaObject}
@@ -355,6 +370,7 @@ const IdpRefSettings = (props: PropsToIdpRefSettings) => {
                     fieldId="ipaidpuserinfoendpoint"
                   >
                     <IpaTextInput
+                      dataCy="idp-references-tab-settings-textbox-ipaidpuserinfoendpoint"
                       name={"ipaidpuserinfoendpoint"}
                       ariaLabel={"User info URI"}
                       ipaObject={ipaObject}
@@ -365,6 +381,7 @@ const IdpRefSettings = (props: PropsToIdpRefSettings) => {
                   </FormGroup>
                   <FormGroup label="JWKS URI" fieldId="ipaidpkeysendpoint">
                     <IpaTextInput
+                      dataCy="idp-references-tab-settings-textbox-ipaidpkeysendpoint"
                       name={"ipaidpkeysendpoint"}
                       ariaLabel={"JWKS URI"}
                       ipaObject={ipaObject}
@@ -375,6 +392,7 @@ const IdpRefSettings = (props: PropsToIdpRefSettings) => {
                   </FormGroup>
                   <FormGroup label="OIDC URL" fieldId="ipaidpissuerurl">
                     <IpaTextInput
+                      dataCy="idp-references-tab-settings-textbox-ipaidpissuerurl"
                       name={"ipaidpissuerurl"}
                       ariaLabel={"OIDC URL"}
                       ipaObject={ipaObject}

--- a/src/pages/KrbTicketPolicy/KrbTicketPolicy.tsx
+++ b/src/pages/KrbTicketPolicy/KrbTicketPolicy.tsx
@@ -141,7 +141,10 @@ const KrbTicketPolicy = () => {
     {
       key: 0,
       element: (
-        <SecondaryButton onClickHandler={krbTicketPolicyData.refetch}>
+        <SecondaryButton
+          dataCy="krb-ticket-policy-button-refresh"
+          onClickHandler={krbTicketPolicyData.refetch}
+        >
           Refresh
         </SecondaryButton>
       ),
@@ -150,6 +153,7 @@ const KrbTicketPolicy = () => {
       key: 1,
       element: (
         <SecondaryButton
+          dataCy="krb-ticket-policy-button-revert"
           isDisabled={!krbTicketPolicyData.modified || isDataLoading}
           onClickHandler={onRevert}
         >
@@ -161,6 +165,7 @@ const KrbTicketPolicy = () => {
       key: 2,
       element: (
         <SecondaryButton
+          dataCy="krb-ticket-policy-button-save"
           isDisabled={!krbTicketPolicyData.modified || isDataLoading}
           onClickHandler={onSave}
         >
@@ -232,6 +237,7 @@ const KrbTicketPolicy = () => {
                     fieldId="krbmaxrenewableage"
                   >
                     <IpaTextInput
+                      dataCy="krb-ticket-policy-textbox-max-renew"
                       name={"krbmaxrenewableage"}
                       ariaLabel={"Max renew (seconds)"}
                       ipaObject={ipaObject}
@@ -249,6 +255,7 @@ const KrbTicketPolicy = () => {
                     fieldId="krbmaxticketlife"
                   >
                     <IpaTextInput
+                      dataCy="krb-ticket-policy-textbox-max-life"
                       name={"krbmaxticketlife"}
                       ariaLabel={"Max life (seconds)"}
                       ipaObject={ipaObject}
@@ -275,6 +282,7 @@ const KrbTicketPolicy = () => {
                     fieldId="krbauthindmaxrenewableage_radius"
                   >
                     <IpaTextInput
+                      dataCy="krb-ticket-policy-textbox-radius-max-renew"
                       name={"krbauthindmaxrenewableage_radius"}
                       ariaLabel={"RADIUS max renew (seconds)"}
                       ipaObject={ipaObject}
@@ -288,6 +296,7 @@ const KrbTicketPolicy = () => {
                     fieldId="krbauthindmaxticketlife_radius"
                   >
                     <IpaTextInput
+                      dataCy="krb-ticket-policy-textbox-radius-max-life"
                       name={"krbauthindmaxticketlife_radius"}
                       ariaLabel={"RADIUS max life (seconds)"}
                       ipaObject={ipaObject}
@@ -301,6 +310,7 @@ const KrbTicketPolicy = () => {
                     fieldId="krbauthindmaxrenewableage_otp"
                   >
                     <IpaTextInput
+                      dataCy="krb-ticket-policy-textbox-otp-max-renew"
                       name={"krbauthindmaxrenewableage_otp"}
                       ariaLabel={"OTP max renew (seconds)"}
                       ipaObject={ipaObject}
@@ -314,6 +324,7 @@ const KrbTicketPolicy = () => {
                     fieldId="krbauthindmaxticketlife_otp"
                   >
                     <IpaTextInput
+                      dataCy="krb-ticket-policy-textbox-otp-max-life"
                       name={"krbauthindmaxticketlife_otp"}
                       ariaLabel={"OTP max life (seconds)"}
                       ipaObject={ipaObject}
@@ -327,6 +338,7 @@ const KrbTicketPolicy = () => {
                     fieldId="krbauthindmaxrenewableage_pkinit"
                   >
                     <IpaTextInput
+                      dataCy="krb-ticket-policy-textbox-pkinit-max-renew"
                       name={"krbauthindmaxrenewableage_pkinit"}
                       ariaLabel={"PKINIT max renew (seconds)"}
                       ipaObject={ipaObject}
@@ -340,6 +352,7 @@ const KrbTicketPolicy = () => {
                     fieldId="krbauthindmaxticketlife_pkinit"
                   >
                     <IpaTextInput
+                      dataCy="krb-ticket-policy-textbox-pkinit-max-life"
                       name={"krbauthindmaxticketlife_pkinit"}
                       ariaLabel={"PKINIT max life (seconds)"}
                       ipaObject={ipaObject}
@@ -357,6 +370,7 @@ const KrbTicketPolicy = () => {
                     fieldId="krbauthindmaxrenewableage_hardened"
                   >
                     <IpaTextInput
+                      dataCy="krb-ticket-policy-textbox-hardened-max-renew"
                       name={"krbauthindmaxrenewableage_hardened"}
                       ariaLabel={"Hardened max renew (seconds)"}
                       ipaObject={ipaObject}
@@ -370,6 +384,7 @@ const KrbTicketPolicy = () => {
                     fieldId="krbauthindmaxticketlife_hardened"
                   >
                     <IpaTextInput
+                      dataCy="krb-ticket-policy-textbox-hardened-max-life"
                       name={"krbauthindmaxticketlife_hardened"}
                       ariaLabel={"Hardened max life (seconds)"}
                       ipaObject={ipaObject}
@@ -383,6 +398,7 @@ const KrbTicketPolicy = () => {
                     fieldId="krbauthindmaxrenewableage_idp"
                   >
                     <IpaTextInput
+                      dataCy="krb-ticket-policy-textbox-idp-max-renew"
                       name={"krbauthindmaxrenewableage_idp"}
                       ariaLabel={"IdP max renew (seconds)"}
                       ipaObject={ipaObject}
@@ -396,6 +412,7 @@ const KrbTicketPolicy = () => {
                     fieldId="krbauthindmaxticketlife_idp"
                   >
                     <IpaTextInput
+                      dataCy="krb-ticket-policy-textbox-idp-max-life"
                       name={"krbauthindmaxticketlife_idp"}
                       ariaLabel={"IdP max life (seconds)"}
                       ipaObject={ipaObject}
@@ -409,6 +426,7 @@ const KrbTicketPolicy = () => {
                     fieldId="krbauthindmaxrenewableage_passkey"
                   >
                     <IpaTextInput
+                      dataCy="krb-ticket-policy-textbox-passkey-max-renew"
                       name={"krbauthindmaxrenewableage_passkey"}
                       ariaLabel={"Passkey max renew (seconds)"}
                       ipaObject={ipaObject}
@@ -422,6 +440,7 @@ const KrbTicketPolicy = () => {
                     fieldId="krbauthindmaxticketlife_passkey"
                   >
                     <IpaTextInput
+                      dataCy="krb-ticket-policy-textbox-passkey-max-life"
                       name={"krbauthindmaxticketlife_passkey"}
                       ariaLabel={"Passkey max life (seconds)"}
                       ipaObject={ipaObject}

--- a/src/pages/Netgroups/Netgroups.tsx
+++ b/src/pages/Netgroups/Netgroups.tsx
@@ -420,6 +420,7 @@ const Netgroups = () => {
       key: 1,
       element: (
         <SearchInputLayout
+          dataCy="search"
           name="search"
           ariaLabel="Search netgroups"
           placeholder="Search"
@@ -440,6 +441,7 @@ const Netgroups = () => {
         <SecondaryButton
           onClickHandler={refreshGroupsData}
           isDisabled={!showTableRows}
+          dataCy="netgroups-button-refresh"
         >
           Refresh
         </SecondaryButton>
@@ -451,6 +453,7 @@ const Netgroups = () => {
         <SecondaryButton
           isDisabled={isDeleteButtonDisabled || !showTableRows}
           onClickHandler={onDeleteHandler}
+          dataCy="netgroups-button-delete"
         >
           Delete
         </SecondaryButton>
@@ -462,6 +465,7 @@ const Netgroups = () => {
         <SecondaryButton
           onClickHandler={onAddClickHandler}
           isDisabled={!showTableRows}
+          dataCy="netgroups-button-add"
         >
           Add
         </SecondaryButton>
@@ -532,7 +536,10 @@ const Netgroups = () => {
           className="pf-v5-u-pb-0 pf-v5-u-pr-md"
         />
       </PageSection>
-      <ModalErrors errors={modalErrors.getAll()} />
+      <ModalErrors
+        errors={modalErrors.getAll()}
+        dataCy="netgroups-modal-error"
+      />
       <AddNetgroup
         show={showAddModal}
         handleModalToggle={onAddModalToggle}

--- a/src/pages/Netgroups/NetgroupsMemberTable.tsx
+++ b/src/pages/Netgroups/NetgroupsMemberTable.tsx
@@ -489,12 +489,14 @@ const NetgroupsMemberTable = (props: PropsToTable) => {
         />
       )}
       <Modal
+        data-cy="add-external-host-modal"
         variant="small"
         title={"Add external host"}
         isOpen={modalOpen}
         onClose={closeExternalModal}
         actions={[
           <Button
+            data-cy="modal-button-add"
             key="add-new-host"
             isDisabled={
               externalHostName === "" ||
@@ -509,6 +511,7 @@ const NetgroupsMemberTable = (props: PropsToTable) => {
             {addSpinning ? "Adding" : "Add"}
           </Button>,
           <Button
+            data-cy="modal-button-cancel"
             key="cancel-new-host"
             variant="link"
             onClick={closeExternalModal}
@@ -525,6 +528,7 @@ const NetgroupsMemberTable = (props: PropsToTable) => {
             isRequired
           >
             <TextInput
+              data-cy="modal-textbox-external-host-name"
               type="text"
               id="externalHostName"
               name="externalHostName"

--- a/src/pages/Netgroups/NetgroupsSettings.tsx
+++ b/src/pages/Netgroups/NetgroupsSettings.tsx
@@ -151,7 +151,10 @@ const NetgroupsSettings = (props: PropsToGroupsSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton onClickHandler={props.onRefresh}>
+        <SecondaryButton
+          dataCy="netgroups-tab-settings-button-refresh"
+          onClickHandler={props.onRefresh}
+        >
           Refresh
         </SecondaryButton>
       ),
@@ -160,6 +163,7 @@ const NetgroupsSettings = (props: PropsToGroupsSettings) => {
       key: 1,
       element: (
         <SecondaryButton
+          dataCy="netgroups-tab-settings-button-revert"
           isDisabled={!props.isModified}
           onClickHandler={onRevert}
         >
@@ -171,6 +175,7 @@ const NetgroupsSettings = (props: PropsToGroupsSettings) => {
       key: 2,
       element: (
         <SecondaryButton
+          dataCy="netgroups-tab-settings-button-save"
           isDisabled={!props.isModified || isSaving}
           onClickHandler={onSave}
           isLoading={isSaving}
@@ -201,6 +206,7 @@ const NetgroupsSettings = (props: PropsToGroupsSettings) => {
         >
           <FormGroup label="Description" fieldId="description">
             <IpaTextArea
+              dataCy="netgroups-tab-settings-textbox-description"
               name="description"
               ipaObject={ipaObject}
               onChange={recordOnChange}
@@ -210,6 +216,7 @@ const NetgroupsSettings = (props: PropsToGroupsSettings) => {
           </FormGroup>
           <FormGroup label="NIS domain name" fieldId="nisdomainname">
             <IpaTextInput
+              dataCy="netgroups-tab-settings-textbox-nisdomainname"
               name="nisdomainname"
               ariaLabel={"NIS domain name"}
               ipaObject={ipaObject}
@@ -227,6 +234,7 @@ const NetgroupsSettings = (props: PropsToGroupsSettings) => {
           className="pf-v5-u-mt-lg"
         />
         <IpaCheckbox
+          dataCy="netgroups-tab-settings-checkbox-usercategory"
           name="usercategory"
           value="usercategory"
           text="Allow anyone"
@@ -292,6 +300,7 @@ const NetgroupsSettings = (props: PropsToGroupsSettings) => {
           className="pf-v5-u-mt-xl"
         />
         <IpaCheckbox
+          dataCy="netgroups-tab-settings-checkbox-hostcategory"
           name="hostcategory"
           value="hostcategory"
           text="Allow any host"

--- a/src/pages/PasswordPolicies/PasswordPolicies.tsx
+++ b/src/pages/PasswordPolicies/PasswordPolicies.tsx
@@ -381,6 +381,7 @@ const PasswordPolicies = () => {
       key: 1,
       element: (
         <SearchInputLayout
+          dataCy="search"
           name="search"
           ariaLabel="Search subIds"
           placeholder="Search"
@@ -399,6 +400,7 @@ const PasswordPolicies = () => {
       key: 3,
       element: (
         <SecondaryButton
+          dataCy="password-policies-button-refresh"
           onClickHandler={refreshData}
           isDisabled={!showTableRows}
         >
@@ -410,6 +412,7 @@ const PasswordPolicies = () => {
       key: 4,
       element: (
         <SecondaryButton
+          dataCy="password-policies-button-delete"
           isDisabled={isDeleteButtonDisabled || !showTableRows}
           onClickHandler={onOpenDeleteModal}
         >
@@ -421,6 +424,7 @@ const PasswordPolicies = () => {
       key: 5,
       element: (
         <SecondaryButton
+          dataCy="password-policies-button-add"
           isDisabled={!showTableRows}
           onClickHandler={onOpenAddModal}
         >

--- a/src/pages/PasswordPolicies/PasswordPoliciesSettings.tsx
+++ b/src/pages/PasswordPolicies/PasswordPoliciesSettings.tsx
@@ -140,7 +140,10 @@ const PasswordPolicySettings = (props: PropsToPwPolicySettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton onClickHandler={props.onRefresh}>
+        <SecondaryButton
+          onClickHandler={props.onRefresh}
+          dataCy="password-policies-button-refresh"
+        >
           Refresh
         </SecondaryButton>
       ),
@@ -151,6 +154,7 @@ const PasswordPolicySettings = (props: PropsToPwPolicySettings) => {
         <SecondaryButton
           isDisabled={!props.isModified || isDataLoading}
           onClickHandler={onRevert}
+          dataCy="password-policies-button-revert"
         >
           Revert
         </SecondaryButton>
@@ -162,6 +166,7 @@ const PasswordPolicySettings = (props: PropsToPwPolicySettings) => {
         <SecondaryButton
           isDisabled={!props.isModified || isDataLoading}
           onClickHandler={onSave}
+          dataCy="password-policies-button-save"
         >
           Save
         </SecondaryButton>
@@ -189,6 +194,7 @@ const PasswordPolicySettings = (props: PropsToPwPolicySettings) => {
                 <Form className="pf-v5-u-mb-lg">
                   <FormGroup label="Group" fieldId="group" role="group">
                     <IpaTextContent
+                      dataCy="password-policies-text-group"
                       name={"cn"}
                       ariaLabel={"Group"}
                       ipaObject={ipaObject}
@@ -204,6 +210,7 @@ const PasswordPolicySettings = (props: PropsToPwPolicySettings) => {
                     fieldId="krbmaxpwdlife"
                   >
                     <IpaTextInput
+                      dataCy="password-policies-tab-settings-textbox-max-lifetime"
                       name={"krbmaxpwdlife"}
                       ariaLabel={"Max lifetime in days"}
                       ipaObject={ipaObject}
@@ -217,6 +224,7 @@ const PasswordPolicySettings = (props: PropsToPwPolicySettings) => {
                     fieldId="krbminpwdlife"
                   >
                     <IpaTextInput
+                      dataCy="password-policies-tab-settings-textbox-min-lifetime"
                       name={"krbminpwdlife"}
                       ariaLabel={"Min lifetime in hours"}
                       ipaObject={ipaObject}
@@ -230,6 +238,7 @@ const PasswordPolicySettings = (props: PropsToPwPolicySettings) => {
                     fieldId="krbpwdhistorylength"
                   >
                     <IpaTextInput
+                      dataCy="password-policies-tab-settings-textbox-history-size"
                       name={"krbpwdhistorylength"}
                       ariaLabel={"History size by number of passwords"}
                       ipaObject={ipaObject}
@@ -243,6 +252,7 @@ const PasswordPolicySettings = (props: PropsToPwPolicySettings) => {
                     fieldId="krbpwdmindiffchars"
                   >
                     <IpaTextInput
+                      dataCy="password-policies-tab-settings-textbox-character-classes"
                       name={"krbpwdmindiffchars"}
                       ariaLabel={"Character classes"}
                       ipaObject={ipaObject}
@@ -253,6 +263,7 @@ const PasswordPolicySettings = (props: PropsToPwPolicySettings) => {
                   </FormGroup>
                   <FormGroup label="Min length" fieldId="krbpwdminlength">
                     <IpaTextInput
+                      dataCy="password-policies-tab-settings-textbox-min-length"
                       name={"krbpwdminlength"}
                       ariaLabel={"Min length"}
                       ipaObject={ipaObject}
@@ -263,6 +274,7 @@ const PasswordPolicySettings = (props: PropsToPwPolicySettings) => {
                   </FormGroup>
                   <FormGroup label="Max failures" fieldId="krbpwdmaxfailure">
                     <IpaTextInput
+                      dataCy="password-policies-tab-settings-textbox-max-failures"
                       name={"krbpwdmaxfailure"}
                       ariaLabel={"Max failures"}
                       ipaObject={ipaObject}
@@ -276,6 +288,7 @@ const PasswordPolicySettings = (props: PropsToPwPolicySettings) => {
                     fieldId="krbpwdfailurecountinterval"
                   >
                     <IpaTextInput
+                      dataCy="password-policies-tab-settings-textbox-failure-reset-interval"
                       name={"krbpwdfailurecountinterval"}
                       ariaLabel={"Failure reset interval in seconds"}
                       ipaObject={ipaObject}
@@ -289,6 +302,7 @@ const PasswordPolicySettings = (props: PropsToPwPolicySettings) => {
                     fieldId="krbpwdlockoutduration"
                   >
                     <IpaTextInput
+                      dataCy="password-policies-tab-settings-textbox-lockout-duration"
                       name={"krbpwdlockoutduration"}
                       ariaLabel={"Lockout duration in seconds"}
                       ipaObject={ipaObject}
@@ -299,6 +313,7 @@ const PasswordPolicySettings = (props: PropsToPwPolicySettings) => {
                   </FormGroup>
                   <FormGroup label="Priority" fieldId="cospriority" isRequired>
                     <IpaTextInput
+                      dataCy="password-policies-tab-settings-textbox-priority"
                       name={"cospriority"}
                       ariaLabel={"Priority"}
                       ipaObject={ipaObject}
@@ -312,6 +327,7 @@ const PasswordPolicySettings = (props: PropsToPwPolicySettings) => {
                     fieldId="passwordgracelimit"
                   >
                     <IpaTextInput
+                      dataCy="password-policies-tab-settings-textbox-grace-login-limit"
                       name={"passwordgracelimit"}
                       ariaLabel={"Grace login limit"}
                       ipaObject={ipaObject}

--- a/src/pages/PreservedUsers/PreservedUsers.tsx
+++ b/src/pages/PreservedUsers/PreservedUsers.tsx
@@ -446,6 +446,7 @@ const PreservedUsers = () => {
       key: 1,
       element: (
         <SearchInputLayout
+          dataCy="search"
           name="search"
           ariaLabel="Search user"
           placeholder="Search"
@@ -466,6 +467,7 @@ const PreservedUsers = () => {
         <SecondaryButton
           onClickHandler={refreshUsersData}
           isDisabled={!showTableRows}
+          dataCy="preserved-users-button-refresh"
         >
           Refresh
         </SecondaryButton>
@@ -477,6 +479,7 @@ const PreservedUsers = () => {
         <SecondaryButton
           isDisabled={isDeleteButtonDisabled || !showTableRows}
           onClickHandler={onDeleteHandler}
+          dataCy="preserved-users-button-delete"
         >
           Delete
         </SecondaryButton>
@@ -488,6 +491,7 @@ const PreservedUsers = () => {
         <SecondaryButton
           isDisabled={!showTableRows || selectedUsers.length === 0}
           onClickHandler={onRestoreHandler}
+          dataCy="preserved-users-button-restore"
         >
           Restore
         </SecondaryButton>
@@ -499,6 +503,7 @@ const PreservedUsers = () => {
         <SecondaryButton
           isDisabled={!showTableRows || selectedUsers.length === 0}
           onClickHandler={onStageHandler}
+          dataCy="preserved-users-button-stage"
         >
           Stage
         </SecondaryButton>
@@ -584,7 +589,10 @@ const PreservedUsers = () => {
             className="pf-v5-u-pb-0 pf-v5-u-pr-md"
           />
         </PageSection>
-        <ModalErrors errors={modalErrors.getAll()} />
+        <ModalErrors
+          errors={modalErrors.getAll()}
+          dataCy="preserved-users-modal-error"
+        />
         <DeleteUsers
           show={showDeleteModal}
           from="preserved-users"

--- a/src/pages/Services/Services.tsx
+++ b/src/pages/Services/Services.tsx
@@ -469,6 +469,7 @@ const Services = () => {
       key: 1,
       element: (
         <SearchInputLayout
+          dataCy="search"
           name="search"
           ariaLabel="Search services"
           placeholder="Search"
@@ -489,6 +490,7 @@ const Services = () => {
         <SecondaryButton
           onClickHandler={refreshServicesData}
           isDisabled={!showTableRows}
+          dataCy="services-button-refresh"
         >
           Refresh
         </SecondaryButton>
@@ -500,6 +502,7 @@ const Services = () => {
         <SecondaryButton
           isDisabled={isDeleteButtonDisabled}
           onClickHandler={onDeleteHandler}
+          dataCy="services-button-delete"
         >
           Delete
         </SecondaryButton>
@@ -511,6 +514,7 @@ const Services = () => {
         <SecondaryButton
           isDisabled={!showTableRows}
           onClickHandler={onAddClickHandler}
+          dataCy="services-button-add"
         >
           Add
         </SecondaryButton>
@@ -592,7 +596,10 @@ const Services = () => {
             className="pf-v5-u-pb-0 pf-v5-u-pr-md"
           />
         </PageSection>
-        <ModalErrors errors={modalErrors.getAll()} />
+        <ModalErrors
+          errors={modalErrors.getAll()}
+          dataCy="services-modal-error"
+        />
         <AddService
           show={showAddModal}
           handleModalToggle={onAddModalToggle}

--- a/src/pages/Services/ServicesSettings.tsx
+++ b/src/pages/Services/ServicesSettings.tsx
@@ -97,6 +97,7 @@ const ServicesSettings = (props: PropsToServicesSettings) => {
 
   const unprovisionModalActions = [
     <Button
+      data-cy="modal-button-unprovision"
       key="unprov-host"
       variant="danger"
       onClick={() => onUnprovision()}
@@ -108,7 +109,12 @@ const ServicesSettings = (props: PropsToServicesSettings) => {
     >
       {modalSpinning ? "Unprovisioning" : "Unprovision"}
     </Button>,
-    <Button key="cancel" variant="link" onClick={onCloseUnprovisionModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel"
+      variant="link"
+      onClick={onCloseUnprovisionModal}
+    >
       Cancel
     </Button>,
   ];
@@ -156,6 +162,7 @@ const ServicesSettings = (props: PropsToServicesSettings) => {
 
   const dropdownItems = [
     <DropdownItem
+      data-cy="services-tab-settings-kebab-new-certificate"
       key="new certificate"
       onClick={() => setIsCertModalOpen(true)}
     >
@@ -166,6 +173,7 @@ const ServicesSettings = (props: PropsToServicesSettings) => {
   if (props.service.has_keytab) {
     dropdownItems.unshift(
       <DropdownItem
+        data-cy="services-tab-settings-kebab-delete-key-unprovision"
         key="delete-key-unprovision"
         onClick={() => setIsUnprovisionModalOpen(true)}
       >
@@ -222,7 +230,10 @@ const ServicesSettings = (props: PropsToServicesSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton onClickHandler={props.onRefresh}>
+        <SecondaryButton
+          dataCy="services-tab-settings-button-refresh"
+          onClickHandler={props.onRefresh}
+        >
           Refresh
         </SecondaryButton>
       ),
@@ -231,6 +242,7 @@ const ServicesSettings = (props: PropsToServicesSettings) => {
       key: 1,
       element: (
         <SecondaryButton
+          dataCy="services-tab-settings-button-revert"
           isDisabled={!props.isModified}
           onClickHandler={onRevert}
         >
@@ -242,6 +254,7 @@ const ServicesSettings = (props: PropsToServicesSettings) => {
       key: 2,
       element: (
         <SecondaryButton
+          dataCy="services-tab-settings-button-save"
           isDisabled={!props.isModified || isSaving}
           onClickHandler={onSave}
           isLoading={isSaving}
@@ -257,6 +270,7 @@ const ServicesSettings = (props: PropsToServicesSettings) => {
       key: 3,
       element: (
         <KebabLayout
+          dataCy="services-tab-settings-kebab"
           direction={"up"}
           onDropdownSelect={onKebabSelect}
           onKebabToggle={onKebabToggle}
@@ -359,8 +373,12 @@ const ServicesSettings = (props: PropsToServicesSettings) => {
           </Flex>
         </SidebarContent>
       </Sidebar>
-      <ModalErrors errors={modalErrors.getAll()} />
+      <ModalErrors
+        errors={modalErrors.getAll()}
+        dataCy="services-modal-error"
+      />
       <ConfirmationModal
+        dataCy="services-unprovision-modal"
         title={"Unprovision service"}
         isOpen={isUnprovisionModalOpen}
         onClose={onCloseUnprovisionModal}

--- a/src/pages/StageUsers/StageUsers.tsx
+++ b/src/pages/StageUsers/StageUsers.tsx
@@ -450,6 +450,7 @@ const StageUsers = () => {
       key: 1,
       element: (
         <SearchInputLayout
+          dataCy="search"
           name="search"
           ariaLabel="Search user"
           placeholder="Search"
@@ -470,6 +471,7 @@ const StageUsers = () => {
         <SecondaryButton
           onClickHandler={refreshUsersData}
           isDisabled={!showTableRows}
+          dataCy="stage-users-button-refresh"
         >
           Refresh
         </SecondaryButton>
@@ -481,6 +483,7 @@ const StageUsers = () => {
         <SecondaryButton
           isDisabled={isDeleteButtonDisabled || !showTableRows}
           onClickHandler={onDeleteHandler}
+          dataCy="stage-users-button-delete"
         >
           Delete
         </SecondaryButton>
@@ -492,6 +495,7 @@ const StageUsers = () => {
         <SecondaryButton
           onClickHandler={onAddClickHandler}
           isDisabled={!showTableRows}
+          dataCy="stage-users-button-add"
         >
           Add
         </SecondaryButton>
@@ -503,6 +507,7 @@ const StageUsers = () => {
         <SecondaryButton
           isDisabled={!showTableRows || selectedUsers.length === 0}
           onClickHandler={onActivateHandler}
+          dataCy="stage-users-button-activate"
         >
           Activate
         </SecondaryButton>
@@ -588,7 +593,10 @@ const StageUsers = () => {
             className="pf-v5-u-pb-0 pf-v5-u-pr-md"
           />
         </PageSection>
-        <ModalErrors errors={modalErrors.getAll()} />
+        <ModalErrors
+          errors={modalErrors.getAll()}
+          dataCy="stage-users-modal-error"
+        />
         <AddUser
           show={showAddModal}
           from="stage-users"

--- a/src/pages/SubordinateIDs/SubIdsStatistics.tsx
+++ b/src/pages/SubordinateIDs/SubIdsStatistics.tsx
@@ -75,7 +75,11 @@ const SubIdsStatistics = () => {
     {
       key: 0,
       element: (
-        <SecondaryButton onClickHandler={onRefresh} isDisabled={!showTableRows}>
+        <SecondaryButton
+          dataCy="subids-statistics-button-refresh"
+          onClickHandler={onRefresh}
+          isDisabled={!showTableRows}
+        >
           Refresh
         </SecondaryButton>
       ),

--- a/src/pages/SubordinateIDs/SubidsSettings.tsx
+++ b/src/pages/SubordinateIDs/SubidsSettings.tsx
@@ -106,7 +106,10 @@ const SubidSettings = (props: PropsToSubidSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton onClickHandler={props.onRefresh}>
+        <SecondaryButton
+          dataCy="subids-tab-settings-button-refresh"
+          onClickHandler={props.onRefresh}
+        >
           Refresh
         </SecondaryButton>
       ),
@@ -115,6 +118,7 @@ const SubidSettings = (props: PropsToSubidSettings) => {
       key: 1,
       element: (
         <SecondaryButton
+          dataCy="subids-tab-settings-button-revert"
           isDisabled={!props.isModified || isDataLoading}
           onClickHandler={onRevert}
         >
@@ -126,6 +130,7 @@ const SubidSettings = (props: PropsToSubidSettings) => {
       key: 2,
       element: (
         <SecondaryButton
+          dataCy="subids-tab-settings-button-save"
           isDisabled={!props.isModified || isDataLoading}
           onClickHandler={onSave}
         >
@@ -154,6 +159,7 @@ const SubidSettings = (props: PropsToSubidSettings) => {
                 <Form className="pf-v5-u-mb-lg">
                   <FormGroup label="Unique ID" fieldId="ipauniqueid">
                     <IpaTextInput
+                      dataCy="subids-tab-settings-textbox-unique-id"
                       name={"ipauniqueid"}
                       ariaLabel={"Unique ID"}
                       ipaObject={ipaObject}
@@ -164,6 +170,7 @@ const SubidSettings = (props: PropsToSubidSettings) => {
                   </FormGroup>
                   <FormGroup label="Description" fieldId="description">
                     <IpaTextInput
+                      dataCy="subids-tab-settings-textbox-description"
                       name={"description"}
                       ariaLabel={"Description"}
                       ipaObject={ipaObject}
@@ -174,6 +181,7 @@ const SubidSettings = (props: PropsToSubidSettings) => {
                   </FormGroup>
                   <FormGroup label="Owner" fieldId="ipaowner" role="group">
                     <IpaTextContent
+                      dataCy="subids-tab-settings-textbox-owner"
                       name={"ipaowner"}
                       ariaLabel={"Owner"}
                       ipaObject={ipaObject}
@@ -190,6 +198,7 @@ const SubidSettings = (props: PropsToSubidSettings) => {
                     fieldId="ipasubgidnumber"
                   >
                     <IpaTextInput
+                      dataCy="subids-tab-settings-textbox-subgid-range-start"
                       name={"ipasubgidnumber"}
                       ariaLabel={"SubGID range start"}
                       ipaObject={ipaObject}
@@ -200,6 +209,7 @@ const SubidSettings = (props: PropsToSubidSettings) => {
                   </FormGroup>
                   <FormGroup label="SubGID range size" fieldId="ipasubgidcount">
                     <IpaTextInput
+                      dataCy="subids-tab-settings-textbox-subgid-range-size"
                       name={"ipasubgidcount"}
                       ariaLabel={"SubGID range size"}
                       ipaObject={ipaObject}
@@ -213,6 +223,7 @@ const SubidSettings = (props: PropsToSubidSettings) => {
                     fieldId="ipasubuidnumber"
                   >
                     <IpaTextInput
+                      dataCy="subids-tab-settings-textbox-subuid-range-start"
                       name={"ipasubuidnumber"}
                       ariaLabel={"SubUID range start"}
                       ipaObject={ipaObject}
@@ -223,6 +234,7 @@ const SubidSettings = (props: PropsToSubidSettings) => {
                   </FormGroup>
                   <FormGroup label="SubUID range size" fieldId="ipasubuidcount">
                     <IpaTextInput
+                      dataCy="subids-tab-settings-textbox-subuid-range-size"
                       name={"ipasubuidcount"}
                       ariaLabel={"SubUID range size"}
                       ipaObject={ipaObject}

--- a/src/pages/SubordinateIDs/SubordinateIDs.tsx
+++ b/src/pages/SubordinateIDs/SubordinateIDs.tsx
@@ -268,6 +268,7 @@ const SubordinateIDs = () => {
       key: 0,
       element: (
         <SearchInputLayout
+          dataCy="search"
           name="search"
           ariaLabel="Search subIds"
           placeholder="Search"
@@ -286,6 +287,7 @@ const SubordinateIDs = () => {
       key: 2,
       element: (
         <SecondaryButton
+          dataCy="subids-button-refresh"
           onClickHandler={refreshData}
           isDisabled={!showTableRows}
         >
@@ -297,6 +299,7 @@ const SubordinateIDs = () => {
       key: 3,
       element: (
         <SecondaryButton
+          dataCy="subids-button-add"
           isDisabled={!showTableRows}
           onClickHandler={onOpenAddModal}
         >

--- a/src/pages/SudoCmdGroups/SudoCmdGroups.tsx
+++ b/src/pages/SudoCmdGroups/SudoCmdGroups.tsx
@@ -418,6 +418,7 @@ const SudoCmds = () => {
       key: 1,
       element: (
         <SearchInputLayout
+          dataCy="search"
           name="search"
           ariaLabel="Search command groups"
           placeholder="Search"
@@ -438,6 +439,7 @@ const SudoCmds = () => {
         <SecondaryButton
           onClickHandler={refreshData}
           isDisabled={!showTableRows}
+          dataCy="sudo-command-groups-button-refresh"
         >
           Refresh
         </SecondaryButton>
@@ -449,6 +451,7 @@ const SudoCmds = () => {
         <SecondaryButton
           isDisabled={isDeleteButtonDisabled || !showTableRows}
           onClickHandler={onDeleteHandler}
+          dataCy="sudo-command-groups-button-delete"
         >
           Delete
         </SecondaryButton>
@@ -460,6 +463,7 @@ const SudoCmds = () => {
         <SecondaryButton
           onClickHandler={onAddClickHandler}
           isDisabled={!showTableRows}
+          dataCy="sudo-command-groups-button-add"
         >
           Add
         </SecondaryButton>
@@ -547,7 +551,10 @@ const SudoCmds = () => {
         buttonsData={deleteCmdsButtonsData}
         onRefresh={refreshData}
       />
-      <ModalErrors errors={modalErrors.getAll()} />
+      <ModalErrors
+        errors={modalErrors.getAll()}
+        dataCy="sudo-cmd-groups-modal-error"
+      />
     </Page>
   );
 };

--- a/src/pages/SudoCmdGroups/SudoCmdGroupsSettings.tsx
+++ b/src/pages/SudoCmdGroups/SudoCmdGroupsSettings.tsx
@@ -87,7 +87,10 @@ const SudoCmdGroupsSettings = (props: PropsToSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton onClickHandler={props.onRefresh}>
+        <SecondaryButton
+          dataCy="sudo-cmd-groups-tab-settings-button-refresh"
+          onClickHandler={props.onRefresh}
+        >
           Refresh
         </SecondaryButton>
       ),
@@ -96,6 +99,7 @@ const SudoCmdGroupsSettings = (props: PropsToSettings) => {
       key: 1,
       element: (
         <SecondaryButton
+          dataCy="sudo-cmd-groups-tab-settings-button-revert"
           isDisabled={!props.isModified}
           onClickHandler={onRevert}
         >
@@ -107,6 +111,7 @@ const SudoCmdGroupsSettings = (props: PropsToSettings) => {
       key: 2,
       element: (
         <SecondaryButton
+          dataCy="sudo-cmd-groups-tab-settings-button-save"
           isDisabled={!props.isModified || isSaving}
           onClickHandler={onSave}
           isLoading={isSaving}
@@ -134,6 +139,7 @@ const SudoCmdGroupsSettings = (props: PropsToSettings) => {
         <Form className="pf-v5-u-mt-sm pf-v5-u-mb-lg pf-v5-u-mr-md">
           <FormGroup label="Description" fieldId="description">
             <IpaTextArea
+              dataCy="sudo-cmd-groups-tab-settings-textbox-description"
               name="description"
               ipaObject={ipaObject}
               onChange={recordOnChange}

--- a/src/pages/SudoCmds/SudoCmds.tsx
+++ b/src/pages/SudoCmds/SudoCmds.tsx
@@ -419,6 +419,7 @@ const SudoCmds = () => {
       key: 1,
       element: (
         <SearchInputLayout
+          dataCy="search"
           name="search"
           ariaLabel="Search commands"
           placeholder="Search"
@@ -439,6 +440,7 @@ const SudoCmds = () => {
         <SecondaryButton
           onClickHandler={refreshData}
           isDisabled={!showTableRows}
+          dataCy="sudo-commands-button-refresh"
         >
           Refresh
         </SecondaryButton>
@@ -450,6 +452,7 @@ const SudoCmds = () => {
         <SecondaryButton
           isDisabled={isDeleteButtonDisabled || !showTableRows}
           onClickHandler={onDeleteHandler}
+          dataCy="sudo-commands-button-delete"
         >
           Delete
         </SecondaryButton>
@@ -461,6 +464,7 @@ const SudoCmds = () => {
         <SecondaryButton
           onClickHandler={onAddClickHandler}
           isDisabled={!showTableRows}
+          dataCy="sudo-commands-button-add"
         >
           Add
         </SecondaryButton>
@@ -548,7 +552,10 @@ const SudoCmds = () => {
         buttonsData={deleteCmdsButtonsData}
         onRefresh={refreshData}
       />
-      <ModalErrors errors={modalErrors.getAll()} />
+      <ModalErrors
+        errors={modalErrors.getAll()}
+        dataCy="sudo-cmds-modal-error"
+      />
     </Page>
   );
 };

--- a/src/pages/SudoCmds/SudoCmdsSettings.tsx
+++ b/src/pages/SudoCmds/SudoCmdsSettings.tsx
@@ -79,7 +79,10 @@ const SudoCmdsSettings = (props: PropsToSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton onClickHandler={props.onRefresh}>
+        <SecondaryButton
+          dataCy="sudo-cmds-tab-settings-button-refresh"
+          onClickHandler={props.onRefresh}
+        >
           Refresh
         </SecondaryButton>
       ),
@@ -88,6 +91,7 @@ const SudoCmdsSettings = (props: PropsToSettings) => {
       key: 1,
       element: (
         <SecondaryButton
+          dataCy="sudo-cmds-tab-settings-button-revert"
           isDisabled={!props.isModified}
           onClickHandler={onRevert}
         >
@@ -99,6 +103,7 @@ const SudoCmdsSettings = (props: PropsToSettings) => {
       key: 2,
       element: (
         <SecondaryButton
+          dataCy="sudo-cmds-tab-settings-button-save"
           isDisabled={!props.isModified || isSaving}
           onClickHandler={onSave}
           isLoading={isSaving}
@@ -126,6 +131,7 @@ const SudoCmdsSettings = (props: PropsToSettings) => {
         <Form className="pf-v5-u-mt-sm pf-v5-u-mb-lg pf-v5-u-mr-md">
           <FormGroup label="Description" fieldId="description">
             <IpaTextArea
+              dataCy="sudo-cmds-tab-settings-textbox-description"
               name="description"
               ipaObject={ipaObject}
               onChange={recordOnChange}

--- a/src/pages/SudoRules/AccessThisHost.tsx
+++ b/src/pages/SudoRules/AccessThisHost.tsx
@@ -341,6 +341,7 @@ const AccessThisHost = (props: PropsToAccessThisHost) => {
       <FlexItem>Host category the rule applies to: </FlexItem>
       <FlexItem>
         <IpaToggleGroup
+          dataCy="access-this-host-toggle-group-hostcategory"
           ipaObject={props.ipaObject}
           name="hostcategory"
           options={options}

--- a/src/pages/SudoRules/SudoRules.tsx
+++ b/src/pages/SudoRules/SudoRules.tsx
@@ -476,6 +476,7 @@ const SudoRules = () => {
       key: 1,
       element: (
         <SearchInputLayout
+          dataCy="search"
           name="search"
           ariaLabel="Search rules"
           placeholder="Search"
@@ -496,6 +497,7 @@ const SudoRules = () => {
         <SecondaryButton
           onClickHandler={refreshRulesData}
           isDisabled={!showTableRows}
+          dataCy="sudo-rules-button-refresh"
         >
           Refresh
         </SecondaryButton>
@@ -507,6 +509,7 @@ const SudoRules = () => {
         <SecondaryButton
           isDisabled={isDeleteButtonDisabled || !showTableRows}
           onClickHandler={onDeleteHandler}
+          dataCy="sudo-rules-button-delete"
         >
           Delete
         </SecondaryButton>
@@ -518,6 +521,7 @@ const SudoRules = () => {
         <SecondaryButton
           onClickHandler={onAddClickHandler}
           isDisabled={!showTableRows}
+          dataCy="sudo-rules-button-add"
         >
           Add
         </SecondaryButton>
@@ -529,6 +533,7 @@ const SudoRules = () => {
         <SecondaryButton
           isDisabled={isDisableButtonDisabled || !showTableRows}
           onClickHandler={() => onEnableDisableHandler(true)}
+          dataCy="sudo-rules-button-disable"
         >
           Disable
         </SecondaryButton>
@@ -540,6 +545,7 @@ const SudoRules = () => {
         <SecondaryButton
           isDisabled={isEnableButtonDisabled || !showTableRows}
           onClickHandler={() => onEnableDisableHandler(false)}
+          dataCy="sudo-rules-button-enable"
         >
           Enable
         </SecondaryButton>
@@ -631,7 +637,10 @@ const SudoRules = () => {
         buttonsData={disableEnableButtonsData}
         onRefresh={refreshRulesData}
       />
-      <ModalErrors errors={modalErrors.getAll()} />
+      <ModalErrors
+        errors={modalErrors.getAll()}
+        dataCy="sudo-rules-modal-error"
+      />
     </Page>
   );
 };

--- a/src/pages/SudoRules/SudoRulesSettings.tsx
+++ b/src/pages/SudoRules/SudoRulesSettings.tsx
@@ -77,16 +77,25 @@ const SudoRulesSettings = (props: PropsToSudoRulesSettings) => {
   const [isKebabOpen, setIsKebabOpen] = React.useState(false);
 
   const dropdownItems = [
-    <DropdownItem key="enable-sudo-rule" onClick={() => onChangeEnableModal()}>
+    <DropdownItem
+      key="enable-sudo-rule"
+      onClick={() => onChangeEnableModal()}
+      data-cy="sudo-rules-tab-settings-kebab-enable"
+    >
       Enable
     </DropdownItem>,
     <DropdownItem
       key="disable-sudo-rule"
       onClick={() => onChangeDisableModal()}
+      data-cy="sudo-rules-tab-settings-kebab-disable"
     >
       Disable
     </DropdownItem>,
-    <DropdownItem key="delete-sudo-rule" onClick={() => onChangeDeleteModal()}>
+    <DropdownItem
+      key="delete-sudo-rule"
+      onClick={() => onChangeDeleteModal()}
+      data-cy="sudo-rules-tab-settings-kebab-delete"
+    >
       Delete
     </DropdownItem>,
   ];
@@ -627,7 +636,10 @@ const SudoRulesSettings = (props: PropsToSudoRulesSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton onClickHandler={props.onRefresh}>
+        <SecondaryButton
+          dataCy="sudo-rules-tab-settings-button-refresh"
+          onClickHandler={props.onRefresh}
+        >
           Refresh
         </SecondaryButton>
       ),
@@ -636,6 +648,7 @@ const SudoRulesSettings = (props: PropsToSudoRulesSettings) => {
       key: 1,
       element: (
         <SecondaryButton
+          dataCy="sudo-rules-tab-settings-button-revert"
           isDisabled={!props.isModified}
           onClickHandler={onRevert}
         >
@@ -647,6 +660,7 @@ const SudoRulesSettings = (props: PropsToSudoRulesSettings) => {
       key: 2,
       element: (
         <SecondaryButton
+          dataCy="sudo-rules-tab-settings-button-save"
           isDisabled={!props.isModified || isSaving}
           onClickHandler={onSave}
           isLoading={isSaving}
@@ -662,6 +676,7 @@ const SudoRulesSettings = (props: PropsToSudoRulesSettings) => {
       key: 3,
       element: (
         <KebabLayout
+          dataCy="sudo-rules-tab-settings-kebab"
           direction={"up"}
           onDropdownSelect={onKebabSelect}
           onKebabToggle={onKebabToggle}

--- a/src/pages/UserGroups/UserGroups.tsx
+++ b/src/pages/UserGroups/UserGroups.tsx
@@ -419,6 +419,7 @@ const UserGroups = () => {
       key: 1,
       element: (
         <SearchInputLayout
+          dataCy="search"
           name="search"
           ariaLabel="Search user groups"
           placeholder="Search"
@@ -439,6 +440,7 @@ const UserGroups = () => {
         <SecondaryButton
           onClickHandler={refreshGroupsData}
           isDisabled={!showTableRows}
+          dataCy="user-groups-button-refresh"
         >
           Refresh
         </SecondaryButton>
@@ -450,6 +452,7 @@ const UserGroups = () => {
         <SecondaryButton
           isDisabled={isDeleteButtonDisabled || !showTableRows}
           onClickHandler={onDeleteHandler}
+          dataCy="user-groups-button-delete"
         >
           Delete
         </SecondaryButton>
@@ -461,6 +464,7 @@ const UserGroups = () => {
         <SecondaryButton
           onClickHandler={onAddClickHandler}
           isDisabled={!showTableRows}
+          dataCy="user-groups-button-add"
         >
           Add
         </SecondaryButton>
@@ -531,7 +535,10 @@ const UserGroups = () => {
           className="pf-v5-u-pb-0 pf-v5-u-pr-md"
         />
       </PageSection>
-      <ModalErrors errors={modalErrors.getAll()} />
+      <ModalErrors
+        errors={modalErrors.getAll()}
+        dataCy="user-groups-modal-error"
+      />
       <AddUserGroup
         show={showAddModal}
         handleModalToggle={onAddModalToggle}

--- a/src/pages/UserGroups/UserGroupsSettings.tsx
+++ b/src/pages/UserGroups/UserGroupsSettings.tsx
@@ -92,14 +92,22 @@ const UserGroupsSettings = (props: PropsToGroupsSettings) => {
   const [isKebabOpen, setIsKebabOpen] = useState(false);
 
   const dropdownItems = [
-    <DropdownItem key="delete-user-group" onClick={() => onOpenDeleteModal()}>
+    <DropdownItem
+      key="delete-user-group"
+      onClick={() => onOpenDeleteModal()}
+      data-cy="user-groups-tab-settings-kebab-delete"
+    >
       Delete group
     </DropdownItem>,
   ];
   if (groupType === "") {
     dropdownItems.push(<Divider key="separator" />);
     dropdownItems.push(
-      <DropdownItem key="change-to-posix" onClick={() => onOpenPOSIXModal()}>
+      <DropdownItem
+        key="change-to-posix"
+        onClick={() => onOpenPOSIXModal()}
+        data-cy="user-groups-tab-settings-kebab-change-to-posix"
+      >
         Change to POSIX group
       </DropdownItem>
     );
@@ -107,6 +115,7 @@ const UserGroupsSettings = (props: PropsToGroupsSettings) => {
       <DropdownItem
         key="change-to-external"
         onClick={() => onOpenExternalModal()}
+        data-cy="user-groups-tab-settings-kebab-change-to-external"
       >
         Change to external group
       </DropdownItem>
@@ -226,6 +235,7 @@ const UserGroupsSettings = (props: PropsToGroupsSettings) => {
 
   const deleteModalActions = [
     <Button
+      data-cy="modal-button-delete"
       key="delete-host"
       variant="danger"
       onClick={doDelete}
@@ -237,13 +247,19 @@ const UserGroupsSettings = (props: PropsToGroupsSettings) => {
     >
       {modalSpinning ? "Deleting" : "Delete"}
     </Button>,
-    <Button key="cancel" variant="link" onClick={onCloseDeleteModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel"
+      variant="link"
+      onClick={onCloseDeleteModal}
+    >
       Cancel
     </Button>,
   ];
 
   const posixModalActions = [
     <Button
+      data-cy="modal-button-change"
       key="change-posix"
       variant="primary"
       onClick={doChangeToPosix}
@@ -255,13 +271,19 @@ const UserGroupsSettings = (props: PropsToGroupsSettings) => {
     >
       {modalSpinning ? "Changing" : "Change Group"}
     </Button>,
-    <Button key="cancel" variant="link" onClick={onClosePOSIXModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel"
+      variant="link"
+      onClick={onClosePOSIXModal}
+    >
       Cancel
     </Button>,
   ];
 
   const externalModalActions = [
     <Button
+      data-cy="modal-button-change"
       key="change-external"
       variant="primary"
       onClick={doChangeToExternal}
@@ -273,7 +295,12 @@ const UserGroupsSettings = (props: PropsToGroupsSettings) => {
     >
       {modalSpinning ? "Changing" : "Change Group"}
     </Button>,
-    <Button key="cancel" variant="link" onClick={onCloseExternalModal}>
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel"
+      variant="link"
+      onClick={onCloseExternalModal}
+    >
       Cancel
     </Button>,
   ];
@@ -312,7 +339,10 @@ const UserGroupsSettings = (props: PropsToGroupsSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton onClickHandler={props.onRefresh}>
+        <SecondaryButton
+          onClickHandler={props.onRefresh}
+          dataCy="user-groups-tab-settings-button-refresh"
+        >
           Refresh
         </SecondaryButton>
       ),
@@ -323,6 +353,7 @@ const UserGroupsSettings = (props: PropsToGroupsSettings) => {
         <SecondaryButton
           isDisabled={!props.isModified}
           onClickHandler={onRevert}
+          dataCy="user-groups-tab-settings-button-revert"
         >
           Revert
         </SecondaryButton>
@@ -334,6 +365,7 @@ const UserGroupsSettings = (props: PropsToGroupsSettings) => {
         <SecondaryButton
           isDisabled={!props.isModified || isSaving}
           onClickHandler={onSave}
+          dataCy="user-groups-tab-settings-button-save"
           isLoading={isSaving}
           spinnerAriaValueText="Saving"
           spinnerAriaLabelledBy="Saving"
@@ -347,6 +379,7 @@ const UserGroupsSettings = (props: PropsToGroupsSettings) => {
       key: 3,
       element: (
         <KebabLayout
+          dataCy="user-groups-tab-settings-kebab"
           direction={"up"}
           onDropdownSelect={onKebabSelect}
           onKebabToggle={onKebabToggle}
@@ -375,6 +408,7 @@ const UserGroupsSettings = (props: PropsToGroupsSettings) => {
         >
           <FormGroup label="Description" fieldId="description">
             <IpaTextArea
+              dataCy="user-groups-tab-settings-textbox-description"
               name="description"
               ipaObject={ipaObject}
               onChange={recordOnChange}
@@ -384,6 +418,7 @@ const UserGroupsSettings = (props: PropsToGroupsSettings) => {
           </FormGroup>
           <FormGroup label="Group type" fieldId="group-type">
             <TextInput
+              data-cy="user-groups-tab-settings-textbox-group-type"
               id="group-type"
               name="grouptype"
               value={groupType}
@@ -394,6 +429,7 @@ const UserGroupsSettings = (props: PropsToGroupsSettings) => {
           </FormGroup>
           <FormGroup label="GID" fieldId="gid">
             <TextInput
+              data-cy="user-groups-tab-settings-textbox-gid"
               id="gid"
               name="gid"
               value={props.userGroup.gidnumber}
@@ -413,6 +449,7 @@ const UserGroupsSettings = (props: PropsToGroupsSettings) => {
         </Form>
       </Flex>
       <ConfirmationModal
+        dataCy="delete-user-group-modal"
         title={"Delete user group"}
         isOpen={isDeleteModalOpen}
         onClose={onCloseDeleteModal}
@@ -421,6 +458,7 @@ const UserGroupsSettings = (props: PropsToGroupsSettings) => {
         messageObj={cn}
       />
       <ConfirmationModal
+        dataCy="change-group-type-posix-modal"
         title={"Change group type"}
         isOpen={isPOSIXModalOpen}
         onClose={onClosePOSIXModal}
@@ -431,6 +469,7 @@ const UserGroupsSettings = (props: PropsToGroupsSettings) => {
         messageObj={cn}
       />
       <ConfirmationModal
+        dataCy="change-group-type-external-modal"
         title={"Change group type"}
         isOpen={isExternalModalOpen}
         onClose={onCloseExternalModal}

--- a/src/patternfly.d.ts
+++ b/src/patternfly.d.ts
@@ -1,0 +1,58 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+// Disabled, as the plugin can't comprehend that it's actually being used due to object spreading.
+
+import {
+  TextInputProps,
+  TextAreaProps,
+  ButtonProps,
+  DropdownProps,
+  DropdownItemProps,
+  SelectProps,
+  SelectOptionProps,
+  RadioProps,
+  SearchInputProps,
+  MenuToggleProps,
+} from "@patternfly/react-core";
+
+declare module "@patternfly/react-core" {
+  interface TextInputProps {
+    "data-cy": string;
+  }
+
+  interface TextAreaProps {
+    "data-cy": string;
+  }
+
+  interface ButtonProps {
+    "data-cy": string;
+  }
+
+  interface DropdownProps {
+    "data-cy": string;
+  }
+
+  interface DropdownItemProps {
+    "data-cy": string;
+  }
+
+  interface SelectProps {
+    "data-cy": string;
+  }
+
+  interface SelectOptionProps {
+    "data-cy": string;
+  }
+
+  interface RadioProps {
+    "data-cy": string;
+  }
+
+  interface SearchInputProps {
+    "data-cy": string;
+  }
+
+  interface MenuToggleProps {
+    "data-cy": string;
+  }
+}


### PR DESCRIPTION
Adds data-cy attribute to almost all interactive components. For custom components, I've added dataCy, that just passes data-cy to children. I've also added README.md defining rules, these rules are strictly obeyed in the PR, but should help moving forward. It's expected that these will be edited as needed and follow the README more strictly once touched.
Lastly I've added type definitions file that enforces data-cy for PatternFly components.

Also fixes SimpleSelector, where we supplied wrongly label instead of key resulting in undefined.

## Summary by Sourcery

Add consistent data-cy attributes across the UI for end-to-end testing, introduce a dataCy prop for custom components and TypeScript enforcement for PatternFly components, document conventions in a new README, and fix a SimpleSelector key mismatch.

New Features:
- Introduce dataCy prop on custom components to pass data-cy attributes to children
- Enforce data-cy attributes on PatternFly components via added TypeScript definitions

Bug Fixes:
- Fix SimpleSelector to use the key property instead of label to avoid undefined values

Enhancements:
- Add README.md detailing data-cy naming conventions
- Apply data-cy attributes to dropdowns, modals, buttons, inputs and other interactive elements throughout the codebase

Documentation:
- Document data-cy usage rules in a new README.md file