### PR TITLE
Fix: Failure stuck in loading

### DIFF
--- a/src/components/MemberOf/MemberOfHostGroups.tsx
+++ b/src/components/MemberOf/MemberOfHostGroups.tsx
@@ -265,6 +265,7 @@ const MemberOfHostGroups = (props: MemberOfHostGroupsProps) => {
         } else if (response.data?.error) {
           // Set alert: error
           const errorMessage = response.data.error as unknown as ErrorResult;
+          setSpinning(false);
           alerts.addAlert(
             "remove-host-groups-error",
             errorMessage.message,

--- a/src/components/modals/DeleteHostGroups.tsx
+++ b/src/components/modals/DeleteHostGroups.tsx
@@ -151,6 +151,7 @@ const DeleteHostGroups = (props: PropsToDeleteGroups) => {
 
               // Handle error
               handleAPIError(error);
+              setBtnSpinning(false);
             } else {
               // Update data from Redux
               props.selectedGroupsData.selectedGroups.map((group) => {

--- a/src/components/modals/DeleteIDViews.tsx
+++ b/src/components/modals/DeleteIDViews.tsx
@@ -145,6 +145,7 @@ const DeleteIDViewsModal = (props: PropsToDeleteViews) => {
 
               // Handle error
               handleAPIError(error);
+              setBtnSpinning(false);
             } else {
               props.selectedViewsData.clearSelectedViews();
               props.buttonsData.updateIsDeleteButtonDisabled(true);

--- a/src/components/modals/DeleteNetgroups.tsx
+++ b/src/components/modals/DeleteNetgroups.tsx
@@ -151,6 +151,7 @@ const DeleteNetgroups = (props: PropsToDeleteGroups) => {
 
               // Handle error
               handleAPIError(error);
+              setBtnSpinning(false);
             } else {
               // Update data from Redux
               props.selectedGroupsData.selectedGroups.map((group) => {

--- a/src/components/modals/DeleteServices.tsx
+++ b/src/components/modals/DeleteServices.tsx
@@ -151,6 +151,7 @@ const DeleteServices = (props: PropsToDeleteServices) => {
 
               // Handle error
               handleAPIError(error);
+              setBtnSpinning(false);
             } else {
               // Update data from Redux
               props.selectedServicesData.selectedElements.map((service) => {

--- a/src/components/modals/DeleteUserGroups.tsx
+++ b/src/components/modals/DeleteUserGroups.tsx
@@ -151,6 +151,7 @@ const DeleteUserGroups = (props: PropsToDeleteGroups) => {
 
               // Handle error
               handleAPIError(error);
+              setBtnSpinning(false);
             } else {
               // Update data from Redux
               props.selectedGroupsData.selectedGroups.map((group) => {

--- a/src/components/modals/DnsZones/DeleteDnsRecords.tsx
+++ b/src/components/modals/DnsZones/DeleteDnsRecords.tsx
@@ -135,6 +135,7 @@ const DeleteDnsRecordsModal = (props: DeleteDnsRecordsModalProps) => {
             };
 
             handleAPIError(error);
+            setBtnSpinning(false);
           } else {
             props.updateIsDeleteButtonDisabled?.(true);
             props.updateIsDeletion?.(true);

--- a/src/components/modals/HbacModals/DeleteHBACRule.tsx
+++ b/src/components/modals/HbacModals/DeleteHBACRule.tsx
@@ -145,6 +145,7 @@ const DeleteHBACRule = (props: PropsToDeleteRules) => {
 
               // Handle error
               handleAPIError(error);
+              setBtnSpinning(false);
             } else {
               props.selectedRulesData.clearSelectedRules();
               props.buttonsData.updateIsDeleteButtonDisabled(true);

--- a/src/components/modals/HbacModals/DeleteHBACService.tsx
+++ b/src/components/modals/HbacModals/DeleteHBACService.tsx
@@ -145,6 +145,7 @@ const DeleteHBACService = (props: PropsToDeleteServices) => {
 
               // Handle error
               handleAPIError(error);
+              setBtnSpinning(false);
             } else {
               props.selectedServicesData.clearSelectedServices();
               props.buttonsData.updateIsDeleteButtonDisabled(true);

--- a/src/components/modals/HbacModals/DeleteHBACServiceGroup.tsx
+++ b/src/components/modals/HbacModals/DeleteHBACServiceGroup.tsx
@@ -148,6 +148,7 @@ const DeleteHBACServiceGroup = (props: PropsToDeleteServices) => {
 
               // Handle error
               handleAPIError(error);
+              setBtnSpinning(false);
             } else {
               props.selectedServicesData.clearSelectedServices();
               props.buttonsData.updateIsDeleteButtonDisabled(true);

--- a/src/components/modals/IdpReferences/DeleteModal.tsx
+++ b/src/components/modals/IdpReferences/DeleteModal.tsx
@@ -142,6 +142,7 @@ const DeleteModal = (props: PropsToDelete) => {
 
             // Handle error
             handleAPIError(error);
+            setBtnSpinning(false);
           } else {
             props.selectedData.clearSelectedElements();
             props.buttonsData.updateIsDeleteButtonDisabled(true);

--- a/src/components/modals/SudoModals/DeleteSudoCmd.tsx
+++ b/src/components/modals/SudoModals/DeleteSudoCmd.tsx
@@ -145,6 +145,7 @@ const DeleteSudoCmd = (props: PropsToDeleteRules) => {
 
               // Handle error
               handleAPIError(error);
+              setBtnSpinning(false);
             } else {
               props.selectedCmdsData.clearSelectedCmds();
               props.buttonsData.updateIsDeleteButtonDisabled(true);

--- a/src/components/modals/SudoModals/DeleteSudoCmdGroups.tsx
+++ b/src/components/modals/SudoModals/DeleteSudoCmdGroups.tsx
@@ -145,6 +145,7 @@ const DeleteSudoCmdGroups = (props: PropsToDeleteRules) => {
 
               // Handle error
               handleAPIError(error);
+              setBtnSpinning(false);
             } else {
               props.selectedCmdGroupsData.clearSelectedCmdGroups();
               props.buttonsData.updateIsDeleteButtonDisabled(true);

--- a/src/components/modals/SudoModals/DeleteSudoRule.tsx
+++ b/src/components/modals/SudoModals/DeleteSudoRule.tsx
@@ -145,6 +145,7 @@ const DeleteSudoRule = (props: PropsToDeleteRules) => {
 
               // Handle error
               handleAPIError(error);
+              setBtnSpinning(false);
             } else {
               props.selectedRulesData.clearSelectedRules();
               props.buttonsData.updateIsDeleteButtonDisabled(true);


### PR DESCRIPTION
Ensure setBtnSpinning(false) is called when deletion of a member fails (e.g., trying to remove an admin). Previously, the spinner would continue indefinitely, blocking further actions.

Closes #822