### PR TITLE
Automember > user groups tests

### DIFF
--- a/cypress/e2e/automember/automember_user_group.feature
+++ b/cypress/e2e/automember/automember_user_group.feature
@@ -1,0 +1,45 @@
+Feature: Automember user group management
+
+    @seed
+    Scenario: Create new user group
+        Given user group "my_automember_usergroup" exists
+
+    @test
+    Scenario: Create new user group rule
+        Given I am logged in as admin
+        And I am on "user-group-rules" page
+
+        When I create user group rule based on user group "my_automember_usergroup"
+        Then I should see user group rule "my_automember_usergroup" in the user group rule table
+
+    @test
+    Scenario: Set default user group rule
+        Given I am logged in as admin
+        And I am on "user-group-rules" page
+
+        When I set default user group rule "my_automember_usergroup"
+        Then I should see user group rule "my_automember_usergroup" as the default user group rule
+
+    @cleanup
+    Scenario: Delete user group rule
+        Given I delete user group rule "my_automember_usergroup"
+
+    @cleanup
+    Scenario: Delete user group
+        Given I delete user group "my_automember_usergroup"
+
+    @seed
+    Scenario: Create new automember user group
+        Given user group rule "my_automember_usergroup" exists
+
+    @test
+    Scenario: Delete automember user group rule
+        Given I am logged in as admin
+        And I am on "user-group-rules" page
+        When I try to delete user group rule "my_automember_usergroup"
+        Then I should not see user group rule "my_automember_usergroup" in the user group rule table
+
+    @cleanup
+    Scenario: Delete user group
+        Given I delete user group "my_automember_usergroup"
+

--- a/cypress/e2e/automember/automember_user_group.ts
+++ b/cypress/e2e/automember/automember_user_group.ts
@@ -1,0 +1,134 @@
+import { When, Then, Given } from "@badeball/cypress-cucumber-preprocessor";
+import {
+  entryDoesNotExist,
+  entryExists,
+  searchForEntry,
+  selectEntry,
+  validateEntry,
+} from "../common/data_tables";
+import "../user_groups/user_groups";
+import "../common/data_tables";
+import { navigateTo } from "../common/navigation";
+import { loginAsAdmin, logout } from "../common/authentication";
+import { isOptionSelected, selectOption } from "../common/ui/select";
+
+export const fillUserGroupRule = (userGroupName: string, selector: string) => {
+  selectOption(userGroupName, selector);
+  isOptionSelected(userGroupName, selector);
+};
+
+export const createUserGroupRule = (userGroupName: string) => {
+  cy.dataCy("auto-member-user-rules-button-add").click();
+  cy.dataCy("add-rule-modal").should("exist");
+
+  fillUserGroupRule(userGroupName, "modal-select-automember");
+
+  cy.dataCy("modal-button-add").click();
+  cy.dataCy("add-rule-modal").should("not.exist");
+  searchForEntry(userGroupName);
+  entryExists(userGroupName);
+};
+
+export const deleteUserGroupRule = (userGroupName: string) => {
+  selectEntry(userGroupName);
+
+  cy.dataCy("auto-member-user-rules-button-delete").click();
+  cy.dataCy("delete-rule-modal").should("exist");
+
+  cy.dataCy("modal-button-delete").click();
+  cy.dataCy("delete-rule-modal").should("not.exist");
+
+  searchForEntry(userGroupName);
+  entryDoesNotExist(userGroupName);
+  cy.dataCy("delete-rule-success").should("exist");
+};
+
+export const setDefaultUserGroupRule = (userGroupName: string) => {
+  cy.dataCy("typeahead-select-toggle").click();
+  cy.dataCy("typeahead-select-" + userGroupName).click();
+  cy.dataCy("auto-member-default-user-rules-modal").should("exist");
+
+  cy.dataCy("modal-button-ok").click();
+  cy.dataCy("auto-member-default-user-rules-modal").should("not.exist");
+  cy.get("[data-cy='typeahead-select-input'] input").should(
+    "have.value",
+    userGroupName
+  );
+  cy.dataCy("default-group-success").should("exist");
+};
+
+Given("user group rule {string} exists", (userGroupName: string) => {
+  loginAsAdmin();
+  navigateTo("user-groups");
+
+  cy.dataCy("user-groups-button-add").click();
+  cy.dataCy("add-user-group-modal").should("exist");
+
+  cy.dataCy("modal-textbox-group-name").type(userGroupName);
+  cy.dataCy("modal-textbox-group-name").should("have.value", userGroupName);
+
+  cy.dataCy("modal-button-add").click();
+  cy.dataCy("add-user-group-modal").should("not.exist");
+  searchForEntry(userGroupName);
+  entryExists(userGroupName);
+
+  navigateTo("user-group-rules");
+  createUserGroupRule(userGroupName);
+
+  searchForEntry(userGroupName);
+  entryExists(userGroupName);
+  logout();
+});
+
+When(
+  "I create user group rule based on user group {string}",
+  (userGroupName: string) => {
+    createUserGroupRule(userGroupName);
+  }
+);
+
+Then(
+  "I should see user group rule {string} in the user group rule table",
+  (userGroupName: string) => {
+    validateEntry(userGroupName);
+  }
+);
+
+Then(
+  "I should see user group rule {string} as the default user group rule",
+  (userGroupName: string) => {
+    cy.dataCy("typeahead-select-input")
+      .find("input")
+      .should("have.value", userGroupName);
+  }
+);
+
+Then(
+  "I should not see user group rule {string} in the user group rule table",
+  (userGroupName: string) => {
+    searchForEntry(userGroupName);
+    entryDoesNotExist(userGroupName);
+  }
+);
+
+Given("I delete user group rule {string}", (userGroupName: string) => {
+  loginAsAdmin();
+  navigateTo("user-group-rules");
+
+  deleteUserGroupRule(userGroupName);
+
+  searchForEntry(userGroupName);
+  entryDoesNotExist(userGroupName);
+  logout();
+});
+
+When("I try to delete user group rule {string}", (userGroupName: string) => {
+  navigateTo("user-group-rules");
+  deleteUserGroupRule(userGroupName);
+  searchForEntry(userGroupName);
+  entryDoesNotExist(userGroupName);
+});
+
+When("I set default user group rule {string}", (userGroupName: string) => {
+  setDefaultUserGroupRule(userGroupName);
+});

--- a/src/components/TypeAheadSelect.tsx
+++ b/src/components/TypeAheadSelect.tsx
@@ -235,7 +235,7 @@ const TypeAheadSelect = (props: PropsToTypeAheadSelect) => {
       onClick={onToggleClick}
       isExpanded={isOpen}
       isFullWidth
-      data-cy="typeahead-select-toggle"
+      data-cy={"typeahead-select-toggle"}
     >
       <TextInputGroup isPlain>
         <TextInputGroupMain
@@ -244,7 +244,7 @@ const TypeAheadSelect = (props: PropsToTypeAheadSelect) => {
           onChange={onTextInputChange}
           onKeyDown={onInputKeyDown}
           id="typeahead-select-input"
-          data-cy="typeahead-select-input"
+          data-cy={"typeahead-select-input"}
           autoComplete="off"
           innerRef={textInputRef}
           placeholder={props.placeholder || ""}

--- a/src/components/modals/Automember/AddRule.tsx
+++ b/src/components/modals/Automember/AddRule.tsx
@@ -224,7 +224,7 @@ const AddRule = (props: PropsToAddRule) => {
 
   const modalActions = [
     <SecondaryButton
-      dataCy="modal-button-add"
+      dataCy={"modal-button-add"}
       key="add"
       onClickHandler={onAdd}
       isLoading={addSpinning}
@@ -235,7 +235,7 @@ const AddRule = (props: PropsToAddRule) => {
       Add
     </SecondaryButton>,
     <SecondaryButton
-      dataCy="modal-button-add-and-add-another"
+      dataCy={"modal-button-add-and-add-another"}
       key="add-another"
       onClickHandler={onAddAndAddAnother}
       isLoading={addAgainSpinning}
@@ -246,7 +246,7 @@ const AddRule = (props: PropsToAddRule) => {
       Add and add another
     </SecondaryButton>,
     <Button
-      data-cy="modal-button-cancel"
+      data-cy={"modal-button-cancel"}
       key="cancel-new-rule"
       variant="link"
       onClick={cleanAndCloseModal}
@@ -260,7 +260,7 @@ const AddRule = (props: PropsToAddRule) => {
     <>
       <alerts.ManagedAlerts />
       <ModalWithFormLayout
-        dataCy="add-rule-modal"
+        dataCy={"add-rule-modal"}
         variantType="small"
         modalPosition="top"
         offPosition="76px"

--- a/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
+++ b/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
@@ -513,7 +513,7 @@ const AutoMemUserRules = () => {
       key: 1,
       element: (
         <SearchInputLayout
-          dataCy="search"
+          dataCy={"search"}
           name="search"
           ariaLabel="Search rules"
           placeholder="Search"
@@ -533,7 +533,7 @@ const AutoMemUserRules = () => {
           selected={defaultGroup}
           placeholder="Default user group"
           onSelectedChange={onShowDefaultGroupOnModal}
-          dataCy="auto-member-user-rules-typeahead-select"
+          dataCy={"auto-member-user-rules-typeahead-select"}
         />
       ),
     },
@@ -545,7 +545,7 @@ const AutoMemUserRules = () => {
       key: 4,
       element: (
         <SecondaryButton
-          dataCy="auto-member-user-rules-button-refresh"
+          dataCy={"auto-member-user-rules-button-refresh"}
           onClickHandler={refreshData}
           isDisabled={!showTableRows}
         >
@@ -557,7 +557,7 @@ const AutoMemUserRules = () => {
       key: 5,
       element: (
         <SecondaryButton
-          dataCy="auto-member-user-rules-button-delete"
+          dataCy={"auto-member-user-rules-button-delete"}
           isDisabled={isDeleteButtonDisabled || !showTableRows}
           onClickHandler={onOpenDeleteModal}
         >
@@ -569,7 +569,7 @@ const AutoMemUserRules = () => {
       key: 6,
       element: (
         <SecondaryButton
-          dataCy="auto-member-user-rules-button-add"
+          dataCy={"auto-member-user-rules-button-add"}
           isDisabled={!showTableRows}
           onClickHandler={onOpenAddModal}
         >
@@ -663,7 +663,7 @@ const AutoMemUserRules = () => {
         ruleType="group"
       />
       <ConfirmationModal
-        dataCy="auto-member-default-user-rules-modal"
+        dataCy={"auto-member-default-user-rules-modal"}
         title="Default user group"
         isOpen={showChangeConfirmationModal}
         onClose={onCloseConfirmationModal}


### PR DESCRIPTION
The tests must cover all the use-cases found in the 'Automember' > 'User groups' page.

## Summary by Sourcery

Add comprehensive Cypress Cucumber end-to-end tests for Automember user group and user group rule management and update components with consistent dataCy selectors

Enhancements:
- Standardize dataCy and data-cy prop syntax in AutoMemUserRules, AddRule, and TypeAheadSelect components for reliable test selection

Tests:
- Introduce Cypress step definitions and fixture utilities for Automember user group flows
- Add Cucumber feature file and scenarios covering create, list, default selection, and deletion of user groups and user group rules