### PR TITLE
Add license, specfile script

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,7 @@
 NULL =
 
 appdir = $(IPA_DATA_DIR)/modern-ui
+licensedir = $(DESTDIR)$(datarootdir)/licenses/$(PACKAGE_NAME)-server-common/modern-ui
 
 EXTRA_DIST =		\
 	$(NULL)
@@ -8,15 +9,18 @@ EXTRA_DIST =		\
 install-exec-local:
 	## We don't want to run this code in prci, prci runs those commands before make install
 	test -d "dist" || npm install
-	test -d "dist" || npm run build
+	test -d "dist" || ( npm run build && rm -rf node_modules && npm install --omit=dev )
 	mkdir -p "$(DESTDIR)$(appdir)"
 	cp -p "dist/index.html" "$(DESTDIR)$(appdir)/index.html"
+	mkdir -p "$(licensedir)"
+	cp -p "dist/COPYING" "$(licensedir)/COPYING"
 	cp -rp "dist/assets" "$(DESTDIR)$(appdir)/assets"
 
 dist-hook:
 	npm install
-	npm run build
-	cp -r "dist/" "$(distdir)/dist/"
+	## We need to build, but we only want the distributable dependencies in the .src.rpm
+	npm run build && rm -rf node_modules && npm install --omit=dev
+	cp -r "." "$(distdir)/"
 
 clean-local:
 	rm -rf node_modules dist

--- a/fix-spec.sh
+++ b/fix-spec.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    cat <<EOF
+usage: $(basename "$0") [-h] [options] [specfile]
+
+Automatically fill in bundled dependencies
+Default action is to update the spec file
+
+Options:
+    -h          Show this message and exit
+    -r          Replace the #NPM_PROVIDES with proper contents
+    -f          Revert the changes, removes Provides bundled(npm(...)) with #NPM_PROVIDES
+    -u          Simply updates the listed dependencies
+    -i          In-place, does not create a new file
+
+
+EOF
+}
+
+replace() {
+    # Patch given spec file to have the correct version and declare bundled NPM dependencies
+    PROVIDES=$(npm ls --omit dev --package-lock-only --depth=Infinity |
+        grep -Eo '[^[:space:]]+@[^[:space:]]+' |
+        sort -u |
+        # only replace the *last* occurrence of @, not e.g. the one in @patternfly/..
+        sed 's/^/Provides: bundled(npm(/; s/\(.*\)@/\1)) = /')
+
+    awk -v p="$PROVIDES" 'gsub(/#NPM_PROVIDES/, p) 1' "$spec" > "$spec".new
+
+    if [ "$backup" = false ]; then
+        mv -f "$spec".new "$spec"
+    fi
+}
+
+revert() {
+    # Delete all lines but the first one containing "Provides: bundled(npm(
+    sed '/^Provides: bundled(npm(/{x;/^$/!d;g;}' < "$spec" > "$spec".new
+
+    # Replace the first line containing "Provides: bundled(npm(" with "#NPM_PROVIDES"
+    sed -i 's/^Provides: bundled(npm(.*/#NPM_PROVIDES/' "$spec".new
+
+    if [ "$backup" = false ]; then
+        mv -f "$spec".new "$spec"
+    fi
+}
+
+update() {
+    revert
+
+    # We need to use the backup file for the next step if not in-place
+    if [ "$backup" = true ]; then
+        spec="$spec".new
+    fi
+
+    replace
+
+    # There is no need for two backups, we can just move the replace backup to the original revert backup
+    if [ "$backup" = true ]; then
+        mv -f "$spec".new "$spec"
+    fi
+}
+
+action="update"
+backup=true
+action_set=false
+
+while { [[ "$#" -ge 1 ]] && [[ "$1" == "-"* ]]; } || [[ "$#" -gt 1 ]];
+do
+    case $1 in
+        "-h")
+            usage
+            exit 0
+            ;;
+        "-r")
+            if [ "$action_set" = true ]; then
+                usage
+                exit 1
+            fi
+            action_set=true
+            ;;
+        "-f")
+            if [ "$action_set" = true ]; then
+                usage
+                exit 1
+            fi
+            action_set=true
+            action="revert"
+            ;;
+        "-u")
+            if [ "$action_set" = true ]; then
+                usage
+                exit 1
+            fi
+            action_set=true
+            action="update"
+            ;;
+        "-i")
+            backup=false
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+spec="${1:-../../freeipa.spec.in}"
+
+if [[ ! -f "$spec" ]]; then
+    echo "Spec file $spec does not exist"
+    exit 1
+fi
+
+case $action in
+    "replace")
+        replace
+        ;;
+    "revert")
+        revert
+        ;;
+    "update")
+        update
+        ;;
+esac

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "globals": "^16.0.0",
         "otpauth": "^9.4.0",
         "prettier": "^3.5.3",
+        "rollup-plugin-license": "^3.6.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.34.0",
@@ -3398,6 +3399,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/array-includes": {
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.8.tgz",
@@ -4293,6 +4304,13 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/commenting": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/commenting/-/commenting-1.1.0.tgz",
+      "integrity": "sha512-YeNK4tavZwtH7jEgK1ZINXzLKm6DZdEMfsaaieOsCAN0S8vsY7UeuO3Q7d/M018EFgE+IeUAuBOKkFccBZsUZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/common-ancestor-path": {
       "version": "1.0.1",
@@ -8599,6 +8617,16 @@
         "node": "*"
       }
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -8973,6 +9001,19 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/package-name-regex": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/package-name-regex/-/package-name-regex-2.0.6.tgz",
+      "integrity": "sha512-gFL35q7kbE/zBaPA3UKhp2vSzcPYx2ecbYuwv1ucE9Il6IIgBDweBlH8D68UFGZic2MkllKa2KHCfC1IQBQUYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/dword-design"
+      }
     },
     "node_modules/pad-right": {
       "version": "0.2.2",
@@ -10068,6 +10109,62 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup-plugin-license": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-license/-/rollup-plugin-license-3.6.0.tgz",
+      "integrity": "sha512-1ieLxTCaigI5xokIfszVDRoy6c/Wmlot1fDEnea7Q/WXSR8AqOjYljHDLObAx7nFxHC2mbxT3QnTSPhaic2IYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commenting": "~1.1.0",
+        "fdir": "^6.4.3",
+        "lodash": "~4.17.21",
+        "magic-string": "~0.30.0",
+        "moment": "~2.30.1",
+        "package-name-regex": "~2.0.6",
+        "spdx-expression-validate": "~2.0.0",
+        "spdx-satisfies": "~5.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
+      }
+    },
+    "node_modules/rollup-plugin-license/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/rollup-plugin-license/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
@@ -10596,6 +10693,18 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/spdx-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-compare/-/spdx-compare-1.0.0.tgz",
+      "integrity": "sha512-C1mDZOX0hnu0ep9dfmuoi03+eOdDoz2yvK79RxbcrVEG1NO1Ph35yW102DHWKN4pk80nwCgeMmSY5L25VE4D9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-find-index": "^1.0.2",
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-ranges": "^2.0.0"
+      }
+    },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -10625,12 +10734,41 @@
         "spdx-license-ids": "^3.0.0"
       }
     },
+    "node_modules/spdx-expression-validate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-validate/-/spdx-expression-validate-2.0.0.tgz",
+      "integrity": "sha512-b3wydZLM+Tc6CFvaRDBOF9d76oGIHNCLYFeHbftFXUWjnfZWganmDmvtM5sm1cRwJc/VDBMLyGGrsLFd1vOxbg==",
+      "dev": true,
+      "license": "(MIT AND CC-BY-3.0)",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
     "node_modules/spdx-license-ids": {
       "version": "3.0.21",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
       "integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/spdx-ranges": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-ranges/-/spdx-ranges-2.1.1.tgz",
+      "integrity": "sha512-mcdpQFV7UDAgLpXEE/jOMqvK4LBoO0uTQg0uvXUewmEFhpiZx5yJSZITHB8w1ZahKdhfZqP5GPEOKLyEq5p8XA==",
+      "dev": true,
+      "license": "(MIT AND CC-BY-3.0)"
+    },
+    "node_modules/spdx-satisfies": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-satisfies/-/spdx-satisfies-5.0.1.tgz",
+      "integrity": "sha512-Nwor6W6gzFp8XX4neaKQ7ChV4wmpSh2sSDemMFSzHxpTw460jxFYeOn+jq4ybnSSw/5sc3pjka9MQPouksQNpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-compare": "^1.0.0",
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-ranges": "^2.0.0"
+      }
     },
     "node_modules/spec-change": {
       "version": "1.11.20",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "globals": "^16.0.0",
     "otpauth": "^9.4.0",
     "prettier": "^3.5.3",
+    "rollup-plugin-license": "^3.6.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.34.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react-swc";
+import license from "rollup-plugin-license";
+import path from "path";
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -7,7 +9,15 @@ export default defineConfig({
   build: {
     sourcemap: true,
   },
-  plugins: [react()],
+  plugins: [
+    react(),
+    license({
+      thirdParty: {
+        output: path.join(__dirname, "dist", "COPYING"),
+        includePrivate: true, // Default is false.
+      },
+    }),
+  ],
   resolve: {
     alias: {
       src: "/src",


### PR DESCRIPTION
The specfile script should be able to automatically update dependencies listed in the main .rpm

Please test and play around with the script.

## Summary by Sourcery

Introduce a Bash script to automate updating RPM specfiles with bundled NPM dependencies and integrate third-party license extraction into the build.

New Features:
- Add fix-spec.sh to automatically fill, update, or revert bundled(npm) Provides entries in specfiles via replace, update, revert, and in-place options
- Integrate rollup-plugin-license into the Vite build to generate dist/LICENSE-dependencies.txt with third-party license data

Enhancements:
- Update Makefile to include LICENSE-dependencies.txt in installation and adjust dist-hook to copy the entire directory
- Add rollup-plugin-license to package.json dependencies