### PR TITLE
Add safely typed useParams

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-redux": "^9.2.0",
-        "react-router": "^7.6.2"
+        "react-router": "^7.6.2",
+        "tiny-invariant": "^1.3.3"
       },
       "devDependencies": {
         "@badeball/cypress-cucumber-preprocessor": "^22.1.0",
@@ -10959,6 +10960,12 @@
     "node_modules/tiny-case": {
       "version": "1.0.3",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
     "node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-redux": "^9.2.0",
-    "react-router": "^7.6.2"
+    "react-router": "^7.6.2",
+    "tiny-invariant": "^1.3.3"
   },
   "scripts": {
     "dev": "npm run dev:prepare && vite",

--- a/src/pages/ActiveUsers/ActiveUsersTabs.tsx
+++ b/src/pages/ActiveUsers/ActiveUsersTabs.tsx
@@ -10,7 +10,7 @@ import {
   TabTitleText,
 } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router";
+import { useNavigate } from "react-router";
 // Components
 import UserSettings from "src/components/UsersSections/UserSettings";
 import UserMemberOf from "./UserMemberOf";
@@ -30,10 +30,11 @@ import { partialUserToUser } from "src/utils/userUtils";
 // Navigation
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 import { NotFound } from "src/components/errors/PageErrors";
+import { UidParams, useSafeParams } from "src/utils/paramsUtils";
 
 // eslint-disable-next-line react/prop-types
 const ActiveUsersTabs = ({ memberof }) => {
-  const { uid } = useParams();
+  const { uid } = useSafeParams<UidParams>(["uid"]);
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
 
@@ -42,25 +43,20 @@ const ActiveUsersTabs = ({ memberof }) => {
   >([]);
 
   React.useEffect(() => {
-    if (!uid) {
-      // Redirect to the active users page
-      navigate("/active-users");
-    } else {
-      // Update breadcrumb route
-      const currentPath: BreadCrumbItem[] = [
-        {
-          name: "Active users",
-          url: URL_PREFIX + "/active-users",
-        },
-        {
-          name: uid,
-          url: URL_PREFIX + "/active-users/" + uid,
-          isActive: true,
-        },
-      ];
-      setBreadcrumbItems(currentPath);
-      dispatch(updateBreadCrumbPath(currentPath));
-    }
+    // Update breadcrumb route
+    const currentPath: BreadCrumbItem[] = [
+      {
+        name: "Active users",
+        url: URL_PREFIX + "/active-users",
+      },
+      {
+        name: uid,
+        url: URL_PREFIX + "/active-users/" + uid,
+        isActive: true,
+      },
+    ];
+    setBreadcrumbItems(currentPath);
+    dispatch(updateBreadCrumbPath(currentPath));
   }, [uid]);
 
   React.useEffect(() => {
@@ -89,7 +85,7 @@ const ActiveUsersTabs = ({ memberof }) => {
   };
 
   // Data loaded from DB
-  const userSettingsData = useUserSettings(uid as string);
+  const userSettingsData = useUserSettings(uid);
 
   // Tab
   const activeTab = memberof ? "memberof" : "settings";

--- a/src/pages/AutoMemUserRules/AutoMemRulesTabs.tsx
+++ b/src/pages/AutoMemUserRules/AutoMemRulesTabs.tsx
@@ -2,7 +2,7 @@ import React from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router";
+import { useNavigate } from "react-router";
 // Components
 import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
 import TitleLayout from "src/components/layouts/TitleLayout";
@@ -17,6 +17,7 @@ import { NotFound } from "src/components/errors/PageErrors";
 
 import AutoMemSettings from "./AutoMemSettings";
 import { useAutomemberSettingsData } from "src/hooks/useAutomemberSettingsData";
+import { CnParams, useSafeParams } from "src/utils/paramsUtils";
 
 interface AutoMemUserRulesTabsProps {
   section: string;
@@ -25,7 +26,7 @@ interface AutoMemUserRulesTabsProps {
 
 const AutoMemUserRulesTabs = (props: AutoMemUserRulesTabsProps) => {
   const { section, automemberType } = props;
-  const { cn } = useParams();
+  const { cn } = useSafeParams<CnParams>(["cn"]);
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
 
@@ -43,28 +44,23 @@ const AutoMemUserRulesTabs = (props: AutoMemUserRulesTabsProps) => {
     navigate("/" + pathname + "/" + cn);
   };
 
-  const settingsData = useAutomemberSettingsData(cn as string, automemberType);
+  const settingsData = useAutomemberSettingsData(cn, automemberType);
 
   React.useEffect(() => {
-    if (!cn) {
-      // Redirect to the User group rule page
-      navigate("/" + pathname);
-    } else {
-      // Update breadcrumb route
-      const currentPath: BreadCrumbItem[] = [
-        {
-          name: sectionName,
-          url: URL_PREFIX + "/" + pathname,
-        },
-        {
-          name: cn,
-          url: URL_PREFIX + "/" + pathname + "/" + cn,
-          isActive: true,
-        },
-      ];
-      setBreadcrumbItems(currentPath);
-      dispatch(updateBreadCrumbPath(currentPath));
-    }
+    // Update breadcrumb route
+    const currentPath: BreadCrumbItem[] = [
+      {
+        name: sectionName,
+        url: URL_PREFIX + "/" + pathname,
+      },
+      {
+        name: cn,
+        url: URL_PREFIX + "/" + pathname + "/" + cn,
+        isActive: true,
+      },
+    ];
+    setBreadcrumbItems(currentPath);
+    dispatch(updateBreadCrumbPath(currentPath));
   }, [cn]);
 
   // If the section is not defined, redirect to the User group rule page
@@ -94,9 +90,9 @@ const AutoMemUserRulesTabs = (props: AutoMemUserRulesTabsProps) => {
           breadcrumbItems={breadcrumbItems}
         />
         <TitleLayout
-          id={cn as string}
+          id={cn}
           preText={sectionName}
-          text={cn as string}
+          text={cn}
           headingLevel="h1"
         />
       </PageSection>

--- a/src/pages/CertificateMapping/CertificateMappingTabs.tsx
+++ b/src/pages/CertificateMapping/CertificateMappingTabs.tsx
@@ -2,7 +2,7 @@ import React from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router";
+import { useNavigate } from "react-router";
 // Navigation
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 import { NotFound } from "src/components/errors/PageErrors";
@@ -16,10 +16,11 @@ import BreadCrumb, {
   BreadCrumbItem,
 } from "src/components/layouts/BreadCrumb/BreadCrumb";
 import CertificateMappingSettings from "./CertificateMappingSettings";
+import { CnParams, useSafeParams } from "src/utils/paramsUtils";
 
 // eslint-disable-next-line react/prop-types
 const CertificateMappingTabs = ({ section }) => {
-  const { cn } = useParams();
+  const { cn } = useSafeParams<CnParams>(["cn"]);
   const navigate = useNavigate();
   const pathname = "cert-id-mapping-rules";
 
@@ -31,9 +32,7 @@ const CertificateMappingTabs = ({ section }) => {
   const [id, setId] = React.useState("");
 
   // Data loaded from the API
-  const certMappingSettingsData = useCertificateMappingSettingsData(
-    cn as string
-  );
+  const certMappingSettingsData = useCertificateMappingSettingsData(cn);
 
   const handleTabClick = (
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
@@ -45,25 +44,20 @@ const CertificateMappingTabs = ({ section }) => {
   };
 
   React.useEffect(() => {
-    if (!cn) {
-      // Redirect to the main page
-      navigate(URL_PREFIX + "/" + pathname);
-    } else {
-      setId(cn);
-      // Update breadcrumb route
-      const currentPath: BreadCrumbItem[] = [
-        {
-          name: "Certificate Identity Mapping Rule",
-          url: URL_PREFIX + "/" + pathname,
-        },
-        {
-          name: cn,
-          url: URL_PREFIX + "/" + pathname + "/" + cn,
-          isActive: true,
-        },
-      ];
-      setBreadcrumbItems(currentPath);
-    }
+    setId(cn);
+    // Update breadcrumb route
+    const currentPath: BreadCrumbItem[] = [
+      {
+        name: "Certificate Identity Mapping Rule",
+        url: URL_PREFIX + "/" + pathname,
+      },
+      {
+        name: cn,
+        url: URL_PREFIX + "/" + pathname + "/" + cn,
+        isActive: true,
+      },
+    ];
+    setBreadcrumbItems(currentPath);
   }, [cn]);
 
   // Handling of the API data

--- a/src/pages/DNSZones/DnsResourceRecordsPreSettings.tsx
+++ b/src/pages/DNSZones/DnsResourceRecordsPreSettings.tsx
@@ -1,6 +1,4 @@
 import React from "react";
-// React Router DOM
-import { useNavigate, useParams } from "react-router";
 // Navigation
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 import { NotFound } from "src/components/errors/PageErrors";
@@ -10,19 +8,24 @@ import { useDnsRecordsData } from "src/hooks/useDnsRecordsData";
 import DataSpinner from "src/components/layouts/DataSpinner";
 import { BreadCrumbItem } from "src/components/layouts/BreadCrumb/BreadCrumb";
 import DnsResourceRecordsSettings from "./DnsResourceRecordsSettings";
+import { useSafeParams } from "src/utils/paramsUtils";
+
+type DnsParams = {
+  idnsname: string;
+  recordName: string;
+};
 
 const DnsResourceRecordsPreSettings = () => {
-  const navigate = useNavigate();
   const pathname = "dns-zones";
 
   // Params
-  const { idnsname, recordName } = useParams();
+  const { idnsname, recordName } = useSafeParams<DnsParams>([
+    "idnsname",
+    "recordName",
+  ]);
 
   // Data loaded from the API
-  const dnsrecordsSettingsData = useDnsRecordsData(
-    idnsname as string,
-    recordName as string
-  );
+  const dnsrecordsSettingsData = useDnsRecordsData(idnsname, recordName);
 
   // Breadcrumbs
   const [breadcrumbItems, setBreadcrumbItems] = React.useState<
@@ -30,28 +33,23 @@ const DnsResourceRecordsPreSettings = () => {
   >([]);
 
   React.useEffect(() => {
-    if (!idnsname || !recordName) {
-      // Redirect to the main page
-      navigate(URL_PREFIX + "/" + pathname);
-    } else {
-      // Update breadcrumb route
-      const currentPath: BreadCrumbItem[] = [
-        {
-          name: "DNS zones",
-          url: URL_PREFIX + "/" + pathname,
-        },
-        {
-          name: idnsname,
-          url: URL_PREFIX + "/" + pathname + "/" + idnsname,
-        },
-        {
-          name: recordName,
-          url: URL_PREFIX + "/" + pathname + "/" + idnsname + "/" + recordName,
-          isActive: true,
-        },
-      ];
-      setBreadcrumbItems(currentPath);
-    }
+    // Update breadcrumb route
+    const currentPath: BreadCrumbItem[] = [
+      {
+        name: "DNS zones",
+        url: URL_PREFIX + "/" + pathname,
+      },
+      {
+        name: idnsname,
+        url: URL_PREFIX + "/" + pathname + "/" + idnsname,
+      },
+      {
+        name: recordName,
+        url: URL_PREFIX + "/" + pathname + "/" + idnsname + "/" + recordName,
+        isActive: true,
+      },
+    ];
+    setBreadcrumbItems(currentPath);
   }, [idnsname, recordName]);
 
   // Handling of the API data
@@ -70,8 +68,8 @@ const DnsResourceRecordsPreSettings = () => {
   // Return component
   return (
     <DnsResourceRecordsSettings
-      idnsname={idnsname as string}
-      recordName={recordName as string}
+      idnsname={idnsname}
+      recordName={recordName}
       dnsRecord={dnsrecordsSettingsData.dnsRecord}
       originalDnsRecord={dnsrecordsSettingsData.originalDnsRecord}
       host={dnsrecordsSettingsData.host}

--- a/src/pages/DNSZones/DnsServersTabs.tsx
+++ b/src/pages/DNSZones/DnsServersTabs.tsx
@@ -2,7 +2,7 @@ import React from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router";
+import { useNavigate } from "react-router";
 // Navigation
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 import { NotFound } from "src/components/errors/PageErrors";
@@ -15,9 +15,14 @@ import BreadCrumb, {
   BreadCrumbItem,
 } from "src/components/layouts/BreadCrumb/BreadCrumb";
 import DnsServersSettings from "src/pages/DNSZones/DnsServersSettings";
+import { useSafeParams } from "src/utils/paramsUtils";
+
+type DnsParams = {
+  idnsserverid: string;
+};
 
 const DnsServersTabs = ({ section }: { section: string }) => {
-  const { idnsserverid } = useParams();
+  const { idnsserverid } = useSafeParams<DnsParams>(["idnsserverid"]);
   const navigate = useNavigate();
   const pathname = "dns-servers";
 
@@ -25,9 +30,7 @@ const DnsServersTabs = ({ section }: { section: string }) => {
     BreadCrumbItem[]
   >([]);
 
-  const dnsServersSettingsData = useDnsServersSettingsData(
-    idnsserverid as string
-  );
+  const dnsServersSettingsData = useDnsServersSettingsData(idnsserverid);
 
   // States - Identifier of the entity (DNS Zone -> idnsname)
   const [id, setId] = React.useState("");
@@ -42,23 +45,19 @@ const DnsServersTabs = ({ section }: { section: string }) => {
   };
 
   React.useEffect(() => {
-    if (!idnsserverid) {
-      navigate(URL_PREFIX + "/" + pathname);
-    } else {
-      setId(idnsserverid);
-      const currentPath: BreadCrumbItem[] = [
-        {
-          name: "DNS servers",
-          url: URL_PREFIX + "/" + pathname,
-        },
-        {
-          name: idnsserverid,
-          url: URL_PREFIX + "/" + pathname + "/" + idnsserverid,
-          isActive: true,
-        },
-      ];
-      setBreadcrumbItems(currentPath);
-    }
+    setId(idnsserverid);
+    const currentPath: BreadCrumbItem[] = [
+      {
+        name: "DNS servers",
+        url: URL_PREFIX + "/" + pathname,
+      },
+      {
+        name: idnsserverid,
+        url: URL_PREFIX + "/" + pathname + "/" + idnsserverid,
+        isActive: true,
+      },
+    ];
+    setBreadcrumbItems(currentPath);
   }, [idnsserverid]);
 
   // Handling of the API data

--- a/src/pages/DNSZones/DnsZonesTabs.tsx
+++ b/src/pages/DNSZones/DnsZonesTabs.tsx
@@ -2,7 +2,7 @@ import React from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router";
+import { useNavigate } from "react-router";
 // Navigation
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 import { NotFound } from "src/components/errors/PageErrors";
@@ -16,9 +16,14 @@ import BreadCrumb, {
 } from "src/components/layouts/BreadCrumb/BreadCrumb";
 import DnsZonesSettings from "./DnsZonesSettings";
 import DnsResourceRecords from "./DnsResourceRecords";
+import { useSafeParams } from "src/utils/paramsUtils";
+
+type DnsParams = {
+  idnsname: string;
+};
 
 const DnsZonesTabs = ({ section }: { section: string }) => {
-  const { idnsname } = useParams();
+  const { idnsname } = useSafeParams<DnsParams>(["idnsname"]);
   const navigate = useNavigate();
   const pathname = "dns-zones";
 
@@ -30,7 +35,7 @@ const DnsZonesTabs = ({ section }: { section: string }) => {
   const [id, setId] = React.useState("");
 
   // Data loaded from the API
-  const dnsZonesSettingsData = useDnsZonesData(idnsname as string);
+  const dnsZonesSettingsData = useDnsZonesData(idnsname);
 
   const handleTabClick = (
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
@@ -44,25 +49,20 @@ const DnsZonesTabs = ({ section }: { section: string }) => {
   };
 
   React.useEffect(() => {
-    if (!idnsname) {
-      // Redirect to the main page
-      navigate(URL_PREFIX + "/" + pathname);
-    } else {
-      setId(idnsname);
-      // Update breadcrumb route
-      const currentPath: BreadCrumbItem[] = [
-        {
-          name: "DNS zones",
-          url: URL_PREFIX + "/" + pathname,
-        },
-        {
-          name: idnsname,
-          url: URL_PREFIX + "/" + pathname + "/" + idnsname,
-          isActive: true,
-        },
-      ];
-      setBreadcrumbItems(currentPath);
-    }
+    setId(idnsname);
+    // Update breadcrumb route
+    const currentPath: BreadCrumbItem[] = [
+      {
+        name: "DNS zones",
+        url: URL_PREFIX + "/" + pathname,
+      },
+      {
+        name: idnsname,
+        url: URL_PREFIX + "/" + pathname + "/" + idnsname,
+        isActive: true,
+      },
+    ];
+    setBreadcrumbItems(currentPath);
   }, [idnsname]);
 
   // Handling of the API data

--- a/src/pages/HBACRules/HBACRulesTabs.tsx
+++ b/src/pages/HBACRules/HBACRulesTabs.tsx
@@ -2,7 +2,7 @@ import React from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router";
+import { useNavigate } from "react-router";
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 // Layouts
 import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
@@ -15,14 +15,15 @@ import { useAppDispatch } from "src/store/hooks";
 import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
 import { NotFound } from "src/components/errors/PageErrors";
 import HBACRulesSettings from "./HBACRulesSettings";
+import { CnParams, useSafeParams } from "src/utils/paramsUtils";
 
 // eslint-disable-next-line react/prop-types
 const HBACRulesTabs = ({ section }) => {
   // Get location (React Router DOM) and get state data
-  const { cn } = useParams();
+  const { cn } = useSafeParams<CnParams>(["cn"]);
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
-  const settingsData = useHBACRuleSettings(cn as string);
+  const settingsData = useHBACRuleSettings(cn);
   const [breadcrumbItems, setBreadcrumbItems] = React.useState<
     BreadCrumbItem[]
   >([]);
@@ -32,25 +33,20 @@ const HBACRulesTabs = ({ section }) => {
   };
 
   React.useEffect(() => {
-    if (!cn) {
-      // Redirect to the main page
-      navigate("/hbac-rules");
-    } else {
-      // Update breadcrumb route
-      const currentPath: BreadCrumbItem[] = [
-        {
-          name: "HBAC rules",
-          url: URL_PREFIX + "/hbac-rules",
-        },
-        {
-          name: cn,
-          url: URL_PREFIX + "/hbac-rules/" + cn,
-          isActive: true,
-        },
-      ];
-      setBreadcrumbItems(currentPath);
-      dispatch(updateBreadCrumbPath(currentPath));
-    }
+    // Update breadcrumb route
+    const currentPath: BreadCrumbItem[] = [
+      {
+        name: "HBAC rules",
+        url: URL_PREFIX + "/hbac-rules",
+      },
+      {
+        name: cn,
+        url: URL_PREFIX + "/hbac-rules/" + cn,
+        isActive: true,
+      },
+    ];
+    setBreadcrumbItems(currentPath);
+    dispatch(updateBreadCrumbPath(currentPath));
   }, [cn]);
 
   // Redirect to the settings page if the section is not defined

--- a/src/pages/HBACServiceGroups/HBACServiceGroupsTabs.tsx
+++ b/src/pages/HBACServiceGroups/HBACServiceGroupsTabs.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router";
+import { useNavigate } from "react-router";
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 // Layouts
 import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
@@ -18,14 +18,15 @@ import HBACServiceGroupsSettings from "./HBACServiceGroupsSettings";
 import HBACSvcGroupMembers from "./HBACServiceGroupsMembers";
 // Utils
 import { partialHBACSvcGrpToHBACSvcGrp } from "src/utils/hbacServiceGrpUtils";
+import { CnParams, useSafeParams } from "src/utils/paramsUtils";
 
 // eslint-disable-next-line react/prop-types
 const HBACServiceGroupsTabs = ({ section }) => {
   // Get location (React Router DOM) and get state data
-  const { cn } = useParams();
+  const { cn } = useSafeParams<CnParams>(["cn"]);
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
-  const settingsData = useHBACServiceGroupSettings(cn as string);
+  const settingsData = useHBACServiceGroupSettings(cn);
   const [breadcrumbItems, setBreadcrumbItems] = React.useState<
     BreadCrumbItem[]
   >([]);
@@ -45,26 +46,21 @@ const HBACServiceGroupsTabs = ({ section }) => {
   };
 
   React.useEffect(() => {
-    if (!cn) {
-      // Redirect to the main page
-      navigate("/hbac-service-groups");
-    } else {
-      // Update breadcrumb route
-      const currentPath: BreadCrumbItem[] = [
-        {
-          name: "HBAC service groups",
-          url: URL_PREFIX + "/hbac-service-groups",
-        },
-        {
-          name: cn,
-          url: URL_PREFIX + "/hbac-service-groups/" + cn,
-          isActive: true,
-        },
-      ];
-      setBreadcrumbItems(currentPath);
-      setActiveTabKey("settings");
-      dispatch(updateBreadCrumbPath(currentPath));
-    }
+    // Update breadcrumb route
+    const currentPath: BreadCrumbItem[] = [
+      {
+        name: "HBAC service groups",
+        url: URL_PREFIX + "/hbac-service-groups",
+      },
+      {
+        name: cn,
+        url: URL_PREFIX + "/hbac-service-groups/" + cn,
+        isActive: true,
+      },
+    ];
+    setBreadcrumbItems(currentPath);
+    setActiveTabKey("settings");
+    dispatch(updateBreadCrumbPath(currentPath));
   }, [cn]);
 
   // Redirect to the settings page if the section is not defined

--- a/src/pages/HBACServices/HBACServicesTabs.tsx
+++ b/src/pages/HBACServices/HBACServicesTabs.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router";
+import { useNavigate } from "react-router";
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 // Layouts
 import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
@@ -17,14 +17,15 @@ import { NotFound } from "src/components/errors/PageErrors";
 import { partialHBACServiceToHBACService } from "src/utils/hbacServicesUtils";
 import HBACServicesSettings from "./HBACServicesSettings";
 import HBACServicesMemberOf from "./HBACServicesMemberOf";
+import { CnParams, useSafeParams } from "src/utils/paramsUtils";
 
 // eslint-disable-next-line react/prop-types
 const HBACServicesTabs = ({ section }) => {
   // Get location (React Router DOM) and get state data
-  const { cn } = useParams();
+  const { cn } = useSafeParams<CnParams>(["cn"]);
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
-  const settingsData = useHBACServiceSettings(cn as string);
+  const settingsData = useHBACServiceSettings(cn);
   const [breadcrumbItems, setBreadcrumbItems] = React.useState<
     BreadCrumbItem[]
   >([]);
@@ -44,26 +45,21 @@ const HBACServicesTabs = ({ section }) => {
   };
 
   React.useEffect(() => {
-    if (!cn) {
-      // Redirect to the main page
-      navigate("/hbac-services");
-    } else {
-      // Update breadcrumb route
-      const currentPath: BreadCrumbItem[] = [
-        {
-          name: "HBAC services",
-          url: URL_PREFIX + "/hbac-services",
-        },
-        {
-          name: cn,
-          url: URL_PREFIX + "/hbac-services/" + cn,
-          isActive: true,
-        },
-      ];
-      setBreadcrumbItems(currentPath);
-      setActiveTabKey("settings");
-      dispatch(updateBreadCrumbPath(currentPath));
-    }
+    // Update breadcrumb route
+    const currentPath: BreadCrumbItem[] = [
+      {
+        name: "HBAC services",
+        url: URL_PREFIX + "/hbac-services",
+      },
+      {
+        name: cn,
+        url: URL_PREFIX + "/hbac-services/" + cn,
+        isActive: true,
+      },
+    ];
+    setBreadcrumbItems(currentPath);
+    setActiveTabKey("settings");
+    dispatch(updateBreadCrumbPath(currentPath));
   }, [cn]);
 
   // Redirect to the settings page if the section is not defined

--- a/src/pages/HostGroups/HostGroupsTabs.tsx
+++ b/src/pages/HostGroups/HostGroupsTabs.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router";
+import { useNavigate } from "react-router";
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 // Layouts
 import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
@@ -20,14 +20,15 @@ import HostGroupsSettings from "./HostGroupsSettings";
 import HostGroupsMembers from "./HostGroupsMembers";
 import HostGroupsMemberOf from "./HostGroupsMemberOf";
 import HostGroupsMemberManagers from "./HostGroupsMemberManagers";
+import { CnParams, useSafeParams } from "src/utils/paramsUtils";
 
 // eslint-disable-next-line react/prop-types
 const HostGroupsTabs = ({ section }) => {
   // Get location (React Router DOM) and get state data
-  const { cn } = useParams();
+  const { cn } = useSafeParams<CnParams>(["cn"]);
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
-  const hostGroupSettingsData = useHostGroupSettings(cn as string);
+  const hostGroupSettingsData = useHostGroupSettings(cn);
   const [breadcrumbItems, setBreadcrumbItems] = React.useState<
     BreadCrumbItem[]
   >([]);
@@ -52,27 +53,22 @@ const HostGroupsTabs = ({ section }) => {
   };
 
   React.useEffect(() => {
-    if (!cn) {
-      // Redirect to the main page
-      navigate("/host-groups");
-    } else {
-      setGroupId(cn);
-      // Update breadcrumb route
-      const currentPath: BreadCrumbItem[] = [
-        {
-          name: "Host groups",
-          url: URL_PREFIX + "/host-groups",
-        },
-        {
-          name: cn,
-          url: URL_PREFIX + "/host-groups/" + cn,
-          isActive: true,
-        },
-      ];
-      setBreadcrumbItems(currentPath);
-      setActiveTabKey("settings");
-      dispatch(updateBreadCrumbPath(currentPath));
-    }
+    setGroupId(cn);
+    // Update breadcrumb route
+    const currentPath: BreadCrumbItem[] = [
+      {
+        name: "Host groups",
+        url: URL_PREFIX + "/host-groups",
+      },
+      {
+        name: cn,
+        url: URL_PREFIX + "/host-groups/" + cn,
+        isActive: true,
+      },
+    ];
+    setBreadcrumbItems(currentPath);
+    setActiveTabKey("settings");
+    dispatch(updateBreadCrumbPath(currentPath));
   }, [cn]);
 
   // Redirect to the settings page if the section is not defined

--- a/src/pages/Hosts/HostsTabs.tsx
+++ b/src/pages/Hosts/HostsTabs.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router";
+import { useNavigate } from "react-router";
 // Components
 import HostsSettings from "./HostsSettings";
 import HostsMemberOf from "./HostsMemberOf";
@@ -23,10 +23,15 @@ import { partialHostToHost } from "src/utils/hostUtils";
 // Navigation
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 import { NotFound } from "src/components/errors/PageErrors";
+import { useSafeParams } from "src/utils/paramsUtils";
+
+type HostsParams = {
+  fqdn: string;
+};
 
 // eslint-disable-next-line react/prop-types
 const HostsTabs = ({ section }) => {
-  const { fqdn } = useParams();
+  const { fqdn } = useSafeParams<HostsParams>(["fqdn"]);
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
 
@@ -60,7 +65,7 @@ const HostsTabs = ({ section }) => {
   }, [section]);
 
   // Data loaded from DB
-  const hostSettingsData = useHostSettings(fqdn as string);
+  const hostSettingsData = useHostSettings(fqdn);
 
   // Tab
   const [activeTabKey, setActiveTabKey] = useState(section);
@@ -84,27 +89,22 @@ const HostsTabs = ({ section }) => {
   };
 
   React.useEffect(() => {
-    if (!fqdn) {
-      // Redirect to the main page
-      navigate(URL_PREFIX + "/hosts");
-    } else {
-      setHostId(fqdn);
-      // Update breadcrumb route
-      const currentPath: BreadCrumbItem[] = [
-        {
-          name: "Hosts",
-          url: URL_PREFIX + "/hosts",
-        },
-        {
-          name: fqdn,
-          url: URL_PREFIX + "/hosts/" + fqdn,
-          isActive: true,
-        },
-      ];
-      setBreadcrumbItems(currentPath);
-      setActiveTabKey("settings");
-      dispatch(updateBreadCrumbPath(currentPath));
-    }
+    setHostId(fqdn);
+    // Update breadcrumb route
+    const currentPath: BreadCrumbItem[] = [
+      {
+        name: "Hosts",
+        url: URL_PREFIX + "/hosts",
+      },
+      {
+        name: fqdn,
+        url: URL_PREFIX + "/hosts/" + fqdn,
+        isActive: true,
+      },
+    ];
+    setBreadcrumbItems(currentPath);
+    setActiveTabKey("settings");
+    dispatch(updateBreadCrumbPath(currentPath));
   }, [fqdn]);
 
   // Redirect to the settings page if the section is not defined

--- a/src/pages/IDViews/IDViewsTabs.tsx
+++ b/src/pages/IDViews/IDViewsTabs.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router";
+import { useNavigate } from "react-router";
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 // Layouts
 import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
@@ -19,14 +19,15 @@ import { NotFound } from "src/components/errors/PageErrors";
 import IDViewsSettings from "./IDViewsSettings";
 import IDViewsOverrides from "./IDViewsOverrides";
 import IDViewsAppliedTo from "./IDViewsAppliedTo";
+import { CnParams, useSafeParams } from "src/utils/paramsUtils";
 
 // eslint-disable-next-line react/prop-types
 const IDViewsTabs = ({ section }) => {
   // Get location (React Router DOM) and get state data
-  const { cn } = useParams();
+  const { cn } = useSafeParams<CnParams>(["cn"]);
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
-  const idViewSettingsData = useIDViewSettings(cn as string);
+  const idViewSettingsData = useIDViewSettings(cn);
   const [breadcrumbItems, setBreadcrumbItems] = React.useState<
     BreadCrumbItem[]
   >([]);
@@ -49,26 +50,21 @@ const IDViewsTabs = ({ section }) => {
   };
 
   React.useEffect(() => {
-    if (!cn) {
-      // Redirect to the main page
-      navigate("/id-views");
-    } else {
-      // Update breadcrumb route
-      const currentPath: BreadCrumbItem[] = [
-        {
-          name: "ID views",
-          url: URL_PREFIX + "/id-views",
-        },
-        {
-          name: cn,
-          url: URL_PREFIX + "/id-views/" + cn,
-          isActive: true,
-        },
-      ];
-      setBreadcrumbItems(currentPath);
-      setActiveTabKey("settings");
-      dispatch(updateBreadCrumbPath(currentPath));
-    }
+    // Update breadcrumb route
+    const currentPath: BreadCrumbItem[] = [
+      {
+        name: "ID views",
+        url: URL_PREFIX + "/id-views",
+      },
+      {
+        name: cn,
+        url: URL_PREFIX + "/id-views/" + cn,
+        isActive: true,
+      },
+    ];
+    setBreadcrumbItems(currentPath);
+    setActiveTabKey("settings");
+    dispatch(updateBreadCrumbPath(currentPath));
   }, [cn]);
 
   // Redirect to the settings page if the section is not defined

--- a/src/pages/IdPReferences/IdpReferencesTabs.tsx
+++ b/src/pages/IdPReferences/IdpReferencesTabs.tsx
@@ -2,7 +2,7 @@ import React from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router";
+import { useNavigate } from "react-router";
 // Navigation
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 import { NotFound } from "src/components/errors/PageErrors";
@@ -15,10 +15,11 @@ import BreadCrumb, {
   BreadCrumbItem,
 } from "src/components/layouts/BreadCrumb/BreadCrumb";
 import IdpRefSettings from "./IdpReferencesSettings";
+import { CnParams, useSafeParams } from "src/utils/paramsUtils";
 
 // eslint-disable-next-line react/prop-types
 const IdpReferencesTabs = ({ section }) => {
-  const { cn } = useParams();
+  const { cn } = useSafeParams<CnParams>(["cn"]);
   const navigate = useNavigate();
   const pathname = "identity-provider-references";
 
@@ -30,7 +31,7 @@ const IdpReferencesTabs = ({ section }) => {
   const [id, setId] = React.useState("");
 
   // Data loaded from the API
-  const idpRefSettingsData = useIdpRefSettingsData(cn as string);
+  const idpRefSettingsData = useIdpRefSettingsData(cn);
 
   // Tab
   const [activeTabKey, setActiveTabKey] = React.useState(section);
@@ -45,26 +46,21 @@ const IdpReferencesTabs = ({ section }) => {
   };
 
   React.useEffect(() => {
-    if (!cn) {
-      // Redirect to the main page
-      navigate(URL_PREFIX + "/" + pathname);
-    } else {
-      setId(cn);
-      // Update breadcrumb route
-      const currentPath: BreadCrumbItem[] = [
-        {
-          name: "Identity provider references",
-          url: URL_PREFIX + "/" + pathname,
-        },
-        {
-          name: cn,
-          url: URL_PREFIX + "/" + pathname + "/" + cn,
-          isActive: true,
-        },
-      ];
-      setBreadcrumbItems(currentPath);
-      setActiveTabKey("settings");
-    }
+    setId(cn);
+    // Update breadcrumb route
+    const currentPath: BreadCrumbItem[] = [
+      {
+        name: "Identity provider references",
+        url: URL_PREFIX + "/" + pathname,
+      },
+      {
+        name: cn,
+        url: URL_PREFIX + "/" + pathname + "/" + cn,
+        isActive: true,
+      },
+    ];
+    setBreadcrumbItems(currentPath);
+    setActiveTabKey("settings");
   }, [cn]);
 
   // Handling of the API data

--- a/src/pages/Netgroups/NetgroupsTabs.tsx
+++ b/src/pages/Netgroups/NetgroupsTabs.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router";
+import { useNavigate } from "react-router";
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 // Layouts
 import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
@@ -18,14 +18,15 @@ import { NotFound } from "src/components/errors/PageErrors";
 import NetgroupsMembers from "./NetgroupsMembers";
 import NetgroupsSettings from "./NetgroupsSettings";
 import NetgroupsMemberOf from "./NetgroupsMemberOf";
+import { CnParams, useSafeParams } from "src/utils/paramsUtils";
 
 // eslint-disable-next-line react/prop-types
 const NetgroupsTabs = ({ section }) => {
   // Get location (React Router DOM) and get state data
-  const { cn } = useParams();
+  const { cn } = useSafeParams<CnParams>(["cn"]);
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
-  const netgroupSettingsData = useNetgroupSettings(cn as string);
+  const netgroupSettingsData = useNetgroupSettings(cn);
   const [breadcrumbItems, setBreadcrumbItems] = React.useState<
     BreadCrumbItem[]
   >([]);
@@ -47,26 +48,21 @@ const NetgroupsTabs = ({ section }) => {
   };
 
   React.useEffect(() => {
-    if (!cn) {
-      // Redirect to the main page
-      navigate("/netgroups");
-    } else {
-      // Update breadcrumb route
-      const currentPath: BreadCrumbItem[] = [
-        {
-          name: "Netgroups",
-          url: URL_PREFIX + "/netgroups",
-        },
-        {
-          name: cn,
-          url: URL_PREFIX + "/netgroups/" + cn,
-          isActive: true,
-        },
-      ];
-      setBreadcrumbItems(currentPath);
-      setActiveTabKey("settings");
-      dispatch(updateBreadCrumbPath(currentPath));
-    }
+    // Update breadcrumb route
+    const currentPath: BreadCrumbItem[] = [
+      {
+        name: "Netgroups",
+        url: URL_PREFIX + "/netgroups",
+      },
+      {
+        name: cn,
+        url: URL_PREFIX + "/netgroups/" + cn,
+        isActive: true,
+      },
+    ];
+    setBreadcrumbItems(currentPath);
+    setActiveTabKey("settings");
+    dispatch(updateBreadCrumbPath(currentPath));
   }, [cn]);
 
   // Redirect to the settings page if the section is not defined

--- a/src/pages/PasswordPolicies/PasswordPoliciesTabs.tsx
+++ b/src/pages/PasswordPolicies/PasswordPoliciesTabs.tsx
@@ -2,7 +2,7 @@ import React from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router";
+import { useNavigate } from "react-router";
 // Navigation
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 import { NotFound } from "src/components/errors/PageErrors";
@@ -13,10 +13,11 @@ import TitleLayout from "src/components/layouts/TitleLayout";
 import DataSpinner from "src/components/layouts/DataSpinner";
 import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
 import PasswordPoliciesSettings from "./PasswordPoliciesSettings";
+import { CnParams, useSafeParams } from "src/utils/paramsUtils";
 
 // eslint-disable-next-line react/prop-types
 const PasswordPoliciesTabs = ({ section }) => {
-  const { cn } = useParams();
+  const { cn } = useSafeParams<CnParams>(["cn"]);
   const navigate = useNavigate();
   const pathname = "password-policies";
 
@@ -28,7 +29,7 @@ const PasswordPoliciesTabs = ({ section }) => {
   const [id, setId] = React.useState("");
 
   // Data loaded from the API
-  const pwPolicySettingsData = usePasswordPolicySettings(cn as string);
+  const pwPolicySettingsData = usePasswordPolicySettings(cn);
 
   // Tab
   const [activeTabKey, setActiveTabKey] = React.useState(section);
@@ -45,26 +46,21 @@ const PasswordPoliciesTabs = ({ section }) => {
   };
 
   React.useEffect(() => {
-    if (!cn) {
-      // Redirect to the main page
-      navigate(URL_PREFIX + "/" + pathname);
-    } else {
-      setId(cn);
-      // Update breadcrumb route
-      const currentPath: BreadCrumbItem[] = [
-        {
-          name: "Password policies",
-          url: URL_PREFIX + "/" + pathname,
-        },
-        {
-          name: cn,
-          url: URL_PREFIX + "/" + pathname + "/" + cn,
-          isActive: true,
-        },
-      ];
-      setBreadcrumbItems(currentPath);
-      setActiveTabKey("settings");
-    }
+    setId(cn);
+    // Update breadcrumb route
+    const currentPath: BreadCrumbItem[] = [
+      {
+        name: "Password policies",
+        url: URL_PREFIX + "/" + pathname,
+      },
+      {
+        name: cn,
+        url: URL_PREFIX + "/" + pathname + "/" + cn,
+        isActive: true,
+      },
+    ];
+    setBreadcrumbItems(currentPath);
+    setActiveTabKey("settings");
   }, [cn]);
 
   // Handling of the API data

--- a/src/pages/PreservedUsers/PreservedUsersTabs.tsx
+++ b/src/pages/PreservedUsers/PreservedUsersTabs.tsx
@@ -1,8 +1,6 @@
 import React, { useState } from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
-// React Router DOM
-import { useNavigate, useParams } from "react-router";
 // Components
 import UserSettings from "src/components/UsersSections/UserSettings";
 import DataSpinner from "src/components/layouts/DataSpinner";
@@ -17,11 +15,11 @@ import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
 // Navigation
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 import { NotFound } from "src/components/errors/PageErrors";
+import { UidParams, useSafeParams } from "src/utils/paramsUtils";
 
 const PreservedUsersTabs = () => {
   // Get location (React Router DOM) and get state data
-  const { uid } = useParams();
-  const navigate = useNavigate();
+  const { uid } = useSafeParams<UidParams>(["uid"]);
   const dispatch = useAppDispatch();
 
   const [breadcrumbItems, setBreadcrumbItems] = React.useState<
@@ -29,26 +27,21 @@ const PreservedUsersTabs = () => {
   >([]);
 
   React.useEffect(() => {
-    if (!uid) {
-      // Redirect to the preserved users page
-      navigate(URL_PREFIX + "/preserved-users");
-    } else {
-      // Update breadcrumb route
-      const currentPath: BreadCrumbItem[] = [
-        {
-          name: "Preserved users",
-          url: URL_PREFIX + "/preserved-users",
-        },
-        {
-          name: uid,
-          url: URL_PREFIX + "/preserved-users/" + uid,
-          isActive: true,
-        },
-      ];
-      setBreadcrumbItems(currentPath);
-      setActiveTabKey(0);
-      dispatch(updateBreadCrumbPath(currentPath));
-    }
+    // Update breadcrumb route
+    const currentPath: BreadCrumbItem[] = [
+      {
+        name: "Preserved users",
+        url: URL_PREFIX + "/preserved-users",
+      },
+      {
+        name: uid,
+        url: URL_PREFIX + "/preserved-users/" + uid,
+        isActive: true,
+      },
+    ];
+    setBreadcrumbItems(currentPath);
+    setActiveTabKey(0);
+    dispatch(updateBreadCrumbPath(currentPath));
   }, [uid]);
 
   // Contextual links panel
@@ -71,7 +64,7 @@ const PreservedUsersTabs = () => {
   };
 
   // Data loaded from DB
-  const userSettingsData = useUserSettings(uid as string);
+  const userSettingsData = useUserSettings(uid);
 
   // Tab
   const [activeTabKey, setActiveTabKey] = useState(0);
@@ -105,9 +98,9 @@ const PreservedUsersTabs = () => {
         <PageSection hasBodyWrapper={false}>
           <BreadCrumb breadcrumbItems={breadcrumbItems} />
           <TitleLayout
-            id={uid ? uid : ""}
+            id={uid}
             preText="Preserved user:"
-            text={uid ? uid : ""}
+            text={uid}
             headingLevel="h1"
           />
         </PageSection>

--- a/src/pages/Services/ServicesTabs.tsx
+++ b/src/pages/Services/ServicesTabs.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router";
+import { useNavigate } from "react-router";
 // Components
 import ServicesSettings from "./ServicesSettings";
 import ServicesMemberOf from "./ServicesMemberOf";
@@ -22,13 +22,18 @@ import DataSpinner from "src/components/layouts/DataSpinner";
 // Navigation
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 import { NotFound } from "src/components/errors/PageErrors";
+import { useSafeParams } from "src/utils/paramsUtils";
+
+type ServicesParams = {
+  id: string;
+};
 
 // eslint-disable-next-line react/prop-types
 const ServicesTabs = ({ section }) => {
-  const { id } = useParams();
+  const { id } = useSafeParams<ServicesParams>(["id"]);
 
   // As the id is sent by React Router DOM partially decoded, this should be fixed
-  const decodedId = decodeURIComponent(id as string); // original ID
+  const decodedId = decodeURIComponent(id); // original ID
   const doubleEncodedId = encodeURIComponent(encodeURIComponent(decodedId)); // double encoded ID
 
   const navigate = useNavigate();
@@ -84,26 +89,21 @@ const ServicesTabs = ({ section }) => {
   };
 
   React.useEffect(() => {
-    if (!id) {
-      // Redirect to the main page
-      navigate("/services");
-    } else {
-      // Update breadcrumb route
-      const currentPath: BreadCrumbItem[] = [
-        {
-          name: "Services",
-          url: URL_PREFIX + "/services",
-        },
-        {
-          name: decodedId,
-          url: URL_PREFIX + "/services/" + doubleEncodedId,
-          isActive: true,
-        },
-      ];
-      setBreadcrumbItems(currentPath);
-      setActiveTabKey("settings");
-      dispatch(updateBreadCrumbPath(currentPath));
-    }
+    // Update breadcrumb route
+    const currentPath: BreadCrumbItem[] = [
+      {
+        name: "Services",
+        url: URL_PREFIX + "/services",
+      },
+      {
+        name: decodedId,
+        url: URL_PREFIX + "/services/" + doubleEncodedId,
+        isActive: true,
+      },
+    ];
+    setBreadcrumbItems(currentPath);
+    setActiveTabKey("settings");
+    dispatch(updateBreadCrumbPath(currentPath));
   }, [id]);
 
   // Redirect to the settings page if the section is not defined

--- a/src/pages/StageUsers/StageUsersTabs.tsx
+++ b/src/pages/StageUsers/StageUsersTabs.tsx
@@ -1,8 +1,6 @@
 import React, { useState } from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
-// React Router DOM
-import { useNavigate, useParams } from "react-router";
 // Components
 import UserSettings from "src/components/UsersSections/UserSettings";
 import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
@@ -17,10 +15,10 @@ import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
 // Navigation
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 import { NotFound } from "src/components/errors/PageErrors";
+import { UidParams, useSafeParams } from "src/utils/paramsUtils";
 
 const StageUsersTabs = () => {
-  const { uid } = useParams();
-  const navigate = useNavigate();
+  const { uid } = useSafeParams<UidParams>(["uid"]);
   const dispatch = useAppDispatch();
 
   const [breadcrumbItems, setBreadcrumbItems] = React.useState<
@@ -28,26 +26,21 @@ const StageUsersTabs = () => {
   >([]);
 
   React.useEffect(() => {
-    if (!uid) {
-      // Redirect to the stage users page
-      navigate(URL_PREFIX + "stage-users");
-    } else {
-      // Update breadcrumb route
-      const currentPath: BreadCrumbItem[] = [
-        {
-          name: "Stage users",
-          url: URL_PREFIX + "/stage-users",
-        },
-        {
-          name: uid,
-          url: URL_PREFIX + "/stage-users/" + uid,
-          isActive: true,
-        },
-      ];
-      setBreadcrumbItems(currentPath);
-      setActiveTabKey(0);
-      dispatch(updateBreadCrumbPath(currentPath));
-    }
+    // Update breadcrumb route
+    const currentPath: BreadCrumbItem[] = [
+      {
+        name: "Stage users",
+        url: URL_PREFIX + "/stage-users",
+      },
+      {
+        name: uid,
+        url: URL_PREFIX + "/stage-users/" + uid,
+        isActive: true,
+      },
+    ];
+    setBreadcrumbItems(currentPath);
+    setActiveTabKey(0);
+    dispatch(updateBreadCrumbPath(currentPath));
   }, [uid]);
 
   // Contextual links panel
@@ -70,7 +63,7 @@ const StageUsersTabs = () => {
   };
 
   // Data loaded from DB
-  const userSettingsData = useStageUserSettings(uid as string);
+  const userSettingsData = useStageUserSettings(uid);
 
   // Tab
   const [activeTabKey, setActiveTabKey] = useState(0);
@@ -104,9 +97,9 @@ const StageUsersTabs = () => {
         <PageSection hasBodyWrapper={false}>
           <BreadCrumb breadcrumbItems={breadcrumbItems} />
           <TitleLayout
-            id={uid ? uid : ""}
+            id={uid}
             preText="Staged user:"
-            text={uid ? uid : ""}
+            text={uid}
             headingLevel="h1"
           />
         </PageSection>

--- a/src/pages/SubordinateIDs/SubIdsTabs.tsx
+++ b/src/pages/SubordinateIDs/SubIdsTabs.tsx
@@ -2,7 +2,7 @@ import React from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router";
+import { useNavigate } from "react-router";
 // Navigation
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 import { NotFound } from "src/components/errors/PageErrors";
@@ -13,10 +13,15 @@ import TitleLayout from "src/components/layouts/TitleLayout";
 import DataSpinner from "src/components/layouts/DataSpinner";
 import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
 import SubidSettings from "./SubidsSettings";
+import { useSafeParams } from "src/utils/paramsUtils";
+
+type SubIdParams = {
+  ipauniqueid: string;
+};
 
 // eslint-disable-next-line react/prop-types
 const SubIdTabs = ({ section }) => {
-  const { ipauniqueid } = useParams();
+  const { ipauniqueid } = useSafeParams<SubIdParams>(["ipauniqueid"]);
   const navigate = useNavigate();
   const pathname = "subordinate-ids";
 
@@ -27,7 +32,7 @@ const SubIdTabs = ({ section }) => {
   const [id, setId] = React.useState("");
 
   // Data loaded from the API
-  const subidSettingsData = useSubidSettings(ipauniqueid as string);
+  const subidSettingsData = useSubidSettings(ipauniqueid);
 
   // Tab
   const [activeTabKey, setActiveTabKey] = React.useState(section);
@@ -44,26 +49,21 @@ const SubIdTabs = ({ section }) => {
   };
 
   React.useEffect(() => {
-    if (!ipauniqueid) {
-      // Redirect to the main page
-      navigate(URL_PREFIX + "/" + pathname);
-    } else {
-      setId(ipauniqueid);
-      // Update breadcrumb route
-      const currentPath: BreadCrumbItem[] = [
-        {
-          name: "Subordinate IDs",
-          url: URL_PREFIX + "/" + pathname,
-        },
-        {
-          name: ipauniqueid,
-          url: URL_PREFIX + "/" + pathname + "/" + ipauniqueid,
-          isActive: true,
-        },
-      ];
-      setBreadcrumbItems(currentPath);
-      setActiveTabKey("settings");
-    }
+    setId(ipauniqueid);
+    // Update breadcrumb route
+    const currentPath: BreadCrumbItem[] = [
+      {
+        name: "Subordinate IDs",
+        url: URL_PREFIX + "/" + pathname,
+      },
+      {
+        name: ipauniqueid,
+        url: URL_PREFIX + "/" + pathname + "/" + ipauniqueid,
+        isActive: true,
+      },
+    ];
+    setBreadcrumbItems(currentPath);
+    setActiveTabKey("settings");
   }, [ipauniqueid]);
 
   if (subidSettingsData.isLoading || !subidSettingsData.subid) {

--- a/src/pages/SudoCmdGroups/SudoCmdGroupsTabs.tsx
+++ b/src/pages/SudoCmdGroups/SudoCmdGroupsTabs.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router";
+import { useNavigate } from "react-router";
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 // Layouts
 import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
@@ -17,14 +17,15 @@ import { NotFound } from "src/components/errors/PageErrors";
 import SudoCmdGroupsSettings from "./SudoCmdGroupsSettings";
 import { partialSudoCmdGroupToSudoCmdGroup } from "src/utils/sudoCmdGroupsUtils";
 import SudoCmdGroupMembers from "./SudoCmdGroupsMembers";
+import { CnParams, useSafeParams } from "src/utils/paramsUtils";
 
 // eslint-disable-next-line react/prop-types
 const SudoCmdGroupsTabs = ({ section }) => {
   // Get location (React Router DOM) and get state data
-  const { cn } = useParams();
+  const { cn } = useSafeParams<CnParams>(["cn"]);
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
-  const settingsData = useSudoCmdGroupsSettings(cn as string);
+  const settingsData = useSudoCmdGroupsSettings(cn);
 
   // Tab
   const [activeTabKey, setActiveTabKey] = useState(section);
@@ -44,26 +45,21 @@ const SudoCmdGroupsTabs = ({ section }) => {
   };
 
   React.useEffect(() => {
-    if (!cn) {
-      // Redirect to the main page
-      navigate("/sudo-command-groups");
-    } else {
-      // Update breadcrumb route
-      const currentPath: BreadCrumbItem[] = [
-        {
-          name: "Sudo command groups",
-          url: URL_PREFIX + "/sudo-command-groups",
-        },
-        {
-          name: cn,
-          url: URL_PREFIX + "/sudo-command-groups/" + cn,
-          isActive: true,
-        },
-      ];
-      setBreadcrumbItems(currentPath);
-      setActiveTabKey("settings");
-      dispatch(updateBreadCrumbPath(currentPath));
-    }
+    // Update breadcrumb route
+    const currentPath: BreadCrumbItem[] = [
+      {
+        name: "Sudo command groups",
+        url: URL_PREFIX + "/sudo-command-groups",
+      },
+      {
+        name: cn,
+        url: URL_PREFIX + "/sudo-command-groups/" + cn,
+        isActive: true,
+      },
+    ];
+    setBreadcrumbItems(currentPath);
+    setActiveTabKey("settings");
+    dispatch(updateBreadCrumbPath(currentPath));
   }, [cn]);
 
   // Redirect to the settings page if the section is not defined

--- a/src/pages/SudoCmds/SudoCmdsTabs.tsx
+++ b/src/pages/SudoCmds/SudoCmdsTabs.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router";
+import { useNavigate } from "react-router";
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 // Layouts
 import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
@@ -17,14 +17,19 @@ import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
 import { NotFound } from "src/components/errors/PageErrors";
 import SudoCmdsSettings from "./SudoCmdsSettings";
 import SudoCmdsMemberOf from "./SudoCmdsMemberOf";
+import { useSafeParams } from "src/utils/paramsUtils";
+
+type SudoCmdsParams = {
+  sudocmd: string;
+};
 
 // eslint-disable-next-line react/prop-types
 const SudoCmdsTabs = ({ section }) => {
   // Get location (React Router DOM) and get state data
-  const { sudocmd } = useParams();
+  const { sudocmd } = useSafeParams<SudoCmdsParams>(["sudocmd"]);
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
-  const settingsData = useSudoCmdsSettings(sudocmd as string);
+  const settingsData = useSudoCmdsSettings(sudocmd);
 
   // Tab
   const [activeTabKey, setActiveTabKey] = useState(section);
@@ -44,26 +49,21 @@ const SudoCmdsTabs = ({ section }) => {
   };
 
   React.useEffect(() => {
-    if (!sudocmd) {
-      // Redirect to the main page
-      navigate("/sudo-commands");
-    } else {
-      // Update breadcrumb route
-      const currentPath: BreadCrumbItem[] = [
-        {
-          name: "Sudo commands",
-          url: URL_PREFIX + "/sudo-commands",
-        },
-        {
-          name: sudocmd,
-          url: URL_PREFIX + "/sudo-commands/" + sudocmd,
-          isActive: true,
-        },
-      ];
-      setBreadcrumbItems(currentPath);
-      setActiveTabKey("settings");
-      dispatch(updateBreadCrumbPath(currentPath));
-    }
+    // Update breadcrumb route
+    const currentPath: BreadCrumbItem[] = [
+      {
+        name: "Sudo commands",
+        url: URL_PREFIX + "/sudo-commands",
+      },
+      {
+        name: sudocmd,
+        url: URL_PREFIX + "/sudo-commands/" + sudocmd,
+        isActive: true,
+      },
+    ];
+    setBreadcrumbItems(currentPath);
+    setActiveTabKey("settings");
+    dispatch(updateBreadCrumbPath(currentPath));
   }, [sudocmd]);
 
   // Redirect to the settings page if the section is not defined

--- a/src/pages/SudoRules/SudoRulesTabs.tsx
+++ b/src/pages/SudoRules/SudoRulesTabs.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router";
+import { useNavigate } from "react-router";
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 // Layouts
 import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
@@ -16,14 +16,15 @@ import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
 import { NotFound } from "src/components/errors/PageErrors";
 import SudoRulesSettings from "./SudoRulesSettings";
 import { partialSudoRuleToSudoRule } from "src/utils/sudoRulesUtils";
+import { CnParams, useSafeParams } from "src/utils/paramsUtils";
 
 // eslint-disable-next-line react/prop-types
 const SudoRulesTabs = ({ section }) => {
   // Get location (React Router DOM) and get state data
-  const { cn } = useParams();
+  const { cn } = useSafeParams<CnParams>(["cn"]);
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
-  const settingsData = useSudoRuleSettings(cn as string);
+  const settingsData = useSudoRuleSettings(cn);
 
   const [breadcrumbItems, setBreadcrumbItems] = React.useState<
     BreadCrumbItem[]
@@ -42,26 +43,21 @@ const SudoRulesTabs = ({ section }) => {
   };
 
   React.useEffect(() => {
-    if (!cn) {
-      // Redirect to the main page
-      navigate("/sudo-rules");
-    } else {
-      // Update breadcrumb route
-      const currentPath: BreadCrumbItem[] = [
-        {
-          name: "Sudo rules",
-          url: URL_PREFIX + "/sudo-rules",
-        },
-        {
-          name: cn,
-          url: URL_PREFIX + "/sudo-rules/" + cn,
-          isActive: true,
-        },
-      ];
-      setBreadcrumbItems(currentPath);
-      setActiveTabKey("settings");
-      dispatch(updateBreadCrumbPath(currentPath));
-    }
+    // Update breadcrumb route
+    const currentPath: BreadCrumbItem[] = [
+      {
+        name: "Sudo rules",
+        url: URL_PREFIX + "/sudo-rules",
+      },
+      {
+        name: cn,
+        url: URL_PREFIX + "/sudo-rules/" + cn,
+        isActive: true,
+      },
+    ];
+    setBreadcrumbItems(currentPath);
+    setActiveTabKey("settings");
+    dispatch(updateBreadCrumbPath(currentPath));
   }, [cn]);
 
   // Redirect to the settings page if the section is not defined

--- a/src/pages/UserGroups/UserGroupsTabs.tsx
+++ b/src/pages/UserGroups/UserGroupsTabs.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router";
+import { useNavigate } from "react-router";
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 // Layouts
 import TitleLayout from "src/components/layouts/TitleLayout";
@@ -20,10 +20,11 @@ import { NotFound } from "src/components/errors/PageErrors";
 // Redux
 import { useAppDispatch } from "src/store/hooks";
 import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
+import { CnParams, useSafeParams } from "src/utils/paramsUtils";
 
 // eslint-disable-next-line react/prop-types
 const UserGroupsTabs = ({ section }) => {
-  const { cn } = useParams();
+  const { cn } = useSafeParams<CnParams>(["cn"]);
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
   const [breadcrumbItems, setBreadcrumbItems] = React.useState<
@@ -32,7 +33,7 @@ const UserGroupsTabs = ({ section }) => {
 
   const [groupId, setGroupId] = useState("");
 
-  const userGroupSettingsData = useUserGroupSettings(cn as string);
+  const userGroupSettingsData = useUserGroupSettings(cn);
 
   // Tab
   const [activeTabKey, setActiveTabKey] = useState(section);
@@ -53,27 +54,22 @@ const UserGroupsTabs = ({ section }) => {
   };
 
   React.useEffect(() => {
-    if (!cn) {
-      // Redirect to the main page
-      navigate("/user-groups");
-    } else {
-      setGroupId(cn);
-      // Update breadcrumb route
-      const currentPath: BreadCrumbItem[] = [
-        {
-          name: "User groups",
-          url: URL_PREFIX + "/user-groups",
-        },
-        {
-          name: cn,
-          url: URL_PREFIX + "/user-groups/" + cn,
-          isActive: true,
-        },
-      ];
-      setBreadcrumbItems(currentPath);
-      setActiveTabKey("settings");
-      dispatch(updateBreadCrumbPath(currentPath));
-    }
+    setGroupId(cn);
+    // Update breadcrumb route
+    const currentPath: BreadCrumbItem[] = [
+      {
+        name: "User groups",
+        url: URL_PREFIX + "/user-groups",
+      },
+      {
+        name: cn,
+        url: URL_PREFIX + "/user-groups/" + cn,
+        isActive: true,
+      },
+    ];
+    setBreadcrumbItems(currentPath);
+    setActiveTabKey("settings");
+    dispatch(updateBreadCrumbPath(currentPath));
   }, [cn]);
 
   // Redirect to the settings page if the section is not defined

--- a/src/utils/invariants.ts
+++ b/src/utils/invariants.ts
@@ -1,0 +1,46 @@
+import { Params } from "react-router";
+import invariant from "tiny-invariant";
+
+type Must<T> = {
+  [P in keyof T]-?: NonNullable<T[P]>;
+};
+
+export type TupleUnion<U extends PropertyKey> = {
+  [S in U]: Exclude<U, S> extends never // for each variant in the union, remove it and..
+    ? [S] // ..stop recursion if it was the last variant
+    : [...TupleUnion<Exclude<U, S>>, S]; // ..recur if not
+}[U]; // extract all values from the object
+
+// https://catchts.com/union-array
+export function invariantNonNullable<T>(
+  value: Readonly<Partial<T> | Params<string>>,
+  properties: TupleUnion<keyof T>
+): asserts value is Must<T> {
+  invariant(
+    value !== undefined && value !== null,
+    "Value is null or undefined"
+  );
+
+  const objectKeys = Object.keys(value);
+
+  invariant(
+    objectKeys.length === properties.length,
+    "Value does not have all properties"
+  );
+
+  invariant(
+    // Keys of objects are always strings, the object is basically Object.keys()
+    objectKeys.every((k) => (properties as TupleUnion<string>).includes(k)),
+    "Value does not have all properties"
+  );
+  if (typeof value === "object") {
+    Object.entries(value).forEach(([k, v]) => {
+      invariant(
+        v !== undefined && v !== null,
+        `Value ${k} is null or undefined`
+      );
+    });
+  }
+}
+
+export { invariant };

--- a/src/utils/paramsUtils.ts
+++ b/src/utils/paramsUtils.ts
@@ -1,0 +1,20 @@
+import { useParams } from "react-router";
+import { invariantNonNullable, TupleUnion } from "./invariants";
+
+export type UidParams = {
+  uid: string;
+};
+
+export type CnParams = {
+  cn: string;
+};
+
+type Params = Record<string, string | undefined>;
+
+export const useSafeParams = <T extends Params>(
+  validation: TupleUnion<keyof T>
+) => {
+  const params = useParams<T>();
+  invariantNonNullable(params, validation);
+  return params;
+};


### PR DESCRIPTION
Replaces useParams, which may include string | undefined with an invariant, that ensures the params must be set.
I might have gone a little bit overboard with the TypeScript magic.

## Summary by Sourcery

Enforce non-null route parameters by introducing a typed useSafeParams hook backed by tiny-invariant and remove redundant undefined checks and type assertions across numerous page components.

Enhancements:
- Add useSafeParams hook in paramsUtils for type-safe route parameters
- Introduce invariantNonNullable util and tiny-invariant dependency to assert parameter presence
- Refactor page and tab components to replace useParams with useSafeParams<T> and remove fallback guards and casts

Build:
- Add tiny-invariant library dependency