### PR TITLE
[Cypress test] Add test for sudo rules handling

### DIFF
--- a/cypress/e2e/common/sudo_rules_management.ts
+++ b/cypress/e2e/common/sudo_rules_management.ts
@@ -1,0 +1,45 @@
+import { Given } from "@badeball/cypress-cucumber-preprocessor";
+import { loginAsAdmin, logout } from "../common/authentication";
+import {
+  entryDoesNotExist,
+  searchForEntry,
+  selectEntry,
+  validateEntry,
+} from "../common/data_tables";
+import { navigateTo } from "../common/navigation";
+import { typeInTextbox } from "../common/ui/textbox";
+
+export const addSudoRule = (ruleName: string) => {
+  cy.dataCy("sudo-rules-button-add").click();
+  cy.dataCy("add-sudo-rule-modal").should("be.visible");
+
+  typeInTextbox("modal-textbox-rule-name", ruleName);
+  cy.dataCy("modal-textbox-rule-name").should("have.value", ruleName);
+
+  cy.dataCy("modal-button-add").click();
+  cy.dataCy("add-sudo-rule-modal").should("not.exist");
+};
+
+Given("sudo rule {string} exists", (ruleName: string) => {
+  loginAsAdmin();
+  navigateTo("sudo-rules");
+  addSudoRule(ruleName);
+  validateEntry(ruleName);
+  logout();
+});
+
+Given("I delete sudo rule {string}", (ruleName: string) => {
+  loginAsAdmin();
+  navigateTo("sudo-rules");
+  selectEntry(ruleName);
+
+  cy.dataCy("sudo-rules-button-delete").click();
+  cy.dataCy("delete-sudo-rules-modal").should("be.visible");
+  cy.dataCy("modal-button-delete").click();
+  cy.dataCy("delete-sudo-rules-modal").should("not.exist");
+  cy.dataCy("remove-sudorules-success").should("be.visible");
+
+  searchForEntry(ruleName);
+  entryDoesNotExist(ruleName);
+  logout();
+});

--- a/cypress/e2e/sudo_rules/sudo_rules.feature
+++ b/cypress/e2e/sudo_rules/sudo_rules.feature
@@ -1,0 +1,177 @@
+Feature: Sudo rules manipulation
+  Manage creation, search, enable/disable and deletion of Sudo rules
+
+  @test
+  Scenario: Add a new rule
+    Given I am logged in as admin
+    And I am on "sudo-rules" page
+
+    When I click on the "sudo-rules-button-add" button
+    Then I should see "add-sudo-rule-modal" modal
+
+    When I type in the "modal-textbox-rule-name" textbox text "rule1"
+    Then I should see "rule1" in the "modal-textbox-rule-name" textbox
+    And I type in the "modal-textbox-description" textbox text "my description"
+    Then I should see "my description" in the "modal-textbox-description" textbox
+    When I click on the "modal-button-add" button
+    Then I should not see "add-sudo-rule-modal" modal
+    And I should see "add-sudorule-success" alert
+
+    When I search for "rule1" in the data table
+    Then I should see "rule1" entry in the data table with attribute "Description" set to "my description"
+
+  @cleanup
+  Scenario: Delete a rule
+    Given I delete sudo rule "rule1"
+
+  @seed
+  Scenario: Create rules
+    Given sudo rule "rule1" exists
+
+  @test
+  Scenario: Search for a rule
+    Given I am logged in as admin
+    And I am on "sudo-rules" page
+
+    When I search for "rule1" in the data table
+    Then I should see "rule1" entry in the data table
+
+  @cleanup
+  Scenario: Delete a rule
+    Given I delete sudo rule "rule1"
+
+  @seed
+  Scenario: Create rule
+    Given sudo rule "rule4" exists
+
+  @test
+  Scenario: Disable a rule
+    Given I am logged in as admin
+    And I am on "sudo-rules" page
+
+    When I search for "rule4" in the data table
+    Then I should see "rule4" entry in the data table
+
+    When I select entry "rule4" in the data table
+    Then I should see "rule4" entry selected in the data table
+    When I click on the "sudo-rules-button-disable" button
+    Then I should see "disable-enable-sudo-rules-modal" modal
+
+    When I click on the "modal-button-disable" button
+    Then I should not see "disable-enable-sudo-rules-modal" modal
+
+    When I search for "rule4" in the data table
+    Then I should see "rule4" entry in the data table
+    And I should see "rule4" entry in the data table with attribute "Status" set to "Disabled"
+
+  @cleanup
+  Scenario: Delete a rule
+    Given I delete sudo rule "rule4"
+
+  @seed
+  Scenario: Create rule
+    Given sudo rule "rule4" exists
+    And I disable sudo rule "rule4"
+
+  @test
+  Scenario: Re-enable a rule
+    Given I am logged in as admin
+    And I am on "sudo-rules" page
+
+    When I search for "rule4" in the data table
+    Then I should see "rule4" entry in the data table
+
+    When I select entry "rule4" in the data table
+    Then I should see "rule4" entry selected in the data table
+    When I click on the "sudo-rules-button-enable" button
+    Then I should see "disable-enable-sudo-rules-modal" modal
+
+    When I click on the "modal-button-enable" button
+    Then I should not see "disable-enable-sudo-rules-modal" modal
+
+    When I search for "rule4" in the data table
+    Then I should see "rule4" entry in the data table
+    And I should see "rule4" entry in the data table with attribute "Status" set to "Enabled"
+
+  @cleanup
+  Scenario: Delete a rule
+    Given I delete sudo rule "rule4"
+
+  @seed
+  Scenario: Create rule
+    Given sudo rule "rule1" exists
+
+  @test
+  Scenario: Delete a rule
+    Given I am logged in as admin
+    And I am on "sudo-rules" page
+
+    When I search for "rule1" in the data table
+    Then I should see "rule1" entry in the data table
+
+    When I select entry "rule1" in the data table
+    Then I should see "rule1" entry selected in the data table
+    When I click on the "sudo-rules-button-delete" button
+    Then I should see "delete-sudo-rules-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "delete-sudo-rules-modal" modal
+    And I should see "remove-sudorules-success" alert
+
+    When I search for "rule1" in the data table
+    Then I should not see "rule1" entry in the data table
+
+  @seed
+  Scenario: Create rules
+    Given sudo rule "rule2" exists
+    And sudo rule "rule3" exists
+    And sudo rule "rule4" exists
+
+  @test
+  Scenario: Delete many rules
+    Given I am logged in as admin
+    And I am on "sudo-rules" page
+
+    When I search for "rule2" in the data table
+    Then I should see "rule2" entry in the data table
+    When I select entry "rule2" in the data table
+    Then I should see "rule2" entry selected in the data table
+
+    When I search for "rule3" in the data table
+    Then I should see "rule3" entry in the data table
+    When I select entry "rule3" in the data table
+    Then I should see "rule3" entry selected in the data table
+
+    When I search for "rule4" in the data table
+    Then I should see "rule4" entry in the data table
+    When I select entry "rule4" in the data table
+    Then I should see "rule4" entry selected in the data table
+
+    When I click on the "sudo-rules-button-delete" button
+    Then I should see "delete-sudo-rules-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "delete-sudo-rules-modal" modal
+    And I should see "remove-sudorules-success" alert
+
+    When I search for "rule2" in the data table
+    Then I should not see "rule2" entry in the data table
+    When I search for "rule3" in the data table
+    Then I should not see "rule3" entry in the data table
+    When I search for "rule4" in the data table
+    Then I should not see "rule4" entry in the data table
+
+  @test
+  Scenario: Cancel creation of a rule
+    Given I am logged in as admin
+    And I am on "sudo-rules" page
+
+    When I click on the "sudo-rules-button-add" button
+    Then I should see "add-sudo-rule-modal" modal
+
+    When I type in the "modal-textbox-rule-name" textbox text "rule-cancel"
+    And I click on the "modal-button-cancel" button
+    Then I should not see "add-sudo-rule-modal" modal
+
+    When I search for "rule-cancel" in the data table
+    Then I should not see "rule-cancel" entry in the data table

--- a/cypress/e2e/sudo_rules/sudo_rules.ts
+++ b/cypress/e2e/sudo_rules/sudo_rules.ts
@@ -1,0 +1,20 @@
+import { Given } from "@badeball/cypress-cucumber-preprocessor";
+import { loginAsAdmin, logout } from "../common/authentication";
+import { selectEntry } from "../common/data_tables";
+import { navigateTo } from "../common/navigation";
+
+const isDisabled = (name: string) => {
+  cy.get("tr[id='" + name + "'] td[data-label=Status]").contains("Disabled");
+};
+
+Given("I disable sudo rule {string}", (ruleName: string) => {
+  loginAsAdmin();
+  navigateTo("sudo-rules");
+  selectEntry(ruleName);
+  cy.dataCy("sudo-rules-button-disable").click();
+  cy.dataCy("disable-enable-sudo-rules-modal").should("be.visible");
+  cy.dataCy("modal-button-disable").click();
+  cy.dataCy("disable-enable-sudo-rules-modal").should("not.exist");
+  isDisabled(ruleName);
+  logout();
+});


### PR DESCRIPTION
sudo_rules handling

## Summary by Sourcery

Implement a comprehensive Cypress test suite for managing sudo rules, covering creation, validation, modification, and removal workflows

New Features:
- Add E2E test scenarios for creating, searching, enabling/disabling, deleting, and batch operations on sudo rules via UI

Tests:
- Add corresponding Cypress step definitions in TypeScript for sudo rule operations using common authentication and navigation utilities