### PR TITLE
Rename Cypress env variable HOSTNAME to DOMAINNAME

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -37,7 +37,6 @@ export default defineConfig({
     BASE_URL: "/ipa/modern-ui",
     ADMIN_LOGIN: "admin",
     ADMIN_PASSWORD: "Secret123",
-    HOSTNAME: "ipa.test",
     SERVER_NAME: "webui.ipa.test",
     TAGS: "not @ignore",
   },

--- a/cypress/e2e/hbac/hbac_rule/hbac_rule.ts
+++ b/cypress/e2e/hbac/hbac_rule/hbac_rule.ts
@@ -67,8 +67,6 @@ Given(
 Given(
   "I have host {string} in rule {string}",
   (host: string, ruleName: string) => {
-    const hostFqdn = `${host}.${Cypress.env("HOSTNAME")}`;
-
     loginAsAdmin();
     navigateTo(`hbac-rules/${ruleName}`);
 
@@ -79,14 +77,14 @@ Given(
     cy.dataCy("dual-list-modal").should("exist");
 
     cy.dataCy("dual-list-search-link").click();
-    addItemToRightList(hostFqdn);
+    addItemToRightList(host);
 
     cy.dataCy("modal-button-add").click();
     cy.dataCy("dual-list-modal").should("not.exist");
     cy.dataCy("add-member-success").should("exist");
 
-    findEntryInTable(hostFqdn, "host");
-    entryExists(hostFqdn);
+    findEntryInTable(host, "host");
+    entryExists(host);
     logout();
   }
 );
@@ -97,23 +95,22 @@ Given(
     loginAsAdmin();
     navigateTo(`hbac-rules/${ruleName}`);
 
-    const fullHost = host + "." + Cypress.env("HOSTNAME");
     cy.dataCy("hbac-rules-tab-settings-tab-hosts").click();
     cy.dataCy("hbac-rules-tab-settings-tab-hosts").should("be.visible");
 
-    findEntryInTable(fullHost, "host");
-    entryExists(fullHost);
+    findEntryInTable(host, "host");
+    entryExists(host);
 
-    findEntryInTable(fullHost, "host");
-    checkEntry(fullHost);
+    findEntryInTable(host, "host");
+    checkEntry(host);
 
     cy.dataCy("settings-button-delete-host").click();
     cy.dataCy("remove-hbac-rule-members-modal").should("exist");
-    entryExists(fullHost);
+    entryExists(host);
 
     cy.dataCy("modal-button-delete").click();
     cy.dataCy("remove-member-success").should("exist");
-    entryDoesNotExist(fullHost);
+    entryDoesNotExist(host);
 
     logout();
   }

--- a/cypress/e2e/hbac/hbac_rule/hbac_rule_settings.feature
+++ b/cypress/e2e/hbac/hbac_rule/hbac_rule_settings.feature
@@ -147,7 +147,7 @@ Feature: Hbac rule settings manipulation
 
   @seed
   Scenario: Add a new host that will be used in the tests
-    Given host "my-new-host" exists
+    Given host "my-new-host.ipa.test" exists
 
   @test
   Scenario: Add host to Host category
@@ -174,7 +174,7 @@ Feature: Hbac rule settings manipulation
 
   @cleanup
   Scenario: Delete the host from the rule
-    Given I delete host "my-new-host" from rule "rule1"
+    Given I delete host "my-new-host.ipa.test" from rule "rule1"
 
   @seed
   Scenario: Add a host to the rule
@@ -310,7 +310,7 @@ Feature: Hbac rule settings manipulation
 
   @cleanup
   Scenario: Delete host for cleanup
-    Given I delete host "my-new-host"
+    Given I delete host "my-new-host.ipa.test"
 
   @test
   Scenario: Add service to Service category

--- a/cypress/e2e/netgroup/netgroup.ts
+++ b/cypress/e2e/netgroup/netgroup.ts
@@ -66,20 +66,15 @@ Given(
     cy.dataCy(`settings-button-add-${elementType}`).click();
     cy.dataCy("dual-list-modal").should("exist");
 
-    const itemToAdd =
-      elementType === "host"
-        ? `${element}.${Cypress.env("HOSTNAME")}`
-        : element;
-
     cy.dataCy("dual-list-search-link").click();
-    addItemToRightList(itemToAdd);
+    addItemToRightList(element);
 
     cy.dataCy("modal-button-add").click();
     cy.dataCy("dual-list-modal").should("not.exist");
     cy.dataCy("add-member-success").should("exist");
 
-    findEntryInTable(itemToAdd, elementType);
-    entryExists(itemToAdd);
+    findEntryInTable(element, elementType);
+    entryExists(element);
 
     logout();
   }
@@ -94,24 +89,19 @@ Given(
     assertMemberEntity(elementType);
     ensureTabVisibleAndOpen(elementType as MemberEntity);
 
-    const itemToDelete =
-      elementType === "host"
-        ? `${element}.${Cypress.env("HOSTNAME")}`
-        : element;
-
-    findEntryInTable(itemToDelete, elementType);
-    entryExists(itemToDelete);
-    checkEntry(itemToDelete);
+    findEntryInTable(element, elementType);
+    entryExists(element);
+    checkEntry(element);
 
     cy.dataCy(`settings-button-delete-${elementType}`).click();
     cy.dataCy("remove-netgroup-members-modal").should("exist");
-    entryExists(itemToDelete);
+    entryExists(element);
 
     cy.dataCy("modal-button-delete").click();
     cy.dataCy("remove-netgroup-members-modal").should("not.exist");
     cy.dataCy("remove-netgroups-success").should("exist");
 
-    entryDoesNotExist(itemToDelete);
+    entryDoesNotExist(element);
 
     logout();
   }

--- a/cypress/e2e/netgroup/netgroup_settings.feature
+++ b/cypress/e2e/netgroup/netgroup_settings.feature
@@ -155,7 +155,7 @@ Feature: Netgroup settings manipulation
 
     @seed
     Scenario: Add a host
-        Given host "my-server" exists
+        Given host "my-server.ipa.test" exists
 
     @test
     Scenario: Add host to Host category
@@ -185,7 +185,7 @@ Feature: Netgroup settings manipulation
 
     @cleanup
     Scenario: Cleanup host from Host category
-        Given I delete element "host" named "my-server" from netgroup "netgroup1"
+        Given I delete element "host" named "my-server.ipa.test" from netgroup "netgroup1"
 
     @seed
     Scenario: Add host to Host category
@@ -234,7 +234,7 @@ Feature: Netgroup settings manipulation
 
     @cleanup
     Scenario: Cleanup host
-        Given I delete host "my-server"
+        Given I delete host "my-server.ipa.test"
 
     @test
     Scenario: Add hostgroup to Host category


### PR DESCRIPTION
Remove Cypress environment variable HOSTNAME

The HOSTNAME environment variable was incorrectly named as it stores the
domain name (ipa.test), not a hostname. As host names are required to be
provided as FQDN, it is better to not add the domain name implicitly and
have the values explicited in the behavior tests.