### PR TITLE
Fix: add screen reader text to table headers for accessibility

### DIFF
--- a/src/components/tables/MainTable.tsx
+++ b/src/components/tables/MainTable.tsx
@@ -230,7 +230,9 @@ const MainTable = <T,>(props: PropsToTable<T>) => {
   // Defining table header and body from here to avoid passing specific names to the Table Layout
   const header = (
     <Tr key="header" id="table-header">
-      {props.hasCheckboxes && <Th modifier="wrap"></Th>}
+      {props.hasCheckboxes && (
+        <Th modifier="wrap" aria-label="Select rows"></Th>
+      )}
       {props.columnNames.map((columnName, idx) => (
         <Th modifier="wrap" key={columnName + "-" + idx}>
           {columnName}

--- a/src/components/tables/UsersTable.tsx
+++ b/src/components/tables/UsersTable.tsx
@@ -208,7 +208,7 @@ const UsersTable = (props: PropsToTable) => {
   // Defining table header and body from here to avoid passing specific names to the Table Layout
   const header = (
     <Tr>
-      <Th modifier="wrap"></Th>
+      <Th modifier="wrap" aria-label="Select rows"></Th>
       <Th modifier="wrap">{columnNames.uid}</Th>
       <Th modifier="wrap">{columnNames.givenname}</Th>
       <Th modifier="wrap">{columnNames.sn}</Th>

--- a/src/pages/AutoMemUserRules/AutomemRulesTable.tsx
+++ b/src/pages/AutoMemUserRules/AutomemRulesTable.tsx
@@ -187,7 +187,7 @@ const MainTable = (props: PropsToTable) => {
   // Defining table header and body from here to avoid passing specific names to the Table Layout
   const header = (
     <Tr>
-      <Th modifier="wrap"></Th>
+      <Th modifier="wrap" aria-label="Select rows"></Th>
       <Th modifier="wrap">{columnNames.automemberRule}</Th>
       <Th modifier="wrap">{columnNames.description}</Th>
     </Tr>

--- a/src/pages/HBACRules/HBACRulesTable.tsx
+++ b/src/pages/HBACRules/HBACRulesTable.tsx
@@ -214,7 +214,7 @@ const HBACRulesTable = (props: PropsToTable) => {
   // Defining table header and body from here to avoid passing specific names to the Table Layout
   const header = (
     <Tr>
-      <Th modifier="wrap"></Th>
+      <Th modifier="wrap" aria-label="Select rows"></Th>
       <Th modifier="wrap">{columnNames.cn}</Th>
       <Th modifier="wrap">{columnNames.ipaenabledflag}</Th>
       <Th modifier="wrap">{columnNames.description}</Th>

--- a/src/pages/HBACServiceGroups/HBACServiceGroupsTable.tsx
+++ b/src/pages/HBACServiceGroups/HBACServiceGroupsTable.tsx
@@ -159,7 +159,7 @@ const HBACServiceGroupsTable = (props: PropsToTable) => {
   // Defining table header and body from here to avoid passing specific names to the Table Layout
   const header = (
     <Tr>
-      <Th modifier="wrap"></Th>
+      <Th modifier="wrap" aria-label="Select rows"></Th>
       <Th modifier="wrap">{columnNames.cn}</Th>
       <Th modifier="wrap">{columnNames.description}</Th>
     </Tr>

--- a/src/pages/HBACServices/HBACServicesTable.tsx
+++ b/src/pages/HBACServices/HBACServicesTable.tsx
@@ -156,7 +156,7 @@ const HBACServicesTable = (props: PropsToTable) => {
   // to the Table Layout
   const header = (
     <Tr>
-      <Th modifier="wrap"></Th>
+      <Th modifier="wrap" aria-label="Select rows"></Th>
       <Th modifier="wrap">{columnNames.cn}</Th>
       <Th modifier="wrap">{columnNames.description}</Th>
     </Tr>

--- a/src/pages/HostGroups/HostGroupsTable.tsx
+++ b/src/pages/HostGroups/HostGroupsTable.tsx
@@ -155,7 +155,7 @@ const HostGroupsTable = (props: PropsToTable) => {
   // Defining table header and body from here to avoid passing specific names to the Table Layout
   const header = (
     <Tr>
-      <Th modifier="wrap"></Th>
+      <Th modifier="wrap" aria-label="Select rows"></Th>
       <Th modifier="wrap">{columnNames.cn}</Th>
       <Th modifier="wrap">{columnNames.description}</Th>
     </Tr>

--- a/src/pages/Hosts/HostsTable.tsx
+++ b/src/pages/Hosts/HostsTable.tsx
@@ -152,7 +152,7 @@ const HostsTable = (props: PropsToTable) => {
   // Defining table header and body from here to avoid passing specific names to the Table Layout
   const header = (
     <Tr>
-      <Th modifier="wrap"></Th>
+      <Th modifier="wrap" aria-label="Select rows"></Th>
       <Th modifier="wrap">{columnNames.fqdn}</Th>
       <Th modifier="wrap">{columnNames.description}</Th>
       <Th modifier="wrap">{columnNames.enrolled}</Th>

--- a/src/pages/IDViews/IDViewsTable.tsx
+++ b/src/pages/IDViews/IDViewsTable.tsx
@@ -155,7 +155,7 @@ const IDViewsTable = (props: PropsToTable) => {
   // Defining table header and body from here to avoid passing specific names to the Table Layout
   const header = (
     <Tr>
-      <Th modifier="wrap"></Th>
+      <Th modifier="wrap" aria-label="Select rows"></Th>
       <Th modifier="wrap">{columnNames.cn}</Th>
       <Th modifier="wrap">{columnNames.description}</Th>
     </Tr>

--- a/src/pages/Netgroups/NetgroupsTable.tsx
+++ b/src/pages/Netgroups/NetgroupsTable.tsx
@@ -155,7 +155,7 @@ const NetgroupsTable = (props: PropsToTable) => {
   // Defining table header and body from here to avoid passing specific names to the Table Layout
   const header = (
     <Tr>
-      <Th modifier="wrap"></Th>
+      <Th modifier="wrap" aria-label="Select rows"></Th>
       <Th modifier="wrap">{columnNames.cn}</Th>
       <Th modifier="wrap">{columnNames.description}</Th>
     </Tr>

--- a/src/pages/Services/ServicesTable.tsx
+++ b/src/pages/Services/ServicesTable.tsx
@@ -158,7 +158,7 @@ const ServicesTable = (props: PropsToTable) => {
   // Defining table header and body from here to avoid passing specific names to the Table Layout
   const header = (
     <Tr>
-      <Th modifier="wrap"></Th>
+      <Th modifier="wrap" aria-label="Select rows"></Th>
       <Th modifier="wrap">{columnNames.principalName}</Th>
     </Tr>
   );

--- a/src/pages/SudoCmdGroups/SudoCmdGroupsTable.tsx
+++ b/src/pages/SudoCmdGroups/SudoCmdGroupsTable.tsx
@@ -157,7 +157,7 @@ const SudoCmdGroupsTable = (props: PropsToTable) => {
   // to the Table Layout
   const header = (
     <Tr>
-      <Th modifier="wrap"></Th>
+      <Th modifier="wrap" aria-label="Select rows"></Th>
       <Th modifier="wrap">{columnNames.cn}</Th>
       <Th modifier="wrap">{columnNames.description}</Th>
     </Tr>

--- a/src/pages/SudoCmds/SudoCmdsTable.tsx
+++ b/src/pages/SudoCmds/SudoCmdsTable.tsx
@@ -154,7 +154,7 @@ const SudoCmdsTable = (props: PropsToTable) => {
   // to the Table Layout
   const header = (
     <Tr>
-      <Th modifier="wrap"></Th>
+      <Th modifier="wrap" aria-label="Select rows"></Th>
       <Th modifier="wrap">{columnNames.sudocmd}</Th>
       <Th modifier="wrap">{columnNames.description}</Th>
     </Tr>

--- a/src/pages/SudoRules/SudoRulesTable.tsx
+++ b/src/pages/SudoRules/SudoRulesTable.tsx
@@ -215,7 +215,7 @@ const SudoRulesTable = (props: PropsToTable) => {
   // Defining table header and body from here to avoid passing specific names to the Table Layout
   const header = (
     <Tr>
-      <Th modifier="wrap"></Th>
+      <Th modifier="wrap" aria-label="Select rows"></Th>
       <Th modifier="wrap">{columnNames.cn}</Th>
       <Th modifier="wrap">{columnNames.sudoorder}</Th>
       <Th modifier="wrap">{columnNames.ipaenabledflag}</Th>

--- a/src/pages/UserGroups/UserGroupsTable.tsx
+++ b/src/pages/UserGroups/UserGroupsTable.tsx
@@ -156,7 +156,7 @@ const UserGroupsTable = (props: PropsToTable) => {
   // Defining table header and body from here to avoid passing specific names to the Table Layout
   const header = (
     <Tr>
-      <Th modifier="wrap"></Th>
+      <Th modifier="wrap" aria-label="Select rows"></Th>
       <Th modifier="wrap">{columnNames.cn}</Th>
       <Th modifier="wrap">{columnNames.gidnumber}</Th>
       <Th modifier="wrap">{columnNames.description}</Th>


### PR DESCRIPTION
Fixes table header accessibility issues by adding screen reader text.
Closes #783.
This also extends beyond MainTable and fixes similar warnings across all affected pages.

## Summary by Sourcery

Add screen reader labels to table header checkbox columns to resolve accessibility warnings across multiple table components

Bug Fixes:
- Add screen reader text "Select rows" to empty header cells for row selection in MainTable and other table components

Enhancements:
- Extend the accessibility fix beyond MainTable to all affected pages and tables across the application