### PR TITLE
Add update dns button

### DIFF
--- a/src/components/modals/HostModals/DeleteHosts.tsx
+++ b/src/components/modals/HostModals/DeleteHosts.tsx
@@ -176,6 +176,7 @@ const DeleteHosts = (props: PropsToDeleteHosts) => {
             }
           }
         }
+        setBtnSpinning(false);
       }
     );
   };

--- a/src/services/rpcHosts.ts
+++ b/src/services/rpcHosts.ts
@@ -54,6 +54,11 @@ export interface HostShowPayload {
   version: string;
 }
 
+export type RemoveHostsPayload = {
+  hosts: Host[];
+  updateDns: boolean;
+};
+
 export interface MemberPayload {
   host: string;
   idsToAdd: string[];
@@ -140,13 +145,13 @@ const extendedApi = api.injectEndpoints({
       },
       invalidatesTags: ["FullHost"],
     }),
-    removeHosts: build.mutation<BatchRPCResponse, Host[]>({
-      query: (hosts) => {
+    removeHosts: build.mutation<BatchRPCResponse, RemoveHostsPayload>({
+      query: (payload) => {
         const hostsToDeletePayload: Command[] = [];
-        hosts.map((host) => {
+        payload.hosts.map((host) => {
           const payloadItem = {
             method: "host_del",
-            params: [[host.fqdn[0]], {}],
+            params: [[host.fqdn[0]], { updatedns: payload.updateDns }],
           } as Command;
           hostsToDeletePayload.push(payloadItem);
         });


### PR DESCRIPTION
Changes

Add checkbox: Allows users to choose whether DNS records should also be removed when deleting a host.

Closes [freeipa/freeipa-webui#698](https://github.com/freeipa/freeipa-webui/issues/698)

Side Fix

Fix bug: disabled delete button

After a deletion error in DeleteHosts, the delete button did not reset to its original state and remained stuck in a loading (spinning) state.

This also prevented deletion actions on other hosts.

## Summary by Sourcery

Add optional DNS record removal to host deletion and ensure delete button resets after errors

New Features:
- Add ‘Remove DNS records’ checkbox in the DeleteHosts modal and extend removeHosts mutation to pass an updateDns flag

Bug Fixes:
- Reset the delete button’s spinning state after any deletion response to prevent it from remaining stuck