### PR TITLE
Add a new page id-range

### DIFF
--- a/src/components/layouts/PaginationLayout.tsx
+++ b/src/components/layouts/PaginationLayout.tsx
@@ -7,8 +7,8 @@ interface PaginationData {
   perPage: number;
   updatePage: (newPage: number) => void;
   updatePerPage: (newSetPerPage: number) => void;
-  updateSelectedPerPage: (selected: number) => void;
-  updateShownElementsList: (newShownElementsList: any[]) => void;
+  updateSelectedPerPage?: (selected: number) => void;
+  updateShownElementsList?: (newShownElementsList: any[]) => void;
   totalCount: number;
 }
 
@@ -40,11 +40,15 @@ const PaginationLayout = (props: PropsToPaginationPrep) => {
     endIdx: number | undefined
   ) => {
     props.paginationData.updatePage(newPage);
-    props.paginationData.updateShownElementsList(
-      props.list.slice(startIdx, endIdx)
-    );
+    if (props.paginationData.updateShownElementsList) {
+      props.paginationData.updateShownElementsList(
+        props.list.slice(startIdx, endIdx)
+      );
+    }
     // Reset 'selectedPerPage'
-    props.paginationData.updateSelectedPerPage(0);
+    if (props.paginationData.updateSelectedPerPage) {
+      props.paginationData.updateSelectedPerPage(0);
+    }
   };
 
   // Handle content on 'perPageSelect'
@@ -57,11 +61,15 @@ const PaginationLayout = (props: PropsToPaginationPrep) => {
   ) => {
     props.paginationData.updatePerPage(newPerPage);
     props.paginationData.updatePage(newPage);
-    props.paginationData.updateShownElementsList(
-      props.list.slice(startIdx, endIdx)
-    );
+    if (props.paginationData.updateShownElementsList) {
+      props.paginationData.updateShownElementsList(
+        props.list.slice(startIdx, endIdx)
+      );
+    }
     // Reset 'selectedPerPage'
-    props.paginationData.updateSelectedPerPage(0);
+    if (props.paginationData.updateSelectedPerPage) {
+      props.paginationData.updateSelectedPerPage(0);
+    }
   };
 
   if (props.perPageSize !== undefined && props.perPageSize === "sm") {

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -68,6 +68,7 @@ import DnsResourceRecordsPreSettings from "src/pages/DNSZones/DnsResourceRecords
 import DnsServers from "src/pages/DNSZones/DnsServers";
 import DnsServersTabs from "src/pages/DNSZones/DnsServersTabs";
 import DnsGlobalConfig from "src/pages/DNSZones/DnsGlobalConfig";
+import IdRanges from "src/pages/IdRanges/IdRanges";
 
 // Renders routes (React)
 export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
@@ -498,6 +499,9 @@ export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
               </Route>
               <Route path="dns-global-config">
                 <Route path="" element={<DnsGlobalConfig />} />
+              </Route>
+              <Route path="id-ranges">
+                <Route path="" element={<IdRanges />} />
               </Route>
               <Route path="configuration" element={<Configuration />} />
               {/* Redirect to Active users page if user is logged in and navigates to the root page */}

--- a/src/navigation/NavRoutes.ts
+++ b/src/navigation/NavRoutes.ts
@@ -22,6 +22,7 @@ const HostGroupsGroupRef = "host-groups";
 const NetgroupsGroupRef = "netgroups";
 // - Views
 const IdViewsGroupRef = "id-views";
+const IdRangesGroupRef = "id-ranges";
 // - Automember
 const AutomemberGroupRef = "automember";
 const UserGroupRulesGroupRef = "user-group-rules";
@@ -390,6 +391,13 @@ export const navigationRoutes = [
     title: `${BASE_TITLE} - IPA Server`,
     path: "",
     items: [
+      {
+        label: "ID ranges",
+        group: IdRangesGroupRef,
+        title: `${BASE_TITLE} - ID ranges`,
+        path: "id-ranges",
+        items: [],
+      },
       {
         label: "Configuration",
         group: ConfigRef,

--- a/src/pages/IdRanges/IdRanges.tsx
+++ b/src/pages/IdRanges/IdRanges.tsx
@@ -1,0 +1,426 @@
+import React from "react";
+// PatternFly
+import {
+  Flex,
+  FlexItem,
+  PageSection,
+  PaginationVariant,
+  ToolbarItemVariant,
+} from "@patternfly/react-core";
+import {
+  InnerScrollContainer,
+  OuterScrollContainer,
+} from "@patternfly/react-table";
+// Hooks
+import useAlerts from "src/hooks/useAlerts";
+import useUpdateRoute from "src/hooks/useUpdateRoute";
+import useApiError from "src/hooks/useApiError";
+// Redux
+import { useAppSelector } from "src/store/hooks";
+// RPC
+import {
+  useGetIdRangeEntriesQuery,
+  useSearchIdRangesEntriesMutation,
+} from "src/services/rpcIdRanges";
+import { IdRange } from "src/utils/datatypes/globalDataTypes";
+// React router
+import { useNavigate } from "react-router";
+// Components
+import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
+import { SerializedError } from "@reduxjs/toolkit";
+import ToolbarLayout, {
+  ToolbarItem,
+} from "src/components/layouts/ToolbarLayout";
+import SearchInputLayout from "src/components/layouts/SearchInputLayout";
+import SecondaryButton from "src/components/layouts/SecondaryButton";
+import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
+import TitleLayout from "src/components/layouts/TitleLayout";
+import GlobalErrors from "src/components/errors/GlobalErrors";
+import MainTable from "src/components/tables/MainTable";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
+import BulkSelectorPrep from "src/components/BulkSelectorPrep";
+import { isIdRangeSelectable } from "src/utils/utils";
+
+const IdRanges = () => {
+  const navigate = useNavigate();
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  const { browserTitle } = useUpdateRoute({ pathname: "id-ranges" });
+
+  // Set the page title to be shown in the browser tab
+  React.useEffect(() => {
+    document.title = browserTitle;
+  }, [browserTitle]);
+
+  // Retrieve API version from environment data
+  const apiVersion = useAppSelector(
+    (state) => state.global.environment.api_version
+  ) as string;
+
+  // Alerts to show in the UI
+  const alerts = useAlerts();
+
+  // URL parameters: page number, page size, search value
+  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+    useListPageSearchParams();
+
+  const [selectedPerPage, setSelectedPerPage] = React.useState<number>(0);
+
+  // Handle API calls errors
+  const globalErrors = useApiError([]);
+
+  // Page indexes
+  const firstIdx = (page - 1) * perPage;
+  const lastIdx = page * perPage;
+
+  const selectedPerPageData = {
+    selectedPerPage,
+    updateSelectedPerPage: setSelectedPerPage,
+  };
+
+  // Selection state for checkboxes
+  const [selectedElements, setSelectedElements] = React.useState<IdRange[]>([]);
+
+  const updateSelectedIdRanges = (idRange: IdRange[], isSelected: boolean) => {
+    let newSelectedIdRanges: IdRange[] = [...selectedElements];
+
+    if (isSelected) {
+      for (let i = 0; i < idRange.length; i++) {
+        const isAlreadySelected = newSelectedIdRanges.some(
+          (selectedIdRange) => selectedIdRange.cn === idRange[i].cn
+        );
+        if (!isAlreadySelected) {
+          newSelectedIdRanges.push(idRange[i]);
+        }
+      }
+    } else {
+      const idsToRemove = new Set(idRange.map((r) => r.cn));
+      newSelectedIdRanges = newSelectedIdRanges.filter(
+        (selectedIdRange) => !idsToRemove.has(selectedIdRange.cn)
+      );
+    }
+
+    setSelectedElements(newSelectedIdRanges);
+  };
+
+  // API calls (batch detailed list)
+  const idRangesDataResponse = useGetIdRangeEntriesQuery({
+    searchValue,
+    apiVersion,
+    sizelimit: 100,
+    startIdx: firstIdx,
+    stopIdx: lastIdx,
+  });
+
+  const {
+    data: batchResponse,
+    isLoading,
+    isFetching,
+    isSuccess,
+    isError,
+    error: batchError,
+  } = idRangesDataResponse;
+
+  // Derived data from query
+  const queryDerived = React.useMemo(() => {
+    if (!isSuccess || !batchResponse) {
+      return { list: [] as IdRange[], total: 0, ready: false };
+    }
+    const listResult = batchResponse.result.results;
+    const total = batchResponse.result.totalCount;
+    const listSize = batchResponse.result.count;
+    const elementsList: IdRange[] = [];
+    for (let i = 0; i < listSize; i++) {
+      elementsList.push(listResult[i].result as IdRange);
+    }
+    return { list: elementsList, total, ready: true };
+  }, [isSuccess, batchResponse]);
+
+  // Track search override results (when using the Search input)
+  const [searchOverride, setSearchOverride] = React.useState<{
+    list: IdRange[];
+    total: number;
+  } | null>(null);
+
+  // Clear alerts while fetching
+  React.useEffect(() => {
+    if (isFetching) {
+      globalErrors.clear();
+    }
+  }, [isFetching]);
+
+  // Redirect on auth errors
+  React.useEffect(() => {
+    if (!isLoading && isError && batchError !== undefined) {
+      navigate("/login");
+      window.location.reload();
+    }
+  }, [isLoading, isError, batchError]);
+
+  // Refresh button handling
+  const refreshData = () => {
+    setSearchOverride(null);
+    idRangesDataResponse.refetch();
+  };
+
+  // Show table rows
+  const showTableRows =
+    !isFetching && (searchOverride !== null || queryDerived.ready);
+
+  // Search API call (batch)
+  const [searchEntry] = useSearchIdRangesEntriesMutation();
+
+  const [isSearchDisabled, setIsSearchDisabled] =
+    React.useState<boolean>(false);
+
+  const submitSearchValue = () => {
+    setSearchOverride(null);
+    searchEntry({
+      searchValue: searchValue,
+      apiVersion,
+      sizelimit: 100,
+      startIdx: 0,
+      stopIdx: 200,
+    }).then((result) => {
+      if ("data" in result && result.data !== undefined) {
+        const searchError = result.data?.error as
+          | FetchBaseQueryError
+          | SerializedError;
+
+        if (searchError) {
+          // Error
+          let errMsg: string | undefined = "";
+          if ("error" in searchError) {
+            errMsg = searchError.error;
+          }
+          alerts.addAlert(
+            "submit-search-value-error",
+            errMsg || "Error when searching for elements",
+            "danger"
+          );
+        } else {
+          // Success
+          const listResult = result.data?.result.results || [];
+          const listSize = result.data?.result.count || 0;
+          const total = result.data?.result.totalCount || 0;
+          const elementsList: IdRange[] = [];
+
+          for (let i = 0; i < listSize; i++) {
+            elementsList.push(listResult[i].result as IdRange);
+          }
+
+          setSearchOverride({ list: elementsList, total });
+        }
+        setIsSearchDisabled(false);
+      }
+    });
+  };
+
+  // Compute shown list and total
+  const shownElementsList = searchOverride
+    ? searchOverride.list
+    : queryDerived.list;
+  const totalCount = searchOverride ? searchOverride.total : queryDerived.total;
+
+  // Selection helpers
+  const selectableIdRangesTable = shownElementsList.filter(isIdRangeSelectable);
+  const setIdRangesSelected = (idRange: IdRange, isSelecting = true) => {
+    if (isIdRangeSelectable(idRange)) {
+      updateSelectedIdRanges([idRange], isSelecting);
+    }
+  };
+
+  const bulkSelectorData = {
+    selected: selectedElements,
+    updateSelected: updateSelectedIdRanges,
+    selectableTable: selectableIdRangesTable,
+    nameAttr: "cn",
+  };
+
+  // Data wrappers
+  const paginationData = {
+    page,
+    perPage,
+    updatePage: setPage,
+    updatePerPage: setPerPage,
+    totalCount,
+  };
+
+  // SearchInputLayout
+  const searchValueData = {
+    searchValue,
+    updateSearchValue: (v: string) => {
+      setSearchOverride(null);
+      setSearchValue(v);
+    },
+    submitSearchValue,
+  };
+
+  // List of Toolbar items
+  const toolbarItems: ToolbarItem[] = [
+    {
+      key: 0,
+      element: (
+        <BulkSelectorPrep
+          list={shownElementsList}
+          shownElementsList={shownElementsList}
+          elementData={bulkSelectorData}
+          buttonsData={{
+            updateIsDeleteButtonDisabled: (disabled: boolean) => {
+              void disabled;
+            },
+          }}
+          selectedPerPageData={selectedPerPageData}
+        />
+      ),
+    },
+    {
+      key: 1,
+      element: (
+        <SearchInputLayout
+          dataCy="search"
+          name="search"
+          ariaLabel="Search ID ranges"
+          placeholder="Search"
+          searchValueData={searchValueData}
+          isDisabled={isSearchDisabled}
+        />
+      ),
+      toolbarItemVariant: ToolbarItemVariant.label,
+      toolbarItemGap: { default: "gapMd" },
+    },
+    {
+      key: 2,
+      toolbarItemVariant: ToolbarItemVariant.separator,
+    },
+    {
+      key: 3,
+      element: (
+        <SecondaryButton
+          dataCy="id-ranges-button-refresh"
+          onClickHandler={refreshData}
+          isDisabled={!showTableRows}
+        >
+          Refresh
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 4,
+      element: (
+        <SecondaryButton
+          isDisabled={selectedElements.length === 0 || !showTableRows}
+          dataCy="id-ranges-button-delete"
+        >
+          Delete
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 5,
+      element: (
+        <SecondaryButton
+          isDisabled={!showTableRows}
+          dataCy="id-ranges-button-add"
+        >
+          Add
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 6,
+      toolbarItemVariant: ToolbarItemVariant.separator,
+    },
+    {
+      key: 7,
+      element: <HelpTextWithIconLayout textContent="Help" />,
+    },
+    {
+      key: 8,
+      element: (
+        <PaginationLayout
+          list={shownElementsList}
+          paginationData={paginationData}
+          widgetId="pagination-options-menu-top"
+          isCompact={true}
+        />
+      ),
+      toolbarItemAlignment: { default: "alignEnd" },
+    },
+  ];
+
+  // Render component
+  return (
+    <div>
+      <alerts.ManagedAlerts />
+      <PageSection hasBodyWrapper={false}>
+        <TitleLayout id="ID ranges page" headingLevel="h1" text="ID ranges" />
+      </PageSection>
+      <PageSection hasBodyWrapper={false} isFilled={false}>
+        <Flex direction={{ default: "column" }}>
+          <FlexItem>
+            <ToolbarLayout toolbarItems={toolbarItems} />
+          </FlexItem>
+          <FlexItem style={{ flex: "1 1 auto", overflow: "hidden" }}>
+            <OuterScrollContainer
+              style={{ height: "100%", overflow: "hidden" }}
+            >
+              <InnerScrollContainer
+                style={{ height: "100%", overflow: "auto" }}
+              >
+                {batchError !== undefined && batchError ? (
+                  <GlobalErrors errors={globalErrors.getAll()} />
+                ) : (
+                  <MainTable
+                    tableTitle="ID ranges table"
+                    shownElementsList={shownElementsList}
+                    pk="cn"
+                    keyNames={[
+                      "cn",
+                      "ipabaseid",
+                      "ipaidrangesize",
+                      "iparangetype",
+                    ]}
+                    columnNames={[
+                      "Range name",
+                      "First Posix ID of the range",
+                      "Number of IDs in the range",
+                      "Range type",
+                    ]}
+                    hasCheckboxes={true}
+                    pathname="id-ranges"
+                    showTableRows={showTableRows}
+                    showLink={false}
+                    elementsData={{
+                      isElementSelectable: isIdRangeSelectable,
+                      selectedElements,
+                      selectableElementsTable:
+                        shownElementsList.filter(isIdRangeSelectable),
+                      setElementsSelected: setIdRangesSelected,
+                      clearSelectedElements: () => setSelectedElements([]),
+                    }}
+                    paginationData={{
+                      selectedPerPage,
+                      updateSelectedPerPage: setSelectedPerPage,
+                    }}
+                  />
+                )}
+              </InnerScrollContainer>
+            </OuterScrollContainer>
+          </FlexItem>
+          <FlexItem style={{ flex: "0 0 auto", position: "sticky", bottom: 0 }}>
+            <PaginationLayout
+              list={shownElementsList}
+              paginationData={paginationData}
+              variant={PaginationVariant.bottom}
+              widgetId="pagination-options-menu-bottom"
+            />
+          </FlexItem>
+        </Flex>
+      </PageSection>
+    </div>
+  );
+};
+
+export default IdRanges;

--- a/src/services/rpcIdRanges.ts
+++ b/src/services/rpcIdRanges.ts
@@ -1,0 +1,247 @@
+import {
+  api,
+  FindRPCResponse,
+  getCommand,
+  getBatchCommand,
+  BatchRPCResponse,
+  Command,
+} from "./rpc";
+// utils
+import { API_VERSION_BACKUP } from "../utils/utils";
+
+/**
+ * ID ranges-related endpoints: useIdRangesFindQuery, useSearchIdRangesEntriesMutation
+ *                              useIdRangesShowQuery
+ *
+ * API commands: idrange_find, idrange_show
+ */
+
+export interface IdRangesFindPayload {
+  searchValue: string;
+  sizeLimit: number;
+  pkeyOnly?: boolean;
+  version?: string;
+  cn?: string;
+  ipabaseid?: number;
+  ipaidrangesize?: number;
+  ipabaserid?: number;
+  ipasecondarybaserid?: number;
+  ipanttrusteddomainsid?: string;
+  iparangetype?: "ipa-ad-trust" | "ipa-ad-trust-posix" | "ipa-local";
+  ipaautoprivategroups?: "true" | "false" | "hybrid";
+  timelimit?: number;
+  all?: boolean; // required flag in docs (default false)
+  raw?: boolean; // required flag in docs (default false)
+}
+
+export interface IdRangesFindResult {
+  dn: string;
+  cn: string[];
+}
+
+export interface IdRangesShowPayload {
+  cn: string;
+  rights?: boolean;
+  all?: boolean;
+  raw?: boolean;
+  version?: string;
+}
+
+export interface IdRangeDataPayload {
+  searchValue: string;
+  apiVersion: string;
+  sizelimit: number;
+  startIdx: number;
+  stopIdx: number;
+}
+
+const extendedApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    /**
+     * Get ID range IDs
+     * @param {IdRangesFindPayload} payload - The payload containing search parameters
+     * @returns {IdRangesFindResponse} - Response data or error
+     */
+    idRangesFind: build.query<FindRPCResponse, IdRangesFindPayload>({
+      query: (payload) => {
+        const params: Record<string, unknown> = {
+          pkey_only: payload.pkeyOnly || true,
+          sizelimit: payload.sizeLimit,
+          version: payload.version || API_VERSION_BACKUP,
+          all: payload.all ?? false,
+          raw: payload.raw ?? false,
+        };
+
+        // Add optional filters if provided
+        const optionalKeys: Array<
+          keyof Omit<
+            IdRangesFindPayload,
+            "searchValue" | "sizeLimit" | "pkeyOnly" | "version" | "all" | "raw"
+          >
+        > = [
+          "cn",
+          "ipabaseid",
+          "ipaidrangesize",
+          "ipabaserid",
+          "ipasecondarybaserid",
+          "ipanttrusteddomainsid",
+          "iparangetype",
+          "ipaautoprivategroups",
+          "timelimit",
+        ];
+
+        optionalKeys.forEach((key) => {
+          const value = payload[key];
+          if (value !== undefined) {
+            params[key] = value;
+          }
+        });
+
+        return getCommand({
+          method: "idrange_find",
+          params: [[payload.searchValue], params],
+        });
+      },
+    }),
+    /**
+     * Search for specific ID ranges (Mutation)
+     * @param {IdRangesFindPayload} payload - The payload containing search parameters
+     * @returns {IdRangesFindResponse} - Response data or error
+     */
+    searchIdRangesEntries: build.mutation<BatchRPCResponse, IdRangeDataPayload>(
+      {
+        async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
+          const { searchValue, apiVersion, sizelimit, startIdx, stopIdx } =
+            payloadData;
+
+          // Prepare find parameters
+          const params = {
+            pkey_only: true,
+            sizelimit: sizelimit,
+            version: apiVersion || API_VERSION_BACKUP,
+          };
+
+          // idrange_find
+          const findResult = await fetchWithBQ(
+            getCommand({
+              method: "idrange_find",
+              params: [[searchValue], params],
+            })
+          );
+          if (findResult.error) {
+            return { error: findResult.error };
+          }
+          const findData = findResult.data as FindRPCResponse;
+          const listSize = findData.result.result.length as number;
+
+          // Build list of cns for the requested range
+          const cnList: string[] = [];
+          for (let i = startIdx; i < listSize && i < stopIdx; i++) {
+            const entry = findData.result.result[i] as IdRangesFindResult;
+            const cn = entry?.cn?.[0] as string | undefined;
+            if (cn) cnList.push(cn);
+          }
+
+          // Batch show
+          const commands: Command[] = cnList.map((cn) => ({
+            method: "idrange_show",
+            params: [[cn], {}],
+          }));
+
+          const batchShow = await fetchWithBQ(
+            getBatchCommand(commands, apiVersion)
+          );
+          if (batchShow.error) {
+            return { error: batchShow.error };
+          }
+          const response = batchShow.data as BatchRPCResponse;
+          if (response) {
+            response.result.totalCount = listSize;
+          }
+          return { data: response };
+        },
+      }
+    ),
+    /**
+     * Get ID range details
+     * @param {IdRangesShowPayload} payload - The payload containing ID range identifier and flags
+     * @returns {Promise<FindRPCResponse>} - Promise with the response data
+     */
+    idRangesShow: build.query<FindRPCResponse, IdRangesShowPayload>({
+      query: (payload) => {
+        const params = {
+          rights: payload.rights ?? false,
+          all: payload.all ?? false,
+          raw: payload.raw ?? false,
+          version: payload.version || API_VERSION_BACKUP,
+        };
+        return getCommand({
+          method: "idrange_show",
+          params: [[payload.cn], params],
+        });
+      },
+    }),
+    /**
+     * Get a paginated list of ID Range entries with details (batch of idrange_show)
+     */
+    getIdRangeEntries: build.query<BatchRPCResponse, IdRangeDataPayload>({
+      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
+        const { searchValue, apiVersion, sizelimit, startIdx, stopIdx } =
+          payloadData;
+
+        // Prepare find parameters
+        const params = {
+          pkey_only: true,
+          sizelimit: sizelimit,
+          version: apiVersion || API_VERSION_BACKUP,
+        };
+
+        // idrange_find
+        const findResult = await fetchWithBQ(
+          getCommand({
+            method: "idrange_find",
+            params: [[searchValue], params],
+          })
+        );
+        if (findResult.error) {
+          return { error: findResult.error };
+        }
+        const findData = findResult.data as FindRPCResponse;
+        const listSize = findData.result.result.length as number;
+
+        // Build list of cns for the requested page range
+        const cnList: string[] = [];
+        for (let i = startIdx; i < listSize && i < stopIdx; i++) {
+          const entry = findData.result.result[i] as IdRangesFindResult;
+          const cn = entry?.cn?.[0] as string | undefined;
+          if (cn) cnList.push(cn);
+        }
+
+        // Build batch idrange_show commands
+        const commands: Command[] = cnList.map((cn) => ({
+          method: "idrange_show",
+          params: [[cn], {}],
+        }));
+
+        const batchShow = await fetchWithBQ(
+          getBatchCommand(commands, apiVersion)
+        );
+        if (batchShow.error) {
+          return { error: batchShow.error };
+        }
+        const response = batchShow.data as BatchRPCResponse;
+        if (response) {
+          response.result.totalCount = listSize;
+        }
+        return { data: response };
+      },
+    }),
+  }),
+});
+
+export const {
+  useIdRangesFindQuery,
+  useSearchIdRangesEntriesMutation,
+  useIdRangesShowQuery,
+  useGetIdRangeEntriesQuery,
+} = extendedApi;

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -488,6 +488,21 @@ export interface IDPServer {
   ipaidpuserinfoendpoint: string[];
 }
 
+export interface IdRange {
+  cn: string;
+  //the 4 following fields are numbers but are returned as strings
+  ipabaseid?: string;
+  ipaidrangesize?: string;
+  ipabaserid?: string;
+  ipasecondarybaserid?: string;
+
+  ipanttrusteddomainsid?: string;
+  ipanttrusteddomainname?: string;
+  iparangetype?: string;
+  ipaautoprivategroups?: string;
+  dn?: string;
+}
+
 export interface Metadata {
   commands?: Record<string, unknown>;
   methods?: Record<string, unknown>;

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -10,6 +10,7 @@ import {
   IDView,
   IDViewOverrideUser,
   IDViewOverrideGroup,
+  IdRange,
   Metadata,
   Netgroup,
   Service,
@@ -219,6 +220,8 @@ export const isDnsForwardZoneSelectable = (dnsForwardZone: DNSForwardZone) =>
 
 export const isDnsServerSelectable = (dnsServerId: string) =>
   dnsServerId !== "";
+
+export const isIdRangeSelectable = (idRange: IdRange) => idRange.cn !== "";
 
 /**
  * Write JSX error messages into 'apiErrorsJsx' array


### PR DESCRIPTION
Create a main page for id-range

- Retrieves updated data from the backend table.
- Matches behavior from the current WebUI.
- Action buttons are not implemented, as they will be handled in a separate PR.

## Summary by Sourcery

Add a new ID ranges management page that fetches and displays backend ID range identifiers in a searchable, paginated table, integrate it into navigation and routing, and introduce RPC hooks to support idrange commands

New Features:
- Add ID ranges page with a paginated, searchable table of ID range names
- Implement RPC endpoints and hooks (useIdRangesFindQuery, useSearchIdRangesEntriesMutation, useIdRangesShowQuery) for idrange_find, idrange_show, and search

Enhancements:
- Integrate the ID ranges page into the main navigation and routing configuration
- Provide placeholder Add and Delete action buttons that trigger warning alerts