### PR TITLE
Fix: shellcheck errors

### DIFF
--- a/fix-spec.sh
+++ b/fix-spec.sh
@@ -28,22 +28,22 @@ replace() {
         # only replace the *last* occurrence of @, not e.g. the one in @patternfly/..
         sed 's/^/Provides: bundled(npm(/; s/\(.*\)@/\1)) = /')
 
-    awk -v p="$PROVIDES" 'gsub(/#NPM_PROVIDES/, p) 1' "$spec" > "$spec".new
+    awk -v p="${PROVIDES}" 'gsub(/#NPM_PROVIDES/, p) 1' "${spec}" > "${spec}".new
 
-    if [ "$backup" = false ]; then
-        mv -f "$spec".new "$spec"
+    if [ "${backup}" = false ]; then
+        mv -f "${spec}".new "${spec}"
     fi
 }
 
 revert() {
     # Delete all lines but the first one containing "Provides: bundled(npm(
-    sed '/^Provides: bundled(npm(/{x;/^$/!d;g;}' < "$spec" > "$spec".new
+    sed '/^Provides: bundled(npm(/{x;/^$/!d;g;}' < "${spec}" > "${spec}".new
 
     # Replace the first line containing "Provides: bundled(npm(" with "#NPM_PROVIDES"
-    sed -i 's/^Provides: bundled(npm(.*/#NPM_PROVIDES/' "$spec".new
+    sed -i 's/^Provides: bundled(npm(.*/#NPM_PROVIDES/' "${spec}".new
 
-    if [ "$backup" = false ]; then
-        mv -f "$spec".new "$spec"
+    if [ "${backup}" = false ]; then
+        mv -f "${spec}".new "${spec}"
     fi
 }
 
@@ -51,15 +51,15 @@ update() {
     revert
 
     # We need to use the backup file for the next step if not in-place
-    if [ "$backup" = true ]; then
-        spec="$spec".new
+    if [ "${backup}" = true ]; then
+        spec="${spec}".new
     fi
 
     replace
 
     # There is no need for two backups, we can just move the replace backup to the original revert backup
-    if [ "$backup" = true ]; then
-        mv -f "$spec".new "$spec"
+    if [ "${backup}" = true ]; then
+        mv -f "${spec}".new "${spec}"
     fi
 }
 
@@ -75,14 +75,14 @@ do
             exit 0
             ;;
         "-r")
-            if [ "$action_set" = true ]; then
+            if [ "${action_set}" = true ]; then
                 usage
                 exit 1
             fi
             action_set=true
             ;;
         "-f")
-            if [ "$action_set" = true ]; then
+            if [ "${action_set}" = true ]; then
                 usage
                 exit 1
             fi
@@ -90,7 +90,7 @@ do
             action="revert"
             ;;
         "-u")
-            if [ "$action_set" = true ]; then
+            if [ "${action_set}" = true ]; then
                 usage
                 exit 1
             fi
@@ -110,12 +110,12 @@ done
 
 spec="${1:-../../freeipa.spec.in}"
 
-if [[ ! -f "$spec" ]]; then
-    echo "Spec file $spec does not exist"
+if [[ ! -f "${spec}" ]]; then
+    echo "Spec file ${spec} does not exist"
     exit 1
 fi
 
-case $action in
+case "${action}" in
     "replace")
         replace
         ;;
@@ -124,5 +124,9 @@ case $action in
         ;;
     "update")
         update
+        ;;
+    *)
+        echo "Error: Unknown action '${action}'" >&2
+        exit 1
         ;;
 esac


### PR DESCRIPTION
This solution fixes the shellCheck-related errors
shown in the CI:

```
 ./fix-spec.sh:31:15: note: Prefer putting braces around variable references even when not strictly required. [SC2250]
./fix-spec.sh:31:56: note: Prefer putting braces around variable references even when not strictly required. [SC2250]
./fix-spec.sh:31:66: note: Prefer putting braces around variable references even when not strictly required. [SC2250]
./fix-spec.sh:33:11: note: Prefer putting braces around variable references even when not strictly required. [SC2250]
./fix-spec.sh:34:16: note: Prefer putting braces around variable references even when not strictly required. [SC2250]
./fix-spec.sh:34:28: note: Prefer putting braces around variable references even when not strictly required. [SC2250]
./fix-spec.sh:40:53: note: Prefer putting braces around variable references even when not strictly required. [SC2250]
./fix-spec.sh:40:63: note: Prefer putting braces around variable references even when not strictly required. [SC2250]
./fix-spec.sh:43:58: note: Prefer putting braces around variable references even when not strictly required. [SC2250]
./fix-spec.sh:45:11: note: Prefer putting braces around variable references even when not strictly required. [SC2250]
./fix-spec.sh:46:16: note: Prefer putting braces around variable references even when not strictly required. [SC2250]
./fix-spec.sh:46:28: note: Prefer putting braces around variable references even when not strictly required. [SC2250]
./fix-spec.sh:54:11: note: Prefer putting braces around variable references even when not strictly required. [SC2250]
./fix-spec.sh:55:15: note: Prefer putting braces around variable references even when not strictly required. [SC2250]
./fix-spec.sh:61:11: note: Prefer putting braces around variable references even when not strictly required. [SC2250]
./fix-spec.sh:62:16: note: Prefer putting braces around variable references even when not strictly required. [SC2250]
./fix-spec.sh:62:28: note: Prefer putting braces around variable references even when not strictly required. [SC2250]
./fix-spec.sh:78:19: note: Prefer putting braces around variable references even when not strictly required. [SC2250]
./fix-spec.sh:85:19: note: Prefer putting braces around variable references even when not strictly required. [SC2250]
./fix-spec.sh:93:19: note: Prefer putting braces around variable references even when not strictly required. [SC2250]
./fix-spec.sh:113:13: note: Prefer putting braces around variable references even when not strictly required. [SC2250]
./fix-spec.sh:114:21: note: Prefer putting braces around variable references even when not strictly required. [SC2250]
./fix-spec.sh:118:1: note: Consider adding a default *) case, even if it just exits with error. [SC2249]
./fix-spec.sh:118:6: note: Prefer putting braces around variable references even when not strictly required. [SC2250]
```

## Summary by Sourcery

Update fix-spec.sh to resolve ShellCheck warnings by bracing variable references, improving quoting consistency, and adding a fallback case in the action handler.

Enhancements:
- Enclose all variable references in braces and quotes throughout fix-spec.sh to satisfy SC2250
- Add a default case in the action switch to handle unknown actions and exit with an error as recommended by SC2249