### PR TITLE
Custom text inputs use input with validation and required input

### DIFF
--- a/src/components/Form/IpaTextInput/IpaTextInput.tsx
+++ b/src/components/Form/IpaTextInput/IpaTextInput.tsx
@@ -6,9 +6,17 @@ import {
   getParamProperties,
   convertToString,
 } from "src/utils/ipaObjectUtils";
+// Layout helpers
+import InputRequiredText from "src/components/layouts/InputRequiredText";
+import InputWithValidation, {
+  RuleProps,
+} from "src/components/layouts/InputWithValidation";
 
 export interface IpaTextInputProps extends IPAParamDefinition {
   dataCy: string;
+  helperTextMessage?: string;
+  errorMessage?: string;
+  rules?: Array<RuleProps>;
 }
 
 const IpaTextInput = (props: IpaTextInputProps) => {
@@ -21,6 +29,64 @@ const IpaTextInput = (props: IpaTextInputProps) => {
   React.useEffect(() => {
     setTextInputValue(convertToString(value));
   }, [value]);
+
+  if (readOnly) {
+    return (
+      <TextInput
+        data-cy={props.dataCy}
+        id={props.name}
+        name={props.name}
+        value={textInputValue}
+        onChange={(_event, value) => {
+          setTextInputValue(value);
+          onChange(value);
+        }}
+        type="text"
+        aria-label={
+          props.ariaLabel !== undefined ? props.ariaLabel : props.name
+        }
+        isRequired={required}
+        readOnlyVariant={"plain"}
+      />
+    );
+  }
+
+  if (props.rules && props.rules.length > 0) {
+    return (
+      <InputWithValidation
+        dataCy={props.dataCy}
+        id={props.name}
+        name={props.name}
+        value={textInputValue}
+        onChange={(value) => {
+          setTextInputValue(value);
+          onChange(value);
+        }}
+        isRequired={required}
+        isDisabled={false}
+        rules={props.rules}
+        type="text"
+      />
+    );
+  }
+
+  if (required) {
+    return (
+      <InputRequiredText
+        dataCy={props.dataCy}
+        id={props.name}
+        name={props.name}
+        value={textInputValue}
+        onChange={(value) => {
+          setTextInputValue(value);
+          onChange(value);
+        }}
+        isDisabled={false}
+        requiredHelperText={props.helperTextMessage}
+        type="text"
+      />
+    );
+  }
 
   return (
     <TextInput
@@ -35,7 +101,6 @@ const IpaTextInput = (props: IpaTextInputProps) => {
       type="text"
       aria-label={props.ariaLabel !== undefined ? props.ariaLabel : props.name}
       isRequired={required}
-      readOnlyVariant={readOnly ? "plain" : undefined}
     />
   );
 };

--- a/src/components/ResetIdpPassword.tsx
+++ b/src/components/ResetIdpPassword.tsx
@@ -1,16 +1,8 @@
 import React from "react";
 // PatternFly
-import {
-  Button,
-  HelperText,
-  HelperTextItem,
-  ValidatedOptions,
-} from "@patternfly/react-core";
+import { Button } from "@patternfly/react-core";
 // Data types
-import {
-  IDPServer,
-  PasswordValidationType,
-} from "src/utils/datatypes/globalDataTypes";
+import { IDPServer } from "src/utils/datatypes/globalDataTypes";
 // Modals
 import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
 // Components
@@ -42,37 +34,6 @@ const ResetIdpPassword = (props: PropsToResetIdpPassword) => {
   const [passwordHidden, setPasswordHidden] = React.useState(true);
   const [verifyPasswordHidden, setVerifyPasswordHidden] = React.useState(true);
 
-  // Verify password
-  const [passwordValidationResult, setPasswordValidationResult] =
-    React.useState<PasswordValidationType>({
-      isError: false,
-      message: "",
-      pfError: ValidatedOptions.default,
-    });
-
-  // Reset the verify password field
-  const resetVerifyPassword = () => {
-    setPasswordValidationResult({
-      isError: false,
-      message: "",
-      pfError: ValidatedOptions.default,
-    });
-  };
-
-  // Checks that the passwords are the same
-  const validatePasswords = () => {
-    if (newPassword !== verifyPassword) {
-      setPasswordValidationResult({
-        isError: true,
-        message: "Passwords must match",
-        pfError: ValidatedOptions.error,
-      });
-      return true; // is error
-    }
-    resetVerifyPassword();
-    return false;
-  };
-
   // Fields
   const fields = [
     {
@@ -84,7 +45,6 @@ const ResetIdpPassword = (props: PropsToResetIdpPassword) => {
           name="password"
           value={newPassword}
           aria-label="new password text input"
-          onFocus={resetVerifyPassword}
           onChange={setNewPassword}
           onRevealHandler={setPasswordHidden}
           passwordHidden={passwordHidden}
@@ -102,27 +62,22 @@ const ResetIdpPassword = (props: PropsToResetIdpPassword) => {
             name="password2"
             value={verifyPassword}
             aria-label="verify password text input"
-            onFocus={resetVerifyPassword}
             onChange={setVerifyPassword}
             onRevealHandler={setVerifyPasswordHidden}
             passwordHidden={verifyPasswordHidden}
-            validated={passwordValidationResult.pfError}
             dataCy="modal-textbox-verify-password"
+            rules={[
+              {
+                id: "verify-match",
+                message: "Passwords must match",
+                validate: (v: string) => v === newPassword,
+              },
+            ]}
           />
-          <HelperText>
-            <HelperTextItem variant="error">
-              {passwordValidationResult.message}
-            </HelperTextItem>
-          </HelperText>
         </>
       ),
     },
   ];
-
-  // Verify the passwords are the same when we update a password value
-  React.useEffect(() => {
-    validatePasswords();
-  }, [newPassword, verifyPassword]);
 
   // Reset fields and close modal
   const resetFieldsAndCloseModal = () => {
@@ -180,9 +135,9 @@ const ResetIdpPassword = (props: PropsToResetIdpPassword) => {
       type="submit"
       form="reset-password-form"
       isDisabled={
-        passwordValidationResult.isError ||
         newPassword === "" ||
-        verifyPassword === ""
+        verifyPassword === "" ||
+        newPassword !== verifyPassword
       }
     >
       Reset password

--- a/src/components/UsersSections/UsersIdentity.tsx
+++ b/src/components/UsersSections/UsersIdentity.tsx
@@ -30,6 +30,7 @@ const UsersIdentity = (props: PropsToUsersIdentity) => {
       onChange={recordOnChange}
       objectName="user"
       metadata={props.metadata}
+      helperTextMessage="Please enter a first name"
     />
   );
 
@@ -43,6 +44,7 @@ const UsersIdentity = (props: PropsToUsersIdentity) => {
       onChange={recordOnChange}
       objectName="user"
       metadata={props.metadata}
+      helperTextMessage="Please enter a last name"
     />
   );
 
@@ -56,6 +58,7 @@ const UsersIdentity = (props: PropsToUsersIdentity) => {
       onChange={recordOnChange}
       objectName="user"
       metadata={props.metadata}
+      helperTextMessage="Please enter a full name"
     />
   );
 

--- a/src/components/layouts/InputRequiredText.tsx
+++ b/src/components/layouts/InputRequiredText.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 // PatternFly
-import { TextInput } from "@patternfly/react-core";
 import HelperTextWithIcon from "./HelperTextWithIcon";
+import { TextInput, TextInputProps } from "@patternfly/react-core";
 
 interface InputRequiredTextProps {
   dataCy: string;
@@ -11,6 +11,7 @@ interface InputRequiredTextProps {
   onChange: (value: string) => void;
   requiredHelperText?: string;
   isDisabled?: boolean;
+  type?: TextInputProps["type"];
 }
 
 const InputRequiredText = (props: InputRequiredTextProps) => {
@@ -23,7 +24,7 @@ const InputRequiredText = (props: InputRequiredTextProps) => {
         id={props.id}
         name={props.name}
         value={props.value}
-        type="text"
+        type={props.type || "text"}
         isRequired={true}
         aria-label={props.name}
         aria-describedby={helperTextId}

--- a/src/components/layouts/InputWithValidation.tsx
+++ b/src/components/layouts/InputWithValidation.tsx
@@ -6,7 +6,10 @@ import {
   HelperTextItem,
   TextInput,
 } from "@patternfly/react-core";
-import type { HelperTextItemProps } from "@patternfly/react-core";
+import type {
+  HelperTextItemProps,
+  TextInputProps,
+} from "@patternfly/react-core";
 
 type HelperTextVariant = NonNullable<HelperTextItemProps["variant"]>;
 type RuleState = {
@@ -14,7 +17,7 @@ type RuleState = {
   state: HelperTextVariant;
   message: string;
 };
-type RuleProps = {
+export type RuleProps = {
   id: string;
   message: string;
   validate: (value: string) => boolean;
@@ -31,6 +34,7 @@ interface InputWithValidationProps {
   placeholder?: string;
   rules: Array<RuleProps>;
   showAlways?: boolean; // if true, show helper text even if value is empty
+  type?: TextInputProps["type"];
 }
 
 const InputWithValidation = (props: InputWithValidationProps) => {
@@ -73,7 +77,7 @@ const InputWithValidation = (props: InputWithValidationProps) => {
         id={props.id}
         name={props.name}
         value={props.value}
-        type="text"
+        type={props.type || "text"}
         isRequired={props.isRequired}
         isDisabled={props.isDisabled}
         aria-label={props.name}

--- a/src/components/layouts/PasswordInput/PasswordInput.tsx
+++ b/src/components/layouts/PasswordInput/PasswordInput.tsx
@@ -8,6 +8,11 @@ import {
 } from "@patternfly/react-core";
 import { EyeSlashIcon } from "@patternfly/react-icons";
 import { EyeIcon } from "@patternfly/react-icons";
+// Layout helpers
+import InputRequiredText from "src/components/layouts/InputRequiredText";
+import InputWithValidation, {
+  RuleProps,
+} from "src/components/layouts/InputWithValidation";
 
 export interface PropsToPasswordInput {
   dataCy: string;
@@ -22,14 +27,83 @@ export interface PropsToPasswordInput {
   validated?: "success" | "warning" | "error" | "default";
   isRequired?: boolean;
   isDisabled?: boolean;
+  // Optional validation rules to enable helper messages rendering
+  rules?: Array<RuleProps>;
+  requiredHelperText?: string;
 }
 
 // Note - onChange function should trigger validation check (validated prop)
 
+const RevealButton = (props: {
+  dataCy: string;
+  passwordHidden?: boolean;
+  onRevealHandler: (value: boolean) => void;
+}) => (
+  <InputGroupItem>
+    <Button
+      data-cy={props.dataCy + "-reveal-button"}
+      variant="control"
+      onClick={() => props.onRevealHandler(!props.passwordHidden)}
+      aria-label={props.passwordHidden ? "Show password" : "Hide password"}
+    >
+      {props.passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
+    </Button>
+  </InputGroupItem>
+);
+
 const PasswordInput = (props: PropsToPasswordInput) => {
+  if (props.rules && props.rules.length > 0) {
+    return (
+      <InputGroup>
+        <div className="pf-v6-u-display-block">
+          <InputWithValidation
+            dataCy={props.dataCy}
+            id={props.id as string}
+            name={props.name as string}
+            value={props.value || ""}
+            onChange={props.onChange}
+            isRequired={props.isRequired}
+            isDisabled={props.isDisabled}
+            rules={props.rules!}
+            type={props.passwordHidden ? "password" : "text"}
+          />
+        </div>
+        <RevealButton
+          dataCy={props.dataCy}
+          passwordHidden={props.passwordHidden}
+          onRevealHandler={props.onRevealHandler}
+        />
+      </InputGroup>
+    );
+  }
+
+  if (props.isRequired) {
+    return (
+      <InputGroup>
+        <div className="pf-v6-u-display-block">
+          <InputRequiredText
+            dataCy={props.dataCy}
+            id={props.id as string}
+            name={props.name as string}
+            value={props.value || ""}
+            onChange={props.onChange}
+            isDisabled={props.isDisabled}
+            requiredHelperText={props.requiredHelperText}
+            type={props.passwordHidden ? "password" : "text"}
+          />
+        </div>
+        <RevealButton
+          dataCy={props.dataCy}
+          passwordHidden={props.passwordHidden}
+          onRevealHandler={props.onRevealHandler}
+        />
+      </InputGroup>
+    );
+  }
+
   return (
     <InputGroup>
-      <InputGroupItem isFill>
+      <InputGroupItem>
         <TextInput
           data-cy={props.dataCy}
           aria-label={props.ariaLabel ?? props.name}
@@ -40,20 +114,15 @@ const PasswordInput = (props: PropsToPasswordInput) => {
           onFocus={props.onFocus}
           onChange={(_event, value) => props.onChange(value)}
           validated={props.validated}
-          required={props.isRequired || false}
+          isRequired={props.isRequired || false}
           isDisabled={props.isDisabled || false}
         />
       </InputGroupItem>
-      <InputGroupItem>
-        <Button
-          data-cy={props.dataCy + "-reveal-button"}
-          variant="control"
-          onClick={() => props.onRevealHandler(!props.passwordHidden)}
-          aria-label={props.passwordHidden ? "Show password" : "Hide password"}
-        >
-          {props.passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
-        </Button>
-      </InputGroupItem>
+      <RevealButton
+        dataCy={props.dataCy}
+        passwordHidden={props.passwordHidden}
+        onRevealHandler={props.onRevealHandler}
+      />
     </InputGroup>
   );
 };

--- a/src/components/modals/HostModals/HostSetPassword.tsx
+++ b/src/components/modals/HostModals/HostSetPassword.tsx
@@ -1,11 +1,6 @@
 import React from "react";
 // PatternFly
-import {
-  Button,
-  HelperText,
-  HelperTextItem,
-  ValidatedOptions,
-} from "@patternfly/react-core";
+import { Button } from "@patternfly/react-core";
 // Modals
 import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
 // Components
@@ -37,22 +32,6 @@ const HostSetPassword = (props: PropsToResetPassword) => {
   const [passwordHidden, setPasswordHidden] = React.useState(true);
   const [verifyPasswordHidden, setVerifyPasswordHidden] = React.useState(true);
 
-  // Verify password
-  const [passwordValidationResult, setPasswordValidationResult] =
-    React.useState({
-      isError: false,
-      message: "",
-      pfError: ValidatedOptions.default,
-    });
-
-  const resetVerifyPassword = () => {
-    setPasswordValidationResult({
-      isError: false,
-      message: "",
-      pfError: ValidatedOptions.default,
-    });
-  };
-
   // Fields
   const fields = [
     {
@@ -65,7 +44,6 @@ const HostSetPassword = (props: PropsToResetPassword) => {
           name="password"
           value={newPassword}
           aria-label="new password text input"
-          onFocus={resetVerifyPassword}
           onChange={setNewPassword}
           onRevealHandler={setPasswordHidden}
           passwordHidden={passwordHidden}
@@ -83,41 +61,21 @@ const HostSetPassword = (props: PropsToResetPassword) => {
             name="password2"
             value={verifyPassword}
             aria-label="verify password text input"
-            onFocus={resetVerifyPassword}
             onChange={setVerifyPassword}
             onRevealHandler={setVerifyPasswordHidden}
             passwordHidden={verifyPasswordHidden}
-            validated={passwordValidationResult.pfError}
+            rules={[
+              {
+                id: "verify-match",
+                message: "Passwords must match",
+                validate: (v: string) => v === newPassword,
+              },
+            ]}
           />
-          <HelperText>
-            <HelperTextItem variant="error">
-              {passwordValidationResult.message}
-            </HelperTextItem>
-          </HelperText>
         </>
       ),
     },
   ];
-
-  // Checks that the passwords are the same
-  const validatePasswords = () => {
-    if (newPassword !== verifyPassword) {
-      const verifyPassVal = {
-        isError: true,
-        message: "Passwords must match",
-        pfError: ValidatedOptions.error,
-      };
-      setPasswordValidationResult(verifyPassVal);
-      return true; // is error
-    }
-    resetVerifyPassword();
-    return false;
-  };
-
-  // Verify the passwords are the same when we update a password value
-  React.useEffect(() => {
-    validatePasswords();
-  }, [newPassword, verifyPassword]);
 
   // Reset fields and close modal
   const resetFieldsAndCloseModal = () => {
@@ -170,9 +128,9 @@ const HostSetPassword = (props: PropsToResetPassword) => {
       type="submit"
       form="reset-password-form"
       isDisabled={
-        passwordValidationResult.isError ||
         newPassword === "" ||
-        verifyPassword === ""
+        verifyPassword === "" ||
+        newPassword !== verifyPassword
       }
     >
       Reset password

--- a/src/components/modals/UserModals/ResetPassword.tsx
+++ b/src/components/modals/UserModals/ResetPassword.tsx
@@ -1,12 +1,6 @@
 import React from "react";
 // PatternFly
-import {
-  Button,
-  HelperText,
-  HelperTextItem,
-  TextInput,
-  ValidatedOptions,
-} from "@patternfly/react-core";
+import { Button, TextInput } from "@patternfly/react-core";
 // Modals
 import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
 // Components
@@ -51,22 +45,6 @@ const ResetPassword = (props: PropsToResetPassword) => {
     React.useState(true);
   const [verifyPasswordHidden, setVerifyPasswordHidden] = React.useState(true);
 
-  // Verify password
-  const [passwordValidationResult, setPasswordValidationResult] =
-    React.useState({
-      isError: false,
-      message: "",
-      pfError: ValidatedOptions.default,
-    });
-
-  const resetVerifyPassword = () => {
-    setPasswordValidationResult({
-      isError: false,
-      message: "",
-      pfError: ValidatedOptions.default,
-    });
-  };
-
   // Fields
   const notLoggedInfields = [
     {
@@ -78,7 +56,6 @@ const ResetPassword = (props: PropsToResetPassword) => {
           name="password"
           value={newPassword}
           aria-label="new password text input"
-          onFocus={resetVerifyPassword}
           onChange={setNewPassword}
           onRevealHandler={setPasswordHidden}
           passwordHidden={passwordHidden}
@@ -96,18 +73,18 @@ const ResetPassword = (props: PropsToResetPassword) => {
             name="password2"
             value={verifyPassword}
             aria-label="verify password text input"
-            onFocus={resetVerifyPassword}
             onChange={setVerifyPassword}
             onRevealHandler={setVerifyPasswordHidden}
             passwordHidden={verifyPasswordHidden}
-            validated={passwordValidationResult.pfError}
             dataCy="modal-textbox-verify-password"
+            rules={[
+              {
+                id: "verify-match",
+                message: "Passwords must match",
+                validate: (v: string) => v === newPassword,
+              },
+            ]}
           />
-          <HelperText>
-            <HelperTextItem variant="error">
-              {passwordValidationResult.message}
-            </HelperTextItem>
-          </HelperText>
         </>
       ),
     },
@@ -123,7 +100,6 @@ const ResetPassword = (props: PropsToResetPassword) => {
           name="current_password"
           value={currentPassword}
           aria-label="current password text input"
-          onFocus={resetVerifyPassword}
           onChange={setCurrentPassword}
           onRevealHandler={setCurrentPasswordHidden}
           passwordHidden={currentPasswordHidden}
@@ -140,7 +116,6 @@ const ResetPassword = (props: PropsToResetPassword) => {
           name="password"
           value={newPassword}
           aria-label="new password text input"
-          onFocus={resetVerifyPassword}
           onChange={setNewPassword}
           onRevealHandler={setPasswordHidden}
           passwordHidden={passwordHidden}
@@ -158,18 +133,18 @@ const ResetPassword = (props: PropsToResetPassword) => {
             name="password2"
             value={verifyPassword}
             aria-label="verify password text input"
-            onFocus={resetVerifyPassword}
             onChange={setVerifyPassword}
             onRevealHandler={setVerifyPasswordHidden}
             passwordHidden={verifyPasswordHidden}
-            validated={passwordValidationResult.pfError}
             dataCy="modal-textbox-verify-password"
+            rules={[
+              {
+                id: "verify-match",
+                message: "Passwords must match",
+                validate: (v: string) => v === newPassword,
+              },
+            ]}
           />
-          <HelperText>
-            <HelperTextItem variant="error">
-              {passwordValidationResult.message}
-            </HelperTextItem>
-          </HelperText>
         </>
       ),
     },
@@ -188,26 +163,6 @@ const ResetPassword = (props: PropsToResetPassword) => {
       ),
     },
   ];
-
-  // Checks that the passwords are the same
-  const validatePasswords = () => {
-    if (newPassword !== verifyPassword) {
-      const verifyPassVal = {
-        isError: true,
-        message: "Passwords must match",
-        pfError: ValidatedOptions.error,
-      };
-      setPasswordValidationResult(verifyPassVal);
-      return true; // is error
-    }
-    resetVerifyPassword();
-    return false;
-  };
-
-  // Verify the passwords are the same when we update a password value
-  React.useEffect(() => {
-    validatePasswords();
-  }, [newPassword, verifyPassword]);
 
   // Reset fields and close modal
   const resetFieldsAndCloseModal = () => {
@@ -289,9 +244,9 @@ const ResetPassword = (props: PropsToResetPassword) => {
       type="submit"
       form="reset-password-form"
       isDisabled={
-        passwordValidationResult.isError ||
         newPassword === "" ||
-        verifyPassword === ""
+        verifyPassword === "" ||
+        newPassword !== verifyPassword
       }
       data-cy="modal-button-reset-password"
     >

--- a/src/login/ResetPasswordPage.tsx
+++ b/src/login/ResetPasswordPage.tsx
@@ -4,13 +4,10 @@ import {
   Form,
   FormGroup,
   TextInput,
-  HelperText,
-  HelperTextItem,
   ActionGroup,
   Button,
   LoginPage,
   ListVariant,
-  ValidatedOptions,
 } from "@patternfly/react-core";
 // Images
 import BrandImg from "src/assets/images/product-name.png";
@@ -69,41 +66,6 @@ const ResetPasswordPage = () => {
   const [newPasswordHidden, setNewPasswordHidden] = React.useState(true);
   const [verifyPasswordHidden, setVerifyPasswordHidden] = React.useState(true);
   const [otpHidden, setOtpHidden] = React.useState(true);
-
-  // Verify passwords
-  const [passwordValidationResult, setPasswordValidationResult] =
-    React.useState({
-      isError: false,
-      message: "",
-      pfError: ValidatedOptions.default,
-    });
-
-  const resetVerifyPassword = () => {
-    setPasswordValidationResult({
-      isError: false,
-      message: "",
-      pfError: ValidatedOptions.default,
-    });
-  };
-  // Checks that the passwords are the same
-  const validatePasswords = () => {
-    if (newPassword !== verifyPassword) {
-      const verifyPassVal = {
-        isError: true,
-        message: "Passwords must match",
-        pfError: ValidatedOptions.error,
-      };
-      setPasswordValidationResult(verifyPassVal);
-      return true; // is error
-    }
-    resetVerifyPassword();
-    return false;
-  };
-
-  // Verify the passwords are the same when we update a password value
-  React.useEffect(() => {
-    validatePasswords();
-  }, [newPassword, verifyPassword]);
 
   // Reset button should be disabled if some conditions are met
   const evaluateResetButtonDisabled = () => {
@@ -243,13 +205,14 @@ const ResetPasswordPage = () => {
           passwordHidden={verifyPasswordHidden}
           isRequired={true}
           isDisabled={!uid}
-          validated={passwordValidationResult.pfError}
+          rules={[
+            {
+              id: "verify-match",
+              message: "Passwords must match",
+              validate: (v: string) => v === newPassword,
+            },
+          ]}
         />
-        <HelperText>
-          <HelperTextItem variant="error">
-            {passwordValidationResult.message}
-          </HelperTextItem>
-        </HelperText>
       </FormGroup>
       <FormGroup label="OTP" fieldId="otp">
         <PasswordInput

--- a/src/pages/Trusts/AddTrustModal.tsx
+++ b/src/pages/Trusts/AddTrustModal.tsx
@@ -5,11 +5,8 @@ import {
   Checkbox,
   Flex,
   FormGroup,
-  HelperTextItem,
-  HelperText,
   Radio,
   TextInput,
-  ValidatedOptions,
 } from "@patternfly/react-core";
 // Components
 import ModalWithFormLayout, {
@@ -29,11 +26,7 @@ import { SerializedError } from "@reduxjs/toolkit";
 // Icons
 import { InfoCircleIcon } from "@patternfly/react-icons";
 // Data types
-import {
-  DEFAULT_ERROR_VALIDATION_DATA,
-  ErrorValidationData,
-  RangeType,
-} from "src/utils/datatypes/globalDataTypes";
+import { RangeType } from "src/utils/datatypes/globalDataTypes";
 
 interface PropsToAddTrustModal {
   isOpen: boolean;
@@ -85,36 +78,15 @@ const AddTrustModal = (props: PropsToAddTrustModal) => {
   const [preSharedPwdVerifyHidden, setPreSharedPwdVerifyHidden] =
     React.useState<boolean>(true);
 
-  React.useEffect(() => {
-    verifyPreSharedPwdVerifyValidationHandler();
-  }, [preSharedPwd, preSharedPwdVerify]);
-
-  // Pre-shared password verify validation
-  const [preSharedPwdVerifyValidation, setPreSharedPwdVerifyValidation] =
-    React.useState<ErrorValidationData>(DEFAULT_ERROR_VALIDATION_DATA);
-
-  const resetPreSharedPwdVerifyValidation = () => {
-    setPreSharedPwdVerifyValidation(DEFAULT_ERROR_VALIDATION_DATA);
-  };
-
-  const verifyPreSharedPwdVerifyValidationHandler = () => {
-    if (preSharedPwd !== preSharedPwdVerify) {
-      const verifyPassVal = {
-        isError: true,
-        message: "Passwords must match",
-        pfError: ValidatedOptions.error,
-      };
-      setPreSharedPwdVerifyValidation(verifyPassVal);
-      return true; // is error
-    }
-    resetPreSharedPwdVerifyValidation();
-    return false;
-  };
-
   const validateFields = () => {
-    resetPreSharedPwdVerifyValidation();
-    const validation = verifyPreSharedPwdVerifyValidationHandler();
-    return !validation;
+    if (authMethod === "pre-shared-pwd") {
+      if (preSharedPwd === "" || preSharedPwdVerify === "") return false;
+      if (preSharedPwd !== preSharedPwdVerify) return false;
+    }
+    if (authMethod === "admin") {
+      if (adminAccount === "" || adminAccounPwd === "") return false;
+    }
+    return domainName !== "";
   };
 
   const clearFields = () => {
@@ -364,7 +336,6 @@ const AddTrustModal = (props: PropsToAddTrustModal) => {
                 onRevealHandler={() =>
                   setPreSharedPwdHidden(!preSharedPwdHidden)
                 }
-                onFocus={resetPreSharedPwdVerifyValidation}
                 passwordHidden={preSharedPwdHidden}
               />
             </FormGroup>
@@ -386,18 +357,15 @@ const AddTrustModal = (props: PropsToAddTrustModal) => {
                   onRevealHandler={() =>
                     setPreSharedPwdVerifyHidden(!preSharedPwdVerifyHidden)
                   }
-                  onFocus={resetPreSharedPwdVerifyValidation}
                   passwordHidden={preSharedPwdVerifyHidden}
-                  validated={preSharedPwdVerifyValidation.pfError}
+                  rules={[
+                    {
+                      id: "verify-match",
+                      message: "Passwords must match",
+                      validate: (v: string) => v === preSharedPwd,
+                    },
+                  ]}
                 />
-                {preSharedPwdVerifyValidation.isError &&
-                  preSharedPwdVerifyValidation.message !== "" && (
-                    <HelperText>
-                      <HelperTextItem variant="error">
-                        {preSharedPwdVerifyValidation.message}
-                      </HelperTextItem>
-                    </HelperText>
-                  )}
               </>
             </FormGroup>
           </div>
@@ -492,7 +460,6 @@ const AddTrustModal = (props: PropsToAddTrustModal) => {
 
   const isButtonDisabled =
     isAddButtonSpinning ||
-    preSharedPwdVerifyValidation.isError ||
     domainName.length === 0 ||
     isAdminAccountDisabled ||
     isPreSharedPwdDisabled;


### PR DESCRIPTION
Changes to custom input components to use a `InputRequiredText` and `InputWithValidation` components
## Summary by Sourcery

Replace manual text input validation in the AddHost modal with a reusable InputWithValidation component and enhance the generic IpaTextInput to support dynamic helper and error messages, aria attributes, and validation state.

New Features:
- Add dynamic helper text and error message support to IpaTextInput via new props and aria attributes
- Use InputWithValidation for host name and IP address fields in the AddHost modal
- Automatically disable the "Force" checkbox until the IP address becomes valid

Enhancements:
- Remove custom validation handlers, refs, and state for text inputs in AddHost and consolidate validation rules into InputWithValidation

Chores:
- Supply default helper and error messages to IpaTextInput instances in UsersIdentity