### PR TITLE
Show error message and hide empty sections when DNS is disabled

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,7 +82,8 @@ const App: React.FunctionComponent = () => {
       const envResponse = initialBatchResponse.result.results[2].result;
       dispatch(updateEnvironment(envResponse));
       // 3: DNS is enabled ("dns_is_enabled")
-      const dnsEnabledResponse = initialBatchResponse.result.results[3].result;
+      const dnsEnabledResponse: boolean =
+        initialBatchResponse.result.results[3].result;
       dispatch(updateDnsIsEnabled(dnsEnabledResponse));
       // 4: Trust configuration ("trustconfig_show")
       const trustConfigResponse = initialBatchResponse.result.results[4].result;

--- a/src/hooks/useDnsConfigData.tsx
+++ b/src/hooks/useDnsConfigData.tsx
@@ -43,6 +43,8 @@ const useDnsConfigData = (): DnsConfigSettingsData => {
     if (
       dnsGlobalConfigData &&
       !dnsGlobalConfigDetails.isFetching &&
+      "result" in dnsGlobalConfigData &&
+      dnsGlobalConfigData.result !== null &&
       "result" in dnsGlobalConfigData.result
     ) {
       const currentDnsConfig: DnsConfig = apiToDnsConfig(

--- a/src/hooks/useUpdateRoute.tsx
+++ b/src/hooks/useUpdateRoute.tsx
@@ -13,6 +13,7 @@ import {
   updateBrowserTitle,
 } from "src/store/Global/routes-slice";
 import { useAppDispatch } from "src/store/hooks";
+import { useConfigurationSettings } from "src/utils/configurationSettings";
 
 /**
  * Given a pathname, this hook updates the Redux route slice with the current route data.
@@ -30,6 +31,8 @@ interface UpdateRouteProps {
 const useUpdateRoute = ({ pathname, noBreadcrumb }: UpdateRouteProps) => {
   const dispatch = useAppDispatch();
 
+  const configurationSettings = useConfigurationSettings();
+
   const [loadedGroup, setLoadedGroup] = React.useState<string[]>([]);
   const [breadCrumbPath, setBreadCrumbPath] = React.useState<BreadCrumbItem[]>(
     []
@@ -38,7 +41,7 @@ const useUpdateRoute = ({ pathname, noBreadcrumb }: UpdateRouteProps) => {
 
   // Get route data when the page is loaded
   React.useEffect(() => {
-    const loadedGroup = getGroupByPath(pathname);
+    const loadedGroup = getGroupByPath(pathname, configurationSettings);
     if (loadedGroup.length > 0) {
       let currentFirstLevel = loadedGroup[loadedGroup.length - 2];
       const currentSecondLevel = loadedGroup[loadedGroup.length - 1];
@@ -59,7 +62,10 @@ const useUpdateRoute = ({ pathname, noBreadcrumb }: UpdateRouteProps) => {
 
     // Get breadcrumb data based on current path
     if (noBreadcrumb === undefined || !noBreadcrumb) {
-      const loadedBreadCrumb = getBreadCrumbByPath(pathname);
+      const loadedBreadCrumb = getBreadCrumbByPath(
+        pathname,
+        configurationSettings
+      );
       if (loadedBreadCrumb.length > 0) {
         setBreadCrumbPath(loadedBreadCrumb);
         dispatch(updateBreadCrumbPath(loadedBreadCrumb));
@@ -67,7 +73,7 @@ const useUpdateRoute = ({ pathname, noBreadcrumb }: UpdateRouteProps) => {
     }
 
     // Get browser title based on current path
-    const currentTitle = getTitleByPath(pathname);
+    const currentTitle = getTitleByPath(pathname, configurationSettings);
     if (currentTitle) {
       setBrowserTitle(currentTitle);
       dispatch(updateBrowserTitle(currentTitle));

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -69,11 +69,15 @@ import DnsServers from "src/pages/DNSZones/DnsServers";
 import DnsServersTabs from "src/pages/DNSZones/DnsServersTabs";
 import DnsGlobalConfig from "src/pages/DNSZones/DnsGlobalConfig";
 import IdRanges from "src/pages/IdRanges/IdRanges";
+import { useConfigurationSettings } from "src/utils/configurationSettings";
 
 // Renders routes (React)
 export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
   // Redux: Get if user is logged in
   const userLoggedIn = useAppSelector((state) => state.auth.isUserLoggedIn);
+
+  const configurationSettings = useConfigurationSettings();
+  const dnsIsEnabled = configurationSettings.dnsIsEnabled;
 
   return (
     <>
@@ -466,25 +470,27 @@ export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
               <Route path="cert-id-mapping-match">
                 <Route path="" element={<CertificateMappingMatch />} />
               </Route>
-              <Route path="dns-zones">
-                <Route path="" element={<DnsZones />} />
-                <Route path=":idnsname">
-                  <Route
-                    path=""
-                    element={<DnsZonesTabs section="settings" />}
-                  />
-                  <Route path="dns-records">
+              {dnsIsEnabled && (
+                <Route path="dns-zones">
+                  <Route path="" element={<DnsZones />} />
+                  <Route path=":idnsname">
                     <Route
                       path=""
-                      element={<DnsZonesTabs section="dns-records" />}
+                      element={<DnsZonesTabs section="settings" />}
                     />
-                    <Route
-                      path=":recordName"
-                      element={<DnsResourceRecordsPreSettings />}
-                    />
+                    <Route path="dns-records">
+                      <Route
+                        path=""
+                        element={<DnsZonesTabs section="dns-records" />}
+                      />
+                      <Route
+                        path=":recordName"
+                        element={<DnsResourceRecordsPreSettings />}
+                      />
+                    </Route>
                   </Route>
                 </Route>
-              </Route>
+              )}
               <Route path="dns-forward-zones">
                 <Route path="" element={<DnsForwardZones />} />
               </Route>

--- a/src/navigation/NavRoutes.ts
+++ b/src/navigation/NavRoutes.ts
@@ -1,4 +1,5 @@
 import { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
+import { ConfigurationSettings } from "src/utils/configurationSettings";
 
 // Navigation
 export const URL_PREFIX = import.meta.env.BASE_URL;
@@ -64,350 +65,358 @@ const DNSGlobalConfigGroupRef = "dns-global-config";
 const ConfigRef = "configuration";
 
 // List of navigation routes (UI)
-export const navigationRoutes = [
-  {
-    label: "Identity",
-    group: "",
-    title: `${BASE_TITLE} - Identity`,
-    path: "",
-    items: [
-      {
-        label: "Users",
-        group: usersGroupRef,
-        title: `${BASE_TITLE} - Users`,
-        path: "",
-        items: [
-          {
-            label: "Active users",
-            group: ActiveUsersGroupRef,
-            title: `${BASE_TITLE} - Active users`,
-            path: "active-users",
-            items: [
+export const getNavigationRoutes = (
+  configurationSettings: ConfigurationSettings
+) => {
+  const dnsIsEnabled = configurationSettings.dnsIsEnabled;
+  return [
+    {
+      label: "Identity",
+      group: "",
+      title: `${BASE_TITLE} - Identity`,
+      path: "",
+      items: [
+        {
+          label: "Users",
+          group: usersGroupRef,
+          title: `${BASE_TITLE} - Users`,
+          path: "",
+          items: [
+            {
+              label: "Active users",
+              group: ActiveUsersGroupRef,
+              title: `${BASE_TITLE} - Active users`,
+              path: "active-users",
+              items: [
+                {
+                  label: "Active users Settings",
+                  group: ActiveUsersGroupRef,
+                  title: `${BASE_TITLE} - Settings`,
+                  path: "active-users/:uid",
+                },
+              ],
+            },
+            {
+              label: "Stage users",
+              group: StageUsersGroupRef,
+              title: `${BASE_TITLE} - Stage users`,
+              path: "stage-users",
+              items: [
+                {
+                  label: "Stage users Settings",
+                  group: StageUsersGroupRef,
+                  title: `${BASE_TITLE} - Settings`,
+                  path: "stage-users/:uid",
+                },
+              ],
+            },
+            {
+              label: "Preserved users",
+              group: PreservedUsersGroupRef,
+              title: `${BASE_TITLE} - Preserved users`,
+              path: "preserved-users",
+              items: [
+                {
+                  label: "Preserved users Settings",
+                  group: PreservedUsersGroupRef,
+                  title: `${BASE_TITLE} - Settings`,
+                  path: "preserved-users/:uid",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          label: "Hosts",
+          group: HostsGroupRef,
+          title: `${BASE_TITLE} - Hosts`,
+          items: [],
+          path: "hosts",
+        },
+        {
+          label: "Services",
+          group: ServicesGroupRef,
+          title: `${BASE_TITLE} - Services`,
+          items: [],
+          path: "services",
+        },
+        {
+          label: "Groups",
+          group: GroupsGroupRef,
+          title: `${BASE_TITLE} - Groups`,
+          path: "",
+          items: [
+            {
+              label: "User groups",
+              group: UserGroupsGroupRef,
+              title: `${BASE_TITLE} - User groups`,
+              path: "user-groups",
+            },
+            {
+              label: "Host groups",
+              group: HostGroupsGroupRef,
+              title: `${BASE_TITLE} - Host groups`,
+              path: "host-groups",
+            },
+            {
+              label: "Netgroups",
+              group: NetgroupsGroupRef,
+              title: `${BASE_TITLE} - Netgroups`,
+              path: "netgroups",
+            },
+          ],
+        },
+        {
+          label: "ID views",
+          group: IdViewsGroupRef,
+          title: `${BASE_TITLE} - ID views`,
+          items: [],
+          path: "id-views",
+        },
+        {
+          label: "Automember",
+          group: AutomemberGroupRef,
+          title: `${BASE_TITLE} - Automember`,
+          path: "",
+          items: [
+            {
+              label: "User Group Rules",
+              group: UserGroupRulesGroupRef,
+              title: `${BASE_TITLE} - User group rules`,
+              path: "user-group-rules",
+            },
+            {
+              label: "Host Group Rules",
+              group: HostGroupRulesGroupRef,
+              title: `${BASE_TITLE} - Host group rules`,
+              path: "host-group-rules",
+            },
+          ],
+        },
+        {
+          label: "Subordinate IDs",
+          group: SubordinateIDsGroupRef,
+          title: `${BASE_TITLE} - Subordinate IDs`,
+          path: "",
+          items: [
+            {
+              label: "Subordinate IDs",
+              group: SubordinateIDsGroupRef,
+              title: `${BASE_TITLE} - Subordinate IDs`,
+              path: "subordinate-ids",
+            },
+            {
+              label: "Subordinate ID Statistics",
+              group: SubordinateIDsStatsGroupRef,
+              title: `${BASE_TITLE} - Subordinate ID Statistics`,
+              path: "subordinate-id-statistics",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      label: "Policy",
+      group: "",
+      title: `${BASE_TITLE} - Policy`,
+      path: "",
+      items: [
+        {
+          label: "Host-based access control",
+          group: HostBasedAccessControlGroupRef,
+          title: `${BASE_TITLE} - Host-based access control`,
+          path: "",
+          items: [
+            {
+              label: "HBAC rules",
+              group: HbacRulesGroupRef,
+              title: `${BASE_TITLE} - HBAC rules`,
+              path: "hbac-rules",
+            },
+            {
+              label: "HBAC services",
+              group: HbacServicesGroupRef,
+              title: `${BASE_TITLE} - HBAC services`,
+              path: "hbac-services",
+            },
+            {
+              label: "HBAC service groups",
+              group: HbacServiceGroupsGroupRef,
+              title: `${BASE_TITLE} - HBAC service groups`,
+              path: "hbac-service-groups",
+            },
+            {
+              label: "HBAC test",
+              group: HbacTestGroupRef,
+              title: `${BASE_TITLE} - HBAC test`,
+              path: "hbac-test",
+            },
+          ],
+        },
+        {
+          label: "Sudo",
+          group: SudoGroupRef,
+          title: `${BASE_TITLE} - Sudo`,
+          path: "",
+          items: [
+            {
+              label: "Sudo rules",
+              group: SudoRulesGroupRef,
+              title: `${BASE_TITLE} - Sudo rules`,
+              path: "sudo-rules",
+            },
+            {
+              label: "Sudo commands",
+              group: SudoCommandsGroupRef,
+              title: `${BASE_TITLE} - Sudo commands`,
+              path: "sudo-commands",
+            },
+            {
+              label: "Sudo command groups",
+              group: SudoCommandGroupsGroupRef,
+              title: `${BASE_TITLE} - Sudo command groups`,
+              path: "sudo-command-groups",
+            },
+          ],
+        },
+        {
+          label: "SELinux user maps",
+          group: SelinuxUserMapsGroupRef,
+          title: `${BASE_TITLE} - SELinux user maps`,
+          path: "selinux-user-maps",
+          items: [],
+        },
+        {
+          label: "Password policies",
+          group: PasswordPoliciesGroupRef,
+          title: `${BASE_TITLE} - Password policies`,
+          path: "password-policies",
+          items: [],
+        },
+        {
+          label: "Kerberos ticket policy",
+          group: KerberosTicketPolicyGroupRef,
+          title: `${BASE_TITLE} - Kerberos ticket policy`,
+          path: "kerberos-ticket-policy",
+          items: [],
+        },
+      ],
+    },
+    {
+      label: "Authentication",
+      group: "",
+      title: `${BASE_TITLE} - Authentication`,
+      path: "",
+      items: [
+        {
+          label: "Identity Provider references",
+          group: IdentityProviderReferencesGroupRef,
+          title: `${BASE_TITLE} - Identity Provider references`,
+          path: "identity-provider-references",
+          items: [],
+        },
+        {
+          label: "Certificate mapping",
+          group: CertificateMappingGroupRef,
+          title: `${BASE_TITLE} - Certificate mapping`,
+          path: "",
+          items: [
+            {
+              label: "Certificate identity mapping rules",
+              group: CertificateMappingGroupRef,
+              title: `${BASE_TITLE} - Certificate identity mapping rules`,
+              path: "cert-id-mapping-rules",
+              items: [],
+            },
+            {
+              label: "Certificate identity mapping global configuration",
+              group: CertificateMappingConfigGroupRef,
+              title: `${BASE_TITLE} - Certificate identity mapping global configuration`,
+              path: "cert-id-mapping-global-config",
+              items: [],
+            },
+            {
+              label: "Certificate identity mapping match",
+              group: CertificateMappingMatchGroupRef,
+              title: `${BASE_TITLE} - Certificate identity mapping match`,
+              path: "cert-id-mapping-match",
+              items: [],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      label: "Network services",
+      group: "",
+      title: `${BASE_TITLE} - Network services`,
+      path: "",
+      items:
+        dnsIsEnabled === true
+          ? [
               {
-                label: "Active users Settings",
-                group: ActiveUsersGroupRef,
-                title: `${BASE_TITLE} - Settings`,
-                path: "active-users/:uid",
+                label: "DNS",
+                group: DNSZonesGroupRef,
+                title: `${BASE_TITLE} - DNS`,
+                path: "",
+                items: [
+                  {
+                    label: "DNS zones",
+                    group: DNSZonesGroupRef,
+                    title: `${BASE_TITLE} - DNS zones`,
+                    path: "dns-zones",
+                    items: [],
+                  },
+                  {
+                    label: "DNS forward zones",
+                    group: DNSForwardZonesGroupRef,
+                    title: `${BASE_TITLE} - DNS forward zones`,
+                    path: "dns-forward-zones",
+                    items: [],
+                  },
+                  {
+                    label: "DNS servers",
+                    group: DNSServersGroupRef,
+                    title: `${BASE_TITLE} - DNS servers`,
+                    path: "dns-servers",
+                    items: [],
+                  },
+                  {
+                    label: "DNS global config",
+                    group: DNSGlobalConfigGroupRef,
+                    title: `${BASE_TITLE} - DNS global config`,
+                    path: "dns-global-config",
+                    items: [],
+                  },
+                ],
               },
-            ],
-          },
-          {
-            label: "Stage users",
-            group: StageUsersGroupRef,
-            title: `${BASE_TITLE} - Stage users`,
-            path: "stage-users",
-            items: [
-              {
-                label: "Stage users Settings",
-                group: StageUsersGroupRef,
-                title: `${BASE_TITLE} - Settings`,
-                path: "stage-users/:uid",
-              },
-            ],
-          },
-          {
-            label: "Preserved users",
-            group: PreservedUsersGroupRef,
-            title: `${BASE_TITLE} - Preserved users`,
-            path: "preserved-users",
-            items: [
-              {
-                label: "Preserved users Settings",
-                group: PreservedUsersGroupRef,
-                title: `${BASE_TITLE} - Settings`,
-                path: "preserved-users/:uid",
-              },
-            ],
-          },
-        ],
-      },
-      {
-        label: "Hosts",
-        group: HostsGroupRef,
-        title: `${BASE_TITLE} - Hosts`,
-        items: [],
-        path: "hosts",
-      },
-      {
-        label: "Services",
-        group: ServicesGroupRef,
-        title: `${BASE_TITLE} - Services`,
-        items: [],
-        path: "services",
-      },
-      {
-        label: "Groups",
-        group: GroupsGroupRef,
-        title: `${BASE_TITLE} - Groups`,
-        path: "",
-        items: [
-          {
-            label: "User groups",
-            group: UserGroupsGroupRef,
-            title: `${BASE_TITLE} - User groups`,
-            path: "user-groups",
-          },
-          {
-            label: "Host groups",
-            group: HostGroupsGroupRef,
-            title: `${BASE_TITLE} - Host groups`,
-            path: "host-groups",
-          },
-          {
-            label: "Netgroups",
-            group: NetgroupsGroupRef,
-            title: `${BASE_TITLE} - Netgroups`,
-            path: "netgroups",
-          },
-        ],
-      },
-      {
-        label: "ID views",
-        group: IdViewsGroupRef,
-        title: `${BASE_TITLE} - ID views`,
-        items: [],
-        path: "id-views",
-      },
-      {
-        label: "Automember",
-        group: AutomemberGroupRef,
-        title: `${BASE_TITLE} - Automember`,
-        path: "",
-        items: [
-          {
-            label: "User Group Rules",
-            group: UserGroupRulesGroupRef,
-            title: `${BASE_TITLE} - User group rules`,
-            path: "user-group-rules",
-          },
-          {
-            label: "Host Group Rules",
-            group: HostGroupRulesGroupRef,
-            title: `${BASE_TITLE} - Host group rules`,
-            path: "host-group-rules",
-          },
-        ],
-      },
-      {
-        label: "Subordinate IDs",
-        group: SubordinateIDsGroupRef,
-        title: `${BASE_TITLE} - Subordinate IDs`,
-        path: "",
-        items: [
-          {
-            label: "Subordinate IDs",
-            group: SubordinateIDsGroupRef,
-            title: `${BASE_TITLE} - Subordinate IDs`,
-            path: "subordinate-ids",
-          },
-          {
-            label: "Subordinate ID Statistics",
-            group: SubordinateIDsStatsGroupRef,
-            title: `${BASE_TITLE} - Subordinate ID Statistics`,
-            path: "subordinate-id-statistics",
-          },
-        ],
-      },
-    ],
-  },
-  {
-    label: "Policy",
-    group: "",
-    title: `${BASE_TITLE} - Policy`,
-    path: "",
-    items: [
-      {
-        label: "Host-based access control",
-        group: HostBasedAccessControlGroupRef,
-        title: `${BASE_TITLE} - Host-based access control`,
-        path: "",
-        items: [
-          {
-            label: "HBAC rules",
-            group: HbacRulesGroupRef,
-            title: `${BASE_TITLE} - HBAC rules`,
-            path: "hbac-rules",
-          },
-          {
-            label: "HBAC services",
-            group: HbacServicesGroupRef,
-            title: `${BASE_TITLE} - HBAC services`,
-            path: "hbac-services",
-          },
-          {
-            label: "HBAC service groups",
-            group: HbacServiceGroupsGroupRef,
-            title: `${BASE_TITLE} - HBAC service groups`,
-            path: "hbac-service-groups",
-          },
-          {
-            label: "HBAC test",
-            group: HbacTestGroupRef,
-            title: `${BASE_TITLE} - HBAC test`,
-            path: "hbac-test",
-          },
-        ],
-      },
-      {
-        label: "Sudo",
-        group: SudoGroupRef,
-        title: `${BASE_TITLE} - Sudo`,
-        path: "",
-        items: [
-          {
-            label: "Sudo rules",
-            group: SudoRulesGroupRef,
-            title: `${BASE_TITLE} - Sudo rules`,
-            path: "sudo-rules",
-          },
-          {
-            label: "Sudo commands",
-            group: SudoCommandsGroupRef,
-            title: `${BASE_TITLE} - Sudo commands`,
-            path: "sudo-commands",
-          },
-          {
-            label: "Sudo command groups",
-            group: SudoCommandGroupsGroupRef,
-            title: `${BASE_TITLE} - Sudo command groups`,
-            path: "sudo-command-groups",
-          },
-        ],
-      },
-      {
-        label: "SELinux user maps",
-        group: SelinuxUserMapsGroupRef,
-        title: `${BASE_TITLE} - SELinux user maps`,
-        path: "selinux-user-maps",
-        items: [],
-      },
-      {
-        label: "Password policies",
-        group: PasswordPoliciesGroupRef,
-        title: `${BASE_TITLE} - Password policies`,
-        path: "password-policies",
-        items: [],
-      },
-      {
-        label: "Kerberos ticket policy",
-        group: KerberosTicketPolicyGroupRef,
-        title: `${BASE_TITLE} - Kerberos ticket policy`,
-        path: "kerberos-ticket-policy",
-        items: [],
-      },
-    ],
-  },
-  {
-    label: "Authentication",
-    group: "",
-    title: `${BASE_TITLE} - Authentication`,
-    path: "",
-    items: [
-      {
-        label: "Identity Provider references",
-        group: IdentityProviderReferencesGroupRef,
-        title: `${BASE_TITLE} - Identity Provider references`,
-        path: "identity-provider-references",
-        items: [],
-      },
-      {
-        label: "Certificate mapping",
-        group: CertificateMappingGroupRef,
-        title: `${BASE_TITLE} - Certificate mapping`,
-        path: "",
-        items: [
-          {
-            label: "Certificate identity mapping rules",
-            group: CertificateMappingGroupRef,
-            title: `${BASE_TITLE} - Certificate identity mapping rules`,
-            path: "cert-id-mapping-rules",
-            items: [],
-          },
-          {
-            label: "Certificate identity mapping global configuration",
-            group: CertificateMappingConfigGroupRef,
-            title: `${BASE_TITLE} - Certificate identity mapping global configuration`,
-            path: "cert-id-mapping-global-config",
-            items: [],
-          },
-          {
-            label: "Certificate identity mapping match",
-            group: CertificateMappingMatchGroupRef,
-            title: `${BASE_TITLE} - Certificate identity mapping match`,
-            path: "cert-id-mapping-match",
-            items: [],
-          },
-        ],
-      },
-    ],
-  },
-  {
-    label: "Network services",
-    group: "",
-    title: `${BASE_TITLE} - Network services`,
-    path: "",
-    items: [
-      {
-        label: "DNS",
-        group: DNSZonesGroupRef,
-        title: `${BASE_TITLE} - DNS`,
-        path: "",
-        items: [
-          {
-            label: "DNS zones",
-            group: DNSZonesGroupRef,
-            title: `${BASE_TITLE} - DNS zones`,
-            path: "dns-zones",
-            items: [],
-          },
-          {
-            label: "DNS forward zones",
-            group: DNSForwardZonesGroupRef,
-            title: `${BASE_TITLE} - DNS forward zones`,
-            path: "dns-forward-zones",
-            items: [],
-          },
-          {
-            label: "DNS servers",
-            group: DNSServersGroupRef,
-            title: `${BASE_TITLE} - DNS servers`,
-            path: "dns-servers",
-            items: [],
-          },
-          {
-            label: "DNS global config",
-            group: DNSGlobalConfigGroupRef,
-            title: `${BASE_TITLE} - DNS global config`,
-            path: "dns-global-config",
-            items: [],
-          },
-        ],
-      },
-    ],
-  },
-  {
-    label: "IPA Server",
-    group: "",
-    title: `${BASE_TITLE} - IPA Server`,
-    path: "",
-    items: [
-      {
-        label: "ID ranges",
-        group: IdRangesGroupRef,
-        title: `${BASE_TITLE} - ID ranges`,
-        path: "id-ranges",
-        items: [],
-      },
-      {
-        label: "Configuration",
-        group: ConfigRef,
-        title: `${BASE_TITLE} - Configuration`,
-        path: "configuration",
-        items: [],
-      },
-    ],
-  },
-];
+            ]
+          : [],
+    },
+    {
+      label: "IPA Server",
+      group: "",
+      title: `${BASE_TITLE} - IPA Server`,
+      path: "",
+      items: [
+        {
+          label: "ID ranges",
+          group: IdRangesGroupRef,
+          title: `${BASE_TITLE} - ID ranges`,
+          path: "id-ranges",
+          items: [],
+        },
+        {
+          label: "Configuration",
+          group: ConfigRef,
+          title: `${BASE_TITLE} - Configuration`,
+          path: "configuration",
+          items: [],
+        },
+      ],
+    },
+  ];
+};
 
 /**
  * Given a path, returns its first level group name (if it belongs to any)
@@ -415,9 +424,12 @@ export const navigationRoutes = [
  * @returns {string[]} Group name
  * @example "active-users" --> ["", "users", "active users"]
  */
-export const getGroupByPath = (path: string) => {
+export const getGroupByPath = (
+  path: string,
+  configurationSettings: ConfigurationSettings
+) => {
   const fullPath: string[] = [];
-  navigationRoutes.forEach((route) => {
+  getNavigationRoutes(configurationSettings).forEach((route) => {
     route.items.forEach((subRoute) => {
       if (path === subRoute.path) {
         fullPath.push(route.group);
@@ -445,9 +457,12 @@ export const getGroupByPath = (path: string) => {
  * @returns {BreadCrumbItem[]} Group name
  * @example "active users" --> [{ name: "Users", url: ""}, {name: "Active users", url: "/active-users"}]
  */
-export const getBreadCrumbByPath = (path: string) => {
+export const getBreadCrumbByPath = (
+  path: string,
+  configurationSettings: ConfigurationSettings
+) => {
   const fullPath: BreadCrumbItem[] = [];
-  navigationRoutes.forEach((route) => {
+  getNavigationRoutes(configurationSettings).forEach((route) => {
     route.items.forEach((subRoute) => {
       if (path === subRoute.path) {
         const item: BreadCrumbItem = {
@@ -485,9 +500,12 @@ export const getBreadCrumbByPath = (path: string) => {
  * @returns {string} title
  * @example "active users" --> "Identity Management - Active users"
  */
-export const getTitleByPath = (path: string) => {
+export const getTitleByPath = (
+  path: string,
+  configurationSettings: ConfigurationSettings
+) => {
   let title = "";
-  navigationRoutes.forEach((route) => {
+  getNavigationRoutes(configurationSettings).forEach((route) => {
     route.items.forEach((subRoute) => {
       if (path === subRoute.path) {
         title = subRoute.title;

--- a/src/pages/DNSZones/DnsForwardZones.tsx
+++ b/src/pages/DNSZones/DnsForwardZones.tsx
@@ -27,8 +27,6 @@ import {
 } from "src/services/rpcDnsForwardZones";
 // Utils
 import { isDnsForwardZoneSelectable } from "src/utils/utils";
-// React router
-import { useNavigate } from "react-router";
 // Components
 import ToolbarLayout, {
   ToolbarItem,
@@ -44,8 +42,6 @@ import BulkSelectorPrep from "src/components/BulkSelectorPrep";
 import { apiToDnsForwardZone } from "src/utils/dnsForwardZonesUtils";
 
 const DnsForwardZones = () => {
-  const navigate = useNavigate();
-
   // Update current route data to Redux and highlight the current page in the Nav bar
   const { browserTitle } = useUpdateRoute({
     pathname: "dns-forward-zones",
@@ -121,18 +117,6 @@ const DnsForwardZones = () => {
       setDnsForwardZones(elementsList);
       // Show table elements
       setShowTableRows(true);
-    }
-
-    // API response: Error
-    if (
-      !forwardDnsZonesResponse.isLoading &&
-      forwardDnsZonesResponse.isError &&
-      forwardDnsZonesResponse.error !== undefined
-    ) {
-      // This normally happens when the user is not authorized to view the data
-      // So instead of adding an error, refresh page
-      navigate("/login");
-      window.location.reload();
     }
   }, [forwardDnsZonesResponse]);
 

--- a/src/pages/DNSZones/DnsResourceRecords.tsx
+++ b/src/pages/DNSZones/DnsResourceRecords.tsx
@@ -21,8 +21,6 @@ import {
   useDnsRecordFindQuery,
   useSearchDnsRecordsEntriesMutation,
 } from "src/services/rpcDnsZones";
-// React router
-import { useNavigate } from "react-router";
 // Utils
 import { isDnsRecordSelectable } from "src/utils/utils";
 // Hooks
@@ -51,8 +49,6 @@ interface DnsResourceRecordsProps {
 }
 
 const DnsResourceRecords = (props: DnsResourceRecordsProps) => {
-  const navigate = useNavigate();
-
   // Alerts to show in the UI
   const alerts = useAlerts();
 
@@ -106,18 +102,6 @@ const DnsResourceRecords = (props: DnsResourceRecordsProps) => {
       setTotalCount(data.count);
       // Show table elements
       setShowTableRows(true);
-    }
-
-    // API response: Error
-    if (
-      !dnsRecordsResponse.isLoading &&
-      dnsRecordsResponse.isError &&
-      dnsRecordsResponse.error !== undefined
-    ) {
-      // This normally happens when the user is not authorized to view the data
-      // So instead of adding an error, refresh page
-      navigate("/login");
-      window.location.reload();
     }
   }, [dnsRecordsResponse]);
 

--- a/src/pages/DNSZones/DnsServers.tsx
+++ b/src/pages/DNSZones/DnsServers.tsx
@@ -27,7 +27,7 @@ import {
   useSearchDnsServersEntriesMutation,
 } from "src/services/rpcDnsServers";
 // React router
-import { Link, useNavigate } from "react-router";
+import { Link } from "react-router";
 // Components
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import { SerializedError } from "@reduxjs/toolkit";
@@ -44,8 +44,6 @@ import TableLayout from "src/components/layouts/TableLayout";
 import SkeletonOnTableLayout from "src/components/layouts/Skeleton/SkeletonOnTableLayout";
 
 const DnsServers = () => {
-  const navigate = useNavigate();
-
   // Update current route data to Redux and highlight the current page in the Nav bar
   const { browserTitle } = useUpdateRoute({
     pathname: "dns-servers",
@@ -109,18 +107,6 @@ const DnsServers = () => {
       setTotalCount(data.data.length || 0);
       setDnsServersId(data.data.slice(firstUserIdx, lastUserIdx) || []);
       setShowTableRows(true);
-    }
-
-    if (
-      !dnsServersResponse.isLoading &&
-      dnsServersResponse.isError &&
-      dnsServersResponse.error !== undefined &&
-      "error" in dnsServersResponse.error
-    ) {
-      // This normally happens when the user is not authorized to view the data
-      // So instead of adding an error, refresh page
-      navigate("/login");
-      window.location.reload();
     }
   }, [dnsServersResponse]);
 

--- a/src/pages/DNSZones/DnsZones.tsx
+++ b/src/pages/DNSZones/DnsZones.tsx
@@ -28,8 +28,6 @@ import {
 // Utils
 import { isDnsZoneSelectable } from "src/utils/utils";
 import { apiToDnsZone } from "src/utils/dnsZonesUtils";
-// React router
-import { useNavigate } from "react-router";
 // Components
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import { SerializedError } from "@reduxjs/toolkit";
@@ -49,8 +47,6 @@ import DeleteDnsZonesModal from "src/components/modals/DnsZones/DeleteDnsZonesMo
 import EnableDisableDnsZonesModal from "src/components/modals/DnsZones/EnableDisableDnsZonesModal";
 
 const DnsZones = () => {
-  const navigate = useNavigate();
-
   // Update current route data to Redux and highlight the current page in the Nav bar
   const { browserTitle } = useUpdateRoute({
     pathname: "dns-zones",
@@ -126,18 +122,6 @@ const DnsZones = () => {
       setDnsZones(elementsList);
       // Show table elements
       setShowTableRows(true);
-    }
-
-    // API response: Error
-    if (
-      !dnsZonesResponse.isLoading &&
-      dnsZonesResponse.isError &&
-      dnsZonesResponse.error !== undefined
-    ) {
-      // This normally happens when the user is not authorized to view the data
-      // So instead of adding an error, refresh page
-      navigate("/login");
-      window.location.reload();
     }
   }, [dnsZonesResponse]);
 

--- a/src/store/Global/global-slice.ts
+++ b/src/store/Global/global-slice.ts
@@ -5,7 +5,7 @@ interface GlobalState {
   ipaServerConfiguration: Record<string, unknown>;
   loggedUserInfo: LoggedUserInfo;
   environment: Record<string, unknown>;
-  dnsIsEnabled: Record<string, unknown>;
+  dnsIsEnabled: boolean;
   trustConfiguration: Record<string, unknown>;
   domainLevel: Record<string, unknown>;
   caIsEnabled: Record<string, unknown>;
@@ -28,7 +28,7 @@ const initialState: GlobalState = {
     object: "",
   },
   environment: {},
-  dnsIsEnabled: {},
+  dnsIsEnabled: false,
   trustConfiguration: {},
   domainLevel: {},
   caIsEnabled: {},
@@ -63,10 +63,7 @@ const globalSlice = createSlice({
       const newEnv = action.payload;
       state.environment = newEnv;
     },
-    updateDnsIsEnabled: (
-      state,
-      action: PayloadAction<Record<string, unknown>>
-    ) => {
+    updateDnsIsEnabled: (state, action: PayloadAction<boolean>) => {
       const newDnsIsEnabled = action.payload;
       state.dnsIsEnabled = newDnsIsEnabled;
     },

--- a/src/utils/configurationSettings.tsx
+++ b/src/utils/configurationSettings.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { useAppSelector } from "src/store/hooks";
+
+/**
+ * Custom hook containing modern WebUI configuration settings
+ * This can be based on:
+ * - metadata
+ * - Redux data
+ * - pre-defined parameters
+ * The hook is flexible and more parameters can be added to be
+ * consumed in other components
+ */
+
+export interface ConfigurationSettings {
+  dnsIsEnabled: boolean;
+  // ... other configuration settings here
+}
+
+const useConfigurationSettings = () => {
+  const dnsIsEnabled = useAppSelector((state) => state.global.dnsIsEnabled);
+
+  const configurationSettings: ConfigurationSettings = React.useMemo(
+    () => ({
+      dnsIsEnabled: dnsIsEnabled,
+      // ... other configuration settings here
+    }),
+    [dnsIsEnabled]
+  );
+
+  return configurationSettings;
+};
+
+export { useConfigurationSettings };


### PR DESCRIPTION
The behavior on some DNS related pages require to manually reload the page when the time session ended, but that also lead to having no clue on what is going on (i.e. no error message showing up). This functionality has been removed and now it should show a general error message.

Also, the DNS section will not show if DNS is not enabled. This has been handled by a custom hook that manages a configuration object containing the `dnsIsEnabled` value from the initial batch API call.

## Summary by Sourcery

Use a custom configurationSettings hook to control whether DNS routes appear, and show a generic error message instead of reloading when DNS requests fail. Update navigation, routing utilities, and state to use the new settings.

New Features:
- Introduce a configuration hook to expose dnsIsEnabled and conditionally include the DNS section in navigation

Bug Fixes:
- Replace silent page reload on DNS API errors with error alerts

Enhancements:
- Refactor navigation and routing helpers to accept configuration settings and dynamically hide disabled features
- Restructure global slice to store dnsIsEnabled with a typed result object