### PR TITLE
Cypress usergroup

### DIFF
--- a/cypress/e2e/common/hbac_rule_management.ts
+++ b/cypress/e2e/common/hbac_rule_management.ts
@@ -1,0 +1,44 @@
+import { Given } from "@badeball/cypress-cucumber-preprocessor";
+import { loginAsAdmin, logout } from "../common/authentication";
+import {
+  selectEntry,
+  searchForEntry,
+  entryDoesNotExist,
+  entryExists,
+} from "../common/data_tables";
+import { navigateTo } from "../common/navigation";
+import { typeInTextbox } from "../common/ui/textbox";
+
+Given("hbac rule {string} exists", (ruleName: string) => {
+  loginAsAdmin();
+  navigateTo("hbac-rules");
+
+  cy.dataCy("hbac-rules-button-add").click();
+  cy.dataCy("add-hbac-rule-modal").should("exist");
+
+  typeInTextbox("modal-textbox-rule-name", ruleName);
+  cy.dataCy("modal-textbox-rule-name").should("have.value", ruleName);
+
+  cy.dataCy("modal-button-add").click();
+  cy.dataCy("add-hbac-rule-modal").should("not.exist");
+
+  searchForEntry(ruleName);
+  entryExists(ruleName);
+  logout();
+});
+
+Given("I delete hbac rule {string}", (ruleName: string) => {
+  loginAsAdmin();
+  navigateTo("hbac-rules");
+  selectEntry(ruleName);
+
+  cy.dataCy("hbac-rules-button-delete").click();
+  cy.dataCy("delete-hbac-rules-modal").should("exist");
+
+  cy.dataCy("modal-button-delete").click();
+  cy.dataCy("delete-hbac-rules-modal").should("not.exist");
+
+  searchForEntry(ruleName);
+  entryDoesNotExist(ruleName);
+  logout();
+});

--- a/cypress/e2e/common/ui/toggle_button.ts
+++ b/cypress/e2e/common/ui/toggle_button.ts
@@ -1,0 +1,20 @@
+import { Then } from "@badeball/cypress-cucumber-preprocessor";
+
+Then("I should see the {string} toggle button is pressed", (button: string) => {
+  cy.get("[data-cy=" + button + "] button").should(
+    "have.attr",
+    "aria-pressed",
+    "true"
+  );
+});
+
+Then(
+  "I should see the {string} toggle button is not pressed",
+  (button: string) => {
+    cy.get("[data-cy=" + button + "] button").should(
+      "have.attr",
+      "aria-pressed",
+      "false"
+    );
+  }
+);

--- a/cypress/e2e/hbac/hbac_rule/hbac_rule.feature
+++ b/cypress/e2e/hbac/hbac_rule/hbac_rule.feature
@@ -25,7 +25,7 @@ Feature: HBAC rules manipulation
 
   @cleanup
     Scenario: Delete a rule
-    Given I delete rule "rule1"
+    Given I delete hbac rule "rule1"
 
   @test
   Scenario: Add several rules
@@ -68,13 +68,13 @@ Feature: HBAC rules manipulation
 
   @cleanup
   Scenario: Delete a rule
-    Given I delete rule "rule2"
-    And I delete rule "rule3"
-    And I delete rule "rule4"
+    Given I delete hbac rule "rule2"
+    And I delete hbac rule "rule3"
+    And I delete hbac rule "rule4"
 
   @seed
   Scenario: Create rules
-    Given rule "rule1" exists
+    Given hbac rule "rule1" exists
 
   @test
   Scenario: Search for a rule
@@ -87,11 +87,11 @@ Feature: HBAC rules manipulation
   
   @cleanup
   Scenario: Delete a rule
-    Given I delete rule "rule1"
+    Given I delete hbac rule "rule1"
 
   @seed 
   Scenario: Create a rule
-    Given rule "rule4" exists
+    Given hbac rule "rule4" exists
 
   @test
     Scenario: Disable a rule
@@ -132,11 +132,11 @@ Feature: HBAC rules manipulation
 
   @cleanup
   Scenario: Delete a rule
-    Given I delete rule "rule4"
+    Given I delete hbac rule "rule4"
 
   @seed 
   Scenario: Create a rule
-    Given rule "rule1" exists
+    Given hbac rule "rule1" exists
 
   @test
   Scenario: Delete a rule
@@ -156,9 +156,9 @@ Feature: HBAC rules manipulation
 
   @seed
   Scenario: Create a rule
-    Given rule "rule2" exists
-    Given rule "rule3" exists
-    Given rule "rule4" exists
+    Given hbac rule "rule2" exists
+    Given hbac rule "rule3" exists
+    Given hbac rule "rule4" exists
 
   @test
   Scenario: Delete many rules

--- a/cypress/e2e/hbac/hbac_rule/hbac_rule.ts
+++ b/cypress/e2e/hbac/hbac_rule/hbac_rule.ts
@@ -1,50 +1,13 @@
 import { Given } from "@badeball/cypress-cucumber-preprocessor";
 import { loginAsAdmin, logout } from "../../common/authentication";
 import {
-  selectEntry,
-  searchForEntry,
   entryDoesNotExist,
   entryExists,
   checkEntry,
 } from "../../common/data_tables";
 import { navigateTo } from "../../common/navigation";
-import { typeInTextbox } from "../../common/ui/textbox";
 import { findEntryInTable } from "../../common/settings_table";
 import { addItemToRightList } from "../../common/ui/dual_list";
-
-Given("rule {string} exists", (ruleName: string) => {
-  loginAsAdmin();
-  navigateTo("hbac-rules");
-
-  cy.dataCy("hbac-rules-button-add").click();
-  cy.dataCy("add-hbac-rule-modal").should("exist");
-
-  typeInTextbox("modal-textbox-rule-name", ruleName);
-  cy.dataCy("modal-textbox-rule-name").should("have.value", ruleName);
-
-  cy.dataCy("modal-button-add").click();
-  cy.dataCy("add-hbac-rule-modal").should("not.exist");
-
-  searchForEntry(ruleName);
-  entryExists(ruleName);
-  logout();
-});
-
-Given("I delete rule {string}", (ruleName: string) => {
-  loginAsAdmin();
-  navigateTo("hbac-rules");
-  selectEntry(ruleName);
-
-  cy.dataCy("hbac-rules-button-delete").click();
-  cy.dataCy("delete-hbac-rules-modal").should("exist");
-
-  cy.dataCy("modal-button-delete").click();
-  cy.dataCy("delete-hbac-rules-modal").should("not.exist");
-
-  searchForEntry(ruleName);
-  entryDoesNotExist(ruleName);
-  logout();
-});
 
 Given(
   "I have element {string} named {string} in rule {string}",

--- a/cypress/e2e/hbac/hbac_rule/hbac_rule_settings.feature
+++ b/cypress/e2e/hbac/hbac_rule/hbac_rule_settings.feature
@@ -3,7 +3,7 @@ Feature: Hbac rule settings manipulation
 
   @seed
   Scenario: Add a new rule
-    Given rule "rule1" exists
+    Given hbac rule "rule1" exists
 
   @test
   Scenario: Add user to Who category
@@ -452,4 +452,4 @@ Feature: Hbac rule settings manipulation
 
   @cleanup
   Scenario: Delete the HBAC rule for cleanup
-    Given I delete rule "rule1"
+    Given I delete hbac rule "rule1"

--- a/cypress/e2e/hbac/hbac_rule/hbac_rule_settings.feature
+++ b/cypress/e2e/hbac/hbac_rule/hbac_rule_settings.feature
@@ -158,19 +158,19 @@ Feature: Hbac rule settings manipulation
     Then I click on the "settings-button-add-host" button
     Then I should see "dual-list-modal" modal
     When I click on search link in dual list
-    Then I should see "item-my-new-host\.dom-server\.ipa\.demo" dual list item on the left
+    Then I should see "item-my-new-host.dom-server.ipa.demo" dual list item on the left
 
-    When I click on "item-my-new-host\.dom-server\.ipa\.demo" dual list item
-    Then I should see "item-my-new-host\.dom-server\.ipa\.demo" dual list item selected
+    When I click on "item-my-new-host.dom-server.ipa.demo" dual list item
+    Then I should see "item-my-new-host.dom-server.ipa.demo" dual list item selected
 
     When I click on the "dual-list-add-selected" button
-    Then I should see "item-my-new-host\.dom-server\.ipa\.demo" dual list item on the right
-    And I should see "item-my-new-host\.dom-server\.ipa\.demo" dual list item not selected
+    Then I should see "item-my-new-host.dom-server.ipa.demo" dual list item on the right
+    And I should see "item-my-new-host.dom-server.ipa.demo" dual list item not selected
 
     When I click on the "modal-button-add" button
     Then I should not see "dual-list-modal" modal
     And I should see "add-member-success" alert
-    Then I should see "my-new-host\.dom-server\.ipa\.demo" entry in the data table
+    Then I should see "my-new-host.dom-server.ipa.demo" entry in the data table
 
   @cleanup
   Scenario: Delete the host from the rule
@@ -185,19 +185,19 @@ Feature: Hbac rule settings manipulation
     Then I click on the "settings-button-add-host" button
     Then I should see "dual-list-modal" modal
     When I click on search link in dual list
-    Then I should see "item-my-new-host\.dom-server\.ipa\.demo" dual list item on the left
+    Then I should see "item-my-new-host.dom-server.ipa.demo" dual list item on the left
 
-    When I click on "item-my-new-host\.dom-server\.ipa\.demo" dual list item
-    Then I should see "item-my-new-host\.dom-server\.ipa\.demo" dual list item selected
+    When I click on "item-my-new-host.dom-server.ipa.demo" dual list item
+    Then I should see "item-my-new-host.dom-server.ipa.demo" dual list item selected
 
     When I click on the "dual-list-add-selected" button
-    Then I should see "item-my-new-host\.dom-server\.ipa\.demo" dual list item on the right
-    And I should see "item-my-new-host\.dom-server\.ipa\.demo" dual list item not selected
+    Then I should see "item-my-new-host.dom-server.ipa.demo" dual list item on the right
+    And I should see "item-my-new-host.dom-server.ipa.demo" dual list item not selected
 
     When I click on the "modal-button-add" button
     Then I should not see "dual-list-modal" modal
     And I should see "add-member-success" alert
-    Then I should see "my-new-host\.dom-server\.ipa\.demo" entry in the data table
+    Then I should see "my-new-host.dom-server.ipa.demo" entry in the data table
 
   @test
   Scenario: Remove host from Host category
@@ -271,19 +271,19 @@ Feature: Hbac rule settings manipulation
     Then I click on the "settings-button-add-host" button
     Then I should see "dual-list-modal" modal
     When I click on search link in dual list
-    Then I should see "item-my-new-host\.dom-server\.ipa\.demo" dual list item on the left
+    Then I should see "item-my-new-host.dom-server.ipa.demo" dual list item on the left
 
-    When I click on "item-my-new-host\.dom-server\.ipa\.demo" dual list item
-    Then I should see "item-my-new-host\.dom-server\.ipa\.demo" dual list item selected
+    When I click on "item-my-new-host.dom-server.ipa.demo" dual list item
+    Then I should see "item-my-new-host.dom-server.ipa.demo" dual list item selected
 
     When I click on the "dual-list-add-selected" button
-    Then I should see "item-my-new-host\.dom-server\.ipa\.demo" dual list item on the right
-    And I should see "item-my-new-host\.dom-server\.ipa\.demo" dual list item not selected
+    Then I should see "item-my-new-host.dom-server.ipa.demo" dual list item on the right
+    And I should see "item-my-new-host.dom-server.ipa.demo" dual list item not selected
 
     When I click on the "modal-button-add" button
     Then I should not see "dual-list-modal" modal
     And I should see "add-member-success" alert
-    Then I should see "my-new-host\.dom-server\.ipa\.demo" entry in the data table
+    Then I should see "my-new-host.dom-server.ipa.demo" entry in the data table
 
     When I click on the "hbac-rules-tab-settings-tab-hostgroups" tab
     Then I click on the "settings-button-add-hostgroup" button

--- a/cypress/e2e/user_groups/user_groups.feature
+++ b/cypress/e2e/user_groups/user_groups.feature
@@ -1,0 +1,184 @@
+Feature: User group manipulation
+  Create, and delete user groups
+
+  @test
+  Scenario: Add a new POSIX group
+    Given I am logged in as admin
+    And I am on "user-groups" page
+
+    When I click on the "user-groups-button-add" button
+    Then I should see "add-user-group-modal" modal
+
+    When I type in the "modal-textbox-group-name" textbox text "a_posix_group"
+    Then I should see "a_posix_group" in the "modal-textbox-group-name" textbox
+
+    When I type in the "modal-textbox-group-gid" textbox text "77777"
+    Then I should see "77777" in the "modal-textbox-group-gid" textbox
+
+    When I click on the "modal-button-add" button
+    Then I should not see "add-user-group-modal" modal
+    And I should see "add-group-success" alert
+
+    When I search for "a_posix_group" in the data table
+    Then I should see "a_posix_group" entry in the data table with attribute "GID" set to "77777"
+
+  @cleanup
+  Scenario: Delete a group
+    Given I delete user group "a_posix_group"
+
+  @test
+  Scenario: Add a new non-POSIX group
+    Given I am logged in as admin
+    And I am on "user-groups" page
+
+    When I click on the "user-groups-button-add" button
+    Then I should see "add-user-group-modal" modal
+
+    When I type in the "modal-textbox-group-name" textbox text "a_non_posix_group"
+    Then I should see "a_non_posix_group" in the "modal-textbox-group-name" textbox
+
+    When I select "non-posix" option in the "modal-group-type-select" selector
+    Then I should see "non-posix" option in the "modal-group-type-select" selector
+
+    When I click on the "modal-button-add" button
+    Then I should not see "add-user-group-modal" modal
+    And I should see "add-group-success" alert
+
+    When I search for "a_non_posix_group" in the data table
+    Then I should see "a_non_posix_group" entry in the data table
+
+  @cleanup
+  Scenario: Delete a group
+    Given I delete user group "a_non_posix_group"
+
+  @test
+  Scenario: Add a new external group
+    Given I am logged in as admin
+    And I am on "user-groups" page
+
+    When I click on the "user-groups-button-add" button
+    Then I should see "add-user-group-modal" modal
+
+    When I type in the "modal-textbox-group-name" textbox text "a_external_group"
+    Then I should see "a_external_group" in the "modal-textbox-group-name" textbox
+
+    When I click on the "modal-button-add" button
+    Then I should not see "add-user-group-modal" modal
+    And I should see "add-group-success" alert
+
+    When I search for "a_external_group" in the data table
+    Then I should see "a_external_group" entry in the data table
+
+  @cleanup
+  Scenario: Delete a group
+    Given I delete user group "a_external_group"
+
+  @test
+  Scenario: Add one group after another
+    Given I am logged in as admin
+    And I am on "user-groups" page
+
+    When I click on the "user-groups-button-add" button
+    Then I should see "add-user-group-modal" modal
+
+    When I type in the "modal-textbox-group-name" textbox text "chain_group1"
+    Then I should see "chain_group1" in the "modal-textbox-group-name" textbox
+
+    When I click on the "modal-button-add-and-add-another" button
+    Then I should see "add-user-group-modal" modal
+    And I should see "add-group-success" alert
+
+    When I type in the "modal-textbox-group-name" textbox text "chain_group2"
+    Then I should see "chain_group2" in the "modal-textbox-group-name" textbox
+
+    When I click on the "modal-button-add" button
+    Then I should not see "add-user-group-modal" modal
+
+    When I search for "chain_group1" in the data table
+    Then I should see "chain_group1" entry in the data table
+
+    When I search for "chain_group2" in the data table
+    Then I should see "chain_group2" entry in the data table
+
+  @cleanup
+  Scenario: Delete groups
+    Given I delete user group "chain_group1"
+    And I delete user group "chain_group2"
+
+  @seed
+  Scenario: Create a group
+    Given user group "a_posix_group" exists
+
+  @test
+  Scenario: Delete a group
+    Given I am logged in as admin
+    And I am on "user-groups" page
+
+    When I search for "a_posix_group" in the data table
+    Then I should see "a_posix_group" entry in the data table
+
+    When I select entry "a_posix_group" in the data table
+    Then I should see "a_posix_group" entry selected in the data table
+
+    When I click on the "user-groups-button-delete" button
+    Then I should see "delete-user-groups-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "delete-user-groups-modal" modal
+    And I should see "remove-user-groups-success" alert
+
+    When I search for "a_posix_group" in the data table
+    Then I should not see "a_posix_group" entry in the data table
+
+  @seed
+  Scenario: Create groups
+    Given user group "group1" exists
+    And user group "group2" exists
+
+  @test
+  Scenario: Delete many groups
+    Given I am logged in as admin
+    And I am on "user-groups" page
+
+    When I search for "group1" in the data table
+    Then I should see "group1" entry in the data table
+    When I select entry "group1" in the data table
+    Then I should see "group1" entry selected in the data table
+
+    When I search for "group2" in the data table
+    Then I should see "group2" entry in the data table
+    When I select entry "group2" in the data table
+    Then I should see "group2" entry selected in the data table
+
+    When I click on the "user-groups-button-delete" button
+    Then I should see "delete-user-groups-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "delete-user-groups-modal" modal
+    And I should see "remove-user-groups-success" alert
+
+    When I search for "group1" in the data table
+    Then I should not see "group1" entry in the data table
+
+    When I search for "group2" in the data table
+    Then I should not see "group2" entry in the data table
+
+  @test
+  Scenario: Cancel creation of a group
+    Given I am logged in as admin
+    And I am on "user-groups" page
+
+    When I search for "cancelgroup" in the data table
+    Then I should not see "cancelgroup" entry in the data table
+
+    When I click on the "user-groups-button-add" button
+    Then I should see "add-user-group-modal" modal
+
+    When I type in the "modal-textbox-group-name" textbox text "cancelgroup"
+    Then I should see "cancelgroup" in the "modal-textbox-group-name" textbox
+
+    When I click on the "modal-button-cancel" button
+    Then I should not see "add-user-group-modal" modal
+
+    When I search for "cancelgroup" in the data table
+    Then I should not see "cancelgroup" entry in the data table

--- a/cypress/e2e/user_groups/user_groups.ts
+++ b/cypress/e2e/user_groups/user_groups.ts
@@ -1,0 +1,146 @@
+import { Given } from "@badeball/cypress-cucumber-preprocessor";
+import { loginAsAdmin, logout } from "../common/authentication";
+import {
+  selectEntry,
+  searchForEntry,
+  entryDoesNotExist,
+  entryExists,
+} from "../common/data_tables";
+import { navigateTo } from "../common/navigation";
+import { selectOption } from "../common/ui/select";
+import { isOptionSelected } from "../common/ui/select";
+import { addItemToRightList } from "../common/ui/dual_list";
+
+Given("I delete user group {string}", (groupName: string) => {
+  loginAsAdmin();
+  navigateTo("user-groups");
+  selectEntry(groupName);
+
+  cy.dataCy("user-groups-button-delete").click();
+  cy.dataCy("delete-user-groups-modal").should("exist");
+
+  cy.dataCy("modal-button-delete").click();
+  cy.dataCy("delete-user-groups-modal").should("not.exist");
+
+  searchForEntry(groupName);
+  entryDoesNotExist(groupName);
+  logout();
+});
+
+Given("user group {string} exists", (groupName: string) => {
+  loginAsAdmin();
+  navigateTo("user-groups");
+
+  cy.dataCy("user-groups-button-add").click();
+  cy.dataCy("add-user-group-modal").should("exist");
+
+  cy.dataCy("modal-textbox-group-name").type(groupName);
+  cy.dataCy("modal-textbox-group-name").should("have.value", groupName);
+
+  cy.dataCy("modal-button-add").click();
+  cy.dataCy("add-user-group-modal").should("not.exist");
+  searchForEntry(groupName);
+  entryExists(groupName);
+  logout();
+});
+
+type MemberType = "member_user" | "member_group" | "member_service";
+
+type MemberOfType =
+  | "memberof_usergroup"
+  | "memberof_netgroup"
+  | "memberof_role"
+  | "memberof_hbacrule"
+  | "memberof_sudorule";
+
+type ManagerType = "manager_user" | "manager_group";
+
+const addMember = (
+  type: MemberType | MemberOfType | ManagerType,
+  member: string,
+  group: string
+) => {
+  loginAsAdmin();
+  navigateTo("user-groups/" + group + "/" + type);
+
+  cy.dataCy("member-of-button-add").click();
+  cy.dataCy("member-of-add-modal").should("exist");
+
+  addItemToRightList(member);
+
+  cy.dataCy("modal-button-add").click();
+  cy.dataCy("member-of-add-modal").should("not.exist");
+
+  searchForEntry(member);
+  entryExists(member);
+  logout();
+};
+
+Given(
+  "user {string} is member of group {string}",
+  (user: string, group: string) => {
+    addMember("member_user", user, group);
+  }
+);
+
+Given(
+  "user group {string} is member of group {string}",
+  (userGroup: string, group: string) => {
+    addMember("member_group", userGroup, group);
+  }
+);
+
+Given(
+  "service {string} is member of group {string}",
+  (service: string, group: string) => {
+    addMember("member_service", service, group);
+  }
+);
+
+Given(
+  "user {string} is manager of group {string}",
+  (user: string, group: string) => {
+    addMember("manager_user", user, group);
+  }
+);
+
+Given(
+  "user group {string} is manager of group {string}",
+  (userGroup: string, group: string) => {
+    addMember("manager_group", userGroup, group);
+  }
+);
+
+Given(
+  "user group {string} is member of role {string}",
+  (group: string, role: string) => {
+    addMember("memberof_role", role, group);
+  }
+);
+
+Given(
+  "user group {string} is member of hbac rule {string}",
+  (group: string, hbacRule: string) => {
+    addMember("memberof_hbacrule", hbacRule, group);
+  }
+);
+
+Given("non-POSIX User group {string} exists", (groupName: string) => {
+  loginAsAdmin();
+  navigateTo("user-groups");
+
+  cy.dataCy("user-groups-button-add").click();
+  cy.dataCy("add-user-group-modal").should("exist");
+
+  cy.dataCy("modal-textbox-group-name").type(groupName);
+  cy.dataCy("modal-textbox-group-name").should("have.value", groupName);
+
+  selectOption("non-posix", "modal-group-type-select");
+  isOptionSelected("non-posix", "modal-group-type-select");
+
+  cy.dataCy("modal-button-add").click();
+  cy.dataCy("add-user-group-modal").should("not.exist");
+  searchForEntry(groupName);
+  entryExists(groupName);
+  logout();
+});

--- a/cypress/e2e/user_groups/user_groups_member_manager.feature
+++ b/cypress/e2e/user_groups/user_groups_member_manager.feature
@@ -1,0 +1,109 @@
+Feature: Usergroup member managers
+  Manage user group member managers across Users and User groups tabs
+
+  @seed
+  Scenario: Create seed data (user and user group)
+    Given User "mmuser" "Member" "Manager" exists and is using password "Secret123"
+    And user group "member-managers-group" exists
+
+  @test
+  Scenario: Add a User member manager into the user group
+    Given I am logged in as admin
+    And I am on "user-groups/member-managers-group/manager_user" page
+
+    When I click on the "member-of-button-add" button
+    Then I should see "member-of-add-modal" modal
+    And I should see "item-mmuser" dual list item on the left
+
+    When I click on "item-mmuser" dual list item
+    Then I should see "item-mmuser" dual list item selected
+    When I click on the "dual-list-add-selected" button
+    Then I should see "item-mmuser" dual list item on the right
+
+    When I click on the "modal-button-add" button
+    Then I should not see "member-of-add-modal" modal
+    And I should see "add-member-managers-success" alert
+
+    When I search for "mmuser" in the data table
+    Then I should see "mmuser" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete user "mmuser"
+    And I delete user group "member-managers-group"
+
+  @seed
+  Scenario: Create seed data (user and user group)
+    Given User "mmuser" "Member" "Manager" exists and is using password "Secret123"
+    And user group "member-managers-group" exists
+    And user "mmuser" is manager of group "member-managers-group"
+
+  @test
+  Scenario: Remove User member manager from the user group
+    Given I am logged in as admin
+    And I am on "user-groups/member-managers-group/manager_user" page
+
+    When I select entry "mmuser" in the data table
+    Then I should see "mmuser" entry selected in the data table
+
+    When I click on the "member-of-button-delete" button
+    Then I should see "member-of-delete-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "member-of-delete-modal" modal
+    And I should see "remove-member-managers-success" alert
+
+    When I search for "mmuser" in the data table
+    Then I should not see "mmuser" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete user "mmuser"
+    And I delete user group "member-managers-group"
+
+  @seed
+  Scenario: Create seed data (user group)
+    Given user group "member-managers-group" exists
+
+  @test
+  Scenario: Add a User group member manager into the user group
+    Given I am logged in as admin
+    And I am on "user-groups/member-managers-group/manager_usergroup" page
+
+    When I click on the "member-of-button-add" button
+    Then I should see "member-of-add-modal" modal
+    And I should see "item-editors" dual list item on the left
+
+    When I click on "item-editors" dual list item
+    Then I should see "item-editors" dual list item selected
+    When I click on the "dual-list-add-selected" button
+    Then I should see "item-editors" dual list item on the right
+
+    When I click on the "modal-button-add" button
+    Then I should not see "member-of-add-modal" modal
+    And I should see "add-member-managers-success" alert
+
+    When I search for "editors" in the data table
+    Then I should see "editors" entry in the data table
+
+  @test
+  Scenario: Remove User group member manager from the user group
+    Given I am logged in as admin
+    And I am on "user-groups/member-managers-group/manager_usergroup" page
+
+    When I select entry "editors" in the data table
+    Then I should see "editors" entry selected in the data table
+
+    When I click on the "member-of-button-delete" button
+    Then I should see "member-of-delete-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "member-of-delete-modal" modal
+    And I should see "remove-member-managers-success" alert
+
+    When I search for "editors" in the data table
+    Then I should not see "editors" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete user group "member-managers-group"

--- a/cypress/e2e/user_groups/user_groups_memberof.feature
+++ b/cypress/e2e/user_groups/user_groups_memberof.feature
@@ -1,0 +1,178 @@
+Feature: Usergroup is a member of
+  Work with usergroup Is a member of section and its operations in all the available tabs
+
+  @seed
+  Scenario: Create seed data (User group)
+    Given user group "a-group" exists
+
+  @test
+  Scenario: Add a User groups membership to the user group
+    Given I am logged in as admin
+    And I am on "user-groups/a-group/memberof_usergroup" page
+
+    When I click on the "member-of-button-add" button
+    Then I should see "member-of-add-modal" modal
+    And I should see "item-editors" dual list item on the left
+
+    When I click on "item-editors" dual list item
+    Then I should see "item-editors" dual list item selected
+    When I click on the "dual-list-add-selected" button
+    Then I should see "item-editors" dual list item on the right
+
+    When I click on the "modal-button-add" button
+    Then I should not see "member-of-add-modal" modal
+    And I should see "add-member-success" alert
+
+    When I search for "editors" in the data table
+    Then I should see "editors" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete user group "a-group"
+
+  @seed
+  Scenario: Create seed data (User group)
+    Given user group "a-group" exists
+    And user group "a-group" is member of group "editors"
+
+  @test
+  Scenario: Delete a User groups membership from the user group
+    Given I am logged in as admin
+    And I am on "user-groups/a-group/memberof_usergroup" page
+
+    When I select entry "editors" in the data table
+    Then I should see "editors" entry selected in the data table
+
+    When I click on the "member-of-button-delete" button
+    Then I should see "member-of-delete-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "member-of-delete-modal" modal
+    And I should see "remove-user-groups-success" alert
+
+    When I search for "editors" in the data table
+    Then I should not see "editors" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete user group "a-group"
+
+  # Add Netgroups
+
+  @seed
+  Scenario: Create seed data (User group)
+    Given user group "a-group" exists
+
+  @test
+  Scenario: Add a role membership to the user group
+    Given I am logged in as admin
+    And I am on "user-groups/a-group/memberof_role" page
+
+    When I click on the "member-of-button-add" button
+    Then I should see "member-of-add-modal" modal
+    And I should see "item-helpdesk" dual list item on the left
+
+    When I click on "item-helpdesk" dual list item
+    Then I should see "item-helpdesk" dual list item selected
+    When I click on the "dual-list-add-selected" button
+    Then I should see "item-helpdesk" dual list item on the right
+
+    When I click on the "modal-button-add" button
+    Then I should not see "member-of-add-modal" modal
+    And I should see "add-member-success" alert
+
+    When I search for "helpdesk" in the data table
+    Then I should see "helpdesk" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete user group "a-group"
+
+  @seed
+  Scenario: Create seed data (User group)
+    Given user group "a-group" exists
+    And user group "a-group" is member of role "helpdesk"
+
+  @test
+  Scenario: Delete a role membership from the user group
+    Given I am logged in as admin
+    And I am on "user-groups/a-group/memberof_role" page
+
+    When I select entry "helpdesk" in the data table
+    Then I should see "helpdesk" entry selected in the data table
+
+    When I click on the "member-of-button-delete" button
+    Then I should see "member-of-delete-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "member-of-delete-modal" modal
+    And I should see "remove-roles-success" alert
+
+    When I search for "helpdesk" in the data table
+    Then I should not see "helpdesk" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete user group "a-group"
+  
+  @seed
+  Scenario: Create seed data (User group and HBAC rule)
+    Given hbac rule "test" exists
+    And user group "a-group" exists
+
+  @test
+  Scenario: Add a hbac rule membership to the user group
+    Given I am logged in as admin
+    And I am on "user-groups/a-group/memberof_hbacrule" page
+
+    When I click on the "member-of-button-add" button
+    Then I should see "member-of-add-modal" modal
+    And I should see "item-test" dual list item on the left
+
+    When I click on "item-test" dual list item
+    Then I should see "item-test" dual list item selected
+    When I click on the "dual-list-add-selected" button
+    Then I should see "item-test" dual list item on the right
+
+    When I click on the "modal-button-add" button
+    Then I should not see "member-of-add-modal" modal
+    And I should see "add-member-success" alert
+
+    When I search for "test" in the data table
+    Then I should see "test" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete user group "a-group"
+    And I delete hbac rule "test"
+
+  @seed
+  Scenario: Create seed data (User group)
+    Given user group "a-group" exists
+    And hbac rule "test" exists
+    And user group "a-group" is member of hbac rule "test"
+
+  @test
+  Scenario: Delete a role membership from the user group
+    Given I am logged in as admin
+    And I am on "user-groups/a-group/memberof_hbacrule" page
+
+    When I select entry "test" in the data table
+    Then I should see "test" entry selected in the data table
+
+    When I click on the "member-of-button-delete" button
+    Then I should see "member-of-delete-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "member-of-delete-modal" modal
+    And I should see "remove-hbac-rules-success" alert
+
+    When I search for "test" in the data table
+    Then I should not see "test" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete user group "a-group"
+    And I delete hbac rule "test"
+
+  # Add Sudo rules

--- a/cypress/e2e/user_groups/user_groups_members.feature
+++ b/cypress/e2e/user_groups/user_groups_members.feature
@@ -1,0 +1,240 @@
+Feature: User group members
+  Manage user group members across Users, User groups, and Services tabs
+
+  @seed
+  Scenario: Create seed data (user and user group)
+    Given User "aturing" "Alan" "Turing" exists and is using password "Secret123"
+    And user group "imitation-game-group" exists
+
+  @test
+  Scenario: Add a User member into the user group
+    Given I am logged in as admin
+    And I am on "user-groups/imitation-game-group/member_user" page
+
+    When I click on the "member-of-button-add" button
+    Then I should see "member-of-add-modal" modal
+    And I should see "item-aturing" dual list item on the left
+
+    When I click on "item-aturing" dual list item
+    Then I should see "item-aturing" dual list item selected
+    When I click on the "dual-list-add-selected" button
+    Then I should see "item-aturing" dual list item on the right
+
+    When I click on the "modal-button-add" button
+    Then I should not see "member-of-add-modal" modal
+    And I should see "add-member-success" alert
+
+    When I search for "aturing" in the data table
+    Then I should see "aturing" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete user "aturing"
+    And I delete user group "imitation-game-group"
+
+  @seed
+  Scenario: Create seed data (user and user group)
+    And user group "imitation-game-group" exists
+
+  @test
+  Scenario: Switch between direct and indirect memberships (Users)
+    Given I am logged in as admin
+    And I am on "user-groups/imitation-game-group/member_user" page
+
+    When I click on the "member-of-toggle-group-item-indirect" button
+    Then I should see the "member-of-toggle-group-item-indirect" toggle button is pressed
+    And I should see the "member-of-button-add" button is disabled
+
+    When I click on the "member-of-toggle-group-item-direct" button
+    Then I should see the "member-of-toggle-group-item-indirect" toggle button is not pressed
+    And I should see the "member-of-toggle-group-item-direct" toggle button is pressed
+    And I should see the "member-of-button-add" button is enabled
+
+  @cleanup
+  Scenario: Cleanup seed data
+    And I delete user group "imitation-game-group"
+
+  @seed
+  Scenario: Create seed data (user and user group)
+    Given User "aturing" "Alan" "Turing" exists and is using password "Secret123"
+    And user group "imitation-game-group" exists
+    And user "aturing" is member of group "imitation-game-group"
+
+  @test
+  Scenario: Remove User from the user group
+    Given I am logged in as admin
+    And I am on "user-groups/imitation-game-group/member_user" page
+
+    When I select entry "aturing" in the data table
+    Then I should see "aturing" entry selected in the data table
+
+    When I click on the "member-of-button-delete" button
+    Then I should see "member-of-delete-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "member-of-delete-modal" modal
+    And I should see "remove-users-success" alert
+
+    When I search for "aturing" in the data table
+    Then I should not see "aturing" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete user "aturing"
+    And I delete user group "imitation-game-group"
+
+  @seed
+  Scenario: Create seed data (user group)
+    Given user group "imitation-game-group" exists
+
+  @test
+  Scenario: Add a User group member into the user group
+    Given I am logged in as admin
+    And I am on "user-groups/imitation-game-group/member_group" page
+
+    When I click on the "member-of-button-add" button
+    Then I should see "member-of-add-modal" modal
+    And I should see "item-editors" dual list item on the left
+
+    When I click on "item-editors" dual list item
+    Then I should see "item-editors" dual list item selected
+    When I click on the "dual-list-add-selected" button
+    Then I should see "item-editors" dual list item on the right
+
+    When I click on the "modal-button-add" button
+    Then I should not see "member-of-add-modal" modal
+    And I should see "add-member-success" alert
+
+    When I search for "editors" in the data table
+    Then I should see "editors" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete user group "imitation-game-group"
+
+  @seed
+  Scenario: Create seed data (user group)
+    Given user group "imitation-game-group" exists
+
+  @test
+  Scenario: Switch between direct and indirect memberships (User groups)
+    Given I am logged in as admin
+    And I am on "user-groups/imitation-game-group/member_group" page
+
+    When I click on the "member-of-toggle-group-item-indirect" button
+    Then I should see the "member-of-toggle-group-item-indirect" toggle button is pressed
+    And I should see the "member-of-button-add" button is disabled
+
+    When I click on the "member-of-toggle-group-item-direct" button
+    Then I should see the "member-of-toggle-group-item-indirect" toggle button is not pressed
+    And I should see the "member-of-toggle-group-item-direct" toggle button is pressed
+    And I should see the "member-of-button-add" button is enabled
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete user group "imitation-game-group"
+
+  @seed
+  Scenario: Create seed data (user group)
+    Given user group "imitation-game-group" exists
+    And user group "editors" is member of group "imitation-game-group"
+
+  @test
+  Scenario: Remove User group from the user group
+    Given I am logged in as admin
+    And I am on "user-groups/imitation-game-group/member_group" page
+
+    When I select entry "editors" in the data table
+    Then I should see "editors" entry selected in the data table
+
+    When I click on the "member-of-button-delete" button
+    Then I should see "member-of-delete-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "member-of-delete-modal" modal
+    And I should see "remove-usersgroups-success" alert
+
+    When I search for "editors" in the data table
+    Then I should not see "editors" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete user group "imitation-game-group"
+
+  @seed
+  Scenario: Create seed data (user group)
+    Given user group "imitation-game-group" exists
+
+  @test
+  Scenario: Add a Service member into the user group
+    Given I am logged in as admin
+    And I am on "user-groups/imitation-game-group/member_service" page
+
+    When I click on the "member-of-button-add" button
+    Then I should see "member-of-add-modal" modal
+    And I should see "item-DNS/server.ipa.demo@DOM-IPA.DEMO" dual list item on the left
+
+    When I click on "item-DNS/server.ipa.demo@DOM-IPA.DEMO" dual list item
+    Then I should see "item-DNS/server.ipa.demo@DOM-IPA.DEMO" dual list item selected
+    When I click on the "dual-list-add-selected" button
+    Then I should see "item-DNS/server.ipa.demo@DOM-IPA.DEMO" dual list item on the right
+
+    When I click on the "modal-button-add" button
+    Then I should not see "member-of-add-modal" modal
+    And I should see "add-member-success" alert
+
+    When I search for "DNS" in the data table
+    Then I should see "DNS/server.ipa.demo@DOM-IPA.DEMO" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete user group "imitation-game-group"
+
+  @seed
+  Scenario: Create seed data (user group)
+    Given user group "imitation-game-group" exists
+
+  @test
+  Scenario: Switch between direct and indirect memberships (Services)
+    Given I am logged in as admin
+    And I am on "user-groups/imitation-game-group/member_service" page
+
+    When I click on the "member-of-toggle-group-item-indirect" button
+    Then I should see the "member-of-toggle-group-item-indirect" toggle button is pressed
+    And I should see the "member-of-button-add" button is disabled
+
+    When I click on the "member-of-toggle-group-item-direct" button
+    Then I should see the "member-of-toggle-group-item-indirect" toggle button is not pressed
+    And I should see the "member-of-toggle-group-item-direct" toggle button is pressed
+    And I should see the "member-of-button-add" button is enabled
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete user group "imitation-game-group"
+
+  @seed
+  Scenario: Create seed data (user group)
+    Given user group "imitation-game-group" exists
+    And service "DNS/server.ipa.demo@DOM-IPA.DEMO" is member of group "imitation-game-group"
+
+  @test
+  Scenario: Remove Service from the user group
+    Given I am logged in as admin
+    And I am on "user-groups/imitation-game-group/member_service" page
+
+    When I select entry "DNS/server.ipa.demo@DOM-IPA.DEMO" in the data table
+    Then I should see "DNS/server.ipa.demo@DOM-IPA.DEMO" entry selected in the data table
+
+    When I click on the "member-of-button-delete" button
+    Then I should see "member-of-delete-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "member-of-delete-modal" modal
+    And I should see "remove-services-success" alert
+
+    When I search for "DNS" in the data table
+    Then I should not see "DNS/server.ipa.demo@DOM-IPA.DEMO" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete user group "imitation-game-group"

--- a/cypress/e2e/user_groups/user_groups_settings.feature
+++ b/cypress/e2e/user_groups/user_groups_settings.feature
@@ -1,0 +1,69 @@
+Feature: User group settings manipulation
+  Modify user group settings
+
+  @seed
+  Scenario: Create group
+    Given user group "group1" exists
+
+  @test
+  Scenario: Set Description
+    Given I am logged in as admin
+    And I am on "user-groups/group1" page
+
+    When I type in the "user-groups-tab-settings-textbox-description" textbox text "test"
+    Then I should see "test" in the "user-groups-tab-settings-textbox-description" textbox
+
+    When I click on the "user-groups-tab-settings-button-save" button
+    Then I should see "save-success" alert
+  
+  @cleanup
+  Scenario: Delete group
+    Given I delete user group "group1"
+
+  @seed
+  Scenario: Create group
+    Given non-POSIX User group "group1" exists
+
+  @test
+  Scenario: Convert group to POSIX group
+    Given I am logged in as admin
+    And I am on "user-groups/group1" page
+
+    When I click on the "user-groups-tab-settings-kebab" kebab menu
+    Then I should see "user-groups-tab-settings-kebab" kebab menu expanded
+
+    When I click on the "user-groups-tab-settings-kebab-change-to-posix" button
+    Then I should see "change-group-type-posix-modal" modal
+
+    When I click on the "modal-button-change" button
+    Then I should not see "change-group-type-posix-modal" modal
+    And I should see "posix-usergroup-success" alert
+    And I should see "POSIX" in the "user-groups-tab-settings-textbox-group-type" textbox
+
+  @cleanup
+  Scenario: Delete group
+    Given I delete user group "group1"
+
+  @seed
+  Scenario: Create group
+    Given non-POSIX User group "group1" exists
+
+  @test
+  Scenario: Convert group to external group
+    Given I am logged in as admin
+    And I am on "user-groups/group1" page
+
+    When I click on the "user-groups-tab-settings-kebab" kebab menu
+    Then I should see "user-groups-tab-settings-kebab" kebab menu expanded
+
+    When I click on the "user-groups-tab-settings-kebab-change-to-external" button
+    Then I should see "change-group-type-external-modal" modal
+
+    When I click on the "modal-button-change" button
+    Then I should not see "change-group-type-external-modal" modal
+    And I should see "external-usergroup-success" alert
+    And I should see "External" in the "user-groups-tab-settings-textbox-group-type" textbox
+
+  @cleanup
+  Scenario: Cleanup: Delete groups
+    Given I delete user group "group1"

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -26,5 +26,5 @@
 //
 
 Cypress.Commands.add("dataCy", (value: string) => {
-  return cy.get(`[data-cy=${value}]`);
+  return cy.get(`[data-cy='${value}']`);
 });

--- a/src/components/MemberOf/MemberOfToolbar.tsx
+++ b/src/components/MemberOf/MemberOfToolbar.tsx
@@ -134,6 +134,7 @@ const MemberOfToolbar = (props: MemberOfToolbarProps) => {
                 aria-label="Toggle group with single selectable"
               >
                 <ToggleGroupItem
+                  data-cy="member-of-toggle-group-item-direct"
                   text="Direct"
                   name="user-memberof-group-type-radio-direct"
                   buttonId="direct"
@@ -143,6 +144,7 @@ const MemberOfToolbar = (props: MemberOfToolbarProps) => {
                   }
                 />
                 <ToggleGroupItem
+                  data-cy="member-of-toggle-group-item-indirect"
                   text="Indirect"
                   name="user-memberof-group-type-radio-indirect"
                   buttonId="indirect"

--- a/src/components/MemberOf/MemberOfToolbarOld.tsx
+++ b/src/components/MemberOf/MemberOfToolbarOld.tsx
@@ -581,6 +581,7 @@ const MemberOfToolbar = (props: PropsToToolbar) => {
             buttonId="direct"
             isSelected={toolbarData().membership.isDirectSelected}
             onChange={toolbarData().membership.onDirectChange}
+            data-cy="member-of-toggle-group-item-direct"
           />
           <ToggleGroupItem
             text="Indirect"
@@ -588,6 +589,7 @@ const MemberOfToolbar = (props: PropsToToolbar) => {
             buttonId="indirect"
             isSelected={toolbarData().membership.isIndirectSelected}
             onChange={toolbarData().membership.onIndirectChange}
+            data-cy="member-of-toggle-group-item-indirect"
           />
         </ToggleGroup>
       ),

--- a/src/components/Members/MembersUserGroups.tsx
+++ b/src/components/Members/MembersUserGroups.tsx
@@ -293,7 +293,7 @@ const MembersUserGroups = (props: PropsToMembersUsergroups) => {
           // Set alert: error
           const errorMessage = response.data.error as unknown as ErrorResult;
           alerts.addAlert(
-            "remove-usergroups-error",
+            "remove-user-groups-error",
             errorMessage.message,
             "danger"
           );

--- a/src/components/modals/AddUserGroup.tsx
+++ b/src/components/modals/AddUserGroup.tsx
@@ -123,9 +123,9 @@ const AddUserGroup = (props: PropsToAddGroup) => {
       name: "Description",
       pfComponent: (
         <TextArea
-          data-cy="modal-textbox-group-desc"
-          id="modal-form-group-desc"
-          name="modal-form-group-desc"
+          data-cy="modal-textbox-group-description"
+          id="modal-form-group-description"
+          name="modal-form-group-description"
           value={description}
           onChange={(_event, value) => setDescription(value)}
           aria-label="Group description"
@@ -138,8 +138,8 @@ const AddUserGroup = (props: PropsToAddGroup) => {
       name: "Group type",
       pfComponent: (
         <SimpleSelector
-          dataCy="modal-simple-provider-type"
-          id="provider-type-selector"
+          dataCy="modal-group-type"
+          id="group-type-selector"
           options={groupTypeOptions}
           selected={groupType}
           onSelectedChange={(selected: string) => setGroupType(selected)}

--- a/src/components/modals/AddUserGroup.tsx
+++ b/src/components/modals/AddUserGroup.tsx
@@ -2,8 +2,6 @@ import React, { useEffect, useState } from "react";
 // PatternFly
 import {
   Button,
-  FormSelect,
-  FormSelectOption,
   HelperText,
   HelperTextItem,
   TextArea,
@@ -30,6 +28,7 @@ import {
   GroupAddPayload,
   useAddGroupMutation,
 } from "../../services/rpcUserGroups";
+import SimpleSelector, { SelectOptionProps } from "../layouts/SimpleSelector";
 interface PropsToAddGroup {
   show: boolean;
   handleModalToggle: () => void;
@@ -37,6 +36,21 @@ interface PropsToAddGroup {
   onCloseAddModal?: () => void;
   onRefresh?: () => void;
 }
+
+const groupTypeOptions: SelectOptionProps[] = [
+  {
+    key: "posix",
+    value: "posix",
+  },
+  {
+    key: "non-posix",
+    value: "non-posix",
+  },
+  {
+    key: "external",
+    value: "external",
+  },
+];
 
 const AddUserGroup = (props: PropsToAddGroup) => {
   // Set dispatch (Redux)
@@ -75,13 +89,6 @@ const AddUserGroup = (props: PropsToAddGroup) => {
       setGID("");
     }
   }, [groupType]);
-
-  const onGroupTypeSelect = (
-    _event: React.FormEvent<HTMLSelectElement>,
-    value: string
-  ) => {
-    setGroupType(value);
-  };
 
   // List of fields
   const fields = [
@@ -130,17 +137,14 @@ const AddUserGroup = (props: PropsToAddGroup) => {
       id: "modal-form-group-type",
       name: "Group type",
       pfComponent: (
-        <FormSelect
-          id="modal-form-group-type"
-          value={groupType}
-          onChange={onGroupTypeSelect}
-          aria-label="Group type selection"
-          ouiaId="GroupTypeSelect"
-        >
-          <FormSelectOption value="posix" label="Posix" />
-          <FormSelectOption value="non-posix" label="Non-posix" />
-          <FormSelectOption value="external" label="External" />
-        </FormSelect>
+        <SimpleSelector
+          dataCy="modal-simple-provider-type"
+          id="provider-type-selector"
+          options={groupTypeOptions}
+          selected={groupType}
+          onSelectedChange={(selected: string) => setGroupType(selected)}
+          ariaLabel="Group type selector"
+        />
       ),
     },
     {

--- a/src/components/modals/DeleteUserGroups.tsx
+++ b/src/components/modals/DeleteUserGroups.tsx
@@ -163,7 +163,7 @@ const DeleteUserGroups = (props: PropsToDeleteGroups) => {
               props.buttonsData.updateIsDeletion(true);
 
               alerts.addAlert(
-                "remove-usergroups-success",
+                "remove-user-groups-success",
                 "User groups removed",
                 "success"
               );
@@ -188,7 +188,7 @@ const DeleteUserGroups = (props: PropsToDeleteGroups) => {
       key="delete-usergroups"
       variant="danger"
       onClick={deleteGroups}
-      form="delete-usergroups-modal"
+      form="delete-user-groups-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
       isLoading={spinning}
@@ -210,12 +210,12 @@ const DeleteUserGroups = (props: PropsToDeleteGroups) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
-        dataCy="delete-usergroups-modal"
+        dataCy="delete-user-groups-modal"
         variantType="medium"
         modalPosition="top"
         offPosition="76px"
         title="Remove user groups"
-        formId="remove-usergroups-modal"
+        formId="remove-user-groups-modal"
         fields={fields}
         show={props.show}
         onClose={closeModal}
@@ -223,7 +223,7 @@ const DeleteUserGroups = (props: PropsToDeleteGroups) => {
       />
       {isModalErrorOpen && (
         <ErrorModal
-          dataCy="delete-usergroups-modal-error"
+          dataCy="delete-user-groups-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
           onClose={onCloseErrorModal}

--- a/src/patternfly.d.ts
+++ b/src/patternfly.d.ts
@@ -55,4 +55,8 @@ declare module "@patternfly/react-core" {
   interface MenuToggleProps {
     "data-cy": string;
   }
+
+  interface ToggleGroupItemProps {
+    "data-cy": string;
+  }
 }


### PR DESCRIPTION
## Summary by Sourcery

Improve user group management UI to support stable Cypress selectors, replace FormSelect with SimpleSelector for group type selection, and add end-to-end tests covering all user group workflows

New Features:
- Introduce comprehensive Cypress end-to-end tests for user group creation, deletion, membership, manager assignments, and settings workflows
- Add SimpleSelector component for selecting group types in the AddUserGroup modal

Enhancements:
- Add and standardize data-cy attributes across components including DualListSelectorGeneric, ToggleGroupItem, modals, and form fields to stabilize test selectors
- Update Cypress support commands and PatternFly typings to support quoted data-cy usage