### PR TITLE
[Cypress tests] DNS servers - Settings page only

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -38,6 +38,7 @@ export default defineConfig({
     ADMIN_LOGIN: "admin",
     ADMIN_PASSWORD: "Secret123",
     HOSTNAME: "ipa.test",
+    SERVER_NAME: "webui.ipa.test",
     TAGS: "not @ignore",
   },
 });

--- a/cypress/e2e/common/ui/textbox_list.ts
+++ b/cypress/e2e/common/ui/textbox_list.ts
@@ -27,12 +27,11 @@ export const removeElementFromTextboxList = (
   dataCy: string
 ) => {
   cy.dataCy(dataCy)
-    .children()
-    .find(`div[name="value"]:has(input[value="${elementToRemove}"])`)
+    .find(`input[value="${elementToRemove}"]`)
+    .closest('div[name="value"]')
     .find('button:contains("Delete")')
     .click();
   cy.dataCy(dataCy)
-    .children()
     .find(`input[value="${elementToRemove}"]`)
     .should("not.exist");
 };

--- a/cypress/e2e/dns/dns_servers_settings.feature
+++ b/cypress/e2e/dns/dns_servers_settings.feature
@@ -1,0 +1,66 @@
+Feature: DNS Servers
+    Configure DNS servers
+
+    @test
+    Scenario: Change SOA name
+        Given I am logged in as admin
+        And I am on "dns-servers/webui.ipa.test" page
+
+        When I change SOA name to "my-soa-name"
+        Then I should see "my-soa-name" in the "dns-servers-tab-settings-textbox-idnssoamname" textbox
+
+        When I click on the "dns-servers-tab-settings-button-save" button
+        Then I should see "my-soa-name" in the "dns-servers-tab-settings-textbox-idnssoamname" textbox
+        And I should see "success" alert
+
+    @test
+    Scenario: Add new forwarder
+        Given I am logged in as admin
+        And I am on "dns-servers/webui.ipa.test" page
+
+        When I add new forwarder to "192.168.44.66"
+        Then I should see "192.168.44.66" in the "dns-servers-tab-settings-textbox-idnsforwarders" textbox list
+
+        When I click on the "dns-servers-tab-settings-button-save" button
+        Then I should see "192.168.44.66" in the "dns-servers-tab-settings-textbox-idnsforwarders" textbox list
+        And I should see "success" alert
+
+    @test
+    Scenario: Remove forwarder
+        Given I am logged in as admin
+        And I am on "dns-servers/webui.ipa.test" page
+
+        When I remove forwarder "192.168.44.66"
+        Then I should not see "192.168.44.66" in the "dns-servers-tab-settings-textbox-idnsforwarders" textbox list
+
+        When I click on the "dns-servers-tab-settings-button-save" button
+        Then I should not see "192.168.44.66" in the "dns-servers-tab-settings-textbox-idnsforwarders" textbox list
+        And I should see "success" alert
+
+    @test
+    Scenario: Select forward policy
+        Given I am logged in as admin
+        And I am on "dns-servers/webui.ipa.test" page
+
+        When I click on the "dns-zone-tab-settings-radio-forward-first" radio button
+        Then I should see the "dns-zone-tab-settings-radio-forward-first" radio button is selected
+
+        When I click on the "dns-servers-tab-settings-button-save" button
+        Then I should see the "dns-zone-tab-settings-radio-forward-first" radio button is selected
+        And I should see "success" alert
+
+    @cleanup
+    Scenario: Set DNS server to default values
+        Given I am logged in as admin
+        And I am on "dns-servers/webui.ipa.test" page
+
+        When I change SOA name to "webui.ipa.test"
+        Then I should see "webui.ipa.test" in the "dns-servers-tab-settings-textbox-idnssoamname" textbox
+
+        When I click on the "dns-zone-tab-settings-radio-forward-only" radio button
+        Then I should see the "dns-zone-tab-settings-radio-forward-only" radio button is selected
+
+        When I click on the "dns-servers-tab-settings-button-save" button
+        Then I should see "webui.ipa.test" in the "dns-servers-tab-settings-textbox-idnssoamname" textbox
+        And I should see the "dns-zone-tab-settings-radio-forward-only" radio button is selected
+        And I should see "success" alert

--- a/cypress/e2e/dns/dns_servers_settings.ts
+++ b/cypress/e2e/dns/dns_servers_settings.ts
@@ -1,0 +1,25 @@
+import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { typeInTextbox } from "../common/ui/textbox";
+import {
+  addElementToTextboxList,
+  removeElementFromTextboxList,
+} from "../common/ui/textbox_list";
+
+When("I change SOA name to {string}", (soaName: string) => {
+  typeInTextbox("dns-servers-tab-settings-textbox-idnssoamname", soaName);
+});
+
+When("I add new forwarder to {string}", (forwarder: string) => {
+  addElementToTextboxList(
+    "dns-servers-tab-settings-textbox-idnsforwarders-button-add",
+    "dns-servers-tab-settings-textbox-idnsforwarders",
+    forwarder
+  );
+});
+
+When("I remove forwarder {string}", (forwarder: string) => {
+  removeElementFromTextboxList(
+    forwarder,
+    "dns-servers-tab-settings-textbox-idnsforwarders"
+  );
+});

--- a/src/pages/DNSZones/DnsServers.tsx
+++ b/src/pages/DNSZones/DnsServers.tsx
@@ -278,10 +278,7 @@ const DnsServers = () => {
   const body = (
     <>
       {dnsServersId.map((dnsServerId) => (
-        <Tr
-          key={`body-row-${dnsServerId}`}
-          id={`table-body-row-${dnsServerId}`}
-        >
+        <Tr key={`body-row-${dnsServerId}`} id={dnsServerId}>
           <Td key={`idnsserverid-${dnsServerId}`}>
             <Link to={`/dns-servers/${dnsServerId}`}>{dnsServerId}</Link>
           </Td>


### PR DESCRIPTION
The tests must cover all the use-cases found in the DNS servers page.

Considering that there is no way to add/delete DNS servers from the main page, those tests have been omitted, as well as some `@seed` and `@cleanup` assertions based on the regular schema.

## Summary by Sourcery

Add Cypress E2E tests for DNS servers settings page and simplify textbox list removal helper

Enhancements:
- Refactor removeElementFromTextboxList helper to simplify DOM traversal when removing list items

Build:
- Add SERVER_NAME environment variable to Cypress config

Tests:
- Add new Cypress feature file and step definitions for DNS servers settings page covering SOA name change, forwarder management, forward policy selection, and cleanup