### PR TITLE
Fix: Kebab is disabled when cancelling op

### DIFF
--- a/src/components/modals/DnsZones/EnableDisableDnsZonesModal.tsx
+++ b/src/components/modals/DnsZones/EnableDisableDnsZonesModal.tsx
@@ -14,12 +14,14 @@ import {
 import ConfirmationModal from "../ConfirmationModal";
 // Utils
 import capitalizeFirstLetter from "src/utils/utils";
+// Data types
+import { DNSZone } from "src/utils/datatypes/globalDataTypes";
 
 interface EnableDisableDnsZonesModalProps {
   isOpen: boolean;
   onClose: () => void;
   elementsList: string[];
-  setElementsList: (elementsList: string[]) => void;
+  setElementsList: (elementsList: DNSZone[]) => void;
   operation: "enable" | "disable";
   setShowTableRows: (value: boolean) => void;
   onRefresh: () => void;
@@ -36,7 +38,6 @@ const EnableDisableDnsZonesModal = (props: EnableDisableDnsZonesModalProps) => {
   const onEnableDisable = () => {
     const operation = props.operation === "enable" ? enableRule : disableRule;
 
-    props.setShowTableRows(false);
     operation(props.elementsList).then((response) => {
       if ("data" in response) {
         const { data } = response;
@@ -59,19 +60,16 @@ const EnableDisableDnsZonesModal = (props: EnableDisableDnsZonesModalProps) => {
           props.onRefresh();
           onClose();
         }
-        props.setShowTableRows(true);
       }
     });
   };
 
   const onClose = () => {
-    props.setShowTableRows(true);
     props.setElementsList([]);
     props.onClose();
   };
 
   const onCloseWithoutClearingElements = () => {
-    props.setShowTableRows(true);
     props.onClose();
   };
 

--- a/src/pages/DNSZones/DnsZones.tsx
+++ b/src/pages/DNSZones/DnsZones.tsx
@@ -522,7 +522,9 @@ const DnsZones = () => {
         isOpen={showEnableDisableModal}
         onClose={() => setShowEnableDisableModal(false)}
         elementsList={selectedElements.map((dnszone) => dnszone.idnsname)}
-        setElementsList={() => {}}
+        setElementsList={(newElementsList: DNSZone[]) =>
+          setSelectedElements(newElementsList)
+        }
         operation={operation}
         setShowTableRows={setShowTableRows}
         onRefresh={refreshData}


### PR DESCRIPTION
In DNS zone pages, the kebab icon is disabled
when clicking the 'Disable' button and cancelling
right away.

There is also an issue affecting the main page
as well: selected elements are not unselected
when performing an enable/disable operation.

Fixes: https://github.com/freeipa/freeipa-webui/issues/899

## Summary by Sourcery

Fix DNS zone enable/disable modal behavior to correctly manage selected rows and avoid leaving related UI controls disabled after operations or cancellations.

Bug Fixes:
- Ensure the DNS zones kebab menu is not left disabled when cancelling an enable/disable operation from the modal.
- Clear or update DNS zone selections after enable/disable operations so selected elements are properly reset on the main page.

Enhancements:
- Align the enable/disable modal API to work with DNSZone-typed element lists for better state handling between the modal and DNS zones page.