### PR TITLE
DNS servers > 'Settings' page

### DIFF
--- a/src/hooks/useDnsServersSettingsData.tsx
+++ b/src/hooks/useDnsServersSettingsData.tsx
@@ -1,0 +1,117 @@
+import React from "react";
+// RPC
+import { useGetObjectMetadataQuery } from "src/services/rpc";
+import { useDnsServersShowQuery } from "src/services/rpcDnsServers";
+// Data types
+import { Metadata, DnsServer } from "src/utils/datatypes/globalDataTypes";
+import { apiToDnsServer } from "src/utils/dnsServersUtils";
+
+type DnsServersSettingsData = {
+  isLoading: boolean;
+  isFetching: boolean;
+  modified: boolean;
+  setModified: (value: boolean) => void;
+  resetValues: () => void;
+  metadata: Metadata;
+  originalDnsServer: Partial<DnsServer>;
+  dnsServer: Partial<DnsServer>;
+  setDnsServer: (dnsServer: Partial<DnsServer>) => void;
+  refetch: () => void;
+  modifiedValues: () => Partial<DnsServer>;
+};
+
+const useDnsServersSettingsData = (
+  dnsServerId: string
+): DnsServersSettingsData => {
+  // [API call] Metadata
+  const metadataQuery = useGetObjectMetadataQuery();
+  const metadata = metadataQuery.data || {};
+  const metadataLoading = metadataQuery.isLoading;
+
+  // [API call] DNS server
+  const dnsServerDetails = useDnsServersShowQuery(dnsServerId);
+  const dnsServerData = dnsServerDetails.data;
+  const isDnsServerDataLoading = dnsServerDetails.isLoading;
+
+  const [modified, setModified] = React.useState(false);
+
+  // Data displayed and modified by the user
+  const [dnsServer, setDnsServer] = React.useState<Partial<DnsServer>>({});
+  const [dnsServerDup, setDnsServerDup] = React.useState<Partial<DnsServer>>(
+    {}
+  );
+
+  React.useEffect(() => {
+    if (
+      dnsServerData &&
+      !dnsServerDetails.isFetching &&
+      "result" in dnsServerData.result
+    ) {
+      const currentDnsServer: DnsServer = apiToDnsServer(
+        dnsServerData.result.result
+      );
+      setDnsServer(currentDnsServer);
+      setDnsServerDup(currentDnsServer);
+    }
+  }, [dnsServerData, dnsServerDetails.isFetching]);
+
+  const settings: DnsServersSettingsData = {
+    isLoading: metadataLoading || isDnsServerDataLoading,
+    isFetching: dnsServerDetails.isFetching,
+    modified,
+    setModified,
+    resetValues: () => {},
+    metadata,
+    originalDnsServer: dnsServer,
+    dnsServer,
+    setDnsServer,
+    refetch: dnsServerDetails.refetch,
+    modifiedValues: () => dnsServer,
+  };
+
+  const getModifiedValues = (): Partial<DnsServer> => {
+    if (dnsServer === dnsServerData) return {};
+    if (!dnsServerDup || !dnsServerData) return {};
+    if (dnsServerData === null) return { ...dnsServer };
+
+    const modifiedValues = {};
+
+    Object.keys(dnsServer).forEach((key) => {
+      if (dnsServerDup[key] !== dnsServer[key]) {
+        modifiedValues[key] = dnsServer[key];
+      }
+    });
+    return modifiedValues;
+  };
+  settings.modifiedValues = getModifiedValues;
+
+  // Detect any change in 'originalDnsServer' and 'dnsServer' objects
+  React.useEffect(() => {
+    if (!dnsServerDup || !dnsServerData) return;
+
+    let modified = false;
+
+    for (const [key, value] of Object.entries(dnsServer)) {
+      if (Array.isArray(value)) {
+        if (JSON.stringify(dnsServerDup[key]) !== JSON.stringify(value)) {
+          modified = true;
+          break;
+        }
+      } else if (dnsServerDup[key] !== value) {
+        modified = true;
+        break;
+      }
+    }
+    setModified(modified);
+  }, [dnsServer, dnsServerData, dnsServerDup]);
+
+  // Reset values
+  const onResetValues = () => {
+    setModified(false);
+  };
+  settings.resetValues = onResetValues;
+
+  return settings;
+};
+
+export { useDnsServersSettingsData };

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -66,6 +66,7 @@ import DnsZonesTabs from "src/pages/DNSZones/DnsZonesTabs";
 import DnsForwardZones from "src/pages/DNSZones/DnsForwardZones";
 import DnsResourceRecordsPreSettings from "src/pages/DNSZones/DnsResourceRecordsPreSettings";
 import DnsServers from "src/pages/DNSZones/DnsServers";
+import DnsServersTabs from "src/pages/DNSZones/DnsServersTabs";
 
 // Renders routes (React)
 export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
@@ -487,6 +488,12 @@ export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
               </Route>
               <Route path="dns-servers">
                 <Route path="" element={<DnsServers />} />
+                <Route path=":idnsserverid">
+                  <Route
+                    path=""
+                    element={<DnsServersTabs section="settings" />}
+                  />
+                </Route>
               </Route>
               <Route path="configuration" element={<Configuration />} />
               {/* Redirect to Active users page if user is logged in and navigates to the root page */}

--- a/src/pages/DNSZones/DnsServers.tsx
+++ b/src/pages/DNSZones/DnsServers.tsx
@@ -27,7 +27,7 @@ import {
   useSearchDnsServersEntriesMutation,
 } from "src/services/rpcDnsServers";
 // React router
-import { useNavigate } from "react-router";
+import { Link, useNavigate } from "react-router";
 // Components
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import { SerializedError } from "@reduxjs/toolkit";
@@ -282,7 +282,9 @@ const DnsServers = () => {
           key={`body-row-${dnsServerId}`}
           id={`table-body-row-${dnsServerId}`}
         >
-          <Td key={`idnsserverid-${dnsServerId}`}>{dnsServerId}</Td>
+          <Td key={`idnsserverid-${dnsServerId}`}>
+            <Link to={`/dns-servers/${dnsServerId}`}>{dnsServerId}</Link>
+          </Td>
         </Tr>
       ))}
     </>

--- a/src/pages/DNSZones/DnsServersSettings.tsx
+++ b/src/pages/DNSZones/DnsServersSettings.tsx
@@ -1,0 +1,239 @@
+import React from "react";
+// PatternFly
+import {
+  Button,
+  Flex,
+  FlexItem,
+  Form,
+  FormGroup,
+  Sidebar,
+  SidebarContent,
+  SidebarPanel,
+} from "@patternfly/react-core";
+// Data types
+import { DnsServer, Metadata } from "src/utils/datatypes/globalDataTypes";
+// Hooks
+import useUpdateRoute from "src/hooks/useUpdateRoute";
+import useAlerts from "src/hooks/useAlerts";
+// Utils
+import { dnsServerAsRecord } from "src/utils/dnsServersUtils";
+// Icons
+import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
+// RPC
+import {
+  DnsServerModPayload,
+  useDnsServersModMutation,
+} from "src/services/rpcDnsServers";
+// Components
+import IpaTextInput from "src/components/Form/IpaTextInput/IpaTextInput";
+import TabLayout from "src/components/layouts/TabLayout";
+import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
+import IpaTextboxList from "src/components/Form/IpaTextboxList/IpaTextboxList";
+import IpaForwardPolicy from "src/components/Form/IpaForwardPolicy";
+
+interface DnsServersSettingsProps {
+  dnsServer: Partial<DnsServer>;
+  originalDnsServer: Partial<DnsServer>;
+  metadata: Metadata;
+  onDnsServerChange: (dnsServer: Partial<DnsServer>) => void;
+  onRefresh: () => void;
+  isModified: boolean;
+  isDataLoading: boolean;
+  modifiedValues: () => Partial<DnsServer>;
+  onResetValues: () => void;
+  pathname: string;
+}
+
+const DnsServersSettings = (props: DnsServersSettingsProps) => {
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  useUpdateRoute({ pathname: props.pathname });
+
+  // States
+  const [isDataLoading, setIsDataLoading] = React.useState(false);
+
+  // Computed state
+  const dnsServerId: string = props.dnsServer.idnsserverid || "";
+
+  // Get 'ipaObject' and 'recordOnChange' to use in 'IpaTextInput'
+  const { ipaObject, recordOnChange } = dnsServerAsRecord(
+    props.dnsServer,
+    props.onDnsServerChange
+  );
+
+  // API calls
+  const [saveDnsServer] = useDnsServersModMutation();
+
+  // 'Revert' handler method
+  const onRevert = () => {
+    props.onDnsServerChange(props.originalDnsServer);
+    props.onRefresh();
+    alerts.addAlert("revert-success", "DNS server data reverted", "success");
+  };
+
+  // Helper method to build the payload based on values
+  const buildPayload = (
+    modifiedValues: Partial<DnsServer>,
+    keyArray: string[]
+  ): DnsServerModPayload => {
+    const payload: DnsServerModPayload = {
+      idnsserverid: dnsServerId,
+    };
+
+    keyArray.forEach((key) => {
+      // Modified values are either the value (in string) or an array ([]) when set to empty string
+      if (modifiedValues[key] !== undefined) {
+        if (modifiedValues[key] === "") {
+          payload[key] = [];
+        } else {
+          payload[key] = modifiedValues[key];
+        }
+      }
+    });
+    return payload;
+  };
+
+  // on Save handler method
+  const onSave = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsDataLoading(true);
+    const modifiedValues = props.modifiedValues();
+
+    const payload = buildPayload(modifiedValues, [
+      "idnssoamname",
+      "idnsforwarders",
+      "idnsforwardpolicy",
+    ]);
+
+    saveDnsServer(payload).then((response) => {
+      if ("data" in response) {
+        const data = response.data;
+        if (data?.error) {
+          alerts.addAlert("error", (data.error as Error).message, "danger");
+        }
+        if (data?.result) {
+          props.onDnsServerChange(data.result.result);
+          alerts.addAlert("success", "DNS server data updated", "success");
+          props.onRefresh();
+        }
+      }
+      setIsDataLoading(false);
+    });
+  };
+
+  // Toolbar
+  const toolbarFields = [
+    {
+      key: 0,
+      element: (
+        <Button
+          variant="secondary"
+          data-cy="dns-servers-tab-settings-button-refresh"
+          onClick={props.onRefresh}
+        >
+          Refresh
+        </Button>
+      ),
+    },
+    {
+      key: 1,
+      element: (
+        <Button
+          variant="secondary"
+          data-cy="dns-servers-tab-settings-button-revert"
+          isDisabled={!props.isModified || isDataLoading}
+          onClick={onRevert}
+        >
+          Revert
+        </Button>
+      ),
+    },
+    {
+      key: 2,
+      element: (
+        <Button
+          variant="primary"
+          data-cy="dns-servers-tab-settings-button-save"
+          isDisabled={!props.isModified || isDataLoading}
+          type="submit"
+          form="dns-servers-tab-settings-form"
+        >
+          Save
+        </Button>
+      ),
+    },
+  ];
+
+  return (
+    <TabLayout id="settings-page" toolbarItems={toolbarFields}>
+      <alerts.ManagedAlerts />
+      <Sidebar isPanelRight>
+        <SidebarPanel variant="sticky">
+          <HelpTextWithIconLayout
+            textContent="Help"
+            icon={
+              <OutlinedQuestionCircleIcon className="pf-v6-u-primary-color-100 pf-v6-u-mr-sm" />
+            }
+          />
+        </SidebarPanel>
+        <SidebarContent className="pf-v6-u-mr-xl">
+          <Flex direction={{ default: "column", lg: "row" }}>
+            <FlexItem flex={{ default: "flex_1" }}>
+              <Form
+                className="pf-v6-u-mb-lg"
+                id="dns-servers-tab-settings-form"
+                onSubmit={onSave}
+              >
+                <FormGroup label="SOA name" role="idnssoamname">
+                  <IpaTextInput
+                    dataCy="dns-servers-tab-settings-textbox-idnssoamname"
+                    name={"idnssoamname"}
+                    ariaLabel={"SOA name text input"}
+                    ipaObject={ipaObject}
+                    onChange={recordOnChange}
+                    objectName="dnsserver"
+                    metadata={props.metadata}
+                  />
+                </FormGroup>
+                <FormGroup label="Server name" role="idnsserverid">
+                  <IpaTextInput
+                    dataCy="dns-servers-tab-settings-textbox-idnsserverid"
+                    name={"idnsserverid"}
+                    ariaLabel={"Server name text input"}
+                    ipaObject={ipaObject}
+                    onChange={recordOnChange}
+                    objectName="dnsserver"
+                    metadata={props.metadata}
+                  />
+                </FormGroup>
+                <FormGroup label="Forwarders" role="idnsforwarders">
+                  <IpaTextboxList
+                    dataCy="dns-servers-tab-settings-textbox-idnsforwarders"
+                    ipaObject={ipaObject}
+                    setIpaObject={recordOnChange}
+                    name="idnsforwarders"
+                    ariaLabel={"Forwarders text input"}
+                  />
+                </FormGroup>
+                <FormGroup label="Forward policy" role="idnsforwardpolicy">
+                  <IpaForwardPolicy
+                    name={"idnsforwardpolicy"}
+                    ariaLabel={"Forward policy radio group"}
+                    ipaObject={ipaObject}
+                    onChange={recordOnChange}
+                    metadata={props.metadata}
+                    objectName="dnsserver"
+                  />
+                </FormGroup>
+              </Form>
+            </FlexItem>
+          </Flex>
+        </SidebarContent>
+      </Sidebar>
+    </TabLayout>
+  );
+};
+
+export default DnsServersSettings;

--- a/src/pages/DNSZones/DnsServersTabs.tsx
+++ b/src/pages/DNSZones/DnsServersTabs.tsx
@@ -1,0 +1,114 @@
+import React from "react";
+// PatternFly
+import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
+// React Router DOM
+import { useNavigate, useParams } from "react-router-dom";
+// Navigation
+import { URL_PREFIX } from "src/navigation/NavRoutes";
+import { NotFound } from "src/components/errors/PageErrors";
+// Hooks
+import { useDnsServersSettingsData } from "src/hooks/useDnsServersSettingsData";
+// Components
+import TitleLayout from "src/components/layouts/TitleLayout";
+import DataSpinner from "src/components/layouts/DataSpinner";
+import BreadCrumb, {
+  BreadCrumbItem,
+} from "src/components/layouts/BreadCrumb/BreadCrumb";
+import DnsServersSettings from "src/pages/DNSZones/DnsServersSettings";
+
+const DnsServersTabs = ({ section }: { section: string }) => {
+  const { idnsserverid } = useParams();
+  const navigate = useNavigate();
+  const pathname = "dns-servers";
+
+  const [breadcrumbItems, setBreadcrumbItems] = React.useState<
+    BreadCrumbItem[]
+  >([]);
+
+  const dnsServersSettingsData = useDnsServersSettingsData(
+    idnsserverid as string
+  );
+
+  // States - Identifier of the entity (DNS Zone -> idnsname)
+  const [id, setId] = React.useState("");
+
+  const handleTabClick = (
+    _event: React.MouseEvent<HTMLElement, MouseEvent>,
+    tabIndex: number | string
+  ) => {
+    if (tabIndex === "settings") {
+      navigate("/" + pathname + "/" + idnsserverid);
+    }
+  };
+
+  React.useEffect(() => {
+    if (!idnsserverid) {
+      navigate(URL_PREFIX + "/" + pathname);
+    } else {
+      setId(idnsserverid);
+      const currentPath: BreadCrumbItem[] = [
+        {
+          name: "DNS servers",
+          url: URL_PREFIX + "/" + pathname,
+        },
+        {
+          name: idnsserverid,
+          url: URL_PREFIX + "/" + pathname + "/" + idnsserverid,
+          isActive: true,
+        },
+      ];
+      setBreadcrumbItems(currentPath);
+    }
+  }, [idnsserverid]);
+
+  // Handling of the API data
+  if (dnsServersSettingsData.isLoading || !dnsServersSettingsData.dnsServer) {
+    return <DataSpinner />;
+  }
+
+  // Show the 'NotFound' page if the certMapping is not found
+  if (
+    !dnsServersSettingsData.isLoading &&
+    Object.keys(dnsServersSettingsData.dnsServer).length === 0
+  ) {
+    return <NotFound />;
+  }
+
+  return (
+    <>
+      <PageSection hasBodyWrapper={false}>
+        <BreadCrumb breadcrumbItems={breadcrumbItems} />
+        <TitleLayout
+          id={id}
+          preText="DNS server:"
+          text={id}
+          headingLevel="h1"
+        />
+      </PageSection>
+      <PageSection hasBodyWrapper={false} isFilled={false}>
+        <Tabs activeKey={section} onSelect={handleTabClick}>
+          <Tab
+            eventKey="settings"
+            title={<TabTitleText>Settings</TabTitleText>}
+          />
+        </Tabs>
+      </PageSection>
+      <PageSection hasBodyWrapper={false}>
+        <DnsServersSettings
+          dnsServer={dnsServersSettingsData.dnsServer}
+          originalDnsServer={dnsServersSettingsData.originalDnsServer}
+          metadata={dnsServersSettingsData.metadata}
+          onDnsServerChange={dnsServersSettingsData.setDnsServer}
+          onRefresh={dnsServersSettingsData.refetch}
+          isModified={dnsServersSettingsData.modified}
+          isDataLoading={dnsServersSettingsData.isLoading}
+          modifiedValues={dnsServersSettingsData.modifiedValues}
+          onResetValues={dnsServersSettingsData.resetValues}
+          pathname={pathname}
+        />
+      </PageSection>
+    </>
+  );
+};
+
+export default DnsServersTabs;

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -1093,6 +1093,6 @@ export interface CertificateMappingConfig {
 export interface DnsServer {
   idnsserverid: string;
   idnssoamname: string;
-  idnsforwardersmultivalued: string[];
+  idnsforwarders: string[];
   idnsforwardpolicy: IDNSForwardPolicy;
 }

--- a/src/utils/dnsServersUtils.tsx
+++ b/src/utils/dnsServersUtils.tsx
@@ -16,18 +16,16 @@ export const dnsServerAsRecord = (
   return { ipaObject, recordOnChange };
 };
 
-const simpleValues = new Set([
-  "idnsserverid",
-  "idnssoamname",
-  "idnsforwardpolicy",
-]);
+const simpleValues = new Set(["idnsserverid", "idnsforwardpolicy"]);
 const dateValues = new Set([]);
+const complexValues = new Map([["idnssoamname", "__dns_name__"]]);
 
 export function apiToDnsServer(apiRecord: Record<string, unknown>): DnsServer {
   const converted = convertApiObj(
     apiRecord,
     simpleValues,
-    dateValues
+    dateValues,
+    complexValues
   ) as Partial<DnsServer>;
   return partialDnsServerToDnsServer(converted);
 }
@@ -45,7 +43,7 @@ export function createEmptyDnsServer(): DnsServer {
   return {
     idnsserverid: "",
     idnssoamname: "",
-    idnsforwardersmultivalued: [],
+    idnsforwarders: [],
     idnsforwardpolicy: "none",
   };
 }


### PR DESCRIPTION
This PR depends on this one to be merged: https://github.com/freeipa/freeipa-webui/pull/803

## Summary by Sourcery

Provide a complete DNS servers management interface by adding a listing page, settings tab, RPC integration, and navigation updates for DNS server entities.

New Features:
- Add DNS servers listing page with search, pagination, and navigation to individual server details
- Add DNS server settings tab under a new DnsServersTabs component, including editable SOA name, forwarders, and forward policy with save, revert, and refresh actions
- Introduce RPC endpoints (dnsserver_find, dnsserver_show, dnsserver_mod) and corresponding data hooks for DNS servers
- Update application routing and navigation to include the DNS servers section
- Define a DnsServer interface and utility functions for DNS server data conversion and selection