### PR TITLE
react-router-dom => react-router

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,7 @@
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-redux": "^9.2.0",
-        "react-router": "^7.6.2",
-        "react-router-dom": "^7.6.2"
+        "react-router": "^7.6.2"
       },
       "devDependencies": {
         "@badeball/cypress-cucumber-preprocessor": "^22.1.0",
@@ -33,7 +32,6 @@
         "@types/node": "^22.13.17",
         "@types/react": "^18.0.0",
         "@types/react-dom": "^18.1.1",
-        "@types/react-router-dom": "^5.3.3",
         "@typescript-eslint/eslint-plugin": "^8.34.0",
         "@typescript-eslint/parser": "^8.34.0",
         "@vitejs/plugin-react": "^5.0.4",
@@ -2302,11 +2300,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/history": {
-      "version": "4.7.11",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "dev": true,
@@ -2345,25 +2338,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
-      }
-    },
-    "node_modules/@types/react-router": {
-      "version": "5.1.20",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*"
-      }
-    },
-    "node_modules/@types/react-router-dom": {
-      "version": "5.3.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router": "*"
       }
     },
     "node_modules/@types/sinonjs__fake-timers": {
@@ -8972,42 +8946,6 @@
       "version": "7.9.3",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.3.tgz",
       "integrity": "sha512-4o2iWCFIwhI/eYAIL43+cjORXYn/aRQPgtFRRZb3VzoyQ5Uej0Bmqj7437L97N9NJW4wnicSwLOLS+yCXfAPgg==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.6.2",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/react-router-dom/node_modules/react-router": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.2.tgz",
-      "integrity": "sha512-U7Nv3y+bMimgWjhlT5CRdzHPu2/KVmqPwKUCChW8en5P3znxUqwlYFlbmyj8Rgp1SF6zs5X4+77kBVknkg6a0w==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-redux": "^9.2.0",
-    "react-router": "^7.6.2",
-    "react-router-dom": "^7.6.2"
+    "react-router": "^7.6.2"
   },
   "scripts": {
     "dev": "npm run dev:prepare && vite",
@@ -47,7 +46,6 @@
     "@types/node": "^22.13.17",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.1.1",
-    "@types/react-router-dom": "^5.3.3",
     "@typescript-eslint/eslint-plugin": "^8.34.0",
     "@typescript-eslint/parser": "^8.34.0",
     "@vitejs/plugin-react": "^5.0.4",

--- a/src/components/Form/IpaTextContent/IpaTextContent.test.tsx
+++ b/src/components/Form/IpaTextContent/IpaTextContent.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, act, cleanup } from "@testing-library/react";
 import { describe, it, expect, afterEach } from "vitest";
 // Component
 import IpaTextContent, { IpaTextContentProps } from "./IpaTextContent";
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter } from "react-router";
 
 describe("IpaTextContent Component", () => {
   const mockMetadata = {

--- a/src/components/Form/IpaTextContent/IpaTextContent.tsx
+++ b/src/components/Form/IpaTextContent/IpaTextContent.tsx
@@ -8,7 +8,7 @@ import {
   convertToString,
 } from "src/utils/ipaObjectUtils";
 // React Router DOM
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 export interface IpaTextContentProps extends IPAParamDefinition {
   dataCy: string;

--- a/src/components/MemberOf/MemberOfSubIds.tsx
+++ b/src/components/MemberOf/MemberOfSubIds.tsx
@@ -16,7 +16,7 @@ import {
 // Utils
 import { API_VERSION_BACKUP, paginate } from "src/utils/utils";
 // React Router DOM
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 interface MemberOfSubIdsProps {
   user: Partial<User>;

--- a/src/components/UsersSections/UserSettings.tsx
+++ b/src/components/UsersSections/UserSettings.tsx
@@ -57,7 +57,7 @@ import RestorePreservedUsers from "src/components/modals/UserModals/RestorePrese
 // Utils
 import { API_VERSION_BACKUP } from "src/utils/utils";
 // Navigate
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 export interface PropsToUserSettings {
   originalUser: Partial<User>;

--- a/src/components/modals/CertificateMapping/DeleteRuleModal.tsx
+++ b/src/components/modals/CertificateMapping/DeleteRuleModal.tsx
@@ -7,7 +7,7 @@ import useAlerts from "src/hooks/useAlerts";
 import { useCertMapRuleDeleteMutation } from "src/services/rpcCertMapping";
 import ConfirmationModal from "../ConfirmationModal";
 // React router
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 interface DeleteRuleModalProps {
   isOpen: boolean;

--- a/src/components/modals/DnsZones/DeleteDnsZonesModal.tsx
+++ b/src/components/modals/DnsZones/DeleteDnsZonesModal.tsx
@@ -15,7 +15,7 @@ import { DNSZone, ErrorData } from "src/utils/datatypes/globalDataTypes";
 import { BatchRPCResponse } from "src/services/rpc";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 // Reacr Router
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 // Components
 import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
 import DeletedElementsTable from "src/components/tables/DeletedElementsTable";

--- a/src/components/modals/UserModals/DeleteUsers.tsx
+++ b/src/components/modals/UserModals/DeleteUsers.tsx
@@ -30,7 +30,7 @@ import { ErrorData, User } from "src/utils/datatypes/globalDataTypes";
 // Hooks
 import useAlerts from "src/hooks/useAlerts";
 // Routing
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 interface ButtonsData {
   updateIsDeleteButtonDisabled?: (value: boolean) => void;

--- a/src/components/tables/KeytabTable.tsx
+++ b/src/components/tables/KeytabTable.tsx
@@ -17,7 +17,7 @@ import {
   UserGroup,
 } from "src/utils/datatypes/globalDataTypes";
 // React Router DOM
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 // Utils
 import { API_VERSION_BACKUP } from "src/utils/utils";
 // RPC

--- a/src/components/tables/KeytabTableWithFilter.tsx
+++ b/src/components/tables/KeytabTableWithFilter.tsx
@@ -2,7 +2,7 @@ import React from "react";
 // PatternFly
 import { Td, Th, Tr } from "@patternfly/react-table";
 // React Router DOM
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 // Layout
 import DualListLayout, {
   DualListTarget,

--- a/src/components/tables/MainTable.tsx
+++ b/src/components/tables/MainTable.tsx
@@ -6,7 +6,7 @@ import TableLayout from "../layouts/TableLayout";
 // Layouts
 import SkeletonOnTableLayout from "../layouts/Skeleton/SkeletonOnTableLayout";
 // React router DOM
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import EmptyBodyTable from "./EmptyBodyTable";
 // Icons
 import { CheckIcon, MinusIcon } from "@patternfly/react-icons";

--- a/src/components/tables/MembershipTable.tsx
+++ b/src/components/tables/MembershipTable.tsx
@@ -26,7 +26,7 @@ import { parseEmptyString } from "src/utils/utils";
 import { CheckIcon } from "@patternfly/react-icons";
 import { MinusIcon } from "@patternfly/react-icons";
 // React Router DOM
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 type EntryDataTypes =
   | HBACRule

--- a/src/components/tables/UsersTable.tsx
+++ b/src/components/tables/UsersTable.tsx
@@ -10,7 +10,7 @@ import SkeletonOnTableLayout from "src/components/layouts/Skeleton/SkeletonOnTab
 // Utils
 import { checkEqualStatus } from "src/utils/utils";
 // React Router DOM
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 // Icons
 import { CheckIcon } from "@patternfly/react-icons";
 import { MinusIcon } from "@patternfly/react-icons";

--- a/src/hooks/useDnsRecordsData.tsx
+++ b/src/hooks/useDnsRecordsData.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 // Routing
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 // RPC
 import { useGetObjectMetadataQuery } from "src/services/rpc";
 import { useShowDnsRecordQuery } from "src/services/rpcDnsZones";

--- a/src/hooks/useListPageSearchParams.tsx
+++ b/src/hooks/useListPageSearchParams.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 import { MembershipDirection } from "src/components/MemberOf/MemberOfToolbar";
 
 const useListPageSearchParams = () => {

--- a/src/login/LoginMainPage.tsx
+++ b/src/login/LoginMainPage.tsx
@@ -33,8 +33,8 @@ import {
 import { useAppDispatch } from "src/store/hooks";
 import { setIsLogin } from "src/store/Global/auth-slice";
 // Navigation
-import { useLocation, useNavigate } from "react-router-dom";
-import { Link } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router";
+import { Link } from "react-router";
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 
 interface StateFromSyncOtpPage {

--- a/src/login/ResetPasswordPage.tsx
+++ b/src/login/ResetPasswordPage.tsx
@@ -25,7 +25,7 @@ import {
 import useAlerts from "src/hooks/useAlerts";
 // Components
 import PasswordInput from "src/components/layouts/PasswordInput";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router";
 
 const ResetPasswordPage = () => {
   // Get user Id

--- a/src/login/SyncOtpPage.tsx
+++ b/src/login/SyncOtpPage.tsx
@@ -21,7 +21,7 @@ import {
   useSyncOtpMutation,
 } from "src/services/rpcAuth";
 // React router DOM
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 // Components
 import PasswordInput from "src/components/layouts/PasswordInput";
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./main.css";
 // react router dom
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter } from "react-router";
 // Redux
 import store from "./store/store";
 import { Provider } from "react-redux";

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import * as React from "react";
 // React router dom
-import { Navigate, Route, Routes } from "react-router-dom";
+import { Navigate, Route, Routes } from "react-router";
 import { NotFound } from "src/components/errors/PageErrors";
 // Layouts
 import DataSpinner from "src/components/layouts/DataSpinner";

--- a/src/navigation/Nav.tsx
+++ b/src/navigation/Nav.tsx
@@ -1,6 +1,6 @@
 import { Nav, NavExpandable, NavItem, NavList } from "@patternfly/react-core";
 import React from "react";
-import { NavLink } from "react-router-dom";
+import { NavLink } from "react-router";
 // Navigation (PatternFly)
 import { navigationRoutes } from "./NavRoutes";
 // Redux

--- a/src/pages/ActiveUsers/ActiveUsersTabs.tsx
+++ b/src/pages/ActiveUsers/ActiveUsersTabs.tsx
@@ -10,7 +10,7 @@ import {
   TabTitleText,
 } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 // Components
 import UserSettings from "src/components/UsersSections/UserSettings";
 import UserMemberOf from "./UserMemberOf";

--- a/src/pages/ActiveUsers/UserMemberOf.tsx
+++ b/src/pages/ActiveUsers/UserMemberOf.tsx
@@ -17,7 +17,7 @@ import { useGetUserByUidQuery } from "src/services/rpcUsers";
 // Utils
 import { convertToString } from "src/utils/ipaObjectUtils";
 // Navigation
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 // Hooks
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 

--- a/src/pages/AutoMemUserRules/AutoMemRulesTabs.tsx
+++ b/src/pages/AutoMemUserRules/AutoMemRulesTabs.tsx
@@ -2,7 +2,7 @@ import React from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 // Components
 import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
 import TitleLayout from "src/components/layouts/TitleLayout";

--- a/src/pages/AutoMemUserRules/AutomemRulesTable.tsx
+++ b/src/pages/AutoMemUserRules/AutomemRulesTable.tsx
@@ -7,7 +7,7 @@ import TableLayout from "../../components/layouts/TableLayout";
 import SkeletonOnTableLayout from "../../components/layouts/Skeleton/SkeletonOnTableLayout";
 // Data types
 import { AutomemberEntry } from "src/utils/datatypes/globalDataTypes";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 interface ElementData {
   isElementSelectable: (element: AutomemberEntry) => boolean;

--- a/src/pages/CertificateMapping/CertificateMapping.tsx
+++ b/src/pages/CertificateMapping/CertificateMapping.tsx
@@ -29,7 +29,7 @@ import {
 import { isCertMapSelectable } from "src/utils/utils";
 import { apiToCertificateMapping } from "src/utils/certMappingUtils";
 // React router
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 // Components
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import { SerializedError } from "@reduxjs/toolkit";

--- a/src/pages/CertificateMapping/CertificateMappingTabs.tsx
+++ b/src/pages/CertificateMapping/CertificateMappingTabs.tsx
@@ -2,7 +2,7 @@ import React from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 // Navigation
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 import { NotFound } from "src/components/errors/PageErrors";

--- a/src/pages/DNSZones/DnsForwardZones.tsx
+++ b/src/pages/DNSZones/DnsForwardZones.tsx
@@ -28,7 +28,7 @@ import {
 // Utils
 import { isDnsForwardZoneSelectable } from "src/utils/utils";
 // React router
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 // Components
 import ToolbarLayout, {
   ToolbarItem,

--- a/src/pages/DNSZones/DnsResourceRecords.tsx
+++ b/src/pages/DNSZones/DnsResourceRecords.tsx
@@ -22,7 +22,7 @@ import {
   useSearchDnsRecordsEntriesMutation,
 } from "src/services/rpcDnsZones";
 // React router
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 // Utils
 import { isDnsRecordSelectable } from "src/utils/utils";
 // Hooks

--- a/src/pages/DNSZones/DnsResourceRecordsPreSettings.tsx
+++ b/src/pages/DNSZones/DnsResourceRecordsPreSettings.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 // React Router DOM
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 // Navigation
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 import { NotFound } from "src/components/errors/PageErrors";

--- a/src/pages/DNSZones/DnsServers.tsx
+++ b/src/pages/DNSZones/DnsServers.tsx
@@ -27,7 +27,7 @@ import {
   useSearchDnsServersEntriesMutation,
 } from "src/services/rpcDnsServers";
 // React router
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router";
 // Components
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import { SerializedError } from "@reduxjs/toolkit";

--- a/src/pages/DNSZones/DnsServersTabs.tsx
+++ b/src/pages/DNSZones/DnsServersTabs.tsx
@@ -2,7 +2,7 @@ import React from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 // Navigation
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 import { NotFound } from "src/components/errors/PageErrors";

--- a/src/pages/DNSZones/DnsZones.tsx
+++ b/src/pages/DNSZones/DnsZones.tsx
@@ -29,7 +29,7 @@ import {
 import { isDnsZoneSelectable } from "src/utils/utils";
 import { apiToDnsZone } from "src/utils/dnsZonesUtils";
 // React router
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 // Components
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import { SerializedError } from "@reduxjs/toolkit";

--- a/src/pages/DNSZones/DnsZonesTabs.tsx
+++ b/src/pages/DNSZones/DnsZonesTabs.tsx
@@ -2,7 +2,7 @@ import React from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 // Navigation
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 import { NotFound } from "src/components/errors/PageErrors";

--- a/src/pages/HBACRules/HBACRulesMemberTable.tsx
+++ b/src/pages/HBACRules/HBACRulesMemberTable.tsx
@@ -8,7 +8,7 @@ import RemoveHBACRuleMembersModal from "src/components/modals/HbacModals/RemoveH
 // Hooks
 import { useAlerts } from "../../hooks/useAlerts";
 // React Router DOM
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 // RPC
 import { ErrorResult } from "../../services/rpc";
 import {

--- a/src/pages/HBACRules/HBACRulesTable.tsx
+++ b/src/pages/HBACRules/HBACRulesTable.tsx
@@ -10,7 +10,7 @@ import { checkEqualStatusHbacRule } from "src/utils/utils";
 // Layouts
 import SkeletonOnTableLayout from "../../components/layouts/Skeleton/SkeletonOnTableLayout";
 // React Router DOM
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 interface RulesData {
   isHbacRuleSelectable: (rule: HBACRule) => boolean;

--- a/src/pages/HBACRules/HBACRulesTabs.tsx
+++ b/src/pages/HBACRules/HBACRulesTabs.tsx
@@ -2,7 +2,7 @@ import React from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 // Layouts
 import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";

--- a/src/pages/HBACServiceGroups/HBACServiceGroupsMembers.tsx
+++ b/src/pages/HBACServiceGroups/HBACServiceGroupsMembers.tsx
@@ -6,7 +6,7 @@ import { HBACServiceGroup } from "src/utils/datatypes/globalDataTypes";
 // Layouts
 import TabLayout from "src/components/layouts/TabLayout";
 // Navigation
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 // Hooks
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 // RPC

--- a/src/pages/HBACServiceGroups/HBACServiceGroupsTable.tsx
+++ b/src/pages/HBACServiceGroups/HBACServiceGroupsTable.tsx
@@ -8,7 +8,7 @@ import { HBACServiceGroup } from "../../utils/datatypes/globalDataTypes";
 // Layouts
 import SkeletonOnTableLayout from "../../components/layouts/Skeleton/SkeletonOnTableLayout";
 // React Router DOM
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 interface ServicesData {
   isHbacServiceSelectable: (service: HBACServiceGroup) => boolean;

--- a/src/pages/HBACServiceGroups/HBACServiceGroupsTabs.tsx
+++ b/src/pages/HBACServiceGroups/HBACServiceGroupsTabs.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 // Layouts
 import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";

--- a/src/pages/HBACServices/HBACServicesMemberOf.tsx
+++ b/src/pages/HBACServices/HBACServicesMemberOf.tsx
@@ -4,7 +4,7 @@ import { Badge, Tab, Tabs, TabTitleText } from "@patternfly/react-core";
 // Data types
 import { HBACService } from "src/utils/datatypes/globalDataTypes";
 // Navigation
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 // Layout
 import TabLayout from "src/components/layouts/TabLayout";
 // Hooks

--- a/src/pages/HBACServices/HBACServicesTable.tsx
+++ b/src/pages/HBACServices/HBACServicesTable.tsx
@@ -7,7 +7,7 @@ import TableLayout from "../../components/layouts/TableLayout";
 import { HBACService } from "../../utils/datatypes/globalDataTypes";
 // Layouts
 import SkeletonOnTableLayout from "../../components/layouts/Skeleton/SkeletonOnTableLayout";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 interface ServicesData {
   isHbacServiceSelectable: (service: HBACService) => boolean;

--- a/src/pages/HBACServices/HBACServicesTabs.tsx
+++ b/src/pages/HBACServices/HBACServicesTabs.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 // Layouts
 import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";

--- a/src/pages/HostGroups/HostGroupsMemberManagers.tsx
+++ b/src/pages/HostGroups/HostGroupsMemberManagers.tsx
@@ -6,7 +6,7 @@ import { HostGroup } from "src/utils/datatypes/globalDataTypes";
 // Layouts
 import TabLayout from "src/components/layouts/TabLayout";
 // Navigation
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 // Hooks
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 // RPC

--- a/src/pages/HostGroups/HostGroupsMemberOf.tsx
+++ b/src/pages/HostGroups/HostGroupsMemberOf.tsx
@@ -4,7 +4,7 @@ import { Badge, Tab, Tabs, TabTitleText } from "@patternfly/react-core";
 // Data types
 import { HostGroup } from "src/utils/datatypes/globalDataTypes";
 // Navigation
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 // Layout
 import TabLayout from "src/components/layouts/TabLayout";
 // Hooks

--- a/src/pages/HostGroups/HostGroupsMembers.tsx
+++ b/src/pages/HostGroups/HostGroupsMembers.tsx
@@ -7,7 +7,7 @@ import { MembershipDirection } from "src/components/MemberOf/MemberOfToolbar";
 // Layouts
 import TabLayout from "src/components/layouts/TabLayout";
 // Navigation
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 // Hooks
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 // RPC

--- a/src/pages/HostGroups/HostGroupsTable.tsx
+++ b/src/pages/HostGroups/HostGroupsTable.tsx
@@ -8,7 +8,7 @@ import { HostGroup } from "../../utils/datatypes/globalDataTypes";
 // Layouts
 import SkeletonOnTableLayout from "../../components/layouts/Skeleton/SkeletonOnTableLayout";
 // React Router DOM
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 interface GroupsData {
   isHostGroupSelectable: (group: HostGroup) => boolean;

--- a/src/pages/HostGroups/HostGroupsTabs.tsx
+++ b/src/pages/HostGroups/HostGroupsTabs.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 // Layouts
 import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";

--- a/src/pages/Hosts/HostsManagedBy.tsx
+++ b/src/pages/Hosts/HostsManagedBy.tsx
@@ -10,7 +10,7 @@ import useUpdateRoute from "src/hooks/useUpdateRoute";
 // RPC
 import { useGetHostByIdQuery } from "src/services/rpcHosts";
 // Navigation
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 // Layouts
 import TabLayout from "src/components/layouts/TabLayout";
 

--- a/src/pages/Hosts/HostsMemberOf.tsx
+++ b/src/pages/Hosts/HostsMemberOf.tsx
@@ -4,7 +4,7 @@ import { Badge, Tab, Tabs, TabTitleText } from "@patternfly/react-core";
 // Data types
 import { Host } from "src/utils/datatypes/globalDataTypes";
 // Navigation
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 // Layouts
 import TabLayout from "src/components/layouts/TabLayout";
 // Hooks

--- a/src/pages/Hosts/HostsTable.tsx
+++ b/src/pages/Hosts/HostsTable.tsx
@@ -8,7 +8,7 @@ import { Host } from "../../utils/datatypes/globalDataTypes";
 // Layouts
 import SkeletonOnTableLayout from "../../components/layouts/Skeleton/SkeletonOnTableLayout";
 // React Router DOM
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 interface HostsData {
   isHostSelectable: (host: Host) => boolean;

--- a/src/pages/Hosts/HostsTabs.tsx
+++ b/src/pages/Hosts/HostsTabs.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 // Components
 import HostsSettings from "./HostsSettings";
 import HostsMemberOf from "./HostsMemberOf";

--- a/src/pages/IDViews/IDViewsAppliedToTable.tsx
+++ b/src/pages/IDViews/IDViewsAppliedToTable.tsx
@@ -6,7 +6,7 @@ import TableLayout from "src/components/layouts/TableLayout";
 // Layouts
 import EmptyBodyTable from "src/components/tables/EmptyBodyTable";
 // React Router DOM
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 // Hooks
 import useShifting from "src/hooks/useShifting";
 

--- a/src/pages/IDViews/IDViewsOverrides.tsx
+++ b/src/pages/IDViews/IDViewsOverrides.tsx
@@ -4,7 +4,7 @@ import { Badge, Tab, Tabs, TabTitleText } from "@patternfly/react-core";
 // Data types
 import { IDView } from "src/utils/datatypes/globalDataTypes";
 // Navigation
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 // Layouts
 import TabLayout from "src/components/layouts/TabLayout";
 // Hooks

--- a/src/pages/IDViews/IDViewsTable.tsx
+++ b/src/pages/IDViews/IDViewsTable.tsx
@@ -8,7 +8,7 @@ import { IDView } from "../../utils/datatypes/globalDataTypes";
 // Layouts
 import SkeletonOnTableLayout from "../../components/layouts/Skeleton/SkeletonOnTableLayout";
 // React Router DOM
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 interface IDViewsData {
   isViewSelectable: (view: IDView) => boolean;

--- a/src/pages/IDViews/IDViewsTabs.tsx
+++ b/src/pages/IDViews/IDViewsTabs.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 // Layouts
 import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";

--- a/src/pages/IdPReferences/IdpReferencesTabs.tsx
+++ b/src/pages/IdPReferences/IdpReferencesTabs.tsx
@@ -2,7 +2,7 @@ import React from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 // Navigation
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 import { NotFound } from "src/components/errors/PageErrors";

--- a/src/pages/Netgroups/NetgroupsMemberOf.tsx
+++ b/src/pages/Netgroups/NetgroupsMemberOf.tsx
@@ -4,7 +4,7 @@ import { Badge, Tab, Tabs, TabTitleText } from "@patternfly/react-core";
 // Data types
 import { Netgroup } from "src/utils/datatypes/globalDataTypes";
 // Navigation
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 // Layout
 import TabLayout from "src/components/layouts/TabLayout";
 // Hooks

--- a/src/pages/Netgroups/NetgroupsMemberTable.tsx
+++ b/src/pages/Netgroups/NetgroupsMemberTable.tsx
@@ -20,7 +20,7 @@ import RemoveNetgroupMembersModal from "src/components/modals/RemoveNetgroupMemb
 // Hooks
 import { useAlerts } from "../../hooks/useAlerts";
 // React Router DOM
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { Netgroup } from "../../utils/datatypes/globalDataTypes";
 // RPC
 import { ErrorResult } from "../../services/rpc";

--- a/src/pages/Netgroups/NetgroupsMembers.tsx
+++ b/src/pages/Netgroups/NetgroupsMembers.tsx
@@ -7,7 +7,7 @@ import { MembershipDirection } from "src/components/MemberOf/MemberOfToolbar";
 // Layouts
 import TabLayout from "src/components/layouts/TabLayout";
 // Navigation
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 // Hooks
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 // RPC

--- a/src/pages/Netgroups/NetgroupsTable.tsx
+++ b/src/pages/Netgroups/NetgroupsTable.tsx
@@ -8,7 +8,7 @@ import { Netgroup } from "../../utils/datatypes/globalDataTypes";
 // Layouts
 import SkeletonOnTableLayout from "../../components/layouts/Skeleton/SkeletonOnTableLayout";
 // React Router DOM
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 interface GroupsData {
   isNetgroupSelectable: (group: Netgroup) => boolean;

--- a/src/pages/Netgroups/NetgroupsTabs.tsx
+++ b/src/pages/Netgroups/NetgroupsTabs.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 // Layouts
 import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";

--- a/src/pages/PasswordPolicies/PasswordPoliciesTabs.tsx
+++ b/src/pages/PasswordPolicies/PasswordPoliciesTabs.tsx
@@ -2,7 +2,7 @@ import React from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 // Navigation
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 import { NotFound } from "src/components/errors/PageErrors";

--- a/src/pages/PreservedUsers/PreservedUsersTabs.tsx
+++ b/src/pages/PreservedUsers/PreservedUsersTabs.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 // Components
 import UserSettings from "src/components/UsersSections/UserSettings";
 import DataSpinner from "src/components/layouts/DataSpinner";

--- a/src/pages/Services/ServicesMemberOf.tsx
+++ b/src/pages/Services/ServicesMemberOf.tsx
@@ -13,7 +13,7 @@ import { Service } from "src/utils/datatypes/globalDataTypes";
 import { useAppDispatch } from "src/store/hooks";
 import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
 // React Router DOM
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 // RPC
 import { useGetServiceByIdQuery } from "src/services/rpcServices";
 // Hooks

--- a/src/pages/Services/ServicesTable.tsx
+++ b/src/pages/Services/ServicesTable.tsx
@@ -8,7 +8,7 @@ import { Service } from "src/utils/datatypes/globalDataTypes";
 // Layouts
 import SkeletonOnTableLayout from "src/components/layouts/Skeleton/SkeletonOnTableLayout";
 // React Router DOM
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 interface ServicesData {
   isServiceSelectable: (service: Service) => boolean;

--- a/src/pages/Services/ServicesTabs.tsx
+++ b/src/pages/Services/ServicesTabs.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 // Components
 import ServicesSettings from "./ServicesSettings";
 import ServicesMemberOf from "./ServicesMemberOf";

--- a/src/pages/SetupBrowserConfig.tsx
+++ b/src/pages/SetupBrowserConfig.tsx
@@ -20,7 +20,7 @@ import HeaderLogo from "src/assets/images/header-logo-black.png";
 // Components
 import TitleLayout from "src/components/layouts/TitleLayout";
 //
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 const SetupBrowserConfig = () => {
   const [isFirefoxExpanded, setIsFirefoxExpanded] = React.useState(false);

--- a/src/pages/StageUsers/StageUsersTabs.tsx
+++ b/src/pages/StageUsers/StageUsersTabs.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 // Components
 import UserSettings from "src/components/UsersSections/UserSettings";
 import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";

--- a/src/pages/SubordinateIDs/SubIdsTabs.tsx
+++ b/src/pages/SubordinateIDs/SubIdsTabs.tsx
@@ -2,7 +2,7 @@ import React from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 // Navigation
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 import { NotFound } from "src/components/errors/PageErrors";

--- a/src/pages/SudoCmdGroups/SudoCmdGroupsMembers.tsx
+++ b/src/pages/SudoCmdGroups/SudoCmdGroupsMembers.tsx
@@ -6,7 +6,7 @@ import { SudoCmdGroup } from "src/utils/datatypes/globalDataTypes";
 // Layouts
 import TabLayout from "src/components/layouts/TabLayout";
 // Navigation
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 // Hooks
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 // RPC

--- a/src/pages/SudoCmdGroups/SudoCmdGroupsTable.tsx
+++ b/src/pages/SudoCmdGroups/SudoCmdGroupsTable.tsx
@@ -8,7 +8,7 @@ import { SudoCmdGroup } from "../../utils/datatypes/globalDataTypes";
 // Layouts
 import SkeletonOnTableLayout from "../../components/layouts/Skeleton/SkeletonOnTableLayout";
 // React Router DOM
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 interface CmdGroupsData {
   isSudoCmdGroupSelectable: (group: SudoCmdGroup) => boolean;

--- a/src/pages/SudoCmdGroups/SudoCmdGroupsTabs.tsx
+++ b/src/pages/SudoCmdGroups/SudoCmdGroupsTabs.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 // Layouts
 import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";

--- a/src/pages/SudoCmds/SudoCmdsMemberOf.tsx
+++ b/src/pages/SudoCmds/SudoCmdsMemberOf.tsx
@@ -4,7 +4,7 @@ import { Badge, Tab, Tabs, TabTitleText } from "@patternfly/react-core";
 // Data types
 import { SudoCmd } from "src/utils/datatypes/globalDataTypes";
 // Navigation
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 // Layout
 import TabLayout from "src/components/layouts/TabLayout";
 // Hooks

--- a/src/pages/SudoCmds/SudoCmdsTable.tsx
+++ b/src/pages/SudoCmds/SudoCmdsTable.tsx
@@ -8,7 +8,7 @@ import { SudoCmd } from "../../utils/datatypes/globalDataTypes";
 // Layouts
 import SkeletonOnTableLayout from "../../components/layouts/Skeleton/SkeletonOnTableLayout";
 // React Router DOM
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 interface CmdsData {
   isSudoCmdSelectable: (cmd: SudoCmd) => boolean;

--- a/src/pages/SudoCmds/SudoCmdsTabs.tsx
+++ b/src/pages/SudoCmds/SudoCmdsTabs.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 // Layouts
 import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";

--- a/src/pages/SudoRules/SudoRulesTable.tsx
+++ b/src/pages/SudoRules/SudoRulesTable.tsx
@@ -10,7 +10,7 @@ import { checkEqualStatusSudoRule } from "src/utils/utils";
 // Layouts
 import SkeletonOnTableLayout from "../../components/layouts/Skeleton/SkeletonOnTableLayout";
 // React Router DOM
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 interface RulesData {
   isSudoRuleSelectable: (rule: SudoRule) => boolean;

--- a/src/pages/SudoRules/SudoRulesTabs.tsx
+++ b/src/pages/SudoRules/SudoRulesTabs.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 // Layouts
 import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";

--- a/src/pages/UserGroups/UserGroupsMemberManagers.tsx
+++ b/src/pages/UserGroups/UserGroupsMemberManagers.tsx
@@ -6,7 +6,7 @@ import { UserGroup } from "src/utils/datatypes/globalDataTypes";
 // Layouts
 import TabLayout from "src/components/layouts/TabLayout";
 // Navigation
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 // Hooks
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 // RPC

--- a/src/pages/UserGroups/UserGroupsMemberOf.tsx
+++ b/src/pages/UserGroups/UserGroupsMemberOf.tsx
@@ -4,7 +4,7 @@ import { Badge, Tab, Tabs, TabTitleText } from "@patternfly/react-core";
 // Data types
 import { UserGroup } from "src/utils/datatypes/globalDataTypes";
 // Navigation
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 // Layout
 import TabLayout from "src/components/layouts/TabLayout";
 // Hooks

--- a/src/pages/UserGroups/UserGroupsMembers.tsx
+++ b/src/pages/UserGroups/UserGroupsMembers.tsx
@@ -7,7 +7,7 @@ import { MembershipDirection } from "src/components/MemberOf/MemberOfToolbar";
 // Layouts
 import TabLayout from "src/components/layouts/TabLayout";
 // Navigation
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 // Hooks
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 // RPC

--- a/src/pages/UserGroups/UserGroupsSettings.tsx
+++ b/src/pages/UserGroups/UserGroupsSettings.tsx
@@ -14,7 +14,7 @@ import {
 import ConfirmationModal from "../../components/modals/ConfirmationModal";
 // Forms
 import IpaTextArea from "../../components/Form/IpaTextArea";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 // Layouts
 import TitleLayout from "src/components/layouts/TitleLayout";
 import SecondaryButton from "src/components/layouts/SecondaryButton";

--- a/src/pages/UserGroups/UserGroupsTable.tsx
+++ b/src/pages/UserGroups/UserGroupsTable.tsx
@@ -8,7 +8,7 @@ import { UserGroup } from "../../utils/datatypes/globalDataTypes";
 // Layouts
 import SkeletonOnTableLayout from "../../components/layouts/Skeleton/SkeletonOnTableLayout";
 // React Router DOM
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 interface GroupsData {
   isUserGroupSelectable: (group: UserGroup) => boolean;

--- a/src/pages/UserGroups/UserGroupsTabs.tsx
+++ b/src/pages/UserGroups/UserGroupsTabs.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 // PatternFly
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 // React Router DOM
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 // Layouts
 import TitleLayout from "src/components/layouts/TitleLayout";


### PR DESCRIPTION
Since v7 react-router fully contains whatever react-router-dom provides. Simplifying the dependencies, by removing now useless react-router-dom.

## Summary by Sourcery

Consolidate routing dependencies by removing react-router-dom and refactoring imports to use react-router directly since v7 includes DOM support.

Enhancements:
- Simplify dependencies by removing the react-router-dom package and its types
- Refactor all imports from react-router-dom to react-router across the codebase

Build:
- Remove react-router-dom and @types/react-router-dom from package.json