### PR TITLE
Fix 404 error after activating/preserving users

### DIFF
--- a/src/components/UsersSections/UserSettings.tsx
+++ b/src/components/UsersSections/UserSettings.tsx
@@ -702,21 +702,21 @@ const UserSettings = (props: PropsToUserSettings) => {
         show={isActivateModalOpen}
         handleModalToggle={onCloseActivateModal}
         selectedUsers={[props.user] as User[]}
-        onSuccess={() => navigate("stage-users")}
+        onSuccess={() => navigate("/stage-users")}
       />
       <StagePreservedUsers
         show={isStageModalOpen}
         handleModalToggle={onCloseStageModal}
         selectedUsers={[props.user] as User[]}
         clearSelectedUsers={clearSelectedUsers}
-        onSuccess={() => navigate("preserved-users")}
+        onSuccess={() => navigate("/preserved-users")}
       />
       <RestorePreservedUsers
         show={isRestoreModalOpen}
         handleModalToggle={onCloseRestoreModal}
         selectedUsers={[props.user] as User[]}
         clearSelectedUsers={clearSelectedUsers}
-        onSuccess={() => navigate("preserved-users")}
+        onSuccess={() => navigate("/preserved-users")}
       />
     </TabLayout>
   );


### PR DESCRIPTION
There is a 404 error (page not found) when activating a given user from its Settings page. This is easily fixed by adjusting the URL passed in the `navigate` function (provided by the `useNavigate` hook).

Fixes: https://github.com/freeipa/freeipa-webui/issues/890

## Summary by Sourcery

Bug Fixes:
- Correct the post-action navigation targets for activating, staging, and restoring users to use the proper routes, preventing 404 errors.