### PR TITLE
Adjust 'Delete' buttons to be 'danger' type

### DIFF
--- a/src/components/CertificateMappingDataOption.tsx
+++ b/src/components/CertificateMappingDataOption.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 // PatternFly
 import {
+  Button,
   Flex,
   FlexItem,
   Form,
@@ -107,15 +108,14 @@ const CertificateMappingDataOption = (
               />
             </FlexItem>
             <FlexItem key={"ipacertmapdata-" + idx + "-delete-button"}>
-              <SecondaryButton
-                dataCy={"modal-button-delete-ipacertmapdata-" + certMap}
+              <Button
+                variant="danger"
+                data-cy={"modal-button-delete-ipacertmapdata-" + certMap}
                 name="remove"
-                onClickHandler={() =>
-                  onRemoveCertificateMappingDataHandler(idx)
-                }
+                onClick={() => onRemoveCertificateMappingDataHandler(idx)}
               >
                 Delete
-              </SecondaryButton>
+              </Button>
             </FlexItem>
           </Flex>
         ))}
@@ -188,13 +188,14 @@ const CertificateMappingDataOption = (
               key={"certificate-" + idx + "-delete-button"}
               name={"certificate-" + idx + "-delete-button"}
             >
-              <SecondaryButton
-                dataCy={"modal-button-delete-certificate-" + certificate}
+              <Button
+                variant="danger"
+                data-cy={"modal-button-delete-certificate-" + certificate}
                 name="remove"
-                onClickHandler={() => onRemoveCertificateHandler(idx)}
+                onClick={() => onRemoveCertificateHandler(idx)}
               >
                 Delete
-              </SecondaryButton>
+              </Button>
             </FlexItem>
           </Flex>
         ))}

--- a/src/components/Form/IpaTextInputFromList/IpaTextInputFromList.tsx
+++ b/src/components/Form/IpaTextInputFromList/IpaTextInputFromList.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 // Patternfly
-import { Flex, FlexItem, TextInput } from "@patternfly/react-core";
+import { Button, Flex, FlexItem, TextInput } from "@patternfly/react-core";
 // Layouts
 import SecondaryButton from "../../layouts/SecondaryButton";
 // Data types
@@ -79,14 +79,16 @@ const IpaTextInputFromList = (props: PropsToTextInputFromList) => {
                     : ""
                 }
               >
-                <SecondaryButton
-                  dataCy={props.dataCy + "-button-remove-" + element}
+                <Button
+                  data-cy={props.dataCy + "-button-remove-" + element}
+                  variant="secondary"
+                  size="sm"
                   name={"remove-principal-alias-" + idx}
-                  onClickHandler={() => props.onRemove(idx)}
+                  onClick={() => props.onRemove(idx)}
                   isDisabled={readOnly || isDisabled(idx)}
                 >
                   Delete
-                </SecondaryButton>
+                </Button>
               </FlexItem>
             </Flex>
           ))}

--- a/src/components/Form/IpaTextboxList/IpaTextboxList.tsx
+++ b/src/components/Form/IpaTextboxList/IpaTextboxList.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 // PatternFly
 import {
+  Button,
   Flex,
   FlexItem,
   TextInput,
@@ -130,13 +131,15 @@ const IpaTextboxList = (props: PropsToIpaTextboxList) => {
               />
             </FlexItem>
             <FlexItem key={props.name + "-" + idx + "-delete-button"}>
-              <SecondaryButton
-                dataCy={props.dataCy + "-button-delete-" + idx}
+              <Button
+                data-cy={props.dataCy + "-button-delete-" + idx}
+                variant="secondary"
                 name={"remove-" + props.name + "-" + idx}
-                onClickHandler={() => onRemoveHandler(idx)}
+                onClick={() => onRemoveHandler(idx)}
+                size="sm"
               >
                 Delete
-              </SecondaryButton>
+              </Button>
             </FlexItem>
           </Flex>
         ))}

--- a/src/components/Form/PrincipalAliasMultiTextBox/PrincipalAliasMultiTextBox.tsx
+++ b/src/components/Form/PrincipalAliasMultiTextBox/PrincipalAliasMultiTextBox.tsx
@@ -233,7 +233,6 @@ const PrincipalAliasMultiTextBox = (props: PrincipalAliasMultiTextBoxProps) => {
       dataCy="modal-button-add"
       key="add-principal-alias"
       onClickHandler={onAddPrincipalAlias}
-      // isDisabled={newAliasValue === "" ? true : false}
       isDisabled={
         (newAliasValue !== "" && !newAliasValue.includes("@")) ||
         modalSpinning ||

--- a/src/components/Form/TextInputList.tsx
+++ b/src/components/Form/TextInputList.tsx
@@ -65,7 +65,7 @@ const TextInputList = (props: TextInputListProps) => {
             <FlexItem key={props.name + "-" + idx + "-delete-button"}>
               <Button
                 data-cy={props.dataCy + "-" + item + "-delete-button"}
-                variant="secondary"
+                variant="danger"
                 name={"remove-" + props.name + "-" + idx}
                 onClick={() => onRemoveHandler(idx)}
               >

--- a/src/components/modals/CertificateMapping/DeleteRuleModal.tsx
+++ b/src/components/modals/CertificateMapping/DeleteRuleModal.tsx
@@ -54,11 +54,11 @@ const DeleteRuleModal = (props: DeleteRuleModalProps) => {
   const modalActions: JSX.Element[] = [
     <Button
       data-cy="modal-button-ok"
+      variant="danger"
       key={"delete-" + props.ruleId}
-      variant="primary"
       onClick={onDelete}
     >
-      OK
+      Delete
     </Button>,
     <Button
       data-cy="modal-button-cancel"

--- a/src/components/modals/HbacModals/RemoveHBACRuleMembers.tsx
+++ b/src/components/modals/HbacModals/RemoveHBACRuleMembers.tsx
@@ -47,6 +47,7 @@ const RemoveHBACRuleMembersModal = (props: PropsToDelete) => {
   const modalActions = [
     <Button
       data-cy="modal-button-delete"
+      variant="danger"
       key={"delete-" + props.elementType}
       form={props.elementType + "-delete-modal"}
       type="submit"

--- a/src/components/modals/KeytabElementsDeleteModal.tsx
+++ b/src/components/modals/KeytabElementsDeleteModal.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import { Button, Content, ContentVariants } from "@patternfly/react-core";
 // Layouts
 import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
-import SecondaryButton from "src/components/layouts/SecondaryButton";
 // Tables
 import DeletedElementsTable from "src/components/tables/DeletedElementsTable";
 
@@ -78,14 +77,15 @@ const KeytabElementsDeleteModal = (props: PropsToDelete) => {
 
   // Buttons that will be shown at the end of the form
   const modalActions = [
-    <SecondaryButton
-      dataCy="modal-button-delete"
+    <Button
+      data-cy="modal-button-delete"
+      variant="danger"
       key={"delete-" + props.elementType}
       form="modal-form"
-      onClickHandler={removeElementFromList}
+      onClick={removeElementFromList}
     >
       Delete
-    </SecondaryButton>,
+    </Button>,
     <Button
       data-cy="modal-button-cancel"
       key={"cancel-delete-" + props.elementType}

--- a/src/components/modals/RemoveNetgroupMembers.tsx
+++ b/src/components/modals/RemoveNetgroupMembers.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import { Button, Content, ContentVariants } from "@patternfly/react-core";
 // Layouts
 import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
-import SecondaryButton from "src/components/layouts/SecondaryButton";
 // Tables
 import DeletedElementsTable from "src/components/tables/DeletedElementsTable";
 
@@ -46,18 +45,19 @@ const RemoveNetgroupMembersModal = (props: PropsToDelete) => {
 
   // Buttons that will be shown at the end of the form
   const modalActions = [
-    <SecondaryButton
-      dataCy="modal-button-delete"
+    <Button
+      variant="danger"
+      data-cy="modal-button-delete"
       key={"delete-" + props.elementType}
       form="modal-form"
-      onClickHandler={() => props.removeMembers(props.elementsToDelete)}
+      onClick={() => props.removeMembers(props.elementsToDelete)}
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
       isLoading={props.spinning}
       isDisabled={props.spinning}
     >
       {props.spinning ? "Deleting" : "Delete"}
-    </SecondaryButton>,
+    </Button>,
     <Button
       data-cy="modal-button-cancel"
       key={"cancel-delete-" + props.elementType}


### PR DESCRIPTION
Some 'Delete' buttons need to be set to type `danger` to follow the right design practices. Comments about which buttons should be danger and/or use trashcan icon can be discussed in this PR.

## Summary by Sourcery

Convert all delete action buttons across multiple components to use the Button component with a danger variant, standardize props, and align UI labels.

Enhancements:
- Replace SecondaryButton components with Button and apply variant="danger" to all delete buttons
- Standardize onClick prop usage replacing onClickHandler and unify data-cy attribute naming
- Add size="sm" to smaller delete buttons for consistent styling
- Update DeleteRuleModal primary action label from "OK" to "Delete"