### PR TITLE
Run build container only for freeipa

### DIFF
--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build-and-push-image:
     name: Build and Push Development Container
+    if: github.repository_owner == 'freeipa'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Forks do not need this action, it is a notification every week.

Not sure whether this works, just followed: https://dev.to/hugovk/til-how-to-disable-cron-for-github-forks-2d0l

## Summary by Sourcery

CI:
- Add a condition to only run the build-and-push-image job when the repository owner is 'freeipa'