### PR TITLE
Replace install with clean-install

### DIFF
--- a/.github/workflows/gating.yml
+++ b/.github/workflows/gating.yml
@@ -37,7 +37,7 @@ jobs:
           restore-keys: npm-
 
       - name: Install project
-        run: npm install
+        run: npm clean-install
 
       - name: Prettier
         run: npm run prettier
@@ -61,7 +61,7 @@ jobs:
           node-version: "22"
 
       - name: Install project
-        run: npm install
+        run: npm clean-install
 
       - name: Run vitest
         run: npm test

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -21,7 +21,7 @@ jobs:
           node-version: "22"
 
       - name: Install dependencies
-        run: npm install
+        run: npm clean-install
 
       - name: Add IPA Server's IP to /etc/hosts
         run: cat developer/hosts | sudo tee -a /etc/hosts

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,8 +8,8 @@ EXTRA_DIST =		\
 
 install-exec-local:
 	## We don't want to run this code in prci, prci runs those commands before make install
-	test -d "dist" || npm install
-	test -d "dist" || ( npm run build && rm -rf node_modules && npm install --omit=dev )
+	test -d "dist" || npm clean-install
+	test -d "dist" || ( npm run build && rm -rf node_modules && npm clean-install --omit=dev )
 	mkdir -p "$(DESTDIR)$(appdir)"
 	cp -p "dist/index.html" "$(DESTDIR)$(appdir)/index.html"
 	mkdir -p "$(licensedir)"
@@ -17,9 +17,9 @@ install-exec-local:
 	cp -rp "dist/assets" "$(DESTDIR)$(appdir)/assets"
 
 dist-hook:
-	npm install
+	npm clean-install
 	## We need to build, but we only want the distributable dependencies in the .src.rpm
-	npm run build && rm -rf node_modules && npm install --omit=dev
+	npm run build && rm -rf node_modules && npm clean-install --omit=dev
 	cp -r "." "$(distdir)/"
 
 clean-local:


### PR DESCRIPTION
Should fix all CI runs, install fails due to different architecture.

## Summary by Sourcery

Switch dependency installation to npm clean-install across build scripts and GitHub workflows to ensure clean installs and fix CI failures

Bug Fixes:
- Fix CI install failures caused by architecture mismatches by using clean-install

Build:
- Replace npm install with npm clean-install in Makefile.am targets

CI:
- Update GitHub Actions workflows to use npm clean-install instead of npm install