### PR TITLE
Sudo rules kebab

### DIFF
--- a/src/components/layouts/KebabLayout/KebabLayout.tsx
+++ b/src/components/layouts/KebabLayout/KebabLayout.tsx
@@ -17,7 +17,7 @@ interface PropsToKebab {
     | undefined;
   isKebabOpen?: boolean;
   className?: string;
-  isDisabled: boolean;
+  isDisabled?: boolean;
   isPlain?: boolean;
   dropdownItems?: any[] | undefined;
   // Toggle

--- a/src/components/modals/SudoModals/DeleteSudoRule.tsx
+++ b/src/components/modals/SudoModals/DeleteSudoRule.tsx
@@ -17,6 +17,8 @@ import { ErrorData, SudoRule } from "src/utils/datatypes/globalDataTypes";
 import ErrorModal from "src/components/modals/ErrorModal";
 import { BatchRPCResponse } from "src/services/rpc";
 import { useRemoveSudoRulesMutation } from "src/services/rpcSudoRules";
+// React Router
+import { useNavigate } from "react-router";
 
 interface ButtonsData {
   updateIsDeleteButtonDisabled: (value: boolean) => void;
@@ -34,10 +36,12 @@ interface PropsToDeleteRules {
   selectedRulesData: SelectedRulesData;
   buttonsData: ButtonsData;
   onRefresh?: () => void;
+  from?: "main" | "settings";
 }
 
 const DeleteSudoRule = (props: PropsToDeleteRules) => {
   const dispatch = useAppDispatch();
+  const navigate = useNavigate();
 
   // Define the column names that will be displayed on the confirmation table.
   // - NOTE: Camel-case should match with the property to show as it is defined in the data.
@@ -165,6 +169,9 @@ const DeleteSudoRule = (props: PropsToDeleteRules) => {
               // Refresh data
               if (props.onRefresh !== undefined) {
                 props.onRefresh();
+              }
+              if (props.from === "settings") {
+                navigate("/sudo-rules");
               }
             }
           }

--- a/src/components/modals/SudoModals/DisableEnableSudoRules.tsx
+++ b/src/components/modals/SudoModals/DisableEnableSudoRules.tsx
@@ -233,11 +233,13 @@ const DisableEnableSudoRules = (props: PropsToDisableEnableRules) => {
             // Close modal
             closeModal();
             // Set alert: success
+            const operation = props.optionSelected ? "Disabled" : "Enabled";
             dispatch(
               addAlert({
-                name: "enable-sudorule-success",
+                name: "enabledisable-sudorule-success",
                 title:
-                  "Enabled Sudo rule '" +
+                  operation +
+                  " Sudo rule '" +
                   props.selectedRulesData.selectedRules[0].cn +
                   "'",
                 variant: "success",

--- a/src/hooks/useSudoRuleSettingsData.tsx
+++ b/src/hooks/useSudoRuleSettingsData.tsx
@@ -33,11 +33,16 @@ const useSudoRuleSettings = (ruleId: string): SettingsData => {
   const [modified, setModified] = useState(false);
   const [rule, setRule] = useState<Partial<SudoRule>>({});
 
+  // Refetch when ruleId changes to ensure fresh data when navigating to the page
   useEffect(() => {
-    if (ruleFullData && !ruleFullDataQuery.isFetching) {
+    ruleFullDataQuery.refetch();
+  }, [ruleId]);
+
+  useEffect(() => {
+    if (ruleFullData?.rule && !ruleFullDataQuery.isFetching) {
       setRule({ ...ruleFullData.rule });
     }
-  }, [ruleFullData, ruleFullDataQuery.isFetching]);
+  }, [ruleFullData?.rule, ruleFullDataQuery.isFetching]);
 
   const settings = {
     isLoading: metadataLoading || isFullDataLoading,

--- a/src/pages/SudoRules/SudoRulesSettings.tsx
+++ b/src/pages/SudoRules/SudoRulesSettings.tsx
@@ -40,6 +40,8 @@ import { TableEntry } from "src/components/tables/KeytabTableWithFilter";
 import AccessThisHost from "./AccessThisHost";
 import RunCommands from "src/components/SudoRuleSections/RunCommands";
 import SudoRuleAsWhom from "src/components/SudoRuleSections/SudoRuleAsWhom";
+import DeleteSudoRule from "src/components/modals/SudoModals/DeleteSudoRule";
+import DisableEnableSudoRules from "src/components/modals/SudoModals/DisableEnableSudoRules";
 
 interface PropsToSudoRulesSettings {
   rule: Partial<SudoRule>;
@@ -75,27 +77,35 @@ const SudoRulesSettings = (props: PropsToSudoRulesSettings) => {
     props.onRuleChange
   );
 
+  // Computed states
+  const isRuleEnabled = React.useMemo<boolean>(
+    () => props.rule.ipaenabledflag === "true",
+    [props.rule.ipaenabledflag]
+  );
+
   // Kebab
   const [isKebabOpen, setIsKebabOpen] = React.useState(false);
 
   const dropdownItems = [
     <DropdownItem
       key="enable-sudo-rule"
-      onClick={() => onChangeEnableModal()}
+      onClick={() => setIsEnableDisableModalOpen(true)}
       data-cy="sudo-rules-tab-settings-kebab-enable"
+      isDisabled={isRuleEnabled}
     >
       Enable
     </DropdownItem>,
     <DropdownItem
       key="disable-sudo-rule"
-      onClick={() => onChangeDisableModal()}
+      onClick={() => setIsEnableDisableModalOpen(true)}
       data-cy="sudo-rules-tab-settings-kebab-disable"
+      isDisabled={!isRuleEnabled}
     >
       Disable
     </DropdownItem>,
     <DropdownItem
       key="delete-sudo-rule"
-      onClick={() => onChangeDeleteModal()}
+      onClick={() => setIsDeleteModalOpen(true)}
       data-cy="sudo-rules-tab-settings-kebab-delete"
     >
       Delete
@@ -115,17 +125,8 @@ const SudoRulesSettings = (props: PropsToSudoRulesSettings) => {
 
   // Confirmation modals
   const [isDeleteModalOpen, setIsDeleteModalOpen] = React.useState(false);
-  const [isDisableModalOpen, setIsDisableModalOpen] = React.useState(false);
-  const [isEnableModalOpen, setIsEnableModalOpen] = React.useState(false);
-  const onChangeDeleteModal = () => {
-    setIsDeleteModalOpen(!isDeleteModalOpen);
-  };
-  const onChangeDisableModal = () => {
-    setIsDisableModalOpen(!isDisableModalOpen);
-  };
-  const onChangeEnableModal = () => {
-    setIsEnableModalOpen(!isEnableModalOpen);
-  };
+  const [isEnableDisableModalOpen, setIsEnableDisableModalOpen] =
+    React.useState(false);
 
   const onSaveRule = () => {
     // Save the rule
@@ -741,7 +742,6 @@ const SudoRulesSettings = (props: PropsToSudoRulesSettings) => {
           idKebab="toggle-action-buttons"
           isKebabOpen={isKebabOpen}
           dropdownItems={dropdownItems}
-          isDisabled={isSaving}
         />
       ),
     },
@@ -913,110 +913,144 @@ const SudoRulesSettings = (props: PropsToSudoRulesSettings) => {
 
   // Render component
   return (
-    <TabLayout id="settings-page" toolbarItems={toolbarFields}>
-      <SidebarLayout itemNames={itemNames}>
-        {/* General */}
-        <Flex direction={{ default: "column" }} flex={{ default: "flex_1" }}>
-          <TitleLayout headingLevel="h2" id="general" text="General" />
-          <SudoRuleGeneral
-            ipaObject={ipaObject}
-            recordOnChange={recordOnChange}
-            metadata={props.metadata}
-          />
-        </Flex>
-        {/* Options */}
-        <Flex direction={{ default: "column" }} flex={{ default: "flex_1" }}>
-          <TitleLayout headingLevel="h2" id="options" text="Options" />
-          <SudoRuleOptions
-            sudoRuleId={props.rule.cn as string}
-            options={sudoOptions}
-          />
-        </Flex>
-        {/* Who */}
-        <Flex
-          direction={{ default: "column" }}
-          flex={{ default: "flex_1" }}
-          className="pf-v6-u-mt-xl"
-        >
-          <TitleLayout headingLevel="h2" id="who" text="Who" />
-          <SudoRulesWho
-            rule={props.rule}
-            ipaObject={ipaObject}
-            onRefresh={props.onRefresh}
-            usersList={usersAndExternalsList}
-            userGroupsList={usergroupsList}
-            recordOnChange={recordOnChange}
-            metadata={props.metadata}
-            onSave={onSave}
-            modifiedValues={props.modifiedValues}
-          />
-        </Flex>
-        {/* Access this host */}
-        <Flex
-          direction={{ default: "column" }}
-          flex={{ default: "flex_1" }}
-          className="pf-v6-u-mt-xl"
-        >
-          <TitleLayout headingLevel="h2" id="who" text="Access this host" />
-          <AccessThisHost
-            rule={props.rule}
-            ipaObject={ipaObject}
-            onRefresh={props.onRefresh}
-            hostsList={hostsAndExternalsList}
-            hostGroupsList={hostgroupsList}
-            recordOnChange={recordOnChange}
-            metadata={props.metadata}
-            onSave={onSave}
-            modifiedValues={props.modifiedValues}
-          />
-        </Flex>
-        {/* Run commands */}
-        <Flex
-          direction={{ default: "column" }}
-          flex={{ default: "flex_1" }}
-          className="pf-v6-u-mt-xl"
-        >
-          <TitleLayout
-            headingLevel="h2"
-            id="run-commands"
-            text="Run commands"
-          />
-          <RunCommands
-            rule={props.rule}
-            ipaObject={ipaObject}
-            onRefresh={props.onRefresh}
-            allowCommandsList={allowCommandsList}
-            allowCommandGroupsList={allowCommandGroupsList}
-            denyCommandsList={denyCommandsList}
-            denyCommandGroupsList={denyCommandGroupsList}
-            recordOnChange={recordOnChange}
-            metadata={props.metadata}
-            onSave={onSave}
-            modifiedValues={props.modifiedValues}
-          />
-        </Flex>
-        {/* As whom */}
-        <Flex
-          direction={{ default: "column" }}
-          flex={{ default: "flex_1" }}
-          className="pf-v6-u-mt-xl"
-        >
-          <TitleLayout headingLevel="h2" id="as-whom" text="As whom" />
-          <SudoRuleAsWhom
-            rule={props.rule}
-            ipaObject={ipaObject}
-            runasuser_users={runAsUsersAndExternalsList}
-            runasuser_groups={runAsUsersGroupsAndExternalsList}
-            runasgroup_group={runAsGroupsAndExternalsList}
-            onRefresh={props.onRefresh}
-            recordOnChange={recordOnChange}
-            metadata={props.metadata}
-            onSave={onSave}
-            modifiedValues={props.modifiedValues}
-          />
-        </Flex>
-      </SidebarLayout>
-    </TabLayout>
+    <>
+      <TabLayout id="settings-page" toolbarItems={toolbarFields}>
+        <SidebarLayout itemNames={itemNames}>
+          {/* General */}
+          <Flex direction={{ default: "column" }} flex={{ default: "flex_1" }}>
+            <TitleLayout headingLevel="h2" id="general" text="General" />
+            <SudoRuleGeneral
+              ipaObject={ipaObject}
+              recordOnChange={recordOnChange}
+              metadata={props.metadata}
+            />
+          </Flex>
+          {/* Options */}
+          <Flex direction={{ default: "column" }} flex={{ default: "flex_1" }}>
+            <TitleLayout headingLevel="h2" id="options" text="Options" />
+            <SudoRuleOptions
+              sudoRuleId={props.rule.cn as string}
+              options={sudoOptions}
+            />
+          </Flex>
+          {/* Who */}
+          <Flex
+            direction={{ default: "column" }}
+            flex={{ default: "flex_1" }}
+            className="pf-v6-u-mt-xl"
+          >
+            <TitleLayout headingLevel="h2" id="who" text="Who" />
+            <SudoRulesWho
+              rule={props.rule}
+              ipaObject={ipaObject}
+              onRefresh={props.onRefresh}
+              usersList={usersAndExternalsList}
+              userGroupsList={usergroupsList}
+              recordOnChange={recordOnChange}
+              metadata={props.metadata}
+              onSave={onSave}
+              modifiedValues={props.modifiedValues}
+            />
+          </Flex>
+          {/* Access this host */}
+          <Flex
+            direction={{ default: "column" }}
+            flex={{ default: "flex_1" }}
+            className="pf-v6-u-mt-xl"
+          >
+            <TitleLayout headingLevel="h2" id="who" text="Access this host" />
+            <AccessThisHost
+              rule={props.rule}
+              ipaObject={ipaObject}
+              onRefresh={props.onRefresh}
+              hostsList={hostsAndExternalsList}
+              hostGroupsList={hostgroupsList}
+              recordOnChange={recordOnChange}
+              metadata={props.metadata}
+              onSave={onSave}
+              modifiedValues={props.modifiedValues}
+            />
+          </Flex>
+          {/* Run commands */}
+          <Flex
+            direction={{ default: "column" }}
+            flex={{ default: "flex_1" }}
+            className="pf-v6-u-mt-xl"
+          >
+            <TitleLayout
+              headingLevel="h2"
+              id="run-commands"
+              text="Run commands"
+            />
+            <RunCommands
+              rule={props.rule}
+              ipaObject={ipaObject}
+              onRefresh={props.onRefresh}
+              allowCommandsList={allowCommandsList}
+              allowCommandGroupsList={allowCommandGroupsList}
+              denyCommandsList={denyCommandsList}
+              denyCommandGroupsList={denyCommandGroupsList}
+              recordOnChange={recordOnChange}
+              metadata={props.metadata}
+              onSave={onSave}
+              modifiedValues={props.modifiedValues}
+            />
+          </Flex>
+          {/* As whom */}
+          <Flex
+            direction={{ default: "column" }}
+            flex={{ default: "flex_1" }}
+            className="pf-v6-u-mt-xl"
+          >
+            <TitleLayout headingLevel="h2" id="as-whom" text="As whom" />
+            <SudoRuleAsWhom
+              rule={props.rule}
+              ipaObject={ipaObject}
+              runasuser_users={runAsUsersAndExternalsList}
+              runasuser_groups={runAsUsersGroupsAndExternalsList}
+              runasgroup_group={runAsGroupsAndExternalsList}
+              onRefresh={props.onRefresh}
+              recordOnChange={recordOnChange}
+              metadata={props.metadata}
+              onSave={onSave}
+              modifiedValues={props.modifiedValues}
+            />
+          </Flex>
+        </SidebarLayout>
+      </TabLayout>
+      <DeleteSudoRule
+        show={isDeleteModalOpen}
+        handleModalToggle={() => setIsDeleteModalOpen(!isDeleteModalOpen)}
+        selectedRulesData={{
+          selectedRules: [props.rule as SudoRule],
+          clearSelectedRules: () => {},
+        }}
+        buttonsData={{
+          updateIsDeleteButtonDisabled: () => {},
+          updateIsDeletion: () => {},
+        }}
+        onRefresh={props.onRefresh}
+        from="settings"
+      />
+      <DisableEnableSudoRules
+        show={isEnableDisableModalOpen}
+        handleModalToggle={() =>
+          setIsEnableDisableModalOpen(!isEnableDisableModalOpen)
+        }
+        optionSelected={isRuleEnabled}
+        selectedRulesData={{
+          selectedRules: [props.rule as SudoRule],
+          clearSelectedRules: () => {},
+        }}
+        buttonsData={{
+          updateIsEnableButtonDisabled: () => {},
+          updateIsDisableButtonDisabled: () => {},
+          updateIsDisableEnableOp: () => {},
+        }}
+        onRefresh={props.onRefresh}
+        singleRule={true}
+      />
+    </>
   );
 };
 

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -250,7 +250,7 @@ export interface SudoRulesOld {
 
 export interface SudoRule {
   cn: string;
-  ipaenabledflag: boolean;
+  ipaenabledflag: string; // "true" | "false"
   externaluser: string[];
   dn: string;
   description: string;

--- a/src/utils/sudoRulesUtils.tsx
+++ b/src/utils/sudoRulesUtils.tsx
@@ -40,7 +40,7 @@ export function partialSudoRuleToSudoRule(
 export function createEmptySudoRule(): SudoRule {
   const sudoRule: SudoRule = {
     cn: "",
-    ipaenabledflag: true,
+    ipaenabledflag: "true",
     dn: "",
     description: "",
     sudoorder: "",

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -100,12 +100,12 @@ export const checkEqualStatusHbacRule = (
 
 /**
  * Helper method: Given a Sudo rule list and status, check if some entry has different status
- * @param {boolean} status - The status to check against
+ * @param {string} status - The status to check against
  * @param {SudoRule[]} rulesList - Array of Sudo rules to check
  * @returns {boolean} - True if all rules have the same status, false otherwise
  */
 export const checkEqualStatusSudoRule = (
-  status: boolean,
+  status: string,
   rulesList: SudoRule[]
 ) => {
   const rulesWithOtherStatus = rulesList.filter(


### PR DESCRIPTION
Fixes: https://github.com/freeipa/freeipa-webui/issues/897

## Summary by Sourcery

Update sudo rule settings kebab actions and modals, and standardize alert handling for ID range and sudo rule operations.

Bug Fixes:
- Prevent enabling an already enabled sudo rule or disabling an already disabled one via the settings kebab menu.
- Ensure the kebab layout can be used without explicitly passing a disabled flag, defaulting to enabled.

Enhancements:
- Wire the sudo rule settings page kebab actions to shared delete and enable/disable modals, including redirecting back to the sudo rules list after deleting from settings.
- Use Redux-based global alerts instead of local alert hooks in ID range add/delete modals and sudo rule enable/disable flows, with clearer success messages.

## Summary by Sourcery

Align sudo rule settings kebab actions with shared enable/disable and delete modals and improve their behavior and messaging.

Bug Fixes:
- Disable the settings kebab enable action when the sudo rule is already enabled and the disable action when the rule is already disabled.
- Allow the kebab layout to be used without explicitly passing a disabled flag by defaulting it to enabled.

Enhancements:
- Wire the sudo rule settings page delete action to the shared delete modal and redirect back to the sudo rules list after deleting from settings.
- Use the shared enable/disable sudo rules modal from the settings page with a computed enabled state for the current rule.
- Clarify the global success alert message for sudo rule enable/disable operations to reflect whether the rule was enabled or disabled.