### PR TITLE
[Cypress] Netgroup members tests

### DIFF
--- a/cypress/e2e/common/authentication.ts
+++ b/cypress/e2e/common/authentication.ts
@@ -1,7 +1,8 @@
 import { When, Given, Then } from "@badeball/cypress-cucumber-preprocessor";
+import { navigateTo } from "./navigation";
 
 const login = (username: string, password: string) => {
-  cy.visit(Cypress.env("BASE_URL") + "/login");
+  navigateTo("login");
 
   cy.get("#pf-login-username-id").type(username);
   cy.get("#pf-login-username-id").should("have.value", username);

--- a/cypress/e2e/common/member_of.ts
+++ b/cypress/e2e/common/member_of.ts
@@ -1,0 +1,60 @@
+import { Given } from "@badeball/cypress-cucumber-preprocessor";
+import { loginAsAdmin, logout } from "./authentication";
+import { navigateTo } from "./navigation";
+import { entryExists } from "./data_tables";
+import { addItemToRightList } from "./ui/dual_list";
+import { searchForMembersEntry } from "./members_table";
+
+const ensureItemExistsInMemberOfTable = (
+  itemName: string,
+  tablePath: string,
+  useDualListSearchLink: boolean = false
+) => {
+  navigateTo(`netgroups/${tablePath}`);
+
+  cy.dataCy("member-of-button-add").click();
+  cy.dataCy("member-of-add-modal").should("exist");
+
+  if (useDualListSearchLink) {
+    cy.dataCy("dual-list-search-link").click();
+  }
+
+  addItemToRightList(itemName);
+  cy.dataCy("member-of-add-modal").should("exist");
+
+  cy.dataCy("modal-button-add").click();
+  cy.dataCy("member-of-add-modal").should("not.exist");
+  cy.dataCy("add-member-success").should("exist");
+
+  searchForMembersEntry(itemName);
+  entryExists(itemName);
+};
+
+// Allowed member entity values (readonly tuple)
+const MEMBER_ENTITIES = [
+  "user group",
+  "hostgroup",
+  "host",
+  "user",
+  "netgroup",
+  "externalhost",
+  "group",
+] as const;
+
+export type MemberEntity = (typeof MEMBER_ENTITIES)[number];
+
+export const isMemberEntity = (value: string): value is MemberEntity => {
+  return MEMBER_ENTITIES.includes(value as MemberEntity);
+};
+
+export const assertMemberEntity = (value: string): void => {
+  if (!isMemberEntity(value)) {
+    throw new Error(`Invalid member entity: ${value}`);
+  }
+};
+
+Given("{string} exists in table {string}", (name: string, table: string) => {
+  loginAsAdmin();
+  ensureItemExistsInMemberOfTable(name, table);
+  logout();
+});

--- a/cypress/e2e/netgroup/netgroup.ts
+++ b/cypress/e2e/netgroup/netgroup.ts
@@ -3,7 +3,6 @@ import { loginAsAdmin, logout } from "../common/authentication";
 import { navigateTo } from "../common/navigation";
 import {
   selectEntry,
-  searchForEntry,
   entryDoesNotExist,
   entryExists,
   checkEntry,
@@ -11,6 +10,8 @@ import {
 import { typeInTextbox } from "../common/ui/textbox";
 import { findEntryInTable } from "../common/settings_table";
 import { addItemToRightList } from "../common/ui/dual_list";
+import { MemberEntity, assertMemberEntity } from "../common/member_of";
+import { searchForMembersEntry } from "../common/members_table";
 
 Given("netgroup {string} exists", (groupName: string) => {
   loginAsAdmin();
@@ -26,7 +27,7 @@ Given("netgroup {string} exists", (groupName: string) => {
   cy.dataCy("add-netgroup-modal").should("not.exist");
   cy.dataCy("add-netgroup-success").should("exist");
 
-  searchForEntry(groupName);
+  searchForMembersEntry(groupName);
   entryExists(groupName);
   logout();
 });
@@ -43,27 +44,12 @@ Given("I delete netgroup {string}", (groupName: string) => {
   cy.dataCy("delete-netgroups-modal").should("not.exist");
   cy.dataCy("remove-netgroups-success").should("exist");
 
-  searchForEntry(groupName);
+  searchForMembersEntry(groupName);
   entryDoesNotExist(groupName);
   logout();
 });
 
-type ElementType = "user" | "group" | "host" | "hostgroup" | "externalhost";
-
-const assertElementType = (elementType: string) => {
-  const validElementTypes: ElementType[] = [
-    "user",
-    "group",
-    "host",
-    "hostgroup",
-    "externalhost",
-  ];
-  if (!validElementTypes.includes(elementType as ElementType)) {
-    throw new Error(`Invalid element type: ${elementType}`);
-  }
-};
-
-const ensureTabVisibleAndOpen = (elementType: string) => {
+const ensureTabVisibleAndOpen = (elementType: MemberEntity) => {
   const tabDataCy = `netgroups-tab-settings-tab-${elementType}s`;
   cy.dataCy(tabDataCy).click();
 };
@@ -74,8 +60,8 @@ Given(
     loginAsAdmin();
     navigateTo(`netgroups/${groupName}`);
 
-    assertElementType(elementType);
-    ensureTabVisibleAndOpen(elementType);
+    assertMemberEntity(elementType);
+    ensureTabVisibleAndOpen(elementType as MemberEntity);
 
     cy.dataCy(`settings-button-add-${elementType}`).click();
     cy.dataCy("dual-list-modal").should("exist");
@@ -105,8 +91,8 @@ Given(
     loginAsAdmin();
     navigateTo(`netgroups/${groupName}`);
 
-    assertElementType(elementType);
-    ensureTabVisibleAndOpen(elementType);
+    assertMemberEntity(elementType);
+    ensureTabVisibleAndOpen(elementType as MemberEntity);
 
     const itemToDelete =
       elementType === "host"
@@ -137,7 +123,7 @@ Given(
     loginAsAdmin();
     navigateTo(`netgroups/${groupName}`);
 
-    assertElementType("externalhost");
+    assertMemberEntity("externalhost");
     ensureTabVisibleAndOpen("externalhost");
 
     cy.dataCy("settings-button-add-externalHost").click();
@@ -162,7 +148,7 @@ Given(
     loginAsAdmin();
     navigateTo(`netgroups/${groupName}`);
 
-    assertElementType("externalhost");
+    assertMemberEntity("externalhost");
     ensureTabVisibleAndOpen("externalhost");
 
     findEntryInTable(externalHost, "externalHost");

--- a/cypress/e2e/netgroup/netgroup_members.feature
+++ b/cypress/e2e/netgroup/netgroup_members.feature
@@ -1,0 +1,284 @@
+Feature: Netgroup members manipulation
+  Manage members of a netgroup across Users, User groups, Hosts, Host groups and Netgroups tabs
+
+  @seed
+  Scenario: Seed data
+    Given netgroup "mynetgroup" exists
+
+  @test
+  Scenario: Add a User member
+    Given I am logged in as admin
+    And I am on "netgroups/mynetgroup/member_user" page
+    And I should be on "netgroups/mynetgroup/member_user" page
+
+    When I click on the "member-of-button-add" button
+    Then I should see "member-of-add-modal" modal
+
+    When I click on "item-admin" dual list item
+    Then I should see "item-admin" dual list item selected
+
+    When I click on the "dual-list-add-selected" button
+    Then I should see "member-of-add-modal" modal
+
+    When I click on the "modal-button-add" button
+    Then I should not see "member-of-add-modal" modal
+    And I should see "add-member-success" alert
+    When I search for "admin" in the members table
+    Then I should see "admin" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup: delete netgroup
+    Given I delete netgroup "mynetgroup"
+
+  @seed
+  Scenario: Seed data
+    Given netgroup "mynetgroup" exists
+    And "admin" exists in table "mynetgroup/member_user"
+
+  @test
+  Scenario: Remove User member
+    Given I am logged in as admin
+    When I am on "netgroups/mynetgroup/member_user" page
+    Then I should be on "netgroups/mynetgroup/member_user" page
+
+    When I select entry "admin" in the members table
+    Then I should see "admin" entry selected in the data table
+    When I click on the "member-of-button-delete" button
+    Then I should see "member-of-delete-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "member-of-delete-modal" modal
+    And I should see "remove-users-success" alert
+    When I search for "admin" in the members table
+    Then I should not see "admin" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup: delete netgroup
+    Given I delete netgroup "mynetgroup"
+
+  @seed
+  Scenario: Seed data
+    Given netgroup "mynetgroup" exists
+
+  @test
+  Scenario: Add a User group member
+    Given I am logged in as admin
+    When I am on "netgroups/mynetgroup/member_group" page
+    Then I should be on "netgroups/mynetgroup/member_group" page
+
+    When I click on the "member-of-button-add" button
+    Then I should see "member-of-add-modal" modal
+
+    When I click on "item-editors" dual list item
+    Then I should see "item-editors" dual list item selected
+
+    When I click on the "dual-list-add-selected" button
+    Then I should see "member-of-add-modal" modal
+
+    When I click on the "modal-button-add" button
+    Then I should not see "member-of-add-modal" modal
+    And I should see "add-member-success" alert
+    When I search for "editors" in the members table
+    Then I should see "editors" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup: delete netgroup
+    Given I delete netgroup "mynetgroup"
+
+  @seed
+  Scenario: Seed data
+    Given netgroup "mynetgroup" exists
+    And "editors" exists in table "mynetgroup/member_group"
+
+  @test
+  Scenario: Remove User group member
+    Given I am logged in as admin
+    When I am on "netgroups/mynetgroup/member_group" page
+    Then I should be on "netgroups/mynetgroup/member_group" page
+
+    When I select entry "editors" in the members table
+    Then I should see "editors" entry selected in the data table
+    When I click on the "member-of-button-delete" button
+    Then I should see "member-of-delete-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "member-of-delete-modal" modal
+    And I should see "remove-usersgroups-success" alert
+    When I search for "editors" in the members table
+    Then I should not see "editors" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup: delete netgroup
+    Given I delete netgroup "mynetgroup"
+
+  @seed
+  Scenario: Seed data
+    Given netgroup "mynetgroup" exists
+
+  @test
+  Scenario: Add a Host member
+    Given I am logged in as admin
+    When I am on "netgroups/mynetgroup/member_host" page
+    Then I should be on "netgroups/mynetgroup/member_host" page
+
+    When I click on the "member-of-button-add" button
+    Then I should see "member-of-add-modal" modal
+
+    When I click on "item-webui.ipa.test" dual list item
+    Then I should see "item-webui.ipa.test" dual list item selected
+
+    When I click on the "dual-list-add-selected" button
+    Then I should see "member-of-add-modal" modal
+
+    When I click on the "modal-button-add" button
+    Then I should not see "member-of-add-modal" modal
+    And I should see "add-member-success" alert
+    When I search for "webui.ipa.test" in the members table
+    Then I should see "webui.ipa.test" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup: delete netgroup
+    Given I delete netgroup "mynetgroup"
+
+  @seed
+  Scenario: Seed data
+    Given netgroup "mynetgroup" exists
+    And "webui.ipa.test" exists in table "mynetgroup/member_host"
+
+  @test
+  Scenario: Remove Host member
+    Given I am logged in as admin
+    And I am on "netgroups/mynetgroup/member_host" page
+    And I should be on "netgroups/mynetgroup/member_host" page
+
+    When I search for "webui.ipa.test" in the members table
+    Then I should see "webui.ipa.test" entry in the data table
+
+    When I select entry "webui.ipa.test" in the members table
+    Then I should see "webui.ipa.test" entry selected in the data table
+    When I click on the "member-of-button-delete" button
+    Then I should see "member-of-delete-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "member-of-delete-modal" modal
+    And I should see "remove-host-success" alert
+    When I search for "webui.ipa.test" in the members table
+    Then I should not see "webui.ipa.test" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup: delete netgroup
+    Given I delete netgroup "mynetgroup"
+
+  @seed
+  Scenario: Seed data
+    Given netgroup "mynetgroup" exists
+
+  @test
+  Scenario: Add a Host group member
+    Given I am logged in as admin
+    And I am on "netgroups/mynetgroup/member_hostgroup" page
+    And I should be on "netgroups/mynetgroup/member_hostgroup" page
+
+    When I click on the "member-of-button-add" button
+    Then I should see "member-of-add-modal" modal
+
+    When I click on "item-ipaservers" dual list item
+    Then I should see "item-ipaservers" dual list item selected
+
+    When I click on the "dual-list-add-selected" button
+    Then I should see "member-of-add-modal" modal
+
+    When I click on the "modal-button-add" button
+    Then I should not see "member-of-add-modal" modal
+    And I should see "add-member-success" alert
+    When I search for "ipaservers" in the members table
+    Then I should see "ipaservers" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup: delete netgroup
+    Given I delete netgroup "mynetgroup"
+
+  @seed
+  Scenario: Seed data
+    Given netgroup "mynetgroup" exists
+    And "ipaservers" exists in table "mynetgroup/member_hostgroup"
+
+  @test
+  Scenario: Remove Host group member
+    Given I am logged in as admin
+    And I am on "netgroups/mynetgroup/member_hostgroup" page
+    And I should be on "netgroups/mynetgroup/member_hostgroup" page
+
+    When I select entry "ipaservers" in the members table
+    Then I should see "ipaservers" entry selected in the data table
+    When I click on the "member-of-button-delete" button
+    Then I should see "member-of-delete-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "member-of-delete-modal" modal
+    And I should see "remove-hostgroups-success" alert
+    When I search for "ipaservers" in the members table
+    Then I should not see "ipaservers" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup: delete netgroup
+    Given I delete netgroup "mynetgroup"
+
+  @seed
+  Scenario: Seed data
+    Given netgroup "mynetgroup" exists
+    And netgroup "mynetgroup2" exists
+
+  @test
+  Scenario: Add a Netgroup member
+    Given I am logged in as admin
+    And I am on "netgroups/mynetgroup/member_netgroup" page
+    And I should be on "netgroups/mynetgroup/member_netgroup" page
+
+    When I click on the "member-of-button-add" button
+    Then I should see "member-of-add-modal" modal
+
+    When I click on "item-mynetgroup2" dual list item
+    Then I should see "item-mynetgroup2" dual list item selected
+
+    When I click on the "dual-list-add-selected" button
+    Then I should see "member-of-add-modal" modal
+
+    When I click on the "modal-button-add" button
+    Then I should not see "member-of-add-modal" modal
+    And I should see "add-member-success" alert
+    When I search for "mynetgroup2" in the members table
+    Then I should see "mynetgroup2" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup: delete netgroup
+    Given I delete netgroup "mynetgroup"
+    And I delete netgroup "mynetgroup2"
+
+  @seed
+  Scenario: Seed data
+    Given netgroup "mynetgroup" exists
+    And netgroup "mynetgroup2" exists
+    And "mynetgroup2" exists in table "mynetgroup/member_netgroup"
+
+  @test
+  Scenario: Remove Netgroup member
+    Given I am logged in as admin
+    When I am on "netgroups/mynetgroup/member_netgroup" page
+    Then I should be on "netgroups/mynetgroup/member_netgroup" page
+
+    When I select entry "mynetgroup2" in the members table
+    Then I should see "mynetgroup2" entry selected in the data table
+    When I click on the "member-of-button-delete" button
+    Then I should see "member-of-delete-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "member-of-delete-modal" modal
+    And I should see "remove-netgroups-success" alert
+    When I search for "mynetgroup2" in the members table
+    Then I should not see "mynetgroup2" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup: delete netgroup
+    Given I delete netgroup "mynetgroup"
+    And I delete netgroup "mynetgroup2"

--- a/src/components/Members/MembersNetgroups.tsx
+++ b/src/components/Members/MembersNetgroups.tsx
@@ -245,7 +245,7 @@ const MembersNetgroups = (props: PropsToMembersNetgroups) => {
         if (response.data?.result) {
           // Set alert: success
           alerts.addAlert(
-            "remove-hnetgroups-success",
+            "remove-netgroups-success",
             "Removed netgroups from netgroup '" + props.id + "'",
             "success"
           );


### PR DESCRIPTION
Please just consider the second commit `Add netgroup memebers integration tests` , as the first is already in a different PR

## Summary by Sourcery

Add data-cy hooks and update auth navigation to support a comprehensive suite of Cypress Cucumber integration tests for netgroup creation, settings, member and member-of management, and fix a minor alert identifier typo.

Bug Fixes:
- Fix alert identifier typo for netgroup removal success

Enhancements:
- Add data-cy attributes to NetgroupsTabs, NetgroupsMembers, and NetgroupsSettings components
- Update authentication helper to use navigateTo for login navigation

Tests:
- Add extensive Cypress Cucumber integration tests for netgroup creation, settings manipulation, and member management across user, group, host, host group, external host, and member-of sections