### PR TITLE
Add entryCount to InclusiveExclusive section and KeyTabTable

### DIFF
--- a/src/components/AutomemberSections/InclusiveExclusiveSection.tsx
+++ b/src/components/AutomemberSections/InclusiveExclusiveSection.tsx
@@ -436,6 +436,7 @@ const InclusiveExclusiveSection = (props: PropsToInclusiveExclusiveSection) => {
         onAddModal={onChangeAddModalVisibility}
         paginationData={paginationData}
         list={shownElements}
+        entryCount={tableEntryList.length}
         entryType={"condition"}
         extraID={props.conditionType}
       />

--- a/src/components/layouts/SettingsTableLayout/SettingsTableLayout.tsx
+++ b/src/components/layouts/SettingsTableLayout/SettingsTableLayout.tsx
@@ -37,6 +37,7 @@ export interface PropsToSettingsTableLayout {
   paginationData: PaginationData;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   list: any[];
+  entryCount?: number;
   entryType: string;
   extraID?: string;
 }
@@ -58,6 +59,7 @@ interface PaginationData {
 
 const SettingsTableLayout = (props: PropsToSettingsTableLayout) => {
   const extraId = props.extraID ? props.extraID : "";
+  const entryCount = props.entryCount ?? props.list.length;
   // Prepare ID for the Add buttons
   // - Should contain the entry type in lowercase and spaces replaced by dashes
   const addButtonId = extraId
@@ -68,7 +70,7 @@ const SettingsTableLayout = (props: PropsToSettingsTableLayout) => {
     <>
       <Flex>
         <FlexItem>
-          {props.list.length > 0 && props.onSearchChange !== undefined && (
+          {entryCount > 0 && props.onSearchChange !== undefined && (
             <SearchInput
               data-cy="search"
               placeholder={"Filter by ..."}
@@ -134,7 +136,7 @@ const SettingsTableLayout = (props: PropsToSettingsTableLayout) => {
               "No " +
               props.entryType.toLowerCase() +
               "s " +
-              (props.list.length > 0 ? " found" : "")
+              (entryCount > 0 ? " found" : "")
             }
             headingLevel="h6"
           />

--- a/src/components/tables/KeytabTable.tsx
+++ b/src/components/tables/KeytabTable.tsx
@@ -555,6 +555,7 @@ const KeytabTable = (props: PropsToTable) => {
         onSearchChange={onSearchChange}
         searchValue={searchValue}
         paginationData={paginationData}
+        entryCount={tableEntryList.length}
         list={tableEntriesFilteredList}
         entryType={props.entryType}
       />


### PR DESCRIPTION
In refactoring SettingsTableLayout, commit 5da6a5cf665bc25b378f6e25007d3370c779235d, a bug was introduced. The entry count is needed where it shows the unfiltered number of elements, ie nclusiveExclusive section and KeyTabTable

## Summary by Sourcery

Add an optional entryCount prop to SettingsTableLayout and propagate it to child components to fix the display of the unfiltered number of elements in InclusiveExclusiveSection and KeytabTable.

Bug Fixes:
- Display the correct unfiltered entry count by using entryCount instead of filtered list length

Enhancements:
- Introduce entryCount prop in SettingsTableLayout with a default fallback to list.length
- Pass entryCount from InclusiveExclusiveSection and KeytabTable to SettingsTableLayout