### PR TITLE
Create Input with validation and input with helper text

### DIFF
--- a/src/components/AutomemberSections/InclusiveExclusiveSection.tsx
+++ b/src/components/AutomemberSections/InclusiveExclusiveSection.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 // Patternfly
 import { Td, Th, Tr } from "@patternfly/react-table";
-import { Button, TextInput } from "@patternfly/react-core";
+import { Button } from "@patternfly/react-core";
 // Hooks
 import useAlerts from "src/hooks/useAlerts";
 // RPC
@@ -16,6 +16,7 @@ import {
 import { Metadata } from "src/utils/datatypes/globalDataTypes";
 // Components
 import SettingsTableLayout from "../layouts/SettingsTableLayout";
+import InputRequiredText from "../layouts/InputRequiredText";
 import ModalWithFormLayout, { Field } from "../layouts/ModalWithFormLayout";
 import MemberOfDeleteModal from "../MemberOf/MemberOfDeleteModal";
 import DeletedElementsTable from "../tables/DeletedElementsTable";
@@ -334,11 +335,12 @@ const InclusiveExclusiveSection = (props: PropsToInclusiveExclusiveSection) => {
       name: "Expression",
       fieldRequired: true,
       pfComponent: (
-        <TextInput
-          data-cy="modal-textbox-expression"
+        <InputRequiredText
+          dataCy="modal-textbox-expression"
           id="expression"
+          name="expression"
           value={expression}
-          onChange={(_event, value: string) => setExpression(value)}
+          onChange={setExpression}
         />
       ),
     },

--- a/src/components/Form/IpaCertificateMappingData/IpaCertificateMappingData.test.tsx
+++ b/src/components/Form/IpaCertificateMappingData/IpaCertificateMappingData.test.tsx
@@ -139,6 +139,7 @@ describe("IpaCertificateMappingData", () => {
     await act(async () => {
       fireEvent.click(radioButtonsElems[1]);
     });
+    expect(radioButtonsElems[1]).toBeChecked();
 
     // Validate Issuer exists
     const issuerInputBox = screen.getByRole("textbox", {

--- a/src/components/IssuerAndSubjectOption.tsx
+++ b/src/components/IssuerAndSubjectOption.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 // PatternFly
-import { Form, FormGroup, Radio, TextInput } from "@patternfly/react-core";
+import { Form, FormGroup, Radio } from "@patternfly/react-core";
 // Components
 import PopoverWithIconLayout from "./layouts/PopoverWithIconLayout";
+import InputRequiredText from "./layouts/InputRequiredText";
 
 interface PropsToIssuerAndSubjectOption {
   isIssuerAndSubjectChecked: boolean;
@@ -73,16 +74,13 @@ const IssuerAndSubjectOption = (props: PropsToIssuerAndSubjectOption) => {
             isRequired={props.isIssuerAndSubjectChecked}
             name="issuer-formgroup"
           >
-            <TextInput
-              data-cy="modal-textbox-issuer"
+            <InputRequiredText
+              dataCy="modal-textbox-issuer"
               id="issuer"
+              name="issuer textbox"
               value={props.issuerValue}
-              type="text"
-              name="issuer"
-              aria-label="issuer textbox"
-              onChange={(_event, value: string) => onChangeIssuer(value)}
               isDisabled={!props.isIssuerAndSubjectChecked}
-              placeholder="O=EXAMPLE.ORG,CN=Issuer Example CA"
+              onChange={onChangeIssuer}
             />
           </FormGroup>
           <FormGroup
@@ -97,16 +95,13 @@ const IssuerAndSubjectOption = (props: PropsToIssuerAndSubjectOption) => {
             isRequired={props.isIssuerAndSubjectChecked}
             name="subject-formgroup"
           >
-            <TextInput
-              data-cy="modal-textbox-subject"
+            <InputRequiredText
+              dataCy="modal-textbox-subject"
               id="subject-textbox"
+              name="subject textbox"
               value={props.subjectValue}
-              type="text"
-              name="subject"
-              aria-label="subject textbox"
-              onChange={(_event, value: string) => onChangeSubject(value)}
               isDisabled={!props.isIssuerAndSubjectChecked}
-              placeholder="CN=Subject example,O=EXAMPLE.ORG"
+              onChange={onChangeSubject}
             />
           </FormGroup>
         </Form>

--- a/src/components/SudoRuleSections/SudoRuleOptions.tsx
+++ b/src/components/SudoRuleSections/SudoRuleOptions.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 // Patternfly
 import { Td, Th, Tr } from "@patternfly/react-table";
-import { Button, TextInput } from "@patternfly/react-core";
+import { Button } from "@patternfly/react-core";
 // Hooks
 import useAlerts from "src/hooks/useAlerts";
 // RPC
@@ -14,6 +14,7 @@ import SettingsTableLayout from "../layouts/SettingsTableLayout";
 import ModalWithFormLayout, { Field } from "../layouts/ModalWithFormLayout";
 import MemberOfDeleteModal from "../MemberOf/MemberOfDeleteModal";
 import DeletedElementsTable from "../tables/DeletedElementsTable";
+import InputRequiredText from "../layouts/InputRequiredText";
 
 interface PropsToSudoRuleOptions {
   sudoRuleId: string;
@@ -264,15 +265,13 @@ const SudoRuleOptions = (props: PropsToSudoRuleOptions) => {
       id: "sudo-option",
       name: "Sudo option",
       pfComponent: (
-        <TextInput
-          data-cy="modal-textbox-sudo-option"
-          type="text"
+        <InputRequiredText
+          dataCy="modal-textbox-sudo-option"
           id="sudo-option"
           name="ipasudoopt"
-          aria-label="Sudo option"
           value={newOption}
-          onChange={(_event, value) => setNewOption(value)}
-          isRequired
+          onChange={setNewOption}
+          requiredHelperText="Required value"
         />
       ),
     },

--- a/src/components/layouts/InputRequiredText.tsx
+++ b/src/components/layouts/InputRequiredText.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+// PatternFly
+import {
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  TextInput,
+  ValidatedOptions,
+} from "@patternfly/react-core";
+
+interface InputRequiredTextProps {
+  dataCy: string;
+  id: string;
+  name: string;
+  value: string;
+  onChange: (value: string) => void;
+  requiredHelperText?: string;
+  isDisabled?: boolean;
+}
+
+const InputRequiredText = (props: InputRequiredTextProps) => {
+  const helperTextId = `${props.id}-helper`;
+
+  return (
+    <>
+      <TextInput
+        data-cy={props.dataCy}
+        id={props.id}
+        name={props.name}
+        value={props.value}
+        type="text"
+        isRequired={true}
+        aria-label={props.name}
+        aria-describedby={helperTextId}
+        onChange={(_event, value) => props.onChange(value)}
+        isDisabled={props.isDisabled}
+      />
+      {props.value === "" && (
+        <FormHelperText>
+          <HelperText id={helperTextId} aria-live="polite">
+            <HelperTextItem variant={ValidatedOptions.default}>
+              {props.requiredHelperText || "This field is required"}
+            </HelperTextItem>
+          </HelperText>
+        </FormHelperText>
+      )}
+    </>
+  );
+};
+
+export default InputRequiredText;

--- a/src/components/layouts/InputWithValidation.tsx
+++ b/src/components/layouts/InputWithValidation.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+// PatternFly
+import {
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  TextInput,
+} from "@patternfly/react-core";
+import type { HelperTextItemProps } from "@patternfly/react-core";
+
+type HelperTextVariant = NonNullable<HelperTextItemProps["variant"]>;
+type RuleState = {
+  id: string;
+  state: HelperTextVariant;
+  message: string;
+};
+type RuleProps = {
+  id: string;
+  message: string;
+  validate: (value: string) => boolean;
+};
+
+interface InputWithValidationProps {
+  dataCy: string;
+  id: string;
+  name: string;
+  value: string;
+  onChange: (value: string) => void;
+  isRequired?: boolean;
+  isDisabled?: boolean;
+  rules: Array<RuleProps>;
+}
+
+const InputWithValidation = (props: InputWithValidationProps) => {
+  const hasRules = props.rules.length > 0;
+
+  const ruleStates = React.useMemo<RuleState[]>(() => {
+    if (!hasRules) return [];
+    if (props.value === "") {
+      return props.rules.map((r) => ({
+        id: r.id,
+        state: "indeterminate",
+        message: r.message,
+      }));
+    }
+    return props.rules.map((r) => ({
+      id: r.id,
+      state: r.validate(props.value) ? "success" : "error",
+      message: r.message,
+    }));
+  }, [props.value, hasRules, props.rules]);
+
+  const nonSuccessRuleIds = React.useMemo<string[]>(
+    () =>
+      hasRules
+        ? ruleStates
+            .filter((s) => s.state !== "success")
+            .map((s) => `${props.id}-${s.id}`)
+        : [],
+    [hasRules, ruleStates, props.id]
+  );
+
+  const ariaInvalid = hasRules
+    ? ruleStates.some((s) => s.state === "error")
+    : false;
+
+  return (
+    <>
+      <TextInput
+        data-cy={props.dataCy}
+        id={props.id}
+        name={props.name}
+        value={props.value}
+        type="text"
+        isRequired={props.isRequired}
+        isDisabled={props.isDisabled}
+        aria-label={props.name}
+        aria-describedby={nonSuccessRuleIds.join(" ")}
+        aria-invalid={ariaInvalid}
+        onChange={(_event, value) => props.onChange(value)}
+      />
+      {props.value && (
+        <FormHelperText>
+          <HelperText component="ul">
+            {ruleStates.map((r) => (
+              <HelperTextItem
+                key={r.id}
+                component="li"
+                id={`${props.id}-${r.id}`}
+                variant={r.state}
+              >
+                {r.message}
+              </HelperTextItem>
+            ))}
+          </HelperText>
+        </FormHelperText>
+      )}
+    </>
+  );
+};
+
+export default InputWithValidation;

--- a/src/components/modals/AddHostGroup.tsx
+++ b/src/components/modals/AddHostGroup.tsx
@@ -1,16 +1,10 @@
 import React, { useEffect, useState } from "react";
 // PatternFly
-import {
-  Button,
-  HelperText,
-  HelperTextItem,
-  TextArea,
-  TextInput,
-  ValidatedOptions,
-} from "@patternfly/react-core";
+import { Button, TextArea } from "@patternfly/react-core";
 // Layouts
 import SecondaryButton from "../layouts/SecondaryButton";
 import ModalWithFormLayout from "../layouts/ModalWithFormLayout";
+import InputRequiredText from "../layouts/InputRequiredText";
 // Modals
 import ErrorModal from "./ErrorModal";
 // Errors
@@ -61,27 +55,16 @@ const AddHostGroup = (props: PropsToAddGroup) => {
       id: "modal-form-hostgroup-name",
       name: "Group name",
       pfComponent: (
-        <>
-          <TextInput
-            data-cy="modal-textbox-hostgroup-name"
-            type="text"
-            id="modal-form-hostgroup-name"
-            name="modal-form-hostgroup-name"
-            value={groupName}
-            onChange={(_event, value: string) => setGroupName(value)}
-            validated={
-              groupName === ""
-                ? ValidatedOptions.error
-                : ValidatedOptions.default
-            }
-          />
-          <HelperText>
-            {groupName === "" && (
-              <HelperTextItem>Required value</HelperTextItem>
-            )}
-          </HelperText>
-        </>
+        <InputRequiredText
+          dataCy="modal-textbox-hostgroup-name"
+          id="modal-form-hostgroup-name"
+          name="modal-form-hostgroup-name"
+          value={groupName}
+          onChange={setGroupName}
+          requiredHelperText="Please enter a group name"
+        />
       ),
+      fieldRequired: true,
     },
     {
       id: "modal-form-hostgroup-desc",

--- a/src/components/modals/AddIDView.tsx
+++ b/src/components/modals/AddIDView.tsx
@@ -1,16 +1,10 @@
 import React, { useEffect, useState } from "react";
 // PatternFly
-import {
-  Button,
-  HelperText,
-  HelperTextItem,
-  TextArea,
-  TextInput,
-  ValidatedOptions,
-} from "@patternfly/react-core";
+import { Button, TextArea } from "@patternfly/react-core";
 // Layouts
 import SecondaryButton from "../layouts/SecondaryButton";
 import ModalWithFormLayout from "../layouts/ModalWithFormLayout";
+import InputRequiredText from "../layouts/InputRequiredText";
 // Modals
 import ErrorModal from "./ErrorModal";
 // Errors
@@ -61,25 +55,16 @@ const AddIDViewModal = (props: PropsToAddIDView) => {
       id: "modal-form-id-view-name",
       name: "ID view name",
       pfComponent: (
-        <>
-          <TextInput
-            data-cy="modal-textbox-id-view-name"
-            type="text"
-            id="modal-form-id-view-name"
-            name="modal-form-id-view-name"
-            value={viewName}
-            onChange={(_event, value: string) => setViewName(value)}
-            validated={
-              viewName === ""
-                ? ValidatedOptions.error
-                : ValidatedOptions.default
-            }
-          />
-          <HelperText>
-            {viewName === "" && <HelperTextItem>Required value</HelperTextItem>}
-          </HelperText>
-        </>
+        <InputRequiredText
+          dataCy="modal-textbox-id-view-name"
+          id="modal-form-id-view-name"
+          name="modal-form-id-view-name"
+          value={viewName}
+          onChange={setViewName}
+          requiredHelperText="Required value"
+        />
       ),
+      fieldRequired: true,
     },
     {
       id: "modal-form-id-view-desc",

--- a/src/components/modals/AddNetgroup.tsx
+++ b/src/components/modals/AddNetgroup.tsx
@@ -1,16 +1,10 @@
 import React, { useEffect, useState } from "react";
 // PatternFly
-import {
-  Button,
-  HelperText,
-  HelperTextItem,
-  TextArea,
-  TextInput,
-  ValidatedOptions,
-} from "@patternfly/react-core";
+import { Button, TextArea } from "@patternfly/react-core";
 // Layouts
 import SecondaryButton from "../layouts/SecondaryButton";
 import ModalWithFormLayout from "../layouts/ModalWithFormLayout";
+import InputRequiredText from "../layouts/InputRequiredText";
 // Modals
 import ErrorModal from "./ErrorModal";
 // Errors
@@ -61,27 +55,16 @@ const AddNetgroup = (props: PropsToAddGroup) => {
       id: "modal-form-netgroup-name",
       name: "Netgroup name",
       pfComponent: (
-        <>
-          <TextInput
-            data-cy="modal-textbox-netgroup-name"
-            type="text"
-            id="modal-form-netgroup-name"
-            name="modal-form-netgroup-name"
-            value={groupName}
-            onChange={(_event, value: string) => setGroupName(value)}
-            validated={
-              groupName === ""
-                ? ValidatedOptions.error
-                : ValidatedOptions.default
-            }
-          />
-          <HelperText>
-            {groupName === "" && (
-              <HelperTextItem>Required value</HelperTextItem>
-            )}
-          </HelperText>
-        </>
+        <InputRequiredText
+          dataCy="modal-textbox-netgroup-name"
+          id="modal-form-netgroup-name"
+          name="modal-form-netgroup-name"
+          value={groupName}
+          onChange={setGroupName}
+          requiredHelperText="Required value"
+        />
       ),
+      fieldRequired: true,
     },
     {
       id: "modal-form-netgroup-desc",

--- a/src/components/modals/AddTextInputFromListModal.tsx
+++ b/src/components/modals/AddTextInputFromListModal.tsx
@@ -7,9 +7,8 @@ import {
   ModalBody,
   ModalFooter,
   ModalHeader,
-  TextInput,
-  ValidatedOptions,
 } from "@patternfly/react-core";
+import InputWithValidation from "../layouts/InputWithValidation";
 
 interface PropsToAddModal {
   dataCy: string;
@@ -49,21 +48,25 @@ const AddTextInputFromListModal = (props: PropsToAddModal) => {
             label={props.textInputTitle}
             type="string"
             fieldId={props.id}
+            isRequired={true}
           >
-            <TextInput
-              data-cy="modal-textbox-new-kerberos-principal-alias"
+            <InputWithValidation
+              dataCy="modal-textbox-new-kerberos-principal-alias"
               id={props.id}
               name={props.textInputName}
               value={props.newValue}
-              onChange={(_event, value) => props.setNewValue(value)}
-              type="text"
-              aria-label={props.textInputName}
+              onChange={props.setNewValue}
               isRequired={true}
-              validated={
-                (props.newValue !== "" && !props.newValue.includes("@")) ||
+              rules={
                 props.textInputValidator
-                  ? ValidatedOptions.default
-                  : ValidatedOptions.error
+                  ? []
+                  : [
+                      {
+                        id: "no-at",
+                        message: "Must not contain '@'",
+                        validate: (value: string) => !value.includes("@"),
+                      },
+                    ]
               }
             />
           </FormGroup>

--- a/src/components/modals/AddUserGroup.tsx
+++ b/src/components/modals/AddUserGroup.tsx
@@ -1,16 +1,11 @@
 import React, { useEffect, useState } from "react";
 // PatternFly
-import {
-  Button,
-  HelperText,
-  HelperTextItem,
-  TextArea,
-  TextInput,
-  ValidatedOptions,
-} from "@patternfly/react-core";
+import { Button, TextArea } from "@patternfly/react-core";
 // Layouts
 import SecondaryButton from "../layouts/SecondaryButton";
 import ModalWithFormLayout from "../layouts/ModalWithFormLayout";
+import InputRequiredText from "../layouts/InputRequiredText";
+import InputWithValidation from "../layouts/InputWithValidation";
 // Modals
 import ErrorModal from "./ErrorModal";
 // Errors
@@ -24,6 +19,7 @@ import {
   useAddGroupMutation,
 } from "../../services/rpcUserGroups";
 import SimpleSelector, { SelectOptionProps } from "../layouts/SimpleSelector";
+import { isEmptyOrNumber, EMPTY_OR_NUMBER_MESSAGE } from "src/utils/utils";
 interface PropsToAddGroup {
   show: boolean;
   handleModalToggle: () => void;
@@ -88,27 +84,16 @@ const AddUserGroup = (props: PropsToAddGroup) => {
       id: "modal-form-group-name",
       name: "Group name",
       pfComponent: (
-        <>
-          <TextInput
-            data-cy="modal-textbox-group-name"
-            type="text"
-            id="modal-form-group-name"
-            name="modal-form-group-name"
-            value={groupName}
-            onChange={(_event, value: string) => setGroupName(value)}
-            validated={
-              groupName === ""
-                ? ValidatedOptions.error
-                : ValidatedOptions.default
-            }
-          />
-          <HelperText>
-            {groupName === "" && (
-              <HelperTextItem>Required value</HelperTextItem>
-            )}
-          </HelperText>
-        </>
+        <InputRequiredText
+          dataCy="modal-textbox-group-name"
+          id="modal-form-group-name"
+          name="modal-form-group-name"
+          value={groupName}
+          onChange={setGroupName}
+          requiredHelperText="Please enter a group name"
+        />
       ),
+      fieldRequired: true,
     },
     {
       id: "modal-form-group-desc",
@@ -143,33 +128,24 @@ const AddUserGroup = (props: PropsToAddGroup) => {
       id: "modal-form-group-gid",
       name: "GID",
       pfComponent: (
-        <>
-          <TextInput
-            data-cy="modal-textbox-group-gid"
-            type="text"
-            id="modal-form-group-gid"
-            name="modal-form-group-gid"
-            value={gidNumber}
-            onChange={(_event, value: string) => setGID(value)}
-            isDisabled={groupType !== "posix"}
-            validated={
-              groupType === "posix" &&
-              gidNumber !== "" &&
-              isNaN(Number(gidNumber))
-                ? ValidatedOptions.error
-                : ValidatedOptions.default
-            }
-          />
-          <HelperText>
-            {groupType === "posix" &&
-              gidNumber !== "" &&
-              isNaN(Number(gidNumber)) && (
-                <HelperTextItem>
-                  Invalid GID value, must be empty or a number
-                </HelperTextItem>
-              )}
-          </HelperText>
-        </>
+        <InputWithValidation
+          dataCy="modal-textbox-group-gid"
+          id="modal-form-group-gid"
+          name="modal-form-group-gid"
+          value={gidNumber}
+          onChange={setGID}
+          rules={
+            groupType === "posix"
+              ? [
+                  {
+                    id: "ruleGid",
+                    message: EMPTY_OR_NUMBER_MESSAGE,
+                    validate: isEmptyOrNumber,
+                  },
+                ]
+              : []
+          }
+        />
       ),
     },
   ];

--- a/src/components/modals/CertificateMapping/AddRuleModal.tsx
+++ b/src/components/modals/CertificateMapping/AddRuleModal.tsx
@@ -19,6 +19,7 @@ import { SerializedError } from "@reduxjs/toolkit";
 // Icons
 import { InfoCircleIcon } from "@patternfly/react-icons";
 import NumberSelector from "src/components/Form/NumberInput";
+import InputRequiredText from "src/components/layouts/InputRequiredText";
 
 interface PropsToAddRuleModal {
   isOpen: boolean;
@@ -119,15 +120,13 @@ const AddRuleModal = (props: PropsToAddRuleModal) => {
       id: "rule-name",
       name: "Rule name",
       pfComponent: (
-        <TextInput
-          data-cy="modal-textbox-rule-name"
-          type="text"
+        <InputRequiredText
+          dataCy="modal-textbox-rule-name"
           id="rule-name"
           name="cn"
           value={ruleName}
-          aria-label="Rule name text input"
-          onChange={(_event, value: string) => setRuleName(value)}
-          isRequired
+          onChange={setRuleName}
+          requiredHelperText="Required value"
         />
       ),
       fieldRequired: true,
@@ -144,7 +143,6 @@ const AddRuleModal = (props: PropsToAddRuleModal) => {
           value={mappingRule}
           aria-label="Mapping rule text input"
           onChange={(_event, value: string) => setMappingRule(value)}
-          isRequired
         />
       ),
       labelIcon: (

--- a/src/components/modals/DnsZones/AddDnsZoneModal.tsx
+++ b/src/components/modals/DnsZones/AddDnsZoneModal.tsx
@@ -5,8 +5,6 @@ import {
   Checkbox,
   Form,
   FormGroup,
-  HelperText,
-  HelperTextItem,
   Modal,
   ModalBody,
   ModalFooter,
@@ -14,7 +12,6 @@ import {
   Radio,
   Spinner,
   TextInput,
-  ValidatedOptions,
 } from "@patternfly/react-core";
 // Components
 import CustomTooltip from "src/components/layouts/CustomTooltip";
@@ -29,6 +26,7 @@ import useAlerts from "src/hooks/useAlerts";
 import { SerializedError } from "@reduxjs/toolkit";
 // Icons
 import { InfoCircleIcon } from "@patternfly/react-icons";
+import InputWithValidation from "src/components/layouts/InputWithValidation";
 
 interface PropsToAddModal {
   isOpen: boolean;
@@ -207,33 +205,25 @@ const AddDnsZoneModal = (props: PropsToAddModal) => {
             isRequired={isReverseZoneIpRadioChecked}
           >
             <>
-              <TextInput
-                data-cy="modal-textbox-reverse-zone-ip"
-                type="text"
+              <InputWithValidation
+                dataCy="modal-textbox-reverse-zone-ip"
                 id="reverse-zone-ip"
                 name="name_from_ip"
                 value={reverseZoneIp}
                 aria-label="Reverse zone IP text input"
-                onChange={(_event, value: string) => setReverseZoneIp(value)}
+                onChange={setReverseZoneIp}
                 isDisabled={
                   !isReverseZoneIpRadioChecked && isZoneNameRadioChecked
                 }
                 isRequired={isReverseZoneIpRadioChecked}
-                validated={
-                  reverseZoneIp !== "" &&
-                  isReverseZoneIpRadioChecked &&
-                  !validateReverseZoneIp(reverseZoneIp)
-                    ? ValidatedOptions.error
-                    : ValidatedOptions.default
-                }
+                rules={[
+                  {
+                    id: "reverse-zone-ip",
+                    message: reverseZoneIpErrorMessage,
+                    validate: validateReverseZoneIp,
+                  },
+                ]}
               />
-              <HelperText data-cy="modal-helper-text-reverse-zone-ip">
-                {reverseZoneIp !== "" &&
-                  isReverseZoneIpRadioChecked &&
-                  !validateReverseZoneIp(reverseZoneIp) && (
-                    <HelperTextItem>{reverseZoneIpErrorMessage}</HelperTextItem>
-                  )}
-              </HelperText>
             </>
           </FormGroup>
         </Form>

--- a/src/components/modals/HbacModals/AddHBACRule.tsx
+++ b/src/components/modals/HbacModals/AddHBACRule.tsx
@@ -1,16 +1,10 @@
 import React, { useEffect, useState } from "react";
 // PatternFly
-import {
-  Button,
-  HelperText,
-  HelperTextItem,
-  TextArea,
-  TextInput,
-  ValidatedOptions,
-} from "@patternfly/react-core";
+import { Button, TextArea } from "@patternfly/react-core";
 // Layouts
 import SecondaryButton from "src/components/layouts/SecondaryButton";
 import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
+import InputRequiredText from "src/components/layouts/InputRequiredText";
 // Modals
 import ErrorModal from "src/components/modals/ErrorModal";
 // Errors
@@ -58,25 +52,16 @@ const AddHBACRule = (props: PropsToAddGroup) => {
       id: "modal-form-rule-name",
       name: "Rule name",
       pfComponent: (
-        <>
-          <TextInput
-            type="text"
-            id="modal-form-rule-name"
-            name="modal-form-rule-name"
-            value={ruleName}
-            onChange={(_event, value: string) => setRuleName(value)}
-            validated={
-              ruleName === ""
-                ? ValidatedOptions.error
-                : ValidatedOptions.default
-            }
-            data-cy="modal-textbox-rule-name"
-          />
-          <HelperText>
-            {ruleName === "" && <HelperTextItem>Required value</HelperTextItem>}
-          </HelperText>
-        </>
+        <InputRequiredText
+          dataCy="modal-textbox-rule-name"
+          id="modal-form-rule-name"
+          name="modal-form-rule-name"
+          value={ruleName}
+          onChange={setRuleName}
+          requiredHelperText="Required value"
+        />
       ),
+      fieldRequired: true,
     },
     {
       id: "modal-form-rule-desc",

--- a/src/components/modals/HbacModals/AddHBACService.tsx
+++ b/src/components/modals/HbacModals/AddHBACService.tsx
@@ -1,16 +1,10 @@
 import React, { useEffect, useState } from "react";
 // PatternFly
-import {
-  Button,
-  HelperText,
-  HelperTextItem,
-  TextArea,
-  TextInput,
-  ValidatedOptions,
-} from "@patternfly/react-core";
+import { Button, TextArea } from "@patternfly/react-core";
 // Layouts
 import SecondaryButton from "src/components/layouts/SecondaryButton";
 import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
+import InputRequiredText from "src/components/layouts/InputRequiredText";
 // Modals
 import ErrorModal from "src/components/modals/ErrorModal";
 // Errors
@@ -58,27 +52,16 @@ const AddHBACService = (props: PropsToAddGroup) => {
       id: "modal-form-service-name",
       name: "Service name",
       pfComponent: (
-        <>
-          <TextInput
-            type="text"
-            id="modal-form-service-name"
-            name="modal-form-service-name"
-            value={serviceName}
-            onChange={(_event, value: string) => setServiceName(value)}
-            validated={
-              serviceName === ""
-                ? ValidatedOptions.error
-                : ValidatedOptions.default
-            }
-            data-cy="modal-textbox-service-name"
-          />
-          <HelperText>
-            {serviceName === "" && (
-              <HelperTextItem>Required value</HelperTextItem>
-            )}
-          </HelperText>
-        </>
+        <InputRequiredText
+          dataCy="modal-textbox-service-name"
+          id="modal-form-service-name"
+          name="modal-form-service-name"
+          value={serviceName}
+          onChange={setServiceName}
+          requiredHelperText="Required value"
+        />
       ),
+      fieldRequired: true,
     },
     {
       id: "modal-form-service-desc",

--- a/src/components/modals/HbacModals/AddHBACServiceGroup.tsx
+++ b/src/components/modals/HbacModals/AddHBACServiceGroup.tsx
@@ -1,16 +1,10 @@
 import React, { useEffect, useState } from "react";
 // PatternFly
-import {
-  Button,
-  HelperText,
-  HelperTextItem,
-  TextArea,
-  TextInput,
-  ValidatedOptions,
-} from "@patternfly/react-core";
+import { Button, TextArea } from "@patternfly/react-core";
 // Layouts
 import SecondaryButton from "src/components/layouts/SecondaryButton";
 import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
+import InputRequiredText from "src/components/layouts/InputRequiredText";
 // Modals
 import ErrorModal from "src/components/modals/ErrorModal";
 // Errors
@@ -58,27 +52,16 @@ const AddHBACServiceGroup = (props: PropsToAddGroup) => {
       id: "modal-form-service-group-name",
       name: "Service group name",
       pfComponent: (
-        <>
-          <TextInput
-            type="text"
-            id="modal-form-service-group-name"
-            name="modal-form-service-group-name"
-            value={serviceName}
-            onChange={(_event, value: string) => setServiceName(value)}
-            validated={
-              serviceName === ""
-                ? ValidatedOptions.error
-                : ValidatedOptions.default
-            }
-            data-cy="modal-textbox-service-group-name"
-          />
-          <HelperText>
-            {serviceName === "" && (
-              <HelperTextItem>Required value</HelperTextItem>
-            )}
-          </HelperText>
-        </>
+        <InputRequiredText
+          dataCy="modal-textbox-service-group-name"
+          id="modal-form-service-group-name"
+          name="modal-form-service-group-name"
+          value={serviceName}
+          onChange={setServiceName}
+          requiredHelperText="Required value"
+        />
       ),
+      fieldRequired: true,
     },
     {
       id: "modal-form-service-group-desc",

--- a/src/components/modals/IdOverrideModals/AddIdOverrideGroup.tsx
+++ b/src/components/modals/IdOverrideModals/AddIdOverrideGroup.tsx
@@ -4,13 +4,13 @@ import {
   Button,
   Spinner,
   Content,
-  TextInput,
   TextArea,
-  ValidatedOptions,
+  TextInput,
 } from "@patternfly/react-core";
 // Layout
 import SecondaryButton from "src/components/layouts/SecondaryButton";
 import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
+import InputWithValidation from "src/components/layouts/InputWithValidation";
 // Redux
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import { SerializedError } from "@reduxjs/toolkit";
@@ -31,6 +31,7 @@ import {
   useAddIDOverrideGroupMutation,
   AddGroupPayload,
 } from "src/services/rpcIdOverrides";
+import { EMPTY_OR_NUMBER_MESSAGE, isEmptyOrNumber } from "src/utils/utils";
 
 interface PropsToAddGroup {
   show: boolean;
@@ -93,7 +94,6 @@ const AddIDOverrideGroupModal = (props: PropsToAddGroup) => {
 
   // Refs
   const loginRef = useRef() as MutableRefObject<HTMLInputElement>;
-  const gidNumberRef = useRef() as MutableRefObject<HTMLInputElement>;
 
   // List of fields
   const fields = [
@@ -130,19 +130,19 @@ const AddIDOverrideGroupModal = (props: PropsToAddGroup) => {
       id: "modal-form-gidnumber",
       name: "GID",
       pfComponent: (
-        <TextInput
-          data-cy="modal-textbox-gidnumber"
-          type="text"
+        <InputWithValidation
+          dataCy="modal-textbox-gidnumber"
           id="modal-form-gidnumber"
           name="modal-form-gidnumber"
           value={gidnumber}
-          onChange={(_event, value: string) => setGidNumber(value)}
-          ref={gidNumberRef}
-          validated={
-            gidnumber !== "" && isNaN(Number(gidnumber))
-              ? ValidatedOptions.error
-              : ValidatedOptions.default
-          }
+          onChange={setGidNumber}
+          rules={[
+            {
+              id: "ruleGid",
+              message: EMPTY_OR_NUMBER_MESSAGE,
+              validate: isEmptyOrNumber,
+            },
+          ]}
         />
       ),
     },

--- a/src/components/modals/IdOverrideModals/AddIdOverrideUser.tsx
+++ b/src/components/modals/IdOverrideModals/AddIdOverrideUser.tsx
@@ -4,9 +4,8 @@ import {
   Button,
   Spinner,
   Content,
-  TextInput,
   TextArea,
-  ValidatedOptions,
+  TextInput,
 } from "@patternfly/react-core";
 // Layout
 import SecondaryButton from "src/components/layouts/SecondaryButton";
@@ -31,6 +30,8 @@ import {
   useAddIDOverrideUserMutation,
   AddUserPayload,
 } from "src/services/rpcIdOverrides";
+import InputWithValidation from "src/components/layouts/InputWithValidation";
+import { EMPTY_OR_NUMBER_MESSAGE, isEmptyOrNumber } from "src/utils/utils";
 
 interface PropsToAddUser {
   show: boolean;
@@ -100,8 +101,6 @@ const AddIDOverrideUserModal = (props: PropsToAddUser) => {
   // Refs
   const loginRef = useRef() as MutableRefObject<HTMLInputElement>;
   const gecosRef = useRef() as MutableRefObject<HTMLInputElement>;
-  const uidNumberRef = useRef() as MutableRefObject<HTMLInputElement>;
-  const gidNumberRef = useRef() as MutableRefObject<HTMLInputElement>;
   const shellRef = useRef() as MutableRefObject<HTMLInputElement>;
   const homedirRef = useRef() as MutableRefObject<HTMLInputElement>;
 
@@ -155,19 +154,19 @@ const AddIDOverrideUserModal = (props: PropsToAddUser) => {
       id: "modal-form-user-uidnumber",
       name: "UID",
       pfComponent: (
-        <TextInput
-          data-cy="modal-textbox-user-uidnumber"
-          type="text"
+        <InputWithValidation
+          dataCy="modal-textbox-user-uidnumber"
           id="modal-form-user-uidnumber"
           name="modal-form-user-uidnumber"
           value={uidnumber}
-          onChange={(_event, value: string) => setUidNumber(value)}
-          ref={uidNumberRef}
-          validated={
-            uidnumber !== "" && isNaN(Number(uidnumber))
-              ? ValidatedOptions.error
-              : ValidatedOptions.default
-          }
+          onChange={setUidNumber}
+          rules={[
+            {
+              id: "ruleUid",
+              message: "Must be empty or a number",
+              validate: (v: string) => v === "" || !isNaN(Number(v)),
+            },
+          ]}
         />
       ),
     },
@@ -175,19 +174,19 @@ const AddIDOverrideUserModal = (props: PropsToAddUser) => {
       id: "modal-form-user-gidnumber",
       name: "GID",
       pfComponent: (
-        <TextInput
-          data-cy="modal-textbox-user-gidnumber"
-          type="text"
+        <InputWithValidation
+          dataCy="modal-textbox-user-gidnumber"
           id="modal-form-user-gidnumber"
           name="modal-form-user-gidnumber"
           value={gidnumber}
-          onChange={(_event, value: string) => setGidNumber(value)}
-          ref={gidNumberRef}
-          validated={
-            gidnumber !== "" && isNaN(Number(gidnumber))
-              ? ValidatedOptions.error
-              : ValidatedOptions.default
-          }
+          onChange={setGidNumber}
+          rules={[
+            {
+              id: "ruleGid",
+              message: EMPTY_OR_NUMBER_MESSAGE,
+              validate: isEmptyOrNumber,
+            },
+          ]}
         />
       ),
     },

--- a/src/components/modals/IdpReferences/AddModal.tsx
+++ b/src/components/modals/IdpReferences/AddModal.tsx
@@ -1,13 +1,6 @@
 import React from "react";
 // PatternFly
-import {
-  Button,
-  HelperText,
-  HelperTextItem,
-  Radio,
-  TextInput,
-  ValidatedOptions,
-} from "@patternfly/react-core";
+import { Button, Radio, TextInput } from "@patternfly/react-core";
 // Components
 import ModalWithFormLayout, {
   Field,
@@ -29,6 +22,8 @@ import useAlerts from "src/hooks/useAlerts";
 import { SerializedError } from "@reduxjs/toolkit";
 // Components
 import TitleLayout from "src/components/layouts/TitleLayout";
+import InputRequiredText from "src/components/layouts/InputRequiredText";
+import InputWithValidation from "src/components/layouts/InputWithValidation";
 
 interface PropsToAddModal {
   isOpen: boolean;
@@ -254,15 +249,13 @@ const AddModal = (props: PropsToAddModal) => {
       id: "identity-provider-reference-name",
       name: "Identity Provider reference name",
       pfComponent: (
-        <TextInput
-          data-cy="modal-textbox-idp-ref-name"
-          type="text"
+        <InputRequiredText
+          dataCy="modal-textbox-idp-ref-name"
           id="identity-provider-reference-name"
           name="cn"
           value={idpRefName}
-          aria-label="Identity Provider reference name"
-          onChange={(_event, value: string) => setIdpRefName(value)}
-          isRequired
+          onChange={setIdpRefName}
+          requiredHelperText="Required value"
         />
       ),
       fieldRequired: true,
@@ -271,15 +264,13 @@ const AddModal = (props: PropsToAddModal) => {
       id: "client-id",
       name: "Client identifier",
       pfComponent: (
-        <TextInput
-          data-cy="modal-textbox-client-id"
-          type="text"
+        <InputRequiredText
+          dataCy="modal-textbox-client-id"
           id="client-id"
           name="ipaidpclientid"
           value={clientId}
-          aria-label="Client identifier"
-          onChange={(_event, value) => setClientId(value)}
-          isRequired
+          onChange={setClientId}
+          requiredHelperText="Required value"
         />
       ),
       fieldRequired: true,
@@ -304,25 +295,21 @@ const AddModal = (props: PropsToAddModal) => {
       name: "Verify secret",
       pfComponent: (
         <>
-          <TextInput
-            data-cy="modal-textbox-verify-secret"
-            type="text"
+          <InputWithValidation
+            dataCy="modal-textbox-verify-secret"
             id="verify-secret"
             name="ipaidpclientsecret_verify"
             value={verifySecret}
             aria-label="Verify secret"
-            onChange={(_event, value) => setVerifySecret(value)}
-            validated={
-              secret !== "" && verifySecret !== secret
-                ? ValidatedOptions.error
-                : ValidatedOptions.default
-            }
+            onChange={setVerifySecret}
+            rules={[
+              {
+                id: "secret-match",
+                message: "Secret should match",
+                validate: (v: string) => v === secret,
+              },
+            ]}
           />
-          <HelperText>
-            {secret !== "" && verifySecret !== secret && (
-              <HelperTextItem>Secret should match</HelperTextItem>
-            )}
-          </HelperText>
         </>
       ),
     },
@@ -395,14 +382,14 @@ const AddModal = (props: PropsToAddModal) => {
       id: "org",
       name: "Organization",
       pfComponent: (
-        <TextInput
-          data-cy="modal-textbox-org"
-          type="text"
+        <InputRequiredText
+          dataCy="modal-textbox-org"
           id="org"
           name="ipaidporg"
           value={org}
           aria-label="Organization"
-          onChange={(_event, value) => setOrg(value)}
+          onChange={setOrg}
+          requiredHelperText="Required value"
         />
       ),
       fieldRequired: true,
@@ -411,14 +398,14 @@ const AddModal = (props: PropsToAddModal) => {
       id: "base-url",
       name: "Base URL",
       pfComponent: (
-        <TextInput
-          data-cy="modal-textbox-base-url"
-          type="text"
+        <InputRequiredText
+          dataCy="modal-textbox-base-url"
           id="base-url"
           name="ipaidpbaseurl"
           value={baseUrl}
           aria-label="Base URL"
-          onChange={(_event, value) => setBaseUrl(value)}
+          onChange={setBaseUrl}
+          requiredHelperText="Required value"
         />
       ),
       fieldRequired: true,
@@ -431,14 +418,14 @@ const AddModal = (props: PropsToAddModal) => {
       id: "org",
       name: "Organization",
       pfComponent: (
-        <TextInput
-          data-cy="modal-textbox-org"
-          type="text"
+        <InputRequiredText
+          dataCy="modal-textbox-org"
           id="org"
           name="ipaidporg"
           value={org}
           aria-label="Organization"
-          onChange={(_event, value) => setOrg(value)}
+          onChange={setOrg}
+          requiredHelperText="Required value"
         />
       ),
       fieldRequired: true,
@@ -450,14 +437,14 @@ const AddModal = (props: PropsToAddModal) => {
       id: "auth-uri",
       name: "Authorization URI",
       pfComponent: (
-        <TextInput
-          data-cy="modal-textbox-auth-uri"
-          type="text"
+        <InputRequiredText
+          dataCy="modal-textbox-auth-uri"
           id="auth-uri"
           name="ipaidpauthendpoint"
           value={authUri}
           aria-label="Authorization URI"
-          onChange={(_event, value) => setAuthUri(value)}
+          onChange={setAuthUri}
+          requiredHelperText="Required value"
         />
       ),
       fieldRequired: true,
@@ -466,14 +453,14 @@ const AddModal = (props: PropsToAddModal) => {
       id: "dev-auth-uri",
       name: "Device authorization URI",
       pfComponent: (
-        <TextInput
-          data-cy="modal-textbox-dev-auth-uri"
-          type="text"
+        <InputRequiredText
+          dataCy="modal-textbox-dev-auth-uri"
           id="dev-auth-uri"
           name="ipaidpdevauthendpoint"
           value={devAuthUri}
           aria-label="Device authorization URI"
-          onChange={(_event, value) => setDevAuthUri(value)}
+          onChange={setDevAuthUri}
+          requiredHelperText="Required value"
         />
       ),
       fieldRequired: true,
@@ -482,14 +469,14 @@ const AddModal = (props: PropsToAddModal) => {
       id: "token-uri",
       name: "Token URI",
       pfComponent: (
-        <TextInput
-          data-cy="modal-textbox-token-uri"
-          type="text"
+        <InputRequiredText
+          dataCy="modal-textbox-token-uri"
           id="token-uri"
           name="ipaidptokenendpoint"
           value={tokenUri}
           aria-label="Token URI"
-          onChange={(_event, value) => setTokenUri(value)}
+          onChange={setTokenUri}
+          requiredHelperText="Required value"
         />
       ),
       fieldRequired: true,
@@ -498,14 +485,14 @@ const AddModal = (props: PropsToAddModal) => {
       id: "user-info-uri",
       name: "User info URI",
       pfComponent: (
-        <TextInput
-          data-cy="modal-textbox-user-info-uri"
-          type="text"
+        <InputRequiredText
+          dataCy="modal-textbox-user-info-uri"
           id="user-info-uri"
           name="ipaidpuserinfoendpoint"
           value={userInfoUri}
           aria-label="User info URI"
-          onChange={(_event, value) => setUserInfoUri(value)}
+          onChange={setUserInfoUri}
+          requiredHelperText="Required value"
         />
       ),
       fieldRequired: true,
@@ -514,14 +501,14 @@ const AddModal = (props: PropsToAddModal) => {
       id: "jwks-uri",
       name: "JWKS URI",
       pfComponent: (
-        <TextInput
-          data-cy="modal-textbox-jwks-uri"
-          type="text"
+        <InputRequiredText
+          dataCy="modal-textbox-jwks-uri"
           id="jwks-uri"
           name="ipaidpkeysendpoint"
           value={jwksUri}
           aria-label="JWKS URI"
-          onChange={(_event, value) => setJwksUri(value)}
+          onChange={setJwksUri}
+          requiredHelperText="Required value"
         />
       ),
       fieldRequired: true,

--- a/src/components/modals/PwPoliciesModals/AddModal.tsx
+++ b/src/components/modals/PwPoliciesModals/AddModal.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 // PatternFly
-import { Button, TextInput } from "@patternfly/react-core";
+import { Button } from "@patternfly/react-core";
 // Components
 import ModalWithFormLayout, {
   Field,
@@ -20,6 +20,7 @@ import { useGetGenericListQuery } from "src/services/rpc";
 import useAlerts from "src/hooks/useAlerts";
 // Errors
 import { SerializedError } from "@reduxjs/toolkit";
+import InputRequiredText from "src/components/layouts/InputRequiredText";
 
 interface PropsToAddModal {
   isOpen: boolean;
@@ -181,14 +182,13 @@ const AddModal = (props: PropsToAddModal) => {
       id: "modal-form-priority",
       name: "Priority",
       pfComponent: (
-        <TextInput
-          data-cy="modal-textbox-priority"
+        <InputRequiredText
+          dataCy="modal-textbox-priority"
           id="modal-form-priority"
           name="cospriority"
-          type="number"
           value={priority}
-          onChange={(event) => setPriority(event.currentTarget.value)}
-          isRequired
+          onChange={setPriority}
+          requiredHelperText="Required value"
         />
       ),
       fieldRequired: true,

--- a/src/components/modals/SudoModals/AddSudoCmd.tsx
+++ b/src/components/modals/SudoModals/AddSudoCmd.tsx
@@ -1,16 +1,10 @@
 import React, { useEffect, useState } from "react";
 // PatternFly
-import {
-  Button,
-  HelperText,
-  HelperTextItem,
-  TextArea,
-  TextInput,
-  ValidatedOptions,
-} from "@patternfly/react-core";
+import { Button, TextArea } from "@patternfly/react-core";
 // Layouts
 import SecondaryButton from "src/components/layouts/SecondaryButton";
 import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
+import InputRequiredText from "src/components/layouts/InputRequiredText";
 // Modals
 import ErrorModal from "src/components/modals/ErrorModal";
 // Errors
@@ -57,23 +51,16 @@ const AddSudoCmd = (props: PropsToAddGroup) => {
       id: "modal-form-cmd-name",
       name: "Command name",
       pfComponent: (
-        <>
-          <TextInput
-            type="text"
-            id="modal-form-cmd-name"
-            name="modal-form-cmd-name"
-            value={cmdName}
-            onChange={(_event, value: string) => setCmdName(value)}
-            validated={
-              cmdName === "" ? ValidatedOptions.error : ValidatedOptions.default
-            }
-            data-cy="modal-textbox-command"
-          />
-          <HelperText>
-            {cmdName === "" && <HelperTextItem>Required value</HelperTextItem>}
-          </HelperText>
-        </>
+        <InputRequiredText
+          dataCy="modal-textbox-command"
+          id="modal-form-cmd-name"
+          name="modal-form-cmd-name"
+          value={cmdName}
+          onChange={setCmdName}
+          requiredHelperText="Required value"
+        />
       ),
+      fieldRequired: true,
     },
     {
       id: "modal-form-cmd-desc",

--- a/src/components/modals/SudoModals/AddSudoCmdGroup.tsx
+++ b/src/components/modals/SudoModals/AddSudoCmdGroup.tsx
@@ -1,16 +1,10 @@
 import React, { useEffect, useState } from "react";
 // PatternFly
-import {
-  Button,
-  HelperText,
-  HelperTextItem,
-  TextArea,
-  TextInput,
-  ValidatedOptions,
-} from "@patternfly/react-core";
+import { Button, TextArea } from "@patternfly/react-core";
 // Layouts
 import SecondaryButton from "src/components/layouts/SecondaryButton";
 import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
+import InputRequiredText from "src/components/layouts/InputRequiredText";
 // Modals
 import ErrorModal from "src/components/modals/ErrorModal";
 // Errors
@@ -58,27 +52,16 @@ const AddSudoCmdGroup = (props: PropsToAddGroup) => {
       id: "modal-form-cmd-grp-name",
       name: "Command group name",
       pfComponent: (
-        <>
-          <TextInput
-            data-cy="modal-textbox-cmd-grp-name"
-            type="text"
-            id="modal-form-cmd-grp-name"
-            name="modal-form-cmd-grp-name"
-            value={cmdGroupName}
-            onChange={(_event, value: string) => setCmdGroupName(value)}
-            validated={
-              cmdGroupName === ""
-                ? ValidatedOptions.error
-                : ValidatedOptions.default
-            }
-          />
-          <HelperText>
-            {cmdGroupName === "" && (
-              <HelperTextItem>Required value</HelperTextItem>
-            )}
-          </HelperText>
-        </>
+        <InputRequiredText
+          dataCy="modal-textbox-cmd-grp-name"
+          id="modal-form-cmd-grp-name"
+          name="modal-form-cmd-grp-name"
+          value={cmdGroupName}
+          onChange={setCmdGroupName}
+          requiredHelperText="Required value"
+        />
       ),
+      fieldRequired: true,
     },
     {
       id: "modal-form-cmd-grp-desc",

--- a/src/components/modals/SudoModals/AddSudoRule.tsx
+++ b/src/components/modals/SudoModals/AddSudoRule.tsx
@@ -1,16 +1,10 @@
 import React, { useEffect, useState } from "react";
 // PatternFly
-import {
-  Button,
-  HelperText,
-  HelperTextItem,
-  TextArea,
-  TextInput,
-  ValidatedOptions,
-} from "@patternfly/react-core";
+import { Button, TextArea } from "@patternfly/react-core";
 // Layouts
 import SecondaryButton from "src/components/layouts/SecondaryButton";
 import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
+import InputRequiredText from "src/components/layouts/InputRequiredText";
 // Modals
 import ErrorModal from "src/components/modals/ErrorModal";
 // Errors
@@ -58,25 +52,16 @@ const AddSudoRule = (props: PropsToAddGroup) => {
       id: "modal-form-rule-name",
       name: "Rule name",
       pfComponent: (
-        <>
-          <TextInput
-            type="text"
-            id="modal-form-rule-name"
-            name="modal-form-rule-name"
-            value={ruleName}
-            onChange={(_event, value: string) => setRuleName(value)}
-            validated={
-              ruleName === ""
-                ? ValidatedOptions.error
-                : ValidatedOptions.default
-            }
-            data-cy="modal-textbox-rule-name"
-          />
-          <HelperText>
-            {ruleName === "" && <HelperTextItem>Required value</HelperTextItem>}
-          </HelperText>
-        </>
+        <InputRequiredText
+          dataCy="modal-textbox-rule-name"
+          id="modal-form-rule-name"
+          name="modal-form-rule-name"
+          value={ruleName}
+          onChange={setRuleName}
+          requiredHelperText="Required value"
+        />
       ),
+      fieldRequired: true,
     },
     {
       id: "modal-form-rule-desc",

--- a/src/components/modals/UserModals/AddUser.tsx
+++ b/src/components/modals/UserModals/AddUser.tsx
@@ -34,6 +34,7 @@ import useAlerts from "src/hooks/useAlerts";
 import { NO_SELECTION_OPTION } from "src/utils/constUtils";
 // Components
 import TypeAheadSelectWithCreate from "src/components/TypeAheadSelectWithCreate";
+import InputWithValidation from "src/components/layouts/InputWithValidation";
 
 interface GroupId {
   cn: string;
@@ -83,55 +84,11 @@ const AddUser = (props: PropsToAddUser) => {
   useEffect(() => {
     verifyPasswordValidationHandler();
   }, [newPassword, verifyNewPassword]);
-
-  // refs
-  const userLoginRef =
-    React.useRef() as React.MutableRefObject<HTMLInputElement>;
-  const firstNameRef =
-    React.useRef() as React.MutableRefObject<HTMLInputElement>;
-  const lastNameRef =
-    React.useRef() as React.MutableRefObject<HTMLInputElement>;
-  const userClassRef =
-    React.useRef() as React.MutableRefObject<HTMLInputElement>;
-
-  // Validation fields
-  const [userLoginValidation, setUserLoginValidation] = useState({
-    isError: false,
-    message: "Only alphanumeric and special characters _-.$",
-    pfError: ValidatedOptions.default,
-  });
-  const [firstNameValidation, setFirstNameValidation] = useState({
-    isError: false,
-    message: "",
-    pfError: ValidatedOptions.default,
-  });
-  const [lastNameValidation, setLastNameValidation] = useState({
-    isError: false,
-    message: "",
-    pfError: ValidatedOptions.default,
-  });
   const [verifyPasswordValidation, setVerifyPasswordValidation] = useState({
     isError: false,
     message: "",
     pfError: ValidatedOptions.default,
   });
-
-  // TextInput setters
-  const userLoginValueHandler = (value: string) => {
-    setUserLogin(value);
-  };
-
-  const firstNameValueHandler = (value: string) => {
-    setFirstName(value);
-  };
-
-  const lastNameValueHandler = (value: string) => {
-    setLastName(value);
-  };
-
-  const userClassValueHandler = (value: string) => {
-    setUserClass(value);
-  };
 
   const newPasswordValueHandler = (value: string) => {
     setNewPassword(value);
@@ -143,8 +100,8 @@ const AddUser = (props: PropsToAddUser) => {
 
   // User login: Valid characters in first char: ., _
   const userLoginFormatFirst = /^([A-Za-z._]).*$/;
-  // User login: Valid characters in body: '_', '-', '.', '$'
-  const userLoginFormatBody = /^.*([A-Za-z.-_$\d])$/;
+  // User login: Valid characters in body (every char must be in set): letters, digits, '_', '-', '.', '$'
+  const userLoginFormatBody = /^[A-Za-z0-9._\-$]*$/;
   // Valid characters: spaces and '-' symbols only
   const format = /[`!@#$%^&*()_+=[\]{};':"\\|,.<>/?~]/;
   // Valid characters: '-' symbols only
@@ -152,48 +109,6 @@ const AddUser = (props: PropsToAddUser) => {
 
   // TextInput validation handlers
   //   Returns true | false if error
-  const userLoginValidationHandler = () => {
-    if (
-      (!userLoginFormatFirst.test(userLogin.charAt(0)) ||
-        !userLoginFormatBody.test(userLogin.substring(1))) &&
-      userLogin.length > 0
-    ) {
-      const userLoginVal = {
-        isError: true,
-        message: "Only alphanumeric and special characters _-.$",
-        pfError: ValidatedOptions.error,
-      };
-      setUserLoginValidation(userLoginVal);
-      return true; // is error
-    }
-    return false;
-  };
-
-  const firstNameValidationHandler = () => {
-    if (format.test(firstName)) {
-      const firstNameVal = {
-        isError: true,
-        message: "First name should not contain special characters",
-        pfError: ValidatedOptions.error,
-      };
-      setFirstNameValidation(firstNameVal);
-      return true; // is error
-    }
-    return false;
-  };
-
-  const lastNameValidationHandler = () => {
-    if (formatWithoutSpaces.test(lastName)) {
-      const lastNameVal = {
-        isError: true,
-        message: "Last name should not contain special characters",
-        pfError: ValidatedOptions.error,
-      };
-      setLastNameValidation(lastNameVal);
-      return true; // is error
-    }
-    return false;
-  };
 
   const verifyPasswordValidationHandler = () => {
     if (newPassword !== verifyNewPassword) {
@@ -209,33 +124,7 @@ const AddUser = (props: PropsToAddUser) => {
     return false;
   };
 
-  // Reset validation methods
-  // - User login
-  const resetUserLoginError = () => {
-    setUserLoginValidation({
-      isError: false,
-      message: "Only alphanumeric and special characters _-.$",
-      pfError: ValidatedOptions.default,
-    });
-  };
-
-  // First name
-  const resetFirstNameError = () => {
-    setFirstNameValidation({
-      isError: false,
-      message: "",
-      pfError: ValidatedOptions.default,
-    });
-  };
-
-  // Last name
-  const resetLastNameError = () => {
-    setLastNameValidation({
-      isError: false,
-      message: "",
-      pfError: ValidatedOptions.default,
-    });
-  };
+  // Reset validation methods (password only)
 
   // Verify password
   const resetVerifyPassword = () => {
@@ -341,56 +230,49 @@ const AddUser = (props: PropsToAddUser) => {
       id: "modal-form-user-login",
       name: "User login",
       pfComponent: (
-        <>
-          <TextInput
-            type="text"
-            data-cy="modal-textbox-login"
-            id="modal-form-user-login"
-            name="modal-form-user-login"
-            onFocus={resetUserLoginError}
-            onBlur={userLoginValidationHandler}
-            value={userLogin}
-            onChange={(_event, value: string) => userLoginValueHandler(value)}
-            validated={userLoginValidation.pfError}
-            ref={userLoginRef}
-          />
-          <HelperText>
-            {!userLoginValidation.isError && (
-              <HelperTextItem>{userLoginValidation.message}</HelperTextItem>
-            )}
-            {userLoginValidation.isError && (
-              <HelperTextItem variant="error">
-                {userLoginValidation.message}
-              </HelperTextItem>
-            )}
-          </HelperText>
-        </>
+        <InputWithValidation
+          dataCy="modal-textbox-login"
+          id="modal-form-user-login"
+          name="modal-form-user-login"
+          isRequired
+          value={userLogin}
+          onChange={setUserLogin}
+          rules={[
+            {
+              id: "ruleLength",
+              message: "Must be at least 3 characters in length",
+              validate: (v: string) => v.length >= 3,
+            },
+            {
+              id: "ruleCharacters",
+              message: "Only alphanumeric and special characters _-.$",
+              validate: (v: string) =>
+                userLoginFormatFirst.test(v.charAt(0)) &&
+                userLoginFormatBody.test(v.substring(1)),
+            },
+          ]}
+        />
       ),
     },
     {
       id: "modal-form-first-name",
       name: "First name",
       pfComponent: (
-        <>
-          <TextInput
-            isRequired
-            type="text"
-            data-cy="modal-textbox-first-name"
-            id="modal-form-first-name"
-            name="modal-form-first-name"
-            onFocus={resetFirstNameError}
-            onBlur={firstNameValidationHandler}
-            value={firstName}
-            onChange={(_event, value: string) => firstNameValueHandler(value)}
-            validated={firstNameValidation.pfError}
-            ref={firstNameRef}
-          />
-          <HelperText>
-            <HelperTextItem variant="error">
-              {firstNameValidation.message}
-            </HelperTextItem>
-          </HelperText>
-        </>
+        <InputWithValidation
+          dataCy="modal-textbox-first-name"
+          id="modal-form-first-name"
+          name="modal-form-first-name"
+          value={firstName}
+          onChange={setFirstName}
+          isRequired
+          rules={[
+            {
+              id: "ruleCharacters",
+              message: "First name should not contain special characters",
+              validate: (v: string) => !format.test(v),
+            },
+          ]}
+        />
       ),
       fieldRequired: true,
     },
@@ -398,26 +280,22 @@ const AddUser = (props: PropsToAddUser) => {
       id: "modal-form-last-name",
       name: "Last name",
       pfComponent: (
-        <>
-          <TextInput
-            isRequired
-            type="text"
-            data-cy="modal-textbox-last-name"
-            id="modal-form-last-name"
-            name="modal-form-last-name"
-            onFocus={resetLastNameError}
-            onBlur={lastNameValidationHandler}
-            value={lastName}
-            onChange={(_event, value: string) => lastNameValueHandler(value)}
-            validated={lastNameValidation.pfError}
-            ref={lastNameRef}
-          />
-          <HelperText>
-            <HelperTextItem variant="error">
-              {lastNameValidation.message}
-            </HelperTextItem>
-          </HelperText>
-        </>
+        <InputWithValidation
+          dataCy="modal-textbox-last-name"
+          id="modal-form-last-name"
+          name="modal-form-last-name"
+          value={lastName}
+          onChange={setLastName}
+          isRequired
+          rules={[
+            {
+              id: "ruleCharacters",
+              message:
+                "Last name should not contain special characters or spaces",
+              validate: (v: string) => !formatWithoutSpaces.test(v),
+            },
+          ]}
+        />
       ),
       fieldRequired: true,
     },
@@ -426,13 +304,11 @@ const AddUser = (props: PropsToAddUser) => {
       name: "Class",
       pfComponent: (
         <TextInput
-          type="text"
           data-cy="modal-textbox-user-class"
           id="modal-form-user-class"
           name="modal-form-user-class"
           value={userClass}
-          onChange={(_event, value: string) => userClassValueHandler(value)}
-          ref={userClassRef}
+          onChange={(_event, value: string) => setUserClass(value)}
         />
       ),
       labelIcon:
@@ -501,11 +377,14 @@ const AddUser = (props: PropsToAddUser) => {
             passwordHidden={verifyPasswordHidden}
             validated={verifyPasswordValidation.pfError}
           />
-          <HelperText>
-            <HelperTextItem variant="error">
-              {verifyPasswordValidation.message}
-            </HelperTextItem>
-          </HelperText>
+          {verifyPasswordValidation.isError &&
+            verifyPasswordValidation.message !== "" && (
+              <HelperText>
+                <HelperTextItem variant="error">
+                  {verifyPasswordValidation.message}
+                </HelperTextItem>
+              </HelperText>
+            )}
         </>
       ),
     },
@@ -521,27 +400,14 @@ const AddUser = (props: PropsToAddUser) => {
 
   // Helper method to reset validation values
   const resetValidations = () => {
-    resetUserLoginError();
-    resetFirstNameError();
-    resetLastNameError();
     resetVerifyPassword();
   };
 
   // List of field validations
   const validateFields = () => {
     resetValidations();
-    const userLoginError = userLoginValidationHandler();
-    const firstNameError = firstNameValidationHandler();
-    const lastNameError = lastNameValidationHandler();
     const verifyPasswordError = verifyPasswordValidationHandler();
-    if (
-      userLoginError ||
-      firstNameError ||
-      lastNameError ||
-      verifyPasswordError
-    ) {
-      return false;
-    } else return true;
+    return !verifyPasswordError;
   };
 
   // Define status flags to determine user added successfully or error

--- a/src/login/SyncOtpPage.tsx
+++ b/src/login/SyncOtpPage.tsx
@@ -24,6 +24,7 @@ import {
 import { useNavigate } from "react-router";
 // Components
 import PasswordInput from "src/components/layouts/PasswordInput";
+import InputRequiredText from "src/components/layouts/InputRequiredText";
 
 const SyncOtpPage = () => {
   // Navigate
@@ -121,14 +122,13 @@ const SyncOtpPage = () => {
   const formFields = (
     <Form isHorizontal>
       <FormGroup label="Username" fieldId="username" required>
-        <TextInput
-          data-cy="sync-otp-textbox-username"
+        <InputRequiredText
+          dataCy="sync-otp-textbox-username"
           id="username"
           name="user"
-          type="text"
           value={uid}
-          onChange={(_ev, newUid) => setUid(newUid)}
-          isRequired={true}
+          onChange={setUid}
+          requiredHelperText="Required value"
         />
       </FormGroup>
       <FormGroup label="Password" fieldId="password" required>

--- a/src/pages/Configuration/ConfigObjectclassTable.tsx
+++ b/src/pages/Configuration/ConfigObjectclassTable.tsx
@@ -3,14 +3,10 @@ import {
   Button,
   Form,
   FormGroup,
-  HelperText,
-  HelperTextItem,
   Modal,
   ModalBody,
   ModalFooter,
   ModalHeader,
-  TextInput,
-  ValidatedOptions,
 } from "@patternfly/react-core";
 import { Table, TableText, Tr, Tbody, Td } from "@patternfly/react-table";
 // Utils
@@ -19,6 +15,7 @@ import {
   getParamProperties,
   updateIpaObject,
 } from "../../utils/ipaObjectUtils";
+import InputWithValidation from "src/components/layouts/InputWithValidation";
 
 interface PropsToTable extends IPAParamDefinition {
   title: string;
@@ -102,25 +99,22 @@ const ConfigObjectclassTable = (props: PropsToTable) => {
               fieldId={"oc"}
               isRequired
             >
-              <TextInput
-                data-cy="modal-textbox-objectclass"
+              <InputWithValidation
+                dataCy="modal-textbox-objectclass"
                 id="oc"
-                type="text"
+                name="oc"
                 value={newOC}
-                validated={
-                  newOC === "" || values.indexOf(newOC.toLowerCase()) !== -1
-                    ? ValidatedOptions.error
-                    : ValidatedOptions.default
-                }
-                onChange={(_event, value: string) => setNewOC(value)}
+                onChange={setNewOC}
+                isRequired
+                rules={[
+                  {
+                    id: "unique",
+                    message: "Must be unique",
+                    validate: (value: string) =>
+                      values.indexOf(value.toLowerCase()) === -1,
+                  },
+                ]}
               />
-              {values.indexOf(newOC.toLowerCase()) !== -1 && (
-                <HelperText>
-                  <HelperTextItem variant="error">
-                    This objectclass is already defined
-                  </HelperTextItem>
-                </HelperText>
-              )}
             </FormGroup>
           </Form>
         </ModalBody>

--- a/src/pages/Netgroups/NetgroupsMemberTable.tsx
+++ b/src/pages/Netgroups/NetgroupsMemberTable.tsx
@@ -8,8 +8,6 @@ import {
   ModalBody,
   ModalFooter,
   ModalHeader,
-  TextInput,
-  ValidatedOptions,
 } from "@patternfly/react-core";
 import { Td, Th, Tr } from "@patternfly/react-table";
 // Layout
@@ -29,6 +27,7 @@ import {
   useAddMemberToNetgroupsMutation,
   useRemoveMemberFromNetgroupsMutation,
 } from "../../services/rpcNetgroups";
+import InputWithValidation from "src/components/layouts/InputWithValidation";
 
 // These name spaces can be reused as the params to RPC (do not change them)
 interface PropsToTable {
@@ -508,18 +507,20 @@ const NetgroupsMemberTable = (props: PropsToTable) => {
               fieldId={"externalHostName"}
               isRequired
             >
-              <TextInput
-                data-cy="modal-textbox-external-host-name"
-                type="text"
+              <InputWithValidation
+                dataCy="modal-textbox-external-host-name"
                 id="externalHostName"
                 name="externalHostName"
                 value={externalHostName}
-                validated={
-                  externalHostName === "" || !externalHostName.includes(".")
-                    ? ValidatedOptions.error
-                    : ValidatedOptions.default
-                }
-                onChange={(_event, value: string) => setExternalHost(value)}
+                isRequired
+                rules={[
+                  {
+                    id: "external-host-name",
+                    message: "Must contain a period",
+                    validate: (value: string) => value.includes("."),
+                  },
+                ]}
+                onChange={setExternalHost}
               />
             </FormGroup>
           </Form>

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -521,6 +521,17 @@ export const isValidIpAddress = (ipAddress: string) => {
 };
 
 /**
+ * Validate that a string is empty or represents a number
+ */
+export const isEmptyOrNumber = (value: string) =>
+  value === "" || !isNaN(Number(value));
+
+/**
+ * Default validation message for empty-or-number fields
+ */
+export const EMPTY_OR_NUMBER_MESSAGE = "Must be empty or a number";
+
+/**
  * Some values in a table might not have a specific value defined
  *
  * (i.e. empty string ""). This is not allowed by the table component.


### PR DESCRIPTION
Changed input based on PF6 design, input is either validated dynamically where possible, in inputs that are required but have no validation, a dynamic helper text is introduced.

When there is a validation in place, the error text is red, this is the component `InputWithValidation`. If the field is required but no validation takes place `InputRequired` component is used and only the helper text is shown and disappears if a field is not empty. 

The two new components `InputRequired`  `InputWithValidation` and follow explampes from the PF6 https://www.patternfly.org/components/helper-text/react-demos "Dynamic helper text
" and "Static text and dynamic status", respectively

Related: #827 

## Summary by Sourcery

Introduce reusable InputWithValidation and InputWithHelperText components and refactor modal forms to use them for consistent dynamic validation and helper text, removing custom inline validation logic and simplifying input handling.

New Features:
- Add InputWithValidation component for applying dynamic validation rules
- Add InputWithHelperText component for displaying required-field helper text

Enhancements:
- Refactor various modal forms to replace PatternFly TextInput and manual validation with the new input components
- Remove per-field validation state and handlers in AddUser and other modals
- Update user login regex to enforce valid character set in body segment