### PR TITLE
Disable integration tests

### DIFF
--- a/.github/workflows/gating.yml
+++ b/.github/workflows/gating.yml
@@ -72,58 +72,58 @@ jobs:
       - name: Run vitest
         run: npm test
 
-  integration-tests:
-    name: Integration tests
-    needs: audit-and-build
-    runs-on: ubuntu-latest
+  # integration-tests:
+  #   name: Integration tests
+  #   needs: audit-and-build
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v4
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - name: Install vagrant
-        run: |
-          sudo apt -y install apt-transport-https ca-certificates curl software-properties-common
-          wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg
-          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-          sudo apt update
-          sudo apt install vagrant virtualbox
+  #     - name: Install vagrant
+  #       run: |
+  #         sudo apt -y install apt-transport-https ca-certificates curl software-properties-common
+  #         wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg
+  #         echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+  #         sudo apt update
+  #         sudo apt install vagrant virtualbox
 
-      - uses: actions/download-artifact@v4
-        with:
-          name: freeipa-webui-build
-          path: dist
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         name: freeipa-webui-build
+  #         path: dist
 
-      - name: Run vagrant up
-        run: vagrant up --no-provision --provider=virtualbox
+  #     - name: Run vagrant up
+  #       run: vagrant up --no-provision --provider=virtualbox
 
-      - name: Run vagrant provision
-        run: vagrant provision
+  #     - name: Run vagrant provision
+  #       run: vagrant provision
 
-      - name: Put IPA Server's IP to /etc/hosts
-        run: sudo echo "$(vagrant ssh -c "hostname -I|sed 's/10\.0\.2\.15//'") server.ipa.demo" | sudo tee -a /etc/hosts
+  #     - name: Put IPA Server's IP to /etc/hosts
+  #       run: sudo echo "$(vagrant ssh -c "hostname -I|sed 's/10\.0\.2\.15//'") server.ipa.demo" | sudo tee -a /etc/hosts
 
-      - name: Save server's IP address to env
-        run: echo "SERVER_IP=$(vagrant ssh -c "hostname -I|sed 's/10\.0\.2\.15//'")" >> $GITHUB_ENV
+  #     - name: Save server's IP address to env
+  #       run: echo "SERVER_IP=$(vagrant ssh -c "hostname -I|sed 's/10\.0\.2\.15//'")" >> $GITHUB_ENV
 
-      - name: Print exported variable
-        run: echo "$SERVER_IP"
+  #     - name: Print exported variable
+  #       run: echo "$SERVER_IP"
 
-      - name: Run Cypress tests
-        uses: cypress-io/github-action@v6
-        with:
-          browser: electron
-          config-file: cypress/cypress.config.ts
+  #     - name: Run Cypress tests
+  #       uses: cypress-io/github-action@v6
+  #       with:
+  #         browser: electron
+  #         config-file: cypress/cypress.config.ts
 
-      - name: Upload cypress screenshots
-        uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: cypress-screenshots
-          path: cypress/screenshots
+  #     - name: Upload cypress screenshots
+  #       uses: actions/upload-artifact@v4
+  #       if: failure()
+  #       with:
+  #         name: cypress-screenshots
+  #         path: cypress/screenshots
 
-      - name: Upload cypress videos
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: cypress-videos
-          path: cypress/videos
+  #     - name: Upload cypress videos
+  #       uses: actions/upload-artifact@v4
+  #       if: always()
+  #       with:
+  #         name: cypress-videos
+  #         path: cypress/videos


### PR DESCRIPTION
We will reenable them once either pipeline starts working for older
Fedora again or once we get the tests stable, which is probably
dependant on the integration test rewrite.

## Summary by Sourcery

CI:
- Disable the integration-tests job in the gating GitHub Actions workflow by commenting out its configuration