### PR TITLE
Add tests for hbac service group handling and group members

### DIFF
--- a/cypress/e2e/common/ui/dual_list.ts
+++ b/cypress/e2e/common/ui/dual_list.ts
@@ -30,7 +30,6 @@ Then("I should see {string} dual list item on the right", (item: string) => {
 
 export const addItemToRightList = (item: string) => {
   const dualListItem = `item-${item}`;
-  cy.dataCy("dual-list-search-link").click();
   cy.dataCy(dualListItem).should("exist");
 
   cy.dataCy(dualListItem).click();

--- a/cypress/e2e/common/ui/tab.ts
+++ b/cypress/e2e/common/ui/tab.ts
@@ -11,3 +11,7 @@ Then("I should not see {string} tab", (tab: string) => {
 Then("I should see {string} tab", (tab: string) => {
   cy.dataCy(tab).should("exist");
 });
+
+Then("I should see {string} tab selected", (tab: string) => {
+  cy.dataCy(tab).should("have.attr", "aria-selected", "true");
+});

--- a/cypress/e2e/hbac/hbac_rule/hbac_rule.ts
+++ b/cypress/e2e/hbac/hbac_rule/hbac_rule.ts
@@ -60,6 +60,7 @@ Given(
     cy.dataCy(`settings-button-add-${elementType}`).click();
     cy.dataCy("dual-list-modal").should("exist");
 
+    cy.dataCy("dual-list-search-link").click();
     addItemToRightList(element);
 
     cy.dataCy("modal-button-add").click();
@@ -114,6 +115,7 @@ Given(
     cy.dataCy("settings-button-add-host").click();
     cy.dataCy("dual-list-modal").should("exist");
 
+    cy.dataCy("dual-list-search-link").click();
     addItemToRightList(hostFqdn);
 
     cy.dataCy("modal-button-add").click();
@@ -166,6 +168,7 @@ Given(
     cy.dataCy("settings-button-add-hbacsvc").click();
     cy.dataCy("dual-list-modal").should("exist");
 
+    cy.dataCy("dual-list-search-link").click();
     addItemToRightList(service);
 
     cy.dataCy("modal-button-add").click();
@@ -218,6 +221,7 @@ Given(
     cy.dataCy("settings-button-add-hbacsvcgroup").click();
     cy.dataCy("dual-list-modal").should("exist");
 
+    cy.dataCy("dual-list-search-link").click();
     addItemToRightList(svcGroup);
 
     cy.dataCy("modal-button-add").click();

--- a/cypress/e2e/hbac/hbac_service_group/hbac_service_group.feature
+++ b/cypress/e2e/hbac/hbac_service_group/hbac_service_group.feature
@@ -1,0 +1,123 @@
+Feature: HBAC service groups manipulation
+  Create and delete HBAC service groups
+
+  @test
+  Scenario: Add a new service group
+    Given I am logged in as admin
+    And I am on "hbac-service-groups" page
+
+    When I click on the "hbac-service-groups-button-add" button
+    Then I should see "add-hbac-service-group-modal" modal
+
+    When I type in the "modal-textbox-service-group-name" textbox text "a_service_group1"
+    Then I should see "a_service_group1" in the "modal-textbox-service-group-name" textbox  
+
+    When I type in the "modal-textbox-description" textbox text "my description"
+    Then I should see "my description" in the "modal-textbox-description" textbox
+
+    When I click on the "modal-button-add" button
+    Then I should not see "add-hbac-service-group-modal" modal
+    And I should see "add-hbacservicegroup-success" alert
+
+    When I search for "a_service_group1" in the data table
+    Then I should see "a_service_group1" entry in the data table
+    And I should see "a_service_group1" entry in the data table with attribute "Description" set to "my description"
+
+  @cleanup
+  Scenario: Cleanup: Delete a service group
+    Given I delete service group "a_service_group1"
+
+  @test
+  Scenario: Add several service groups
+    Given I am logged in as admin
+    And I am on "hbac-service-groups" page
+
+    When I click on the "hbac-service-groups-button-add" button
+    Then I should see "add-hbac-service-group-modal" modal
+
+    When I type in the "modal-textbox-service-group-name" textbox text "a_service_group2"
+    Then I should see "a_service_group2" in the "modal-textbox-service-group-name" textbox
+
+    When I click on the "modal-button-add-and-add-another" button
+    Then I should see "add-hbac-service-group-modal" modal
+    And I should see "add-hbacservicegroup-success" alert
+
+    When I type in the "modal-textbox-service-group-name" textbox text "a_service_group3"
+    Then I should see "a_service_group3" in the "modal-textbox-service-group-name" textbox
+
+    When I click on the "modal-button-add" button
+    Then I should not see "add-hbac-service-group-modal" modal
+    And I should see "add-hbacservicegroup-success" alert
+
+    When I search for "a_service_group2" in the data table
+    Then I should see "a_service_group2" entry in the data table
+
+    When I search for "a_service_group3" in the data table
+    Then I should see "a_service_group3" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup: Delete a service group
+    Given I delete service group "a_service_group2"
+    And I delete service group "a_service_group3"
+
+  @seed
+  Scenario: Seed: Ensure service group exists
+    Given HBAC service group "a_service_group2" exists
+
+  @test
+  Scenario: Search for a service group
+    Given I am logged in as admin
+    And I am on "hbac-service-groups" page
+
+    When I search for "a_service_group2" in the data table
+    Then I should see "a_service_group2" entry in the data table
+    And I should not see "a_service_group1" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup: Delete a service group
+    Given I delete service group "a_service_group2"
+
+  @seed
+  Scenario: Seed: Ensure service group exists
+    Given HBAC service group "a_service_group2" exists
+    And HBAC service group "a_service_group3" exists
+
+  @test
+  Scenario: Delete many service groups
+    Given I am logged in as admin
+    And I am on "hbac-service-groups" page
+
+    When I search for "a_service_group2" in the data table
+    Then I should see "a_service_group2" entry in the data table
+    When I select entry "a_service_group2" in the data table
+    Then I should see "a_service_group2" entry selected in the data table
+
+    When I search for "a_service_group3" in the data table
+    Then I should see "a_service_group3" entry in the data table
+    When I select entry "a_service_group3" in the data table
+    Then I should see "a_service_group3" entry selected in the data table
+
+    When I click on the "hbac-service-groups-button-delete" button
+    Then I should see "delete-hbac-service-groups-modal" modal
+    And I should see "a_service_group2" entry in the data table
+    And I should see "a_service_group3" entry in the data table
+
+    When I click on the "modal-button-delete" button
+    Then I should see "remove-hbacservicegroups-success" alert
+    And I should not see "a_service_group2" entry in the data table
+    And I should not see "a_service_group3" entry in the data table
+
+  @test
+  Scenario: Cancel creation of a service group
+    Given I am logged in as admin
+    And I am on "hbac-service-groups" page
+
+    When I click on the "hbac-service-groups-button-add" button
+    Then I should see "add-hbac-service-group-modal" modal
+
+    When I type in the "modal-textbox-service-group-name" textbox text "a_service_group_cancel"
+    Then I should see "a_service_group_cancel" in the "modal-textbox-service-group-name" textbox
+
+    When I click on the "modal-button-cancel" button
+    Then I should not see "add-hbac-service-group-modal" modal
+    And I should not see "a_service_group_cancel" entry in the data table

--- a/cypress/e2e/hbac/hbac_service_group/hbac_service_group.ts
+++ b/cypress/e2e/hbac/hbac_service_group/hbac_service_group.ts
@@ -1,0 +1,110 @@
+import { Given } from "@badeball/cypress-cucumber-preprocessor";
+import { loginAsAdmin, logout } from "../../common/authentication";
+import { navigateTo } from "../../common/navigation";
+import {
+  entryExists,
+  entryDoesNotExist,
+  searchForEntry,
+  selectEntry,
+} from "../../common/data_tables";
+import { typeInTextbox } from "../../common/ui/textbox";
+import { addItemToRightList } from "cypress/e2e/common/ui/dual_list";
+
+Given("HBAC service group {string} exists", (groupName: string) => {
+  loginAsAdmin();
+  navigateTo("hbac-service-groups");
+
+  searchForEntry(groupName);
+
+  cy.dataCy("hbac-service-groups-button-add").click();
+  cy.dataCy("add-hbac-service-group-modal").should("exist");
+
+  typeInTextbox("modal-textbox-service-group-name", groupName);
+  cy.dataCy("modal-textbox-service-group-name").should("have.value", groupName);
+
+  cy.dataCy("modal-button-add").click();
+  cy.dataCy("add-hbac-service-group-modal").should("not.exist");
+  cy.dataCy("add-hbacservicegroup-success").should("exist");
+
+  searchForEntry(groupName);
+  entryExists(groupName);
+
+  logout();
+});
+
+Given("I delete service group {string}", (groupName: string) => {
+  loginAsAdmin();
+  navigateTo("hbac-service-groups");
+
+  searchForEntry(groupName);
+  selectEntry(groupName);
+
+  cy.dataCy("hbac-service-groups-button-delete").click();
+  cy.dataCy("delete-hbac-service-groups-modal").should("exist");
+  entryExists(groupName);
+
+  cy.dataCy("modal-button-delete").click();
+  cy.dataCy("remove-hbacservicegroups-success").should("exist");
+  entryDoesNotExist(groupName);
+
+  logout();
+});
+
+Given(
+  "I add service group member {string} to service group {string}",
+  (serviceName: string, groupName: string) => {
+    loginAsAdmin();
+    navigateTo(`hbac-service-groups/${groupName}`);
+
+    cy.dataCy("hbac-service-groups-tab-members").click();
+    cy.dataCy("hbac-service-groups-tab-members").should(
+      "have.attr",
+      "aria-selected",
+      "true"
+    );
+
+    cy.dataCy("member-of-button-add").click();
+    cy.dataCy("member-of-add-modal").should("exist");
+
+    addItemToRightList(serviceName);
+
+    cy.dataCy("modal-button-add").click();
+    cy.dataCy("member-of-add-modal").should("not.exist");
+    cy.dataCy("add-member-success").should("exist");
+
+    searchForEntry(serviceName);
+    entryExists(serviceName);
+
+    logout();
+  }
+);
+
+Given(
+  "I delete service group member {string} from service group {string}",
+  (serviceName: string, groupName: string) => {
+    loginAsAdmin();
+    navigateTo(`hbac-service-groups/${groupName}`);
+
+    cy.dataCy("hbac-service-groups-tab-members").click();
+    cy.dataCy("hbac-service-groups-tab-members").should(
+      "have.attr",
+      "aria-selected",
+      "true"
+    );
+
+    searchForEntry(serviceName);
+    selectEntry(serviceName);
+
+    cy.dataCy("member-of-button-delete").click();
+    cy.dataCy("member-of-delete-modal").should("exist");
+
+    cy.dataCy("modal-button-delete").click();
+    cy.dataCy("member-of-delete-modal").should("not.exist");
+    cy.dataCy("remove-members-success").should("exist");
+
+    searchForEntry(serviceName);
+    entryDoesNotExist(serviceName);
+
+    logout();
+  }
+);

--- a/cypress/e2e/hbac/hbac_service_group/hbac_service_group_members.feature
+++ b/cypress/e2e/hbac/hbac_service_group/hbac_service_group_members.feature
@@ -1,0 +1,77 @@
+Feature: HBAC service group members
+  Work with Members section and its operations
+
+  @test
+  Scenario: Add an HBAC service member
+    Given I am logged in as admin
+    And I am on "hbac-service-groups/ftp" page
+
+    When I click on the "hbac-service-groups-tab-members" tab
+    Then I should see "hbac-service-groups-tab-members" tab selected
+    And I should see "hbac-service-groups-tab-members-tab-hbacservices" tab
+
+    When I click on the "member-of-button-add" button
+    Then I should see "member-of-add-modal" modal
+    And I should see "item-crond" dual list item on the left
+
+    When I click on "item-crond" dual list item
+    Then I should see "item-crond" dual list item selected
+
+    When I click on the "dual-list-add-selected" button
+    Then I should see "item-crond" dual list item on the right
+    And I should see "item-crond" dual list item not selected
+
+    When I click on the "modal-button-add" button
+    Then I should not see "member-of-add-modal" modal
+    And I should see "add-member-success" alert
+    And I should see "crond" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup: Remove HBAC service member
+    Given I delete service group member "crond" from service group "ftp"
+
+  @seed
+  Scenario: Seed: Ensure service exists
+    Given I add service group member "crond" to service group "ftp"
+
+
+  @test
+  Scenario: Search within HBAC service members
+    Given I am logged in as admin
+    And I am on "hbac-service-groups/ftp" page
+
+    When I click on the "hbac-service-groups-tab-members" tab
+    Then I should see "hbac-service-groups-tab-members" tab selected
+
+    When I search for "crond" in the data table
+    Then I should see "crond" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup: Remove HBAC service member
+    Given I delete service group member "crond" from service group "ftp"
+
+
+  @seed
+  Scenario: Seed: Ensure service exists
+    Given I add service group member "crond" to service group "ftp"
+
+
+  @test
+  Scenario: Remove HBAC service member
+    Given I am logged in as admin
+    And I am on "hbac-service-groups/ftp" page
+
+    When I click on the "hbac-service-groups-tab-members" tab
+    Then I should see "hbac-service-groups-tab-members" tab selected
+
+    Then I should see "crond" entry in the data table
+    When I select entry "crond" in the data table
+
+    When I click on the "member-of-button-delete" button
+    Then I should see "member-of-delete-modal" modal
+    And I should see "crond" entry in the data table
+
+    When I click on the "modal-button-delete" button
+    Then I should see "remove-members-success" alert
+    And I should not see "crond" entry in the data table
+

--- a/src/components/layouts/DualListLayout/DualListLayout.tsx
+++ b/src/components/layouts/DualListLayout/DualListLayout.tsx
@@ -346,7 +346,7 @@ const DualListTableLayoutInner = (props: DualListProps) => {
     {
       id: "dual-list-selector",
       pfComponent: (
-        <DualListSelector>
+        <DualListSelector data-cy="dual-list-selector">
           <DualListSelectorPane
             status={getAvailableOptionsStatus()}
             data-cy="dual-list-left"

--- a/src/components/layouts/DualListSelectorGeneric.tsx
+++ b/src/components/layouts/DualListSelectorGeneric.tsx
@@ -17,6 +17,7 @@ import {
 export interface DualListOption {
   text: string;
   selected: boolean;
+  dataCy: string;
 }
 
 interface DualListGenericProps {
@@ -37,6 +38,7 @@ export const optionsToDualListOptions = (
   return options.map((option) => ({
     text: option,
     selected: false,
+    dataCy: `item-${option}`,
   }));
 };
 
@@ -107,12 +109,14 @@ const DualListSelectorGeneric = (props: DualListGenericProps) => {
     <DualListSelector
       id={props.id}
       aria-label={props.ariaLabel || "Dual list selector"}
+      data-cy="dual-list-selector"
     >
       <DualListSelectorPane
         title={props.availableOptionsTitle || "Available options"}
         status={`${availableOptions.filter((option) => option.selected).length} of ${
           availableOptions.length
         } options selected`}
+        data-cy="dual-list-left"
       >
         <DualListSelectorList>
           {availableOptions.map((option, index) => (
@@ -121,6 +125,7 @@ const DualListSelectorGeneric = (props: DualListGenericProps) => {
               isSelected={option.selected}
               id={`basic-available-option-${index}`}
               onOptionSelect={(e) => onOptionSelect(e, index, false)}
+              data-cy={option.dataCy}
             >
               {option.text}
             </DualListSelectorListItem>
@@ -132,24 +137,28 @@ const DualListSelectorGeneric = (props: DualListGenericProps) => {
           isDisabled={!availableOptions.some((option) => option.selected)}
           onClick={() => moveSelected(true)}
           aria-label="Add selected"
+          data-cy="dual-list-add-selected"
           icon={<AngleRightIcon />}
         />
         <DualListSelectorControl
           isDisabled={availableOptions.length === 0}
           onClick={() => moveAll(true)}
           aria-label="Add all"
+          data-cy="dual-list-add-all"
           icon={<AngleDoubleRightIcon />}
         />
         <DualListSelectorControl
           isDisabled={chosenOptions.length === 0}
           onClick={() => moveAll(false)}
           aria-label="Remove all"
+          data-cy="dual-list-remove-all"
           icon={<AngleDoubleLeftIcon />}
         />
         <DualListSelectorControl
           onClick={() => moveSelected(false)}
           isDisabled={!chosenOptions.some((option) => option.selected)}
           aria-label="Remove selected"
+          data-cy="dual-list-remove-selected"
           icon={<AngleLeftIcon />}
         />
       </DualListSelectorControlsWrapper>
@@ -159,6 +168,7 @@ const DualListSelectorGeneric = (props: DualListGenericProps) => {
           chosenOptions.length
         } options selected`}
         isChosen
+        data-cy="dual-list-right"
       >
         <DualListSelectorList>
           {chosenOptions.map((option, index) => (
@@ -167,6 +177,7 @@ const DualListSelectorGeneric = (props: DualListGenericProps) => {
               isSelected={option.selected}
               id={`composable-basic-chosen-option-${index}`}
               onOptionSelect={(e) => onOptionSelect(e, index, true)}
+              data-cy={option.dataCy}
             >
               {option.text}
             </DualListSelectorListItem>

--- a/src/pages/HBACServiceGroups/HBACServiceGroupsMembers.tsx
+++ b/src/pages/HBACServiceGroups/HBACServiceGroupsMembers.tsx
@@ -70,6 +70,7 @@ const HBACSvcGroupMembers = (props: PropsToSvcGroupsMembers) => {
           <Tab
             eventKey={"member_hbacsvc"}
             name="member_hbacsvc"
+            data-cy="hbac-service-groups-tab-members-tab-hbacservices"
             title={
               <TabTitleText>
                 HBAC services{" "}

--- a/src/pages/HBACServiceGroups/HBACServiceGroupsTabs.tsx
+++ b/src/pages/HBACServiceGroups/HBACServiceGroupsTabs.tsx
@@ -138,6 +138,7 @@ const HBACServiceGroupsTabs = ({ section }) => {
           <Tab
             eventKey={"members"}
             name="members-details"
+            data-cy="hbac-service-groups-tab-members"
             title={<TabTitleText>Members</TabTitleText>}
           >
             <HBACSvcGroupMembers


### PR DESCRIPTION
Adding tests for hbac service group handling and group members

Depends on #823

## Summary by Sourcery

Enable Cypress-driven end-to-end testing of HBAC services, service groups, and group membership by adding data-cy selectors to UI components and introducing corresponding E2E test suites.

New Features:
- Introduce Cypress E2E test suites for HBAC services CRUD, HBAC service groups CRUD, and service group membership management.

Enhancements:
- Add data-cy attributes to DualListSelectorGeneric options, controls, and panes to support reliable UI element selection.
- Include data-cy properties on DualListLayout selector and HBACServiceGroups tabs for test targeting.

Tests:
- Update existing hbac_rule spec to invoke the dual-list search link before adding items and remove its redundant click from the helper function.
- Add new Cypress feature files and spec scaffolds for HBAC services, service groups, and service group member operations covering create, search, delete, and cancel scenarios.