### PR TITLE
Rename url modern_ui -> modern-ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ $ npm run build
 ```
 
 Now your dev environment is ready, you can do changes and see them at:
-`https://server.ipa.demo/ipa/modern_ui/`
+`https://server.ipa.demo/ipa/modern-ui/`
 
 The default credentials are **admin** and **Secret123**.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -58,7 +58,7 @@ Vagrant.configure("2") do |config|
     set -e
     cat >> /etc/httpd/conf.d/ipa.conf <<EOF
 
-    Alias /ipa/modern_ui "/usr/src/freeipa-webui/dist"
+    Alias /ipa/modern-ui "/usr/src/freeipa-webui/dist"
     <Directory "/usr/src/freeipa-webui/dist">
       SetHandler None
       AllowOverride None

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
     },
   },
   env: {
-    BASE_URL: "/ipa/modern_ui",
+    BASE_URL: "/ipa/modern-ui",
     ADMIN_LOGIN: "admin",
     ADMIN_PASSWORD: "Secret123",
     TAGS: "not @ignore",

--- a/doc/designs/login-via-certificates.md
+++ b/doc/designs/login-via-certificates.md
@@ -71,4 +71,4 @@ As a final step, you must enable the post-handshake auth parameter:
 
 ## Try certificate authentication in the modern WebUI
 
-To test the certificate authentication, go to the [modern WebUI login page](https://server.ipa.demo/ipa/modern_ui/login), write the username `mshelley` and click `Login using Certificate`.
+To test the certificate authentication, go to the [modern WebUI login page](https://server.ipa.demo/ipa/modern-ui/login), write the username `mshelley` and click `Login using Certificate`.

--- a/index.dev.html
+++ b/index.dev.html
@@ -7,14 +7,14 @@
     <link rel="icon" href="./favicon.ico" />
     <title>Identity Management</title>
     <script type="module">
-      import { injectIntoGlobalHook } from "http://localhost:5173/ipa/modern_ui/@react-refresh";
+      import { injectIntoGlobalHook } from "http://localhost:5173/ipa/modern-ui/@react-refresh";
       injectIntoGlobalHook(window);
       window.$RefreshReg$ = () => {};
       window.$RefreshSig$ = () => (type) => type;
     </script>
     <script
       type="module"
-      src="http://localhost:5173/ipa/modern_ui/@vite/client"
+      src="http://localhost:5173/ipa/modern-ui/@vite/client"
     ></script>
   </head>
   <body>
@@ -28,7 +28,7 @@
     </div>
     <script
       type="module"
-      src="http://localhost:5173/ipa/modern_ui/src/main.tsx"
+      src="http://localhost:5173/ipa/modern-ui/src/main.tsx"
     ></script>
   </body>
 </html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import react from "@vitejs/plugin-react-swc";
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: "/ipa/modern_ui",
+  base: "/ipa/modern-ui",
   build: {
     sourcemap: true,
   },


### PR DESCRIPTION
If the release is getting a slight rename, then development should get the rename as well. If both change, then there's no need to specify build from development.

## Summary by Sourcery

Enhancements:
- Rename the web UI path segment from modern_ui to modern-ui across development and production configs