### PR TITLE
Fix: roles' table functionality

### DIFF
--- a/src/pages/Hosts/HostsMemberOf.tsx
+++ b/src/pages/Hosts/HostsMemberOf.tsx
@@ -246,7 +246,7 @@ const HostsMemberOf = (props: PropsToHostsMemberOf) => {
             <MemberOfRoles
               entity={host}
               id={host.fqdn as string}
-              from={"roles"}
+              from={"hosts"}
               isDataLoading={hostQuery.isFetching}
               onRefreshData={onRefreshHostData}
               setDirection={updateRoleDirection}


### PR DESCRIPTION
The functionality of the 'Roles' table (located in Hosts > Is a member of > Roles) must be fixed in
order to perform basic operations. This bug comes
from a bad assignment of the `from` parameter in
the `MemberOfRoles` component.

Fix: https://github.com/freeipa/freeipa-webui/issues/891

## Summary by Sourcery

Bug Fixes:
- Correct the context identifier used by the host 'Roles' membership table to restore proper role management operations.