### PR TITLE
Trusts > 'Settings' page

### DIFF
--- a/src/hooks/useTrustsSettingsData.tsx
+++ b/src/hooks/useTrustsSettingsData.tsx
@@ -1,0 +1,111 @@
+/* eslint-disable @eslint-react/hooks-extra/no-direct-set-state-in-use-effect */
+import React from "react";
+// RPC
+import { useGetObjectMetadataQuery } from "src/services/rpc";
+// Data types
+import { Trust, Metadata } from "src/utils/datatypes/globalDataTypes";
+// Utils
+import { apiToTrust } from "src/utils/trustsUtils";
+import { useTrustShowQuery } from "src/services/rpcTrusts";
+
+type TrustsSettingsData = {
+  isLoading: boolean;
+  isFetching: boolean;
+  modified: boolean;
+  setModified: (value: boolean) => void;
+  resetValues: () => void;
+  metadata: Metadata;
+  trust: Partial<Trust>;
+  originalTrust: Partial<Trust>;
+  setTrust: (trust: Partial<Trust>) => void;
+  refetch: () => void;
+  modifiedValues: () => Partial<Trust>;
+};
+
+const useTrustsSettingsData = (trustId: string): TrustsSettingsData => {
+  // [API call] Metadata
+  const metadataQuery = useGetObjectMetadataQuery();
+  const metadata = metadataQuery.data || {};
+  const metadataLoading = metadataQuery.isLoading;
+
+  // [API call] Trust
+  const trustDetails = useTrustShowQuery(trustId);
+  const trustData = trustDetails.data?.result?.result;
+  const isTrustDataLoading = trustDetails.isLoading;
+  const trustDataToTrust = apiToTrust(trustData || {});
+
+  // States
+  const [modified, setModified] = React.useState(false);
+  const [trust, setTrust] = React.useState<Partial<Trust>>(trustDataToTrust);
+  const [trustDuplicate, setTrustDuplicate] =
+    React.useState<Partial<Trust>>(trustDataToTrust);
+
+  // Detect any change between 'originalTrust' and 'trust' objects
+  React.useEffect(() => {
+    if (trustData && !trustDetails.isFetching) {
+      setTrust(trustDataToTrust);
+      setTrustDuplicate(trustDataToTrust);
+    }
+  }, [trustData, trustDetails.isFetching]);
+
+  const settings: TrustsSettingsData = {
+    isLoading: metadataLoading || isTrustDataLoading,
+    isFetching: trustDetails.isFetching,
+    modified,
+    setModified,
+    metadata,
+    resetValues: () => {},
+    originalTrust: trust,
+    trust,
+    setTrust,
+    refetch: trustDetails.refetch,
+    modifiedValues: () => trust,
+  };
+
+  settings.originalTrust = trustData || {};
+
+  const getModifiedValues = (): Partial<Trust> => {
+    if (!trustData || !trustDuplicate) {
+      return {};
+    }
+
+    const modifiedValues = {};
+    Object.keys(trust).forEach((key) => {
+      if (trustDuplicate[key] !== trust[key]) {
+        modifiedValues[key] = trust[key];
+      }
+    });
+    return modifiedValues;
+  };
+
+  settings.modifiedValues = getModifiedValues;
+
+  // Detect any change between 'originalTrust' and 'trust' objects
+  React.useEffect(() => {
+    if (!trustData) {
+      return;
+    }
+    let modified = false;
+    for (const [key, value] of Object.entries(trust)) {
+      if (Array.isArray(value)) {
+        if (JSON.stringify(trustData[key]) !== JSON.stringify(value)) {
+          modified = true;
+          break;
+        }
+      } else if (trustData[key] !== value) {
+        modified = true;
+        break;
+      }
+    }
+    setModified(modified);
+  }, [trust, trustData]);
+
+  const onResetValues = () => {
+    setModified(false);
+  };
+  settings.resetValues = onResetValues;
+
+  return settings;
+};
+
+export { useTrustsSettingsData };

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -71,6 +71,7 @@ import DnsGlobalConfig from "src/pages/DNSZones/DnsGlobalConfig";
 import IdRanges from "src/pages/IdRanges/IdRanges";
 import { useConfigurationSettings } from "src/utils/configurationSettings";
 import Trusts from "src/pages/Trusts/Trusts";
+import TrustsTabs from "src/pages/Trusts/TrustsTabs";
 
 // Renders routes (React)
 export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
@@ -512,6 +513,9 @@ export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
               </Route>
               <Route path="trusts">
                 <Route path="" element={<Trusts />} />
+                <Route path=":cn">
+                  <Route path="" element={<TrustsTabs section="settings" />} />
+                </Route>
               </Route>
               <Route path="configuration" element={<Configuration />} />
               {/* Redirect to Active users page if user is logged in and navigates to the root page */}

--- a/src/pages/Trusts/Trusts.tsx
+++ b/src/pages/Trusts/Trusts.tsx
@@ -411,7 +411,7 @@ const Trusts = () => {
                     hasCheckboxes={true}
                     pathname="trusts"
                     showTableRows={showTableRows}
-                    showLink={false}
+                    showLink={true}
                     elementsData={{
                       isElementSelectable: isTrustSelectable,
                       selectedElements,

--- a/src/pages/Trusts/TrustsSettings.tsx
+++ b/src/pages/Trusts/TrustsSettings.tsx
@@ -1,0 +1,308 @@
+import React from "react";
+// PatternFly
+import {
+  Flex,
+  FlexItem,
+  Form,
+  FormGroup,
+  JumpLinks,
+  JumpLinksItem,
+  Sidebar,
+  SidebarContent,
+  SidebarPanel,
+} from "@patternfly/react-core";
+// Data types
+import { Trust, Metadata } from "src/utils/datatypes/globalDataTypes";
+// Hooks
+import useUpdateRoute from "src/hooks/useUpdateRoute";
+// Utils
+import { asRecord } from "src/utils/trustsUtils";
+// RPC
+import { TrustModPayload, useTrustModMutation } from "src/services/rpcTrusts";
+// Components
+import IpaTextInput from "src/components/Form/IpaTextInput/IpaTextInput";
+import TabLayout from "src/components/layouts/TabLayout";
+import SecondaryButton from "src/components/layouts/SecondaryButton";
+import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
+import IpaTextboxList from "src/components/Form/IpaTextboxList";
+import TitleLayout from "src/components/layouts/TitleLayout";
+// Redux
+import { addAlert } from "src/store/Global/alerts-slice";
+import { useAppDispatch } from "src/store/hooks";
+
+interface TrustsSettingsProps {
+  trust: Partial<Trust>;
+  originalTrust: Partial<Trust>;
+  metadata: Metadata;
+  onTrustChange: (trust: Partial<Trust>) => void;
+  onRefresh: () => void;
+  isModified: boolean;
+  isDataLoading: boolean;
+  modifiedValues: () => Partial<Trust>;
+  onResetValues: () => void;
+  pathname: string;
+}
+
+const TrustsSettings = (props: TrustsSettingsProps) => {
+  // Alerts to show in the UI
+  const dispatch = useAppDispatch();
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  useUpdateRoute({ pathname: props.pathname });
+
+  // States
+  const [isDataLoading, setIsDataLoading] = React.useState(false);
+
+  // API calls
+  const [saveTrust] = useTrustModMutation();
+
+  // 'Revert' handler method
+  const onRevert = () => {
+    props.onTrustChange(props.originalTrust);
+    props.onRefresh();
+    dispatch(
+      addAlert({
+        name: "revert-success",
+        title: "Trust data reverted",
+        variant: "success",
+      })
+    );
+  };
+
+  // Helper method to build the payload based on values
+  const buildPayload = (
+    modifiedValues: Partial<Trust>,
+    keyArray: string[]
+  ): TrustModPayload => {
+    const payload: TrustModPayload = { cn: props.trust.cn || "" };
+
+    keyArray.forEach((key) => {
+      payload[key] = modifiedValues[key];
+    });
+    return payload;
+  };
+
+  // Get 'ipaObject' and 'recordOnChange' to use in 'IpaTextInput'
+  const { ipaObject, recordOnChange } = asRecord(
+    props.trust,
+    props.onTrustChange
+  );
+
+  // 'Save' handler method
+  const onSave = () => {
+    setIsDataLoading(true);
+    const modifiedValues = props.modifiedValues();
+
+    const payload = buildPayload(modifiedValues, [
+      "ipantadditionalsuffixes",
+      "ipantsidblacklistincoming",
+      "ipantsidblacklistoutgoing",
+    ]);
+
+    saveTrust(payload)
+      .then((response) => {
+        if ("data" in response) {
+          const data = response.data;
+          if (data?.error) {
+            dispatch(
+              addAlert({
+                name: "error",
+                title: (data.error as Error).message,
+                variant: "danger",
+              })
+            );
+          }
+          if (data?.result) {
+            props.onTrustChange(data.result.result);
+            dispatch(
+              addAlert({
+                name: "save-success",
+                title: "Trust data updated",
+                variant: "success",
+              })
+            );
+            props.onRefresh();
+          }
+        }
+      })
+      .finally(() => {
+        setIsDataLoading(false);
+      });
+  };
+
+  // Toolbar
+  const toolbarFields = [
+    {
+      key: 0,
+      element: (
+        <SecondaryButton
+          dataCy="trusts-tab-settings-button-refresh"
+          onClickHandler={props.onRefresh}
+        >
+          Refresh
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 1,
+      element: (
+        <SecondaryButton
+          dataCy="trusts-tab-settings-button-revert"
+          isDisabled={!props.isModified || isDataLoading}
+          onClickHandler={onRevert}
+        >
+          Revert
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 2,
+      element: (
+        <SecondaryButton
+          dataCy="trusts-tab-settings-button-save"
+          isDisabled={!props.isModified || isDataLoading}
+          onClickHandler={onSave}
+        >
+          Save
+        </SecondaryButton>
+      ),
+    },
+  ];
+
+  // Return component
+  return (
+    <TabLayout
+      id="settings-page"
+      toolbarItems={toolbarFields}
+      dataCy="trusts-settings"
+    >
+      <Sidebar isPanelRight>
+        <SidebarPanel variant="sticky">
+          <HelpTextWithIconLayout textContent="Help" />
+          <JumpLinks
+            isVertical
+            label="Jump to section"
+            scrollableSelector="#settings-page"
+            offset={220} // for masthead
+            expandable={{ default: "expandable", md: "nonExpandable" }}
+          >
+            <JumpLinksItem key={0} href="#trusts-settings">
+              Trusts settings
+            </JumpLinksItem>
+            <JumpLinksItem key={1} href="#alternative-upn-suffixes">
+              Alternative UPN suffixes
+            </JumpLinksItem>
+            <JumpLinksItem key={2} href="#sid-blocklists">
+              SID blocklists
+            </JumpLinksItem>
+          </JumpLinks>
+        </SidebarPanel>
+        <SidebarContent className="pf-v6-u-mr-xl">
+          <Flex direction={{ default: "column" }} flex={{ default: "flex_1" }}>
+            <FlexItem flex={{ default: "flex_1" }}>
+              <TitleLayout
+                key={0}
+                headingLevel="h2"
+                id="trusts-settings"
+                text="Trusts settings"
+              />
+              <Form isHorizontal>
+                <FormGroup label="Realm Name" fieldId="cn" role="group">
+                  <IpaTextInput
+                    dataCy="trusts-tab-settings-input-realm-name"
+                    name="cn"
+                    objectName="trust"
+                    metadata={props.metadata}
+                    ipaObject={ipaObject}
+                    onChange={recordOnChange}
+                  />
+                </FormGroup>
+                <FormGroup
+                  label="Domain NetBIOS name"
+                  fieldId="ipandomainnetbiosname"
+                  role="group"
+                >
+                  <IpaTextInput
+                    dataCy="trusts-tab-settings-input-domain-netbios-name"
+                    name="ipandomainnetbiosname"
+                    objectName="trust"
+                    metadata={props.metadata}
+                    ipaObject={ipaObject}
+                    onChange={recordOnChange}
+                  />
+                </FormGroup>
+                <FormGroup label="Trust Type" fieldId="trusttype" role="group">
+                  <IpaTextInput
+                    dataCy="trusts-tab-settings-input-trust-type"
+                    name="trusttype"
+                    objectName="trust"
+                    metadata={props.metadata}
+                    ipaObject={ipaObject}
+                    onChange={recordOnChange}
+                  />
+                </FormGroup>
+              </Form>
+            </FlexItem>
+            <FlexItem flex={{ default: "flex_1" }}>
+              <TitleLayout
+                key={1}
+                headingLevel="h2"
+                id="alternative-upn-suffixes"
+                text="Alternative UPN suffixes"
+              />
+              <Form isHorizontal>
+                <FormGroup
+                  label="Alternative UPN suffixes"
+                  fieldId="ipantadditionalsuffixes"
+                  role="group"
+                >
+                  <IpaTextboxList
+                    dataCy="trusts-tab-settings-textbox-alternative-upn-suffixes"
+                    name="ipantadditionalsuffixes"
+                    ipaObject={ipaObject}
+                    setIpaObject={recordOnChange}
+                    ariaLabel="Alternative UPN suffixes list"
+                  />
+                </FormGroup>
+                <TitleLayout
+                  key={2}
+                  headingLevel="h2"
+                  id="sid-blocklists"
+                  text="SID blocklists"
+                />
+                <FormGroup
+                  label="SID blocklists incoming"
+                  fieldId="ipantsidblocklistincoming"
+                  role="group"
+                >
+                  <IpaTextboxList
+                    dataCy="trusts-tab-settings-textbox-sid-blocklists"
+                    name="ipantsidblocklistincoming"
+                    ipaObject={ipaObject}
+                    setIpaObject={recordOnChange}
+                    ariaLabel="SID blocklists incoming list"
+                  />
+                </FormGroup>
+                <FormGroup
+                  label="SID blocklists outgoing"
+                  fieldId="ipantsidblocklistoutgoing"
+                  role="group"
+                >
+                  <IpaTextboxList
+                    dataCy="trusts-tab-settings-textbox-sid-blocklists-outgoing"
+                    name="ipantsidblocklistoutgoing"
+                    ipaObject={ipaObject}
+                    setIpaObject={recordOnChange}
+                    ariaLabel="SID blocklists outgoing list"
+                  />
+                </FormGroup>
+              </Form>
+            </FlexItem>
+          </Flex>
+        </SidebarContent>
+      </Sidebar>
+    </TabLayout>
+  );
+};
+
+export default TrustsSettings;

--- a/src/pages/Trusts/TrustsTabs.tsx
+++ b/src/pages/Trusts/TrustsTabs.tsx
@@ -1,0 +1,104 @@
+import React from "react";
+// PatternFly
+import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
+// React Router DOM
+import { useNavigate } from "react-router";
+// Navigation
+import { URL_PREFIX } from "src/navigation/NavRoutes";
+import { NotFound } from "src/components/errors/PageErrors";
+// Hooks
+import { useTrustsSettingsData } from "src/hooks/useTrustsSettingsData";
+// Components
+import TitleLayout from "src/components/layouts/TitleLayout";
+import DataSpinner from "src/components/layouts/DataSpinner";
+import BreadCrumb, {
+  BreadCrumbItem,
+} from "src/components/layouts/BreadCrumb/BreadCrumb";
+import TrustsSettings from "src/pages/Trusts/TrustsSettings";
+import { CnParams, useSafeParams } from "src/utils/paramsUtils";
+
+const TrustsTabs = ({ section }: { section: string }) => {
+  const { cn } = useSafeParams<CnParams>(["cn"]);
+  const navigate = useNavigate();
+  const pathname = "trusts";
+
+  // Data loaded from the API
+  const trustsSettingsData = useTrustsSettingsData(cn);
+
+  const handleTabClick = (
+    _event: React.MouseEvent<HTMLElement, MouseEvent>,
+    tabIndex: number | string
+  ) => {
+    if (tabIndex === "settings") {
+      navigate("/" + pathname + "/" + cn);
+    } else if (tabIndex === "trusted-domains") {
+      navigate("/" + pathname + "/" + cn + "/trusted-domains");
+    }
+  };
+
+  const breadcrumbItems: BreadCrumbItem[] = React.useMemo(
+    () => [
+      {
+        name: "Trusts",
+        url: URL_PREFIX + "/" + pathname,
+      },
+    ],
+    [pathname]
+  );
+
+  // Handling of the API data
+  if (trustsSettingsData.isLoading || !trustsSettingsData.trust) {
+    return <DataSpinner />;
+  }
+
+  // Show the 'NotFound' page if the trust is not found
+  if (
+    !trustsSettingsData.isLoading &&
+    (!trustsSettingsData.trust || trustsSettingsData.trust.cn === "")
+  ) {
+    return <NotFound />;
+  }
+
+  // Return component
+  return (
+    <>
+      <PageSection hasBodyWrapper={false}>
+        <BreadCrumb breadcrumbItems={breadcrumbItems} />
+      </PageSection>
+      <PageSection hasBodyWrapper={true}>
+        <TitleLayout id={cn} preText="Trust:" text={cn} headingLevel="h1" />
+        <Tabs
+          activeKey={section}
+          onSelect={handleTabClick}
+          variant="secondary"
+          isBox
+          className="pf-v6-u-ml-lg"
+          mountOnEnter
+          unmountOnExit
+        >
+          <Tab
+            eventKey="settings"
+            name="settings-details"
+            title={<TabTitleText>Settings</TabTitleText>}
+            data-cy="trusts-tab-settings"
+          >
+            <TrustsSettings
+              trust={trustsSettingsData.trust}
+              originalTrust={trustsSettingsData.originalTrust}
+              metadata={trustsSettingsData.metadata}
+              onTrustChange={trustsSettingsData.setTrust}
+              onRefresh={trustsSettingsData.refetch}
+              isModified={trustsSettingsData.modified}
+              isDataLoading={trustsSettingsData.isLoading}
+              modifiedValues={trustsSettingsData.modifiedValues}
+              onResetValues={trustsSettingsData.resetValues}
+              pathname={pathname}
+            />
+          </Tab>
+        </Tabs>
+      </PageSection>
+    </>
+  );
+};
+
+export default TrustsTabs;


### PR DESCRIPTION
The settings page must show the information of a given Trust, allowing to also add suffixes and blocklists.

## Summary by Sourcery

Provide a dedicated settings page for individual Trusts by wiring new RPC commands, state management hook, routes, and UI components to view and update trust properties.

New Features:
- Add trust_show and trust_mod RPC endpoints with useTrustShowQuery and useTrustModMutation for fetching and updating trust details
- Implement TrustsSettings component to display and edit trust settings including realm name, UPN suffixes, and SID blocklists
- Add TrustsTabs component and extend AppRoutes to support /trusts/:cn settings view
- Introduce useTrustsSettingsData hook to fetch metadata, load trust data, track modifications, and handle save/revert actions

Enhancements:
- Enable clickable rows in the Trusts table and adjust list presence check