### PR TITLE
Update PatternFly libraries to 6.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.1.6",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@patternfly/patternfly": "^6.3.0",
-        "@patternfly/react-core": "^6.3.0",
-        "@patternfly/react-table": "^6.3.0",
+        "@patternfly/patternfly": "^6.3.1",
+        "@patternfly/react-core": "^6.3.1",
+        "@patternfly/react-table": "^6.3.1",
         "@reduxjs/toolkit": "^2.6.1",
         "qrcode.react": "^4.2.0",
         "react": "^18.0.0",
@@ -1963,20 +1963,18 @@
       }
     },
     "node_modules/@patternfly/patternfly": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-6.3.0.tgz",
-      "integrity": "sha512-I/Z0uuaVYfv9QqNAP2/iCGUGhUb0idatNTfFLQk0VnUi2hSMgznDogvAjmlVtZu2DW0P0FymS0oo5EjL+uW6Dg==",
-      "license": "MIT"
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-6.3.1.tgz",
+      "integrity": "sha512-O/lTo5EHKzer/HNzqMQOQEAMG7izDDkEHpAeJ5+sGaeQ/maB3RK7sQsOPS4DjrnMxt4/cC6LogK2mowlbf1j5Q=="
     },
     "node_modules/@patternfly/react-core": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.3.0.tgz",
-      "integrity": "sha512-TM+pLwLd5DzaDlOQhqeju9H9QUFQypQiNwXQLNIxOV5r3fmKh4NTp2Av/8WmFkpCj8mejDOfp4TNxoU1zdjCkQ==",
-      "license": "MIT",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.3.1.tgz",
+      "integrity": "sha512-1qV20nU4M6PA28qnikH9fPLQlkteaZZToFlATjBNBw7aUI6zIvj7U0akkHz8raWcfHAI+tAzGV7dfKjiv035/g==",
       "dependencies": {
-        "@patternfly/react-icons": "^6.3.0",
-        "@patternfly/react-styles": "^6.3.0",
-        "@patternfly/react-tokens": "^6.3.0",
+        "@patternfly/react-icons": "^6.3.1",
+        "@patternfly/react-styles": "^6.3.1",
+        "@patternfly/react-tokens": "^6.3.1",
         "focus-trap": "7.6.4",
         "react-dropzone": "^14.3.5",
         "tslib": "^2.8.1"
@@ -1987,31 +1985,28 @@
       }
     },
     "node_modules/@patternfly/react-icons": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.3.0.tgz",
-      "integrity": "sha512-W39JyqKW1UL6/YGuinDnpjbhmmLAfuxVrgDcdFBaK4D7D1iqkkqrDMV8zIzmV/RkodJ79xRnucYhYb2RukG4RA==",
-      "license": "MIT",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.3.1.tgz",
+      "integrity": "sha512-uiMounSIww1iZLM4pq+X8c3upzwl9iowXRPjR5CA8entb70lwgAXg3PqvypnuTAcilTq1Y3k5sFTqkhz7rgKcQ==",
       "peerDependencies": {
         "react": "^17 || ^18 || ^19",
         "react-dom": "^17 || ^18 || ^19"
       }
     },
     "node_modules/@patternfly/react-styles": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.3.0.tgz",
-      "integrity": "sha512-FvuyNsY2oN8f2dvCl4Hx8CxBWCIF3BC9JE3Ay1lCuVqY1WYkvW4AQn3/0WVRINCxB9FkQxVNkSjARdwHNCEulw==",
-      "license": "MIT"
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.3.1.tgz",
+      "integrity": "sha512-hyb+PlO8YITjKh2wBvjdeZhX6FyB3hlf4r6yG4rPOHk4SgneXHjNSdGwQ3szAxgGqtbENCYtOqwD/8ai72GrxQ=="
     },
     "node_modules/@patternfly/react-table": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-6.3.0.tgz",
-      "integrity": "sha512-klC0HKZvKhrRRJX8j1bLmfvzJyMeqpwbKeV7np9Ggvvh79IxWpBBKX2XbJkjHtl+sCwIVN1VZatil3HGba5CZQ==",
-      "license": "MIT",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-6.3.1.tgz",
+      "integrity": "sha512-ZndBbPcMr/vInP5eELRe9m7MWzRoejRAhWx+25xOdjVAd31/CmMK1nBgZk4QAXaWjH1P+uZaZYsTgr/FMTte2g==",
       "dependencies": {
-        "@patternfly/react-core": "^6.3.0",
-        "@patternfly/react-icons": "^6.3.0",
-        "@patternfly/react-styles": "^6.3.0",
-        "@patternfly/react-tokens": "^6.3.0",
+        "@patternfly/react-core": "^6.3.1",
+        "@patternfly/react-icons": "^6.3.1",
+        "@patternfly/react-styles": "^6.3.1",
+        "@patternfly/react-tokens": "^6.3.1",
         "lodash": "^4.17.21",
         "tslib": "^2.8.1"
       },
@@ -2021,10 +2016,9 @@
       }
     },
     "node_modules/@patternfly/react-tokens": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-6.3.0.tgz",
-      "integrity": "sha512-yWStfkbxg4RWAExFKS/JRGScyadOy35yr4DFispNeHrkZWMp4pwKf0VdwlQZ7+ZtSgEWtzzy1KFxMLmWh3mEqA==",
-      "license": "MIT"
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-6.3.1.tgz",
+      "integrity": "sha512-wt/xKU1tGCDXUueFb+8/Cwxlm4vUD/Xl26O8MxbSLm6NZAHOUPwytJ7gugloGSPvc/zcsXxEgKANL8UZNO6DTw=="
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "author": "",
   "license": "GPL-3.0-or-later",
   "dependencies": {
-    "@patternfly/patternfly": "^6.3.0",
-    "@patternfly/react-core": "^6.3.0",
-    "@patternfly/react-table": "^6.3.0",
+    "@patternfly/patternfly": "^6.3.1",
+    "@patternfly/react-core": "^6.3.1",
+    "@patternfly/react-table": "^6.3.1",
     "@reduxjs/toolkit": "^2.6.1",
     "qrcode.react": "^4.2.0",
     "react": "^18.0.0",


### PR DESCRIPTION
The latest version 6.3.1[1] contains some bugs, being one of them the one affecting to the `PageToggleButton` component.

[1] - https://www.patternfly.org/get-started/release-highlights/#patternfly-6.3.1
Fixes: https://github.com/freeipa/freeipa-webui/issues/824