### PR TITLE
pre-commit: Enable pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+---
+repos:
+  - repo: local
+    hooks:
+      - id: prettier
+        name: Check code formatting
+        language: node
+        entry: npx
+        args: ["prettier", "--check"]
+        exclude: |
+          \.feature$
+        files: \.(css|tsx?|html|js|json|yaml|md)$
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.11.0
+    hooks:
+      - id: shellcheck
+        args:
+          [
+            "-x",
+            "-a",
+            "-o",
+            "all",
+            "-e",
+            "SC2292",
+            "-e",
+            "SC2310",
+            "-e",
+            "SC2311",
+            "-P",
+            "./developer",
+          ]
+        files: \.sh$


### PR DESCRIPTION
By enabling pre-commit linter and code style checks can be executed before opening a pull request, speeding up development.

## Summary by Sourcery

Enable pre-commit checks for code formatting using Prettier

Enhancements:
- Add .pre-commit-config.yaml with a local Prettier hook targeting CSS, TS, JS, JSON, YAML, HTML, and MD files
- Exclude .feature files from the Prettier check