### PR TITLE
[Cypress tests] Add integration tests for netgroup

### DIFF
--- a/cypress/e2e/netgroup/netgroup.feature
+++ b/cypress/e2e/netgroup/netgroup.feature
@@ -1,0 +1,157 @@
+Feature: Netgroup manipulation
+  Create, and delete netgroups
+
+  @test
+  Scenario: Add a new netgroup
+    Given I am logged in as admin
+    And I am on "netgroups" page
+
+    When I click on the "netgroups-button-add" button
+    Then I should see "add-netgroup-modal" modal
+
+    When I type in the "modal-textbox-netgroup-name" textbox text "a_net_group"
+    Then I should see "a_net_group" in the "modal-textbox-netgroup-name" textbox
+
+    When I click on the "modal-button-add" button
+    Then I should not see "add-netgroup-modal" modal
+    And I should see "add-netgroup-success" alert
+
+    When I search for "a_net_group" in the data table
+    Then I should see "a_net_group" entry in the data table
+
+  @cleanup
+  Scenario: Delete a netgroup
+    Given I delete netgroup "a_net_group"
+
+  @test
+  Scenario: Add a new netgroup with description
+    Given I am logged in as admin
+    And I am on "netgroups" page
+
+    When I click on the "netgroups-button-add" button
+    Then I should see "add-netgroup-modal" modal
+
+    When I type in the "modal-textbox-netgroup-name" textbox text "b_net_group"
+    Then I should see "b_net_group" in the "modal-textbox-netgroup-name" textbox
+
+    When I type in the "modal-textbox-netgroup-description" textbox text "my description"
+    Then I should see "my description" in the "modal-textbox-netgroup-description" textbox
+
+    When I click on the "modal-button-add" button
+    Then I should not see "add-netgroup-modal" modal
+    And I should see "add-netgroup-success" alert
+
+    When I search for "b_net_group" in the data table
+    Then I should see "b_net_group" entry in the data table
+
+  @cleanup
+  Scenario: Delete a netgroup
+    Given I delete netgroup "b_net_group"
+
+  @test
+  Scenario: Add one netgroup after another
+    Given I am logged in as admin
+    And I am on "netgroups" page
+
+    When I click on the "netgroups-button-add" button
+    Then I should see "add-netgroup-modal" modal
+
+    When I type in the "modal-textbox-netgroup-name" textbox text "c_net_group"
+    Then I should see "c_net_group" in the "modal-textbox-netgroup-name" textbox
+
+    When I click on the "modal-button-add-and-add-another" button
+    Then I should see "add-netgroup-modal" modal
+    And I should see "add-netgroup-success" alert
+
+    When I type in the "modal-textbox-netgroup-name" textbox text "d_net_group"
+    Then I should see "d_net_group" in the "modal-textbox-netgroup-name" textbox
+
+    When I click on the "modal-button-add" button
+    Then I should not see "add-netgroup-modal" modal
+    And I should see "add-netgroup-success" alert
+
+    When I search for "c_net_group" in the data table
+    Then I should see "c_net_group" entry in the data table
+
+    When I search for "d_net_group" in the data table
+    Then I should see "d_net_group" entry in the data table
+
+  @cleanup
+  Scenario: Delete netgroups
+    Given I delete netgroup "c_net_group"
+    And I delete netgroup "d_net_group"
+
+  @seed
+  Scenario: Create netgroups
+    Given netgroup "a_net_group" exists
+
+  @test
+  Scenario: Delete a netgroup via toolbar
+    Given I am logged in as admin
+    And I am on "netgroups" page
+
+    When I select entry "a_net_group" in the data table
+    Then I should see "a_net_group" entry selected in the data table
+
+    When I click on the "netgroups-button-delete" button
+    Then I should see "delete-netgroups-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "delete-netgroups-modal" modal
+    And I should see "remove-netgroups-success" alert
+
+    When I search for "a_net_group" in the data table
+    Then I should not see "a_net_group" entry in the data table
+
+  @seed
+  Scenario: Create netgroups
+    Given netgroup "b_net_group" exists
+    And netgroup "c_net_group" exists
+    And netgroup "d_net_group" exists
+
+  @test
+  Scenario: Delete many netgroups via toolbar
+    Given I am logged in as admin
+    And I am on "netgroups" page
+
+    When I select entry "b_net_group" in the data table
+    Then I should see "b_net_group" entry selected in the data table
+
+    When I select entry "c_net_group" in the data table
+    Then I should see "c_net_group" entry selected in the data table
+
+    When I select entry "d_net_group" in the data table
+    Then I should see "d_net_group" entry selected in the data table
+
+    When I click on the "netgroups-button-delete" button
+    Then I should see "delete-netgroups-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "delete-netgroups-modal" modal
+    And I should see "remove-netgroups-success" alert
+
+    When I search for "b_net_group" in the data table
+    Then I should not see "b_net_group" entry in the data table
+
+    When I search for "c_net_group" in the data table
+    Then I should not see "c_net_group" entry in the data table
+
+    When I search for "d_net_group" in the data table
+    Then I should not see "d_net_group" entry in the data table
+
+  @test
+  Scenario: Cancel creation of a netgroup
+    Given I am logged in as admin
+    And I am on "netgroups" page
+
+    When I click on the "netgroups-button-add" button
+    Then I should see "add-netgroup-modal" modal
+
+    When I type in the "modal-textbox-netgroup-name" textbox text "cancelgroup"
+    Then I should see "cancelgroup" in the "modal-textbox-netgroup-name" textbox
+
+    When I click on the "modal-button-cancel" button
+    Then I should not see "add-netgroup-modal" modal
+
+    When I search for "cancelgroup" in the data table
+    Then I should not see "cancelgroup" entry in the data table

--- a/cypress/e2e/netgroup/netgroup.ts
+++ b/cypress/e2e/netgroup/netgroup.ts
@@ -1,0 +1,183 @@
+import { Given } from "@badeball/cypress-cucumber-preprocessor";
+import { loginAsAdmin, logout } from "../common/authentication";
+import { navigateTo } from "../common/navigation";
+import {
+  selectEntry,
+  searchForEntry,
+  entryDoesNotExist,
+  entryExists,
+  checkEntry,
+} from "../common/data_tables";
+import { typeInTextbox } from "../common/ui/textbox";
+import { findEntryInTable } from "../common/settings_table";
+import { addItemToRightList } from "../common/ui/dual_list";
+
+Given("netgroup {string} exists", (groupName: string) => {
+  loginAsAdmin();
+  navigateTo("netgroups");
+
+  cy.dataCy("netgroups-button-add").click();
+  cy.dataCy("add-netgroup-modal").should("exist");
+
+  typeInTextbox("modal-textbox-netgroup-name", groupName);
+  cy.dataCy("modal-textbox-netgroup-name").should("have.value", groupName);
+
+  cy.dataCy("modal-button-add").click();
+  cy.dataCy("add-netgroup-modal").should("not.exist");
+  cy.dataCy("add-netgroup-success").should("exist");
+
+  searchForEntry(groupName);
+  entryExists(groupName);
+  logout();
+});
+
+Given("I delete netgroup {string}", (groupName: string) => {
+  loginAsAdmin();
+  navigateTo("netgroups");
+  selectEntry(groupName);
+
+  cy.dataCy("netgroups-button-delete").click();
+  cy.dataCy("delete-netgroups-modal").should("exist");
+
+  cy.dataCy("modal-button-delete").click();
+  cy.dataCy("delete-netgroups-modal").should("not.exist");
+  cy.dataCy("remove-netgroups-success").should("exist");
+
+  searchForEntry(groupName);
+  entryDoesNotExist(groupName);
+  logout();
+});
+
+type ElementType = "user" | "group" | "host" | "hostgroup" | "externalhost";
+
+const assertElementType = (elementType: string) => {
+  const validElementTypes: ElementType[] = [
+    "user",
+    "group",
+    "host",
+    "hostgroup",
+    "externalhost",
+  ];
+  if (!validElementTypes.includes(elementType as ElementType)) {
+    throw new Error(`Invalid element type: ${elementType}`);
+  }
+};
+
+const ensureTabVisibleAndOpen = (elementType: string) => {
+  const tabDataCy = `netgroups-tab-settings-tab-${elementType}s`;
+  cy.dataCy(tabDataCy).click();
+};
+
+Given(
+  "I have element {string} named {string} in netgroup {string}",
+  (elementType: string, element: string, groupName: string) => {
+    loginAsAdmin();
+    navigateTo(`netgroups/${groupName}`);
+
+    assertElementType(elementType);
+    ensureTabVisibleAndOpen(elementType);
+
+    cy.dataCy(`settings-button-add-${elementType}`).click();
+    cy.dataCy("dual-list-modal").should("exist");
+
+    const itemToAdd =
+      elementType === "host"
+        ? `${element}.${Cypress.env("HOSTNAME")}`
+        : element;
+
+    cy.dataCy("dual-list-search-link").click();
+    addItemToRightList(itemToAdd);
+
+    cy.dataCy("modal-button-add").click();
+    cy.dataCy("dual-list-modal").should("not.exist");
+    cy.dataCy("add-member-success").should("exist");
+
+    findEntryInTable(itemToAdd, elementType);
+    entryExists(itemToAdd);
+
+    logout();
+  }
+);
+
+Given(
+  "I delete element {string} named {string} from netgroup {string}",
+  (elementType: string, element: string, groupName: string) => {
+    loginAsAdmin();
+    navigateTo(`netgroups/${groupName}`);
+
+    assertElementType(elementType);
+    ensureTabVisibleAndOpen(elementType);
+
+    const itemToDelete =
+      elementType === "host"
+        ? `${element}.${Cypress.env("HOSTNAME")}`
+        : element;
+
+    findEntryInTable(itemToDelete, elementType);
+    entryExists(itemToDelete);
+    checkEntry(itemToDelete);
+
+    cy.dataCy(`settings-button-delete-${elementType}`).click();
+    cy.dataCy("remove-netgroup-members-modal").should("exist");
+    entryExists(itemToDelete);
+
+    cy.dataCy("modal-button-delete").click();
+    cy.dataCy("remove-netgroup-members-modal").should("not.exist");
+    cy.dataCy("remove-netgroups-success").should("exist");
+
+    entryDoesNotExist(itemToDelete);
+
+    logout();
+  }
+);
+
+Given(
+  "I have external host {string} in netgroup {string}",
+  (externalHost: string, groupName: string) => {
+    loginAsAdmin();
+    navigateTo(`netgroups/${groupName}`);
+
+    assertElementType("externalhost");
+    ensureTabVisibleAndOpen("externalhost");
+
+    cy.dataCy("settings-button-add-externalHost").click();
+    cy.dataCy("add-external-host-modal").should("exist");
+
+    typeInTextbox("modal-textbox-external-host-name", externalHost);
+
+    cy.dataCy("modal-button-add").click();
+    cy.dataCy("add-external-host-modal").should("not.exist");
+    cy.dataCy("add-member-success").should("exist");
+
+    findEntryInTable(externalHost, "externalHost");
+    entryExists(externalHost);
+
+    logout();
+  }
+);
+
+Given(
+  "I delete external host {string} from netgroup {string}",
+  (externalHost: string, groupName: string) => {
+    loginAsAdmin();
+    navigateTo(`netgroups/${groupName}`);
+
+    assertElementType("externalhost");
+    ensureTabVisibleAndOpen("externalhost");
+
+    findEntryInTable(externalHost, "externalHost");
+    entryExists(externalHost);
+    checkEntry(externalHost);
+
+    cy.dataCy("settings-button-delete-externalHost").click();
+    cy.dataCy("remove-netgroup-members-modal").should("exist");
+
+    cy.dataCy("modal-button-delete").click();
+    cy.dataCy("remove-netgroup-members-modal").should("not.exist");
+    cy.dataCy("remove-netgroups-success").should("exist");
+
+    entryDoesNotExist(externalHost);
+
+    logout();
+  }
+);

--- a/cypress/e2e/netgroup/netgroup_member_of.feature
+++ b/cypress/e2e/netgroup/netgroup_member_of.feature
@@ -1,0 +1,70 @@
+Feature: Netgroup Member Of manipulation
+    Manage netgroup membership in the "Member of" section
+
+    @seed
+    Scenario: Create netgroups
+        Given netgroup "my_netgroup" exists
+        And netgroup "my_netgroup_2" exists
+
+    @test
+    Scenario: Add a netgroup member into the new netgroup
+        Given I am logged in as admin
+        And I am on "netgroups/my_netgroup" page
+
+        When I click on the "netgroups-tab-memberof" tab
+        Then I should see "netgroups-tab-memberof" tab
+
+        When I click on the "member-of-button-add" button
+        Then I should see "member-of-add-modal" modal
+        And I should see "item-my_netgroup_2" dual list item on the left
+
+        When I click on "item-my_netgroup_2" dual list item
+        Then I should see "item-my_netgroup_2" dual list item selected
+
+        When I click on the "dual-list-add-selected" button
+        Then I should see "item-my_netgroup_2" dual list item on the right
+
+        When I click on the "modal-button-add" button
+        Then I should not see "member-of-add-modal" modal
+        And I should see "add-member-success" alert
+        And I should see "my_netgroup_2" entry in the data table
+
+    @test
+    Scenario: Search for a netgroup member
+        Given I am logged in as admin
+        And I am on "netgroups/my_netgroup" page
+
+        When I click on the "netgroups-tab-memberof" tab
+        Then I should see "netgroups-tab-memberof" tab
+
+        When I search for "my_netgroup_2" in the data table
+        Then I should see "my_netgroup_2" entry in the data table
+        And I should not see "my_netgroup" entry in the data table
+
+        When I search for "notthere" in the data table
+        Then I should not see "notthere" entry in the data table
+        And I should not see "my_netgroup_2" entry in the data table
+
+    @test
+    Scenario: Delete a netgroup member from the netgroup
+        Given I am logged in as admin
+        And I am on "netgroups/my_netgroup" page
+
+        When I click on the "netgroups-tab-memberof" tab
+        Then I should see "netgroups-tab-memberof" tab
+
+        When I select entry "my_netgroup_2" in the data table
+        Then I should see "my_netgroup_2" entry selected in the data table
+        When I click on the "member-of-button-delete" button
+        Then I should see "member-of-delete-modal" modal
+        And I should see "my_netgroup_2" entry in the data table
+
+        When I click on the "modal-button-delete" button
+        Then I should not see "member-of-delete-modal" modal
+        And I should see "remove-netgroups-success" alert
+        And I should not see "my_netgroup_2" entry in the data table
+
+    @cleanup
+    Scenario: Delete netgroups
+        Given I delete netgroup "my_netgroup"
+        And I delete netgroup "my_netgroup_2"

--- a/cypress/e2e/netgroup/netgroup_settings.feature
+++ b/cypress/e2e/netgroup/netgroup_settings.feature
@@ -1,0 +1,357 @@
+Feature: Netgroup settings manipulation
+    Modify a netgroup
+
+    @seed
+    Scenario: Create netgroup
+        Given netgroup "netgroup1" exists
+
+    @test
+    Scenario: Set Description
+        Given I am logged in as admin
+        And I am on "netgroups/netgroup1" page
+
+        When I type in the "netgroups-tab-settings-textbox-description" textbox text "test"
+        Then I should see "test" in the "netgroups-tab-settings-textbox-description" textbox
+        And I should see the "netgroups-tab-settings-button-save" button is enabled
+
+        When I click on the "netgroups-tab-settings-button-save" button
+        Then I should see "save-success" alert
+
+    @cleanup
+    Scenario: Cleanup netgroup
+        Given I delete netgroup "netgroup1"
+
+    @seed
+    Scenario: Create netgroup
+        Given netgroup "netgroup1" exists
+
+    @test
+    Scenario: Set NIS domain name
+        Given I am logged in as admin
+        And I am on "netgroups/netgroup1" page
+
+        When I type in the "netgroups-tab-settings-textbox-nisdomainname" textbox text "newNIS"
+        Then I should see "newNIS" in the "netgroups-tab-settings-textbox-nisdomainname" textbox
+        And I should see the "netgroups-tab-settings-button-save" button is enabled
+
+        When I click on the "netgroups-tab-settings-button-save" button
+        Then I should see "save-success" alert
+        And I should see "newNIS" in the "netgroups-tab-settings-textbox-nisdomainname" textbox
+    
+    @cleanup
+    Scenario: Cleanup netgroup
+        Given I delete netgroup "netgroup1"
+
+    @seed
+    Scenario: Create netgroup
+        Given netgroup "netgroup1" exists
+
+    @test
+    Scenario: Add user to User category
+        Given I am logged in as admin
+        And I am on "netgroups/netgroup1" page
+
+        When I click on the "netgroups-tab-settings-tab-users" tab
+        Then I should see "netgroups-tab-settings-tab-users" tab
+
+        When I click on the "settings-button-add-user" button
+        Then I should see "dual-list-modal" modal
+
+        When I click on search link in dual list
+        Then I should see "item-admin" dual list item on the left
+
+        When I click on "item-admin" dual list item
+        Then I should see "item-admin" dual list item selected
+
+        When I click on the "dual-list-add-selected" button
+        Then I should see "item-admin" dual list item on the right
+        And I should see "item-admin" dual list item not selected
+
+        When I click on the "modal-button-add" button
+        Then I should not see "dual-list-modal" modal
+        And I should see "add-member-success" alert
+        And I should see "admin" entry in the data table
+
+    @cleanup
+    Scenario: Cleanup user "admin"
+        Given I delete element "user" named "admin" from netgroup "netgroup1"
+
+    @seed
+    Scenario: Add user "admin"
+        Given I have element "user" named "admin" in netgroup "netgroup1"
+
+    @test
+    Scenario: Remove user from User category
+        Given I am logged in as admin
+        And I am on "netgroups/netgroup1" page
+
+        When I click on the "netgroups-tab-settings-tab-users" tab
+        Then I should see "netgroups-tab-settings-tab-users" tab
+        And I should see "admin" entry in the data table
+
+        When I select entry "admin" in the settings data table "user"
+        Then I should see "admin" entry selected in the data table
+
+        When I click on the "settings-button-delete-user" button
+        Then I should see "remove-netgroup-members-modal" modal
+
+        When I click on the "modal-button-delete" button
+        Then I should not see "remove-netgroup-members-modal" modal
+        And I should see "remove-netgroups-success" alert
+        And I should not see "admin" entry in the data table
+
+    @test
+    Scenario: Add group to User category
+        Given I am logged in as admin
+        And I am on "netgroups/netgroup1" page
+
+        When I click on the "netgroups-tab-settings-tab-groups" tab
+        Then I should see "netgroups-tab-settings-tab-groups" tab
+
+        When I click on the "settings-button-add-group" button
+        Then I should see "dual-list-modal" modal
+
+        When I click on search link in dual list
+        Then I should see "item-admins" dual list item on the left
+
+        When I click on "item-admins" dual list item
+        Then I should see "item-admins" dual list item selected
+
+        When I click on the "dual-list-add-selected" button
+        Then I should see "item-admins" dual list item on the right
+        And I should see "item-admins" dual list item not selected
+
+        When I click on the "modal-button-add" button
+        Then I should not see "dual-list-modal" modal
+        And I should see "add-member-success" alert
+        And I should see "admins" entry in the data table
+
+    @cleanup
+    Scenario: Cleanup group "admins"
+        Given I delete element "group" named "admins" from netgroup "netgroup1"
+
+    @seed
+    Scenario: Add group "admins"
+        Given I have element "group" named "admins" in netgroup "netgroup1"
+
+    @test
+    Scenario: Remove group from User category
+        Given I am logged in as admin
+        And I am on "netgroups/netgroup1" page
+
+        When I click on the "netgroups-tab-settings-tab-groups" tab
+        Then I should see "netgroups-tab-settings-tab-groups" tab
+        And I should see "admins" entry in the data table
+
+        When I select entry "admins" in the settings data table "group"
+        Then I should see "admins" entry selected in the data table
+        When I click on the "settings-button-delete-group" button
+        Then I should see "remove-netgroup-members-modal" modal
+
+        When I click on the "modal-button-delete" button
+        Then I should not see "remove-netgroup-members-modal" modal
+        And I should see "remove-netgroups-success" alert
+        And I should not see "admins" entry in the data table
+
+    @seed
+    Scenario: Add a host
+        Given host "my-server" exists
+
+    @test
+    Scenario: Add host to Host category
+        Given I am logged in as admin
+        And I am on "netgroups/netgroup1" page
+
+        When I click on the "netgroups-tab-settings-tab-hosts" tab
+        Then I should see "netgroups-tab-settings-tab-hosts" tab
+
+        When I click on the "settings-button-add-host" button
+        Then I should see "dual-list-modal" modal
+
+        When I click on search link in dual list
+        Then I should see "item-my-server.dom-server.ipa.demo" dual list item on the left
+
+        When I click on "item-my-server.dom-server.ipa.demo" dual list item
+        Then I should see "item-my-server.dom-server.ipa.demo" dual list item selected
+
+        When I click on the "dual-list-add-selected" button
+        Then I should see "item-my-server.dom-server.ipa.demo" dual list item on the right
+        And I should see "item-my-server.dom-server.ipa.demo" dual list item not selected
+
+        When I click on the "modal-button-add" button
+        Then I should not see "dual-list-modal" modal
+        And I should see "add-member-success" alert
+        And I should see "my-server.dom-server.ipa.demo" entry in the data table
+
+    @cleanup
+    Scenario: Cleanup host from Host category
+        Given I delete element "host" named "my-server" from netgroup "netgroup1"
+
+    @seed
+    Scenario: Add host to Host category
+        Given I am logged in as admin
+        And I am on "netgroups/netgroup1" page
+
+        When I click on the "netgroups-tab-settings-tab-hosts" tab
+        Then I should see "netgroups-tab-settings-tab-hosts" tab
+
+        When I click on the "settings-button-add-host" button
+        Then I should see "dual-list-modal" modal
+
+        When I click on search link in dual list
+        Then I should see "item-my-server.dom-server.ipa.demo" dual list item on the left
+
+        When I click on "item-my-server.dom-server.ipa.demo" dual list item
+        Then I should see "item-my-server.dom-server.ipa.demo" dual list item selected
+
+        When I click on the "dual-list-add-selected" button
+        Then I should see "item-my-server.dom-server.ipa.demo" dual list item on the right
+        And I should see "item-my-server.dom-server.ipa.demo" dual list item not selected
+
+        When I click on the "modal-button-add" button
+        Then I should not see "dual-list-modal" modal
+        And I should see "add-member-success" alert
+        And I should see "my-server.dom-server.ipa.demo" entry in the data table
+
+    @test
+    Scenario: Remove host from Host category
+        Given I am logged in as admin
+        And I am on "netgroups/netgroup1" page
+
+        When I click on the "netgroups-tab-settings-tab-hosts" tab
+        Then I should see "netgroups-tab-settings-tab-hosts" tab
+
+        Then I should see "my-server.dom-server.ipa.demo" entry in the data table
+        When I select entry "my-server.dom-server.ipa.demo" in the settings data table "host"
+        Then I should see "my-server.dom-server.ipa.demo" entry selected in the data table
+        When I click on the "settings-button-delete-host" button
+        Then I should see "remove-netgroup-members-modal" modal
+
+        When I click on the "modal-button-delete" button
+        Then I should not see "remove-netgroup-members-modal" modal
+        And I should see "remove-netgroups-success" alert
+        And I should not see "my-server.dom-server.ipa.demo" entry in the data table
+
+    @cleanup
+    Scenario: Cleanup host
+        Given I delete host "my-server"
+
+    @test
+    Scenario: Add hostgroup to Host category
+        Given I am logged in as admin
+        And I am on "netgroups/netgroup1" page
+
+        When I click on the "netgroups-tab-settings-tab-hostgroups" tab
+        Then I should see "netgroups-tab-settings-tab-hostgroups" tab
+
+        When I click on the "settings-button-add-hostgroup" button
+        Then I should see "dual-list-modal" modal
+
+        When I click on search link in dual list
+        Then I should see "item-ipaservers" dual list item on the left
+
+        When I click on "item-ipaservers" dual list item
+        Then I should see "item-ipaservers" dual list item selected
+
+        When I click on the "dual-list-add-selected" button
+        Then I should see "item-ipaservers" dual list item on the right
+        And I should see "item-ipaservers" dual list item not selected
+
+        When I click on the "modal-button-add" button
+        Then I should not see "dual-list-modal" modal
+        And I should see "add-member-success" alert
+        And I should see "ipaservers" entry in the data table
+
+    @cleanup
+    Scenario: Cleanup hostgroup "ipaservers"
+        Given I delete element "hostgroup" named "ipaservers" from netgroup "netgroup1"
+
+    @seed
+    Scenario: Add hostgroup "ipaservers"
+        Given I have element "hostgroup" named "ipaservers" in netgroup "netgroup1"
+
+    @test
+    Scenario: Remove hostgroup from Host category
+        Given I am logged in as admin
+        And I am on "netgroups/netgroup1" page
+
+        When I click on the "netgroups-tab-settings-tab-hostgroups" tab
+        Then I should see "netgroups-tab-settings-tab-hostgroups" tab
+
+        Then I should see "ipaservers" entry in the data table
+        When I select entry "ipaservers" in the settings data table "hostgroup"
+        Then I should see "ipaservers" entry selected in the data table
+        When I click on the "settings-button-delete-hostgroup" button
+        Then I should see "remove-netgroup-members-modal" modal
+
+        When I click on the "modal-button-delete" button
+        Then I should not see "remove-netgroup-members-modal" modal
+        And I should see "remove-netgroups-success" alert
+        And I should not see "ipaservers" entry in the data table
+
+    @test
+    Scenario: Add external host to Host category
+        Given I am logged in as admin
+        And I am on "netgroups/netgroup1" page
+
+        When I click on the "netgroups-tab-settings-tab-externalhosts" tab
+        Then I should see "netgroups-tab-settings-tab-externalhosts" tab
+
+        When I click on the "settings-button-add-externalHost" button
+        Then I should see "add-external-host-modal" modal
+
+        When I type in the "modal-textbox-external-host-name" textbox text "test.test.test"
+        Then I should see "test.test.test" in the "modal-textbox-external-host-name" textbox
+        When I click on the "modal-button-add" button
+        Then I should not see "add-external-host-modal" modal
+        And I should see "add-member-success" alert
+        And I should see "test.test.test" entry in the data table
+
+    @cleanup
+    Scenario: Cleanup external host "test.test.test"
+        Given I delete external host "test.test.test" from netgroup "netgroup1"
+
+    @seed
+    Scenario: Add external host "test.test.test"
+        Given I have external host "test.test.test" in netgroup "netgroup1"
+
+    @test
+    Scenario: Remove external host from Host category
+        Given I am logged in as admin
+        And I am on "netgroups/netgroup1" page
+
+        When I click on the "netgroups-tab-settings-tab-externalhosts" tab
+        Then I should see "netgroups-tab-settings-tab-externalhosts" tab
+
+        Then I should see "test.test.test" entry in the data table
+        When I select entry "test.test.test" in the settings data table "externalHost"
+        Then I should see "test.test.test" entry selected in the data table
+        When I click on the "settings-button-delete-externalHost" button
+        Then I should see "remove-netgroup-members-modal" modal
+
+        When I click on the "modal-button-delete" button
+        Then I should not see "remove-netgroup-members-modal" modal
+        And I should see "remove-netgroups-success" alert
+        And I should not see "test.test.test" entry in the data table
+
+    @test
+    Scenario: Toggle user category allow anyone
+        Given I am logged in as admin
+        And I am on "netgroups/netgroup1" page
+
+        When I click on the "netgroups-tab-settings-checkbox-usercategory" checkbox
+        Then I should not see "netgroups-tab-settings-tab-users" tab
+        And I should not see "netgroups-tab-settings-tab-groups" tab
+
+    @test
+    Scenario: Toggle host category allow any host
+        Given I am logged in as admin
+        And I am on "netgroups/netgroup1" page
+
+        When I click on the "netgroups-tab-settings-checkbox-hostcategory" checkbox
+        Then I should not see "netgroups-tab-settings-tab-hosts" tab
+        And I should not see "netgroups-tab-settings-tab-hostgroups" tab
+
+    @cleanup
+    Scenario: Cleanup netgroup
+        Given I delete netgroup "netgroup1"

--- a/src/pages/Netgroups/NetgroupsMembers.tsx
+++ b/src/pages/Netgroups/NetgroupsMembers.tsx
@@ -124,6 +124,7 @@ const NetgroupsMembers = (props: PropsToNetgroupsMembers) => {
           unmountOnExit
         >
           <Tab
+            data-cy="members-tab-users"
             eventKey={"member_user"}
             name="member_user"
             title={
@@ -147,6 +148,7 @@ const NetgroupsMembers = (props: PropsToNetgroupsMembers) => {
             />
           </Tab>
           <Tab
+            data-cy="members-tab-user-groups"
             eventKey={"member_group"}
             name="member_group"
             title={
@@ -170,6 +172,7 @@ const NetgroupsMembers = (props: PropsToNetgroupsMembers) => {
             />
           </Tab>
           <Tab
+            data-cy="members-tab-hosts"
             eventKey={"member_host"}
             name="member_host"
             title={
@@ -193,6 +196,7 @@ const NetgroupsMembers = (props: PropsToNetgroupsMembers) => {
             />
           </Tab>
           <Tab
+            data-cy="members-tab-host-groups"
             eventKey={"member_hostgroup"}
             name="member_hostgroup"
             title={
@@ -216,6 +220,7 @@ const NetgroupsMembers = (props: PropsToNetgroupsMembers) => {
             />
           </Tab>
           <Tab
+            data-cy="members-tab-netgroups"
             eventKey={"member_netgroup"}
             name="member_netgroup"
             title={

--- a/src/pages/Netgroups/NetgroupsSettings.tsx
+++ b/src/pages/Netgroups/NetgroupsSettings.tsx
@@ -255,6 +255,7 @@ const NetgroupsSettings = (props: PropsToGroupsSettings) => {
             <Tab
               eventKey={0}
               name="users"
+              data-cy="netgroups-tab-settings-tab-users"
               title={
                 <TabTitleText>
                   Users <Label isCompact>{memberUsers.length}</Label>
@@ -274,6 +275,7 @@ const NetgroupsSettings = (props: PropsToGroupsSettings) => {
             <Tab
               eventKey={1}
               name="groups"
+              data-cy="netgroups-tab-settings-tab-groups"
               title={
                 <TabTitleText>
                   Groups <Label isCompact>{memberGroups.length}</Label>
@@ -321,6 +323,7 @@ const NetgroupsSettings = (props: PropsToGroupsSettings) => {
             <Tab
               eventKey={0}
               name="memberHosts"
+              data-cy="netgroups-tab-settings-tab-hosts"
               title={
                 <TabTitleText>
                   Hosts <Label isCompact>{memberHosts.length}</Label>
@@ -340,6 +343,7 @@ const NetgroupsSettings = (props: PropsToGroupsSettings) => {
             <Tab
               eventKey={1}
               name="memberHostGroups"
+              data-cy="netgroups-tab-settings-tab-hostgroups"
               title={
                 <TabTitleText>
                   Host groups <Label isCompact>{memberHostGroups.length}</Label>
@@ -360,6 +364,7 @@ const NetgroupsSettings = (props: PropsToGroupsSettings) => {
             <Tab
               eventKey={2}
               name="memberExternalHosts"
+              data-cy="netgroups-tab-settings-tab-externalhosts"
               title={
                 <TabTitleText>
                   External hosts{" "}

--- a/src/pages/Netgroups/NetgroupsTabs.tsx
+++ b/src/pages/Netgroups/NetgroupsTabs.tsx
@@ -126,6 +126,7 @@ const NetgroupsTabs = ({ section }) => {
           unmountOnExit
         >
           <Tab
+            data-cy="netgroups-tab-settings"
             eventKey={"settings"}
             name="settings-details"
             title={<TabTitleText>Settings</TabTitleText>}
@@ -143,6 +144,7 @@ const NetgroupsTabs = ({ section }) => {
             />
           </Tab>
           <Tab
+            data-cy={"netgroups-tab-member"}
             eventKey={"member"}
             name={"members-details"}
             title={<TabTitleText>Members</TabTitleText>}
@@ -150,6 +152,7 @@ const NetgroupsTabs = ({ section }) => {
             <NetgroupsMembers netgroup={netgroup} tabSection={section} />
           </Tab>
           <Tab
+            data-cy="netgroups-tab-memberof"
             eventKey={"memberof"}
             name="memberof-details"
             title={<TabTitleText>Is a member of</TabTitleText>}


### PR DESCRIPTION
Add integration tests for netgroup write body. Covers netgroup_member_of, netgroup, and netgroup_settings.  Added cy attributes where it was needed.

## Summary by Sourcery

Add comprehensive Cypress integration tests for netgroup functionality, including creation, deletion, settings manipulation, and membership management in the “Member of” section; annotate key UI components with data-cy attributes to support automation.

New Features:
- Add E2E tests for netgroup creation, deletion, and search on the main netgroups page
- Add E2E tests for managing netgroup settings (description, NIS domain, members, hosts, hostgroups, external hosts, and category toggles)
- Add E2E tests for the “Member of” section of netgroups

Enhancements:
- Add data-cy attributes to DualListSelector components, Netgroups tabs, and related UI elements to enable Cypress targeting
- Extend common Cypress tab step definitions to assert visibility and selected state

Tests:
- Introduce feature files for netgroup, netgroup_settings, and netgroup_member_of scenarios
- Add supporting step definitions in cypress/e2e/netgroup/netgroup.ts for netgroup operations and cleanup flows