### PR TITLE
Fix missing alerts in ID range pages

### DIFF
--- a/src/components/modals/IdRanges/AddIdRangeModal.tsx
+++ b/src/components/modals/IdRanges/AddIdRangeModal.tsx
@@ -14,8 +14,9 @@ import SecondaryButton from "src/components/layouts/SecondaryButton";
 import ModalWithFormLayout, {
   Field,
 } from "src/components/layouts/ModalWithFormLayout";
-// Hooks
-import useAlerts from "src/hooks/useAlerts";
+// Redux
+import { addAlert } from "src/store/Global/alerts-slice";
+import { useAppDispatch } from "src/store/hooks";
 // RPC
 import {
   AddIdRangePayload,
@@ -44,8 +45,7 @@ const autoPrivateGroupsOptions = [
 // Fields will follow the shared ModalWithFormLayout.Field shape
 
 const AddIdRangeModal = (props: PropsToAddModal) => {
-  // Alerts
-  const alerts = useAlerts();
+  const dispatch = useAppDispatch();
 
   // API
   const [addIdRange] = useAddIdRangeMutation();
@@ -147,14 +147,22 @@ const AddIdRangeModal = (props: PropsToAddModal) => {
           const error = result.data?.error as SerializedError;
 
           if (error) {
-            alerts.addAlert("add-idrange-error", error.message, "danger");
+            dispatch(
+              addAlert({
+                name: "add-idrange-error",
+                title: error.message,
+                variant: "danger",
+              })
+            );
           }
 
           if (data) {
-            alerts.addAlert(
-              "add-idrange-success",
-              "ID range successfully added",
-              "success"
+            dispatch(
+              addAlert({
+                name: "add-idrange-success",
+                title: "ID range successfully added",
+                variant: "success",
+              })
             );
             clearFields();
             props.onRefresh();
@@ -371,21 +379,18 @@ const AddIdRangeModal = (props: PropsToAddModal) => {
   ];
 
   return (
-    <>
-      <alerts.ManagedAlerts />
-      <ModalWithFormLayout
-        dataCy="add-id-range-modal"
-        variantType="small"
-        modalPosition="top"
-        offPosition="76px"
-        title={props.title}
-        formId="add-id-range-modal"
-        fields={fields}
-        show={props.isOpen}
-        onClose={cleanAndClose}
-        actions={modalActions}
-      />
-    </>
+    <ModalWithFormLayout
+      dataCy="add-id-range-modal"
+      variantType="small"
+      modalPosition="top"
+      offPosition="76px"
+      title={props.title}
+      formId="add-id-range-modal"
+      fields={fields}
+      show={props.isOpen}
+      onClose={cleanAndClose}
+      actions={modalActions}
+    />
   );
 };
 

--- a/src/components/modals/IdRanges/DeleteModal.tsx
+++ b/src/components/modals/IdRanges/DeleteModal.tsx
@@ -5,7 +5,6 @@ import { Content, ContentVariants, Button } from "@patternfly/react-core";
 import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
 import DeletedElementsTable from "src/components/tables/DeletedElementsTable";
 // Hooks
-import useAlerts from "src/hooks/useAlerts";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import { SerializedError } from "@reduxjs/toolkit";
 // RPC
@@ -15,6 +14,9 @@ import { useDeleteIdRangesMutation } from "src/services/rpcIdRanges";
 import { ErrorData, IdRange } from "src/utils/datatypes/globalDataTypes";
 // Modals
 import ErrorModal from "src/components/modals/ErrorModal";
+// Redux
+import { addAlert } from "src/store/Global/alerts-slice";
+import { useAppDispatch } from "src/store/hooks";
 
 interface ButtonsData {
   updateIsDeleteButtonDisabled: (value: boolean) => void;
@@ -37,8 +39,7 @@ interface PropsToDelete {
 }
 
 const DeleteModal = (props: PropsToDelete) => {
-  // Alerts
-  const alerts = useAlerts();
+  const dispatch = useAppDispatch();
 
   // API calls
   const [deleteIdRanges] = useDeleteIdRangesMutation();
@@ -147,10 +148,12 @@ const DeleteModal = (props: PropsToDelete) => {
               props.buttonsData.updateIsDeleteButtonDisabled(true);
               props.buttonsData.updateIsDeletion(true);
 
-              alerts.addAlert(
-                "remove-idranges-success",
-                "ID ranges removed",
-                "success"
+              dispatch(
+                addAlert({
+                  name: "remove-idranges-success",
+                  title: "ID ranges removed",
+                  variant: "success",
+                })
               );
               props.onClose();
               props.onRefresh();
@@ -189,7 +192,6 @@ const DeleteModal = (props: PropsToDelete) => {
 
   return (
     <>
-      <alerts.ManagedAlerts />
       <ModalWithFormLayout
         dataCy="delete-idranges-modal"
         variantType="medium"


### PR DESCRIPTION
Alert management recently changed to be used via Redux. Some ID range-related components need some adjustments to follow the new approach.

## Summary by Sourcery

Migrate alert handling in ID range modals to the new Redux-based global alert system

Bug Fixes:
- Restore missing success and error alerts in ID range pages

Enhancements:
- Replace useAlerts hook with useAppDispatch and addAlert dispatch in AddIdRangeModal
- Replace useAlerts hook with useAppDispatch and addAlert dispatch in DeleteModal
- Remove local ManagedAlerts components from both modals
- Add necessary imports for addAlert action and useAppDispatch hook