### PR TITLE
Composes modal id of formId + suffix

### DIFF
--- a/src/components/layouts/ModalWithFormLayout.tsx
+++ b/src/components/layouts/ModalWithFormLayout.tsx
@@ -64,8 +64,8 @@ const ModalWithFormLayout = (props: PropsToModal) => {
       isOpen={props.show}
       onClose={props.onClose}
     >
-      <ModalHeader title={props.title} labelId={props.dataCy} />
-      <ModalBody id={props.dataCy + "-modal-body"}>
+      <ModalHeader title={props.title} labelId={props.formId + "-header"} />
+      <ModalBody id={props.formId + "-modal-body"}>
         <Form
           onSubmit={onSubmit}
           id={props.formId}


### PR DESCRIPTION
The change tries to ensure it's more difficult to hit duplicate IDs, occasionally we had duplicates IDs which prevented form submission.

## Summary by Sourcery

Bug Fixes:
- Use formId with the “-header” suffix for ModalHeader.labelId and the “-modal-body” suffix for ModalBody.id to ensure unique IDs