### PR TITLE
[Cypress tests] Add automember pages > Settings 

### DIFF
--- a/cypress/e2e/automember/automember_hostgroup.ts
+++ b/cypress/e2e/automember/automember_hostgroup.ts
@@ -18,7 +18,7 @@ const fillHostgroupRule = (hostgroupName: string) => {
   isOptionSelected(hostgroupName, "modal-select-automember");
 };
 
-const createHostgroupRule = (hostgroupName: string) => {
+export const createHostgroupRule = (hostgroupName: string) => {
   cy.dataCy("auto-member-host-rules-button-add").click();
   cy.dataCy("add-rule-modal").should("exist");
 

--- a/cypress/e2e/automember/automember_settings.feature
+++ b/cypress/e2e/automember/automember_settings.feature
@@ -1,0 +1,200 @@
+Feature: Automember > Settings page
+    Modify automember settings
+
+    @seed
+    Scenario: Prep: Create a new user group to work with
+        Given user group rule "my_automember_usergroup" exists
+
+    @test
+    Scenario: Set 'Description' textarea field
+        Given I am logged in as admin
+        And I am on "user-group-rules/my_automember_usergroup" page
+
+        When I type in the "auto-member-tab-settings-textbox-description" textbox text "This is a test user group rule"
+        Then I should see "This is a test user group rule" in the "auto-member-tab-settings-textbox-description" textbox
+
+        When I click on the "auto-member-tab-settings-button-save" button
+        Then I should see "save-success" alert
+        And I should see "This is a test user group rule" in the "auto-member-tab-settings-textbox-description" textbox
+
+    @cleanup
+    Scenario: Delete user group rule
+        Given I delete user group rule "my_automember_usergroup"
+        And I delete user group "my_automember_usergroup"
+
+    @seed
+    Scenario: Prep: Create a new user group to work with
+        Given user group rule "my_automember_usergroup" exists
+
+    @test
+    Scenario: Add a new inclusive user group rule
+        Given I am logged in as admin
+        And I am on "user-group-rules/my_automember_usergroup" page
+
+        When I click on the "settings-button-add-automemberinclusiveregex" button
+        Then I should see "add-automember-condition-modal" modal
+
+        When I select "departmentnumber" option in the "modal-attribute-select" selector
+        Then I should see "departmentnumber" option in the "modal-attribute-select" selector
+
+        When I type in the "modal-textbox-expression" textbox text "my-department"
+        Then I should see "my-department" in the "modal-textbox-expression" textbox
+
+        When I click on the "modal-button-add" button
+        Then I should see "add-automember-condition-success" alert
+        And I should see "my-department" entry in the data table with ID "automemberinclusiveregex-table"
+
+    @cleanup
+    Scenario: Delete user group rule
+        Given I delete user group rule "my_automember_usergroup"
+        And I delete user group "my_automember_usergroup"
+
+    @seed
+    Scenario: Prep: Create a new user group to work with
+        Given user group rule "my_automember_usergroup" exists
+
+    @test
+    Scenario: Add a new exclusive user group rule
+        Given I am logged in as admin
+        And I am on "user-group-rules/my_automember_usergroup" page
+
+        When I click on the "settings-button-add-automemberexclusiveregex" button
+        Then I should see "add-automember-condition-modal" modal
+
+        When I select "carlicense" option in the "modal-attribute-select" selector
+        Then I should see "carlicense" option in the "modal-attribute-select" selector
+
+        When I type in the "modal-textbox-expression" textbox text "license123"
+        Then I should see "license123" in the "modal-textbox-expression" textbox
+
+        When I click on the "modal-button-add" button
+        Then I should see "add-automember-condition-success" alert
+        And I should see "license123" entry in the data table with ID "automemberexclusiveregex-table"
+
+    @cleanup
+    Scenario: Delete user group rule
+        Given I delete user group rule "my_automember_usergroup"
+        And I delete user group "my_automember_usergroup"
+
+    @seed
+    Scenario: Prep: Create a new host group rule to work with
+        Given hostgroup rule "my_automember_hostgroup" exists
+
+    @test
+    Scenario: Set 'Description' textarea field for host group rule
+        Given I am logged in as admin
+        And I am on "host-group-rules/my_automember_hostgroup" page
+
+        When I type in the "auto-member-tab-settings-textbox-description" textbox text "This is a test host group rule"
+        Then I should see "This is a test host group rule" in the "auto-member-tab-settings-textbox-description" textbox
+
+        When I click on the "auto-member-tab-settings-button-save" button
+        Then I should see "save-success" alert
+        And I should see "This is a test host group rule" in the "auto-member-tab-settings-textbox-description" textbox
+
+    @cleanup
+    Scenario: Delete host group rule
+        Given I delete hostgroup rule "my_automember_hostgroup"
+        And I delete hostgroup "my_automember_hostgroup"
+
+    @seed
+    Scenario: Prep: Create a new host group to work with
+        Given hostgroup rule "my_automember_hostgroup" exists
+
+    # 'Inclusive' subsection
+    Scenario: Add a new inclusive host group rule
+        Given I am logged in as admin
+        And I am on "host-group-rules/my_automember_hostgroup" page
+
+        When I click on the "settings-button-add-automemberinclusiveregex" button
+        Then I should see "add-automember-condition-modal" modal
+
+        When I select "departmentnumber" option in the "modal-attribute-select" selector
+        Then I should see "departmentnumber" option in the "modal-attribute-select" selector
+
+        When I type in the "modal-textbox-expression" textbox text "my-department"
+        Then I should see "my-department" in the "modal-textbox-expression" textbox
+
+        When I click on the "modal-button-add" button
+        Then I should see "add-automember-condition-success" alert
+        And I should see "my-department" entry in the data table with ID "automemberinclusiveregex-table"
+
+    @cleanup
+    Scenario: Delete host group rule
+        Given I delete hostgroup rule "my_automember_hostgroup"
+        And I delete hostgroup "my_automember_hostgroup"
+
+    @seed
+    Scenario: Prep: Create a new host group to work with
+        Given hostgroup rule "my_automember_hostgroup" exists
+
+    @test
+    Scenario: Add a new exclusive host group rule
+        Given I am logged in as admin
+        And I am on "host-group-rules/my_automember_hostgroup" page
+
+        When I click on the "settings-button-add-automemberexclusiveregex" button
+        Then I should see "add-automember-condition-modal" modal
+
+        When I select "employeetype" option in the "modal-attribute-select" selector
+        Then I should see "employeetype" option in the "modal-attribute-select" selector
+
+        When I type in the "modal-textbox-expression" textbox text "Software engineer"
+        Then I should see "Software engineer" in the "modal-textbox-expression" textbox
+
+        When I click on the "modal-button-add" button
+        Then I should see "add-automember-condition-success" alert
+        And I should see "Software engineer" entry in the data table with ID "automemberexclusiveregex-table"
+
+    @cleanup
+    Scenario: Delete host group rule
+        Given I delete hostgroup rule "my_automember_hostgroup"
+        And I delete hostgroup "my_automember_hostgroup"
+
+    @seed
+    Scenario: Prep: Create a new host group to work with
+        Given hostgroup rule "my_automember_hostgroup" exists and has inclusive entry "my-department" with category "businesscategory"
+
+    @test
+    Scenario: Host group rule: Delete inclusive entry from table
+        Given I am logged in as admin
+        And I am on "host-group-rules/my_automember_hostgroup" page
+
+        When I select "my-department" entry in the data table with ID "automemberinclusiveregex-table"
+        Then I should see "my-department" entry selected in the data table with ID "automemberinclusiveregex-table"
+
+        When I click on the "settings-button-delete-automemberinclusiveregex" button
+        Then I should see "member-of-delete-modal" modal
+
+        When I click on the "modal-button-delete" button
+        Then I should see "remove-condition-success" alert
+        Then I should see no table with ID "automemberinclusiveregex-table"
+
+    @cleanup
+    Scenario: Delete host group rule
+        Given I delete hostgroup rule "my_automember_hostgroup"
+        And I delete hostgroup "my_automember_hostgroup"
+
+    @seed
+    Scenario: Prep: Create a new user group to work with
+        Given user group rule "my_automember_usergroup" exists and has inclusive entry "my-department" with category "businesscategory"
+
+    @test
+    Scenario: User group rule: Delete inclusive entry from table
+        Given I am logged in as admin
+        And I am on "user-group-rules/my_automember_usergroup" page
+
+        When I select "my-department" entry in the data table with ID "automemberinclusiveregex-table"
+        Then I should see "my-department" entry selected in the data table with ID "automemberinclusiveregex-table"
+
+        When I click on the "settings-button-delete-automemberinclusiveregex" button
+        Then I should see "member-of-delete-modal" modal
+
+        When I click on the "modal-button-delete" button
+        Then I should see "remove-condition-success" alert
+        Then I should see no table with ID "automemberinclusiveregex-table"
+
+    @cleanup
+    Scenario: Delete user group rule
+        Given I delete user group rule "my_automember_usergroup"
+        And I delete user group "my_automember_usergroup"

--- a/cypress/e2e/automember/automember_settings.ts
+++ b/cypress/e2e/automember/automember_settings.ts
@@ -1,0 +1,92 @@
+import { Given } from "@badeball/cypress-cucumber-preprocessor";
+import { loginAsAdmin, logout } from "../common/authentication";
+import { navigateTo } from "../common/navigation";
+import { entryExists, searchForEntry } from "../common/data_tables";
+import { createHostgroup } from "../hostgroups/hostgroup";
+import { createHostgroupRule } from "./automember_hostgroup";
+import { createUserGroupRule } from "./automember_user_group";
+import { isOptionSelected } from "../common/ui/select";
+import { typeInTextbox } from "../common/ui/textbox";
+import { createUserGroup } from "../user_groups/user_groups";
+import { EntryType } from "./parameter_types";
+
+const addEntryTableToGroupRule = (
+  entryType: EntryType,
+  entry: string,
+  category: string
+) => {
+  cy.dataCy("settings-button-add-automember" + entryType + "regex").click();
+  cy.dataCy("add-automember-condition-modal").should("exist");
+
+  cy.dataCy("modal-attribute-select-toggle").click();
+  cy.dataCy("modal-attribute-select-toggle").should(
+    "have.attr",
+    "aria-expanded",
+    "true"
+  );
+  cy.dataCy("modal-attribute-select-" + category).click();
+  isOptionSelected(category, "modal-attribute-select");
+
+  typeInTextbox("modal-textbox-expression", entry);
+  cy.dataCy("modal-textbox-expression").should("have.value", entry);
+
+  cy.dataCy("modal-button-add").click();
+  cy.dataCy("add-automember-condition-success").should("exist");
+
+  cy.get("#automember" + entryType + "regex-table")
+    .find("td")
+    .contains(entry)
+    .should("exist");
+};
+
+Given(
+  "hostgroup rule {string} exists and has {EntryType} entry {string} with category {string}",
+  (
+    hostGroupName: string,
+    entryType: EntryType,
+    entry: string,
+    category: string
+  ) => {
+    loginAsAdmin();
+    navigateTo("host-groups");
+
+    createHostgroup(hostGroupName, "test");
+    searchForEntry(hostGroupName);
+    entryExists(hostGroupName);
+
+    navigateTo("host-group-rules");
+    createHostgroupRule(hostGroupName);
+
+    searchForEntry(hostGroupName);
+    entryExists(hostGroupName);
+
+    navigateTo("host-group-rules/" + hostGroupName);
+    addEntryTableToGroupRule(entryType, entry, category);
+    logout();
+  }
+);
+
+Given(
+  "user group rule {string} exists and has {EntryType} entry {string} with category {string}",
+  (
+    userGroupName: string,
+    entryType: EntryType,
+    entry: string,
+    category: string
+  ) => {
+    loginAsAdmin();
+    navigateTo("user-groups");
+
+    createUserGroup(userGroupName);
+
+    navigateTo("user-group-rules");
+    createUserGroupRule(userGroupName);
+
+    searchForEntry(userGroupName);
+    entryExists(userGroupName);
+
+    navigateTo("user-group-rules/" + userGroupName);
+    addEntryTableToGroupRule(entryType, entry, category);
+    logout();
+  }
+);

--- a/cypress/e2e/automember/automember_user_group.ts
+++ b/cypress/e2e/automember/automember_user_group.ts
@@ -17,7 +17,7 @@ const fillUserGroupRule = (userGroupName: string, selector: string) => {
   isOptionSelected(userGroupName, selector);
 };
 
-const createUserGroupRule = (userGroupName: string) => {
+export const createUserGroupRule = (userGroupName: string) => {
   cy.dataCy("auto-member-user-rules-button-add").click();
   cy.dataCy("add-rule-modal").should("exist");
 

--- a/cypress/e2e/automember/parameter_types.ts
+++ b/cypress/e2e/automember/parameter_types.ts
@@ -1,0 +1,9 @@
+import { defineParameterType } from "@badeball/cypress-cucumber-preprocessor";
+
+export type EntryType = "inclusive" | "exclusive";
+
+defineParameterType({
+  name: "EntryType",
+  regexp: /inclusive|exclusive/,
+  transformer: (s: string) => s as EntryType,
+});

--- a/cypress/e2e/common/data_tables.ts
+++ b/cypress/e2e/common/data_tables.ts
@@ -53,9 +53,29 @@ Then("I should see {string} entry in the data table", (name: string) => {
   entryExists(name);
 });
 
+Then(
+  "I should see {string} entry in the data table with ID {string}",
+  (name: string, tableId: string) => {
+    cy.get("#" + tableId)
+      .find("td")
+      .contains(name)
+      .should("exist");
+  }
+);
+
 Then("I should not see {string} entry in the data table", (name: string) => {
   entryDoesNotExist(name);
 });
+
+Then(
+  "I should not see {string} entry in the data table with ID {string}",
+  (name: string, tableId: string) => {
+    cy.get("#" + tableId)
+      .find("td")
+      .contains(name)
+      .should("not.exist");
+  }
+);
 
 Then(
   "I should see {string} entry in the data table with attribute {string} set to {string}",
@@ -72,10 +92,32 @@ When("I select entry {string} in the data table", (name: string) => {
   selectEntry(name);
 });
 
+When(
+  "I select {string} entry in the data table with ID {string}",
+  (name: string, tableId: string) => {
+    cy.get("#" + tableId)
+      .contains("td", name)
+      .parent("tr")
+      .find("input[type=checkbox]")
+      .check();
+  }
+);
+
 Then(
   "I should see {string} entry selected in the data table",
   (name: string) => {
     isSelected(name);
+  }
+);
+
+Then(
+  "I should see {string} entry selected in the data table with ID {string}",
+  (name: string, tableId: string) => {
+    cy.get("#" + tableId)
+      .contains("td", name)
+      .parent("tr")
+      .find("input[type=checkbox]")
+      .should("be.checked");
   }
 );
 
@@ -85,3 +127,7 @@ Then(
     isNotSelected(name);
   }
 );
+
+Then("I should see no table with ID {string}", (tableId: string) => {
+  cy.get("table#" + tableId).should("not.exist");
+});

--- a/cypress/e2e/user_groups/user_groups.ts
+++ b/cypress/e2e/user_groups/user_groups.ts
@@ -11,6 +11,19 @@ import { selectOption } from "../common/ui/select";
 import { isOptionSelected } from "../common/ui/select";
 import { addItemToRightList } from "../common/ui/dual_list";
 
+export const createUserGroup = (groupName: string) => {
+  cy.dataCy("user-groups-button-add").click();
+  cy.dataCy("add-user-group-modal").should("exist");
+
+  cy.dataCy("modal-textbox-group-name").type(groupName);
+  cy.dataCy("modal-textbox-group-name").should("have.value", groupName);
+
+  cy.dataCy("modal-button-add").click();
+  cy.dataCy("add-user-group-modal").should("not.exist");
+  searchForEntry(groupName);
+  entryExists(groupName);
+};
+
 Given("I delete user group {string}", (groupName: string) => {
   loginAsAdmin();
   navigateTo("user-groups");
@@ -31,16 +44,7 @@ Given("user group {string} exists", (groupName: string) => {
   loginAsAdmin();
   navigateTo("user-groups");
 
-  cy.dataCy("user-groups-button-add").click();
-  cy.dataCy("add-user-group-modal").should("exist");
-
-  cy.dataCy("modal-textbox-group-name").type(groupName);
-  cy.dataCy("modal-textbox-group-name").should("have.value", groupName);
-
-  cy.dataCy("modal-button-add").click();
-  cy.dataCy("add-user-group-modal").should("not.exist");
-  searchForEntry(groupName);
-  entryExists(groupName);
+  createUserGroup(groupName);
   logout();
 });
 


### PR DESCRIPTION
The test must cover all the use-cases found in Automember pages > Settings page.

## Summary by Sourcery

Add comprehensive Cypress tests and supporting step definitions for the Automember Settings page.

New Features:
- Add Automember Settings feature file covering description updates, inclusive/exclusive regex additions, and deletion flows for user and host group rules.
- Implement new step definitions and utilities in automember_settings.ts for setting up rules and adding entries to group rules.

Enhancements:
- Extend common data table step definitions to handle tables by ID, entry selection, and absence checks.
- Refactor user group tests by extracting a reusable createUserGroup helper in user_groups.ts.

Tests:
- Add Cypress scenarios for Automember > Settings page, testing save, add, select, and delete operations for both user and host group rules.