### PR TITLE
Add id view tests

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     baseUrl: "https://server.ipa.demo/",
     testIsolation: true,
     experimentalMemoryManagement: true,
+    numTestsKeptInMemory: 5,
     async setupNodeEvents(
       on: Cypress.PluginEvents,
       config: Cypress.PluginConfigOptions

--- a/cypress/e2e/common/data_tables.ts
+++ b/cypress/e2e/common/data_tables.ts
@@ -43,6 +43,17 @@ Then("I should not see {string} entry in the data table", (name: string) => {
   entryDoesNotExist(name);
 });
 
+Then(
+  "I should see {string} entry in the data table with attribute {string} set to {string}",
+  (name: string, attribute: string, value: string) => {
+    entryExists(name);
+    cy.get("tr[id='" + name + "'] td[data-label='" + attribute + "']").should(
+      "have.text",
+      value
+    );
+  }
+);
+
 When("I select entry {string} in the data table", (name: string) => {
   selectEntry(name);
 });

--- a/cypress/e2e/common/ui/button.ts
+++ b/cypress/e2e/common/ui/button.ts
@@ -7,3 +7,7 @@ When("I click on the {string} button", (button: string) => {
 Then("I should see the {string} button is disabled", (button: string) => {
   cy.dataCy(button).should("be.disabled");
 });
+
+Then("I should see the {string} button is enabled", (button: string) => {
+  cy.dataCy(button).should("be.enabled");
+});

--- a/cypress/e2e/common/ui/dual_list.ts
+++ b/cypress/e2e/common/ui/dual_list.ts
@@ -1,0 +1,31 @@
+import { Then, When } from "@badeball/cypress-cucumber-preprocessor";
+
+When("I click on search link in dual list", () => {
+  cy.dataCy("dual-list-search-link").click();
+});
+
+When("I click on {string} dual list item", (item: string) => {
+  cy.dataCy(item).click();
+});
+
+Then("I should see {string} dual list item", (item: string) => {
+  cy.dataCy(item).should("exist");
+});
+
+Then("I should see {string} dual list item selected", (item: string) => {
+  cy.dataCy(item).should("have.attr", "aria-selected", "true");
+});
+
+Then("I should see {string} dual list item not selected", (item: string) => {
+  cy.dataCy(item).should("have.attr", "aria-selected", "false");
+});
+
+Then("I should see {string} dual list item on the left", (item: string) => {
+  cy.get("[data-cy=dual-list-left]").get(`[data-cy='${item}']`).should("exist");
+});
+
+Then("I should see {string} dual list item on the right", (item: string) => {
+  cy.get("[data-cy=dual-list-right]")
+    .get(`[data-cy='${item}']`)
+    .should("exist");
+});

--- a/cypress/e2e/common/ui/textbox.ts
+++ b/cypress/e2e/common/ui/textbox.ts
@@ -1,11 +1,15 @@
 import { Then, When } from "@badeball/cypress-cucumber-preprocessor";
 
+export const typeInTextbox = (textbox: string, text: string) => {
+  cy.dataCy(textbox).clear();
+  cy.dataCy(textbox).should("have.value", "");
+  cy.dataCy(textbox).type(text);
+};
+
 When(
   "I type in the {string} textbox text {string}",
   (textbox: string, text: string) => {
-    cy.dataCy(textbox).clear();
-    cy.dataCy(textbox).should("have.value", "");
-    cy.dataCy(textbox).type(text);
+    typeInTextbox(textbox, text);
   }
 );
 

--- a/cypress/e2e/id_views/id_views.feature
+++ b/cypress/e2e/id_views/id_views.feature
@@ -1,0 +1,210 @@
+Feature: ID View manipulation
+  Create, and delete ID views
+
+  @test
+  Scenario: Add a new view
+    Given I am logged in as admin
+    And I am on "id-views" page
+
+    When I click on the "id-views-button-add" button
+    Then I should see "add-id-view-modal" modal
+
+    When I type in the "modal-textbox-id-view-name" textbox text "a_new_view"
+    Then I should see "a_new_view" in the "modal-textbox-id-view-name" textbox
+
+    When I click on the "modal-button-add" button
+    Then I should not see "add-id-view-modal" modal
+    And I should see "add-id-view-success" alert
+    
+    When I search for "a_new_view" in the data table
+    Then I should see "a_new_view" entry in the data table
+
+  @cleanup
+  Scenario: Delete a view
+    Given I delete view "a_new_view"
+
+  @test
+  Scenario: Add a new view with description
+    Given I am logged in as admin
+    And I am on "id-views" page
+
+    When I click on the "id-views-button-add" button
+    Then I should see "add-id-view-modal" modal
+
+    When I type in the "modal-textbox-id-view-name" textbox text "a_new_view"
+    Then I should see "a_new_view" in the "modal-textbox-id-view-name" textbox
+
+    When I type in the "modal-textbox-id-view-description" textbox text "my description"
+    Then I should see "my description" in the "modal-textbox-id-view-description" textbox
+
+    When I click on the "modal-button-add" button
+    Then I should not see "add-id-view-modal" modal
+    And I should see "add-id-view-success" alert
+
+    When I search for "a_new_view" in the data table
+    Then I should see "a_new_view" entry in the data table
+    And I should see "a_new_view" entry in the data table with attribute "Description" set to "my description"
+
+  @cleanup
+  Scenario: Delete a view
+    Given I delete view "a_new_view"
+
+  @test
+  Scenario: Add one view after another
+    Given I am logged in as admin
+    And I am on "id-views" page
+
+    When I click on the "id-views-button-add" button
+    Then I should see "add-id-view-modal" modal
+
+    When I type in the "modal-textbox-id-view-name" textbox text "a_new_view"
+    Then I should see "a_new_view" in the "modal-textbox-id-view-name" textbox
+
+    When I click on the "modal-button-add-and-add-another" button
+    Then I should see "add-id-view-modal" modal
+    And I should see "add-id-view-success" alert
+
+    When I click on the "modal-button-cancel" button
+    Then I should not see "add-id-view-modal" modal
+    
+    When I search for "a_new_view" in the data table
+    Then I should see "a_new_view" entry in the data table
+
+  @cleanup
+  Scenario: Delete a view
+    Given I delete view "a_new_view"
+
+  @seed
+  Scenario: Create views
+    Given view "a_new_view" exists
+
+  @test
+  Scenario: Unapply views from hosts
+    Given I am logged in as admin
+    And I am on "id-views" page
+
+    When I click on the "id-views-kebab" kebab menu
+    Then I should see "id-views-kebab" kebab menu expanded
+
+    When I click on the "id-views-kebab-unapply-hosts" button
+    Then I should see "dual-list-modal" modal
+
+    When I click on search link in dual list
+    Then I should see "item-server\.ipa\.demo" dual list item on the left
+
+    When I click on "item-server\.ipa\.demo" dual list item
+    Then I should see "item-server\.ipa\.demo" dual list item selected
+
+    When I click on the "dual-list-add-selected" button
+    Then I should see "item-server\.ipa\.demo" dual list item on the right
+    And I should see "item-server\.ipa\.demo" dual list item not selected
+
+    When I click on the "modal-button-add" button
+    Then I should not see "dual-list-modal" modal
+    And I should see "unapply-id-views-hosts-success" alert
+
+  @test
+  Scenario: Unapply views from host groups
+    Given I am logged in as admin
+    And I am on "id-views" page
+
+    When I click on the "id-views-kebab" kebab menu
+    Then I should see "id-views-kebab" kebab menu expanded
+
+    When I click on the "id-views-kebab-unapply-hostgroups" button
+    Then I should see "dual-list-modal" modal
+
+    When I click on search link in dual list
+    Then I should see "item-ipaservers" dual list item on the left
+
+    When I click on "item-ipaservers" dual list item
+    Then I should see "item-ipaservers" dual list item selected
+
+    When I click on the "dual-list-add-selected" button
+    Then I should see "item-ipaservers" dual list item on the right
+    And I should see "item-ipaservers" dual list item not selected
+
+    When I click on the "modal-button-add" button
+    Then I should not see "dual-list-modal" modal
+    And I should see "unapply-id-views-hosts-success" alert
+
+  @cleanup
+  Scenario: Delete a view
+    Given I delete view "a_new_view"
+
+  @seed
+  Scenario: Create view "a_new_view"
+    Given view "a_new_view" exists
+
+  @test
+  Scenario: Delete a view
+    Given I am logged in as admin
+    And I am on "id-views" page
+
+    When I search for "a_new_view" in the data table
+    Then I should see "a_new_view" entry in the data table
+
+    When I select entry "a_new_view" in the data table
+    Then I should see "a_new_view" entry selected in the data table
+
+    When I click on the "id-views-button-delete" button
+    Then I should see "delete-id-views-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "delete-id-views-modal" modal
+    And I should see "remove-id-views-success" alert
+
+    When I search for "a_new_view" in the data table
+    Then I should not see "a_new_view" entry in the data table
+
+  @seed
+  Scenario: Create views
+    Given view "a_new_view" exists
+    Given view "b_new_view" exists
+
+  @test
+  Scenario: Delete many views
+    Given I am logged in as admin
+    And I am on "id-views" page
+
+    When I search for "a_new_view" in the data table
+    Then I should see "a_new_view" entry in the data table
+
+    When I select entry "a_new_view" in the data table
+    Then I should see "a_new_view" entry selected in the data table
+
+    When I search for "b_new_view" in the data table
+    Then I should see "b_new_view" entry in the data table
+
+    When I select entry "b_new_view" in the data table
+    Then I should see "b_new_view" entry selected in the data table
+
+    When I click on the "id-views-button-delete" button
+    Then I should see "delete-id-views-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "delete-id-views-modal" modal
+    And I should see "remove-id-views-success" alert
+
+    When I search for "a_new_view" in the data table
+    Then I should not see "a_new_view" entry in the data table
+
+    When I search for "b_new_view" in the data table
+    Then I should not see "b_new_view" entry in the data table
+
+  @test
+  Scenario: Cancel creation of a view
+    Given I am logged in as admin
+    And I am on "id-views" page
+
+    When I click on the "id-views-button-add" button
+    Then I should see "add-id-view-modal" modal
+
+    When I type in the "modal-textbox-id-view-name" textbox text "a_new_view"
+    Then I should see "a_new_view" in the "modal-textbox-id-view-name" textbox
+
+    When I click on the "modal-button-cancel" button
+    Then I should not see "add-id-view-modal" modal
+    
+    When I search for "a_new_view" in the data table
+    Then I should not see "a_new_view" entry in the data table

--- a/cypress/e2e/id_views/id_views.ts
+++ b/cypress/e2e/id_views/id_views.ts
@@ -1,0 +1,44 @@
+import { Given } from "@badeball/cypress-cucumber-preprocessor";
+import { loginAsAdmin, logout } from "../common/authentication";
+import {
+  selectEntry,
+  searchForEntry,
+  entryDoesNotExist,
+  entryExists,
+} from "../common/data_tables";
+import { navigateTo } from "../common/navigation";
+import { typeInTextbox } from "../common/ui/textbox";
+
+Given("I delete view {string}", (viewName: string) => {
+  loginAsAdmin();
+  navigateTo("id-views");
+  selectEntry(viewName);
+
+  cy.dataCy("id-views-button-delete").click();
+  cy.dataCy("delete-id-views-modal").should("exist");
+
+  cy.dataCy("modal-button-delete").click();
+  cy.dataCy("delete-id-views-modal").should("not.exist");
+
+  searchForEntry(viewName);
+  entryDoesNotExist(viewName);
+  logout();
+});
+
+Given("view {string} exists", (viewName: string) => {
+  loginAsAdmin();
+  navigateTo("id-views");
+
+  cy.dataCy("id-views-button-add").click();
+  cy.dataCy("add-id-view-modal").should("exist");
+
+  typeInTextbox("modal-textbox-id-view-name", viewName);
+  cy.dataCy("modal-textbox-id-view-name").should("have.value", viewName);
+
+  cy.dataCy("modal-button-add").click();
+  cy.dataCy("add-id-view-modal").should("not.exist");
+
+  searchForEntry(viewName);
+  entryExists(viewName);
+  logout();
+});

--- a/cypress/e2e/id_views/id_views_settings.feature
+++ b/cypress/e2e/id_views/id_views_settings.feature
@@ -1,0 +1,34 @@
+Feature: ID View manipulation
+  Modify an ID view
+
+  @seed
+  Scenario: Create views
+    Given view "a_new_view" exists
+
+  @test
+  Scenario: Set Description
+    Given I am logged in as admin
+    And I am on "id-views/a_new_view" page
+
+    When I type in the "id-views-tab-settings-textbox-description" textbox text "test"
+    Then I should see "test" in the "id-views-tab-settings-textbox-description" textbox
+    And I should see the "id-views-tab-settings-button-save" button is enabled 
+
+    When I click on the "id-views-tab-settings-button-save" button
+    Then I should see "save-success" alert
+
+  @test
+  Scenario: Set domain resolution order
+    Given I am logged in as admin
+    And I am on "id-views/a_new_view" page
+
+    When I type in the "id-views-tab-settings-textbox-ipadomainresolutionorder" textbox text "dom-server.ipa.demo"
+    Then I should see "dom-server.ipa.demo" in the "id-views-tab-settings-textbox-ipadomainresolutionorder" textbox
+    And I should see the "id-views-tab-settings-button-save" button is enabled 
+
+    When I click on the "id-views-tab-settings-button-save" button
+    Then I should see "save-success" alert
+
+  @cleanup
+  Scenario: Delete a view
+    Given I delete view "a_new_view"

--- a/src/components/layouts/DualListLayout/DualListLayout.tsx
+++ b/src/components/layouts/DualListLayout/DualListLayout.tsx
@@ -347,7 +347,10 @@ const DualListTableLayoutInner = (props: DualListProps) => {
       id: "dual-list-selector",
       pfComponent: (
         <DualListSelector>
-          <DualListSelectorPane status={getAvailableOptionsStatus()}>
+          <DualListSelectorPane
+            status={getAvailableOptionsStatus()}
+            data-cy="dual-list-left"
+          >
             <DualListSelectorList>{getListItems(status)}</DualListSelectorList>
           </DualListSelectorPane>
           <DualListSelectorControlsWrapper>
@@ -384,7 +387,11 @@ const DualListTableLayoutInner = (props: DualListProps) => {
               <AngleLeftIcon />
             </DualListSelectorControl>
           </DualListSelectorControlsWrapper>
-          <DualListSelectorPane isChosen status={getChosenOptionsStatus()}>
+          <DualListSelectorPane
+            isChosen
+            status={getChosenOptionsStatus()}
+            data-cy="dual-list-right"
+          >
             <DualListSelectorList>
               {chosenOptions.map((option, index) => (
                 <DualListSelectorListItem

--- a/src/pages/IDViews/IDViews.tsx
+++ b/src/pages/IDViews/IDViews.tsx
@@ -690,21 +690,19 @@ const IDViews = () => {
         buttonsData={deleteViewsButtonsData}
         onRefresh={refreshViewsData}
       />
-      {showHostModal && (
-        <DualListLayout
-          entry={""}
-          target={"host"}
-          showModal={showHostModal}
-          onCloseModal={closeUnapplyHostModal}
-          onOpenModal={openUnapplyHostModal}
-          tableElementsList={[]}
-          action={onUnapplyHosts}
-          title={"Unapply ID views from hosts"}
-          spinning={unapplySpinning}
-          addBtnName="Unapply"
-          addSpinningBtnName="Unappling"
-        />
-      )}
+      <DualListLayout
+        entry={""}
+        target={"host"}
+        showModal={showHostModal}
+        onCloseModal={closeUnapplyHostModal}
+        onOpenModal={openUnapplyHostModal}
+        tableElementsList={[]}
+        action={onUnapplyHosts}
+        title={"Unapply ID views from hosts"}
+        spinning={unapplySpinning}
+        addBtnName="Unapply"
+        addSpinningBtnName="Unappling"
+      />
       <DualListLayout
         entry={""}
         target={"hostgroup"}


### PR DESCRIPTION
Adds id view tests, all required changes.
Also had to create interface for the DualList component. AppliedTo will be added once we get hosts tests ready. Also had to lower the amount of tests held in memory.

Signed-off-by: David Hanina dhanina@redhat.com

## Summary by Sourcery

Add end-to-end tests for ID Views functionality and update UI components and Cypress configuration to support them

Enhancements:
- Simplify DualListLayout rendering for host unapply modal
- Add data-cy attributes to DualListLayout panes for consistent selectors

Tests:
- Add comprehensive Cucumber feature files for ID Views CRUD, unapply, and settings scenarios
- Extend common Cypress steps with table attribute assertion, textbox input helper, and button enabled check
- Configure Cypress to retain only five tests in memory via numTestsKeptInMemory