### PR TITLE
WIP: Reword strings in the Add host dialog

### DIFF
--- a/src/components/modals/HostModals/AddHost.tsx
+++ b/src/components/modals/HostModals/AddHost.tsx
@@ -152,7 +152,7 @@ const AddHost = (props: PropsToAddHost) => {
       const hostNameVal = {
         hostname,
         isError: true,
-        message: "Invalid host name, must be a single domain component",
+        message: "Invalid host name. Host name must be a single domain component, like idmhost.",
         pfError: ValidatedOptions.error,
       };
       setHostNameValidation(hostNameVal);
@@ -398,7 +398,7 @@ const AddHost = (props: PropsToAddHost) => {
           />
           <HelperText>
             <HelperTextItem variant="indeterminate">
-              Allow adding host objects that does not have DNS entries
+              Enable adding host objects that do not have DNS entries
               associated with them
             </HelperTextItem>
           </HelperText>


### PR DESCRIPTION
A small docs update to the Add host dialog. Reword string descriptions.

I just quickly checked the Web UI but a little demonstration how we could work together if you are interested.

## Summary by Sourcery

Improve clarity of UI messages in the Add Host dialog by refining the validation error and helper text

Enhancements:
- Reword host name validation message to specify required format with an example
- Update helper text to clarify enabling host objects without DNS entries