### PR TITLE
Fix: Pagination not working in some tables

### DIFF
--- a/src/pages/CertificateMapping/CertificateMapping.tsx
+++ b/src/pages/CertificateMapping/CertificateMapping.tsx
@@ -90,7 +90,7 @@ const CertificateMappingPage = () => {
   const certMapsResponse = useGetCertMapRuleEntriesQuery({
     searchValue,
     apiVersion,
-    sizelimit: perPage,
+    sizelimit: 100,
     startIdx: firstUserIdx,
     stopIdx: lastUserIdx,
   });
@@ -114,7 +114,6 @@ const CertificateMappingPage = () => {
       data !== undefined
     ) {
       const listResult = data.result.results;
-      const totalCount = data.result.totalCount;
       const listSize = data.result.count;
       const elementsList: CertificateMapping[] = [];
 
@@ -122,7 +121,7 @@ const CertificateMappingPage = () => {
         elementsList.push(apiToCertificateMapping(listResult[i].result));
       }
 
-      setTotalCount(totalCount);
+      setTotalCount(certMapsResponse.data.result.totalCount);
       // Update the list of elements
       setCertMapRules(elementsList);
       // Show table elements

--- a/src/pages/DNSZones/DnsZones.tsx
+++ b/src/pages/DNSZones/DnsZones.tsx
@@ -89,7 +89,7 @@ const DnsZones = () => {
   const dnsZonesResponse = useGetDnsZonesFullDataQuery({
     searchValue,
     apiVersion,
-    sizelimit: perPage,
+    sizelimit: 100,
     startIdx: firstUserIdx,
     stopIdx: lastUserIdx,
   });
@@ -113,7 +113,6 @@ const DnsZones = () => {
       data !== undefined
     ) {
       const listResult = data.result.results;
-      const totalCount = data.result.totalCount;
       const listSize = data.result.count;
       const elementsList: DNSZone[] = [];
 
@@ -121,7 +120,7 @@ const DnsZones = () => {
         elementsList.push(apiToDnsZone(listResult[i].result));
       }
 
-      setTotalCount(totalCount);
+      setTotalCount(dnsZonesResponse.data.result.totalCount);
       // Update the list of elements
       setDnsZones(elementsList);
       // Show table elements


### PR DESCRIPTION
The pagination in some pages is not working
properly: when the number of elements is greater
than the pagination size, the table only lists
the first N elements and doesn't give the option
to move to the next page.

This has been fixed by adapting the `sizeLimit`
parameter used in the API call to 100 to retrieve
the first 100 elements (it is not possible to
retrieve big number of elements due to LDAP
restrictions). In the future we might want to investigate
further how is this affecting the tables with greats
amounts of data.

Fixes: https://github.com/freeipa/freeipa-webui/issues/774

## Summary by Sourcery

Adjust API queries for CertificateMapping and DNSZones tables to restore pagination support for larger data sets.

Bug Fixes:
- Set a fixed API sizelimit of 100 instead of perPage for CertificateMapping and DNSZones queries to retrieve sufficient entries for pagination.
- Source totalCount directly from the API response data to enable correct page navigation.