### PR TITLE
POC: Replace given seeds with direct ipa calls and cleanup

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -4,6 +4,7 @@ import { addCucumberPreprocessorPlugin } from "@badeball/cypress-cucumber-prepro
 import createEsbuildPlugin from "@badeball/cypress-cucumber-preprocessor/esbuild";
 import { verifyDownloadTasks } from "cy-verify-downloads";
 import { polyfillNode } from "esbuild-plugin-polyfill-node";
+import { ipaCleanup } from "./cypress/support/ipaCleanup";
 
 export default defineConfig({
   video: true,
@@ -28,7 +29,11 @@ export default defineConfig({
           ],
         })
       );
-      on("task", verifyDownloadTasks);
+
+      on("task", {
+        ...verifyDownloadTasks,
+        ipaCleanup,
+      });
 
       return config;
     },

--- a/cypress/e2e/cleanupHook.ts
+++ b/cypress/e2e/cleanupHook.ts
@@ -1,0 +1,10 @@
+import { Before } from "@badeball/cypress-cucumber-preprocessor";
+
+Before(() => {
+  cy.log("Running IPA cleanup)");
+  cy.task("ipaCleanup", {
+    serverName: Cypress.env("SERVER_NAME"),
+    adminLogin: Cypress.env("ADMIN_LOGIN"),
+    adminPassword: Cypress.env("ADMIN_PASSWORD"),
+  });
+});

--- a/cypress/e2e/common/hbac_rule_management.ts
+++ b/cypress/e2e/common/hbac_rule_management.ts
@@ -4,27 +4,16 @@ import {
   selectEntry,
   searchForEntry,
   entryDoesNotExist,
-  entryExists,
 } from "../common/data_tables";
 import { navigateTo } from "../common/navigation";
-import { typeInTextbox } from "../common/ui/textbox";
 
 Given("hbac rule {string} exists", (ruleName: string) => {
-  loginAsAdmin();
-  navigateTo("hbac-rules");
-
-  cy.dataCy("hbac-rules-button-add").click();
-  cy.dataCy("add-hbac-rule-modal").should("exist");
-
-  typeInTextbox("modal-textbox-rule-name", ruleName);
-  cy.dataCy("modal-textbox-rule-name").should("have.value", ruleName);
-
-  cy.dataCy("modal-button-add").click();
-  cy.dataCy("add-hbac-rule-modal").should("not.exist");
-
-  searchForEntry(ruleName);
-  entryExists(ruleName);
-  logout();
+  cy.ipa({
+    command: "hbacrule-add",
+    name: ruleName,
+  }).then((result) => {
+    cy.log(result.stderr);
+  });
 });
 
 Given("I delete hbac rule {string}", (ruleName: string) => {

--- a/cypress/e2e/common/host_management.ts
+++ b/cypress/e2e/common/host_management.ts
@@ -1,13 +1,7 @@
 import { Given } from "@badeball/cypress-cucumber-preprocessor";
 import { loginAsAdmin, logout } from "./authentication";
-import {
-  selectEntry,
-  searchForEntry,
-  entryDoesNotExist,
-  entryExists,
-} from "./data_tables";
+import { selectEntry, searchForEntry, entryDoesNotExist } from "./data_tables";
 import { navigateTo } from "./navigation";
-import { typeInTextbox } from "./ui/textbox";
 
 Given("I delete host {string}", (hostName: string) => {
   loginAsAdmin();
@@ -26,22 +20,11 @@ Given("I delete host {string}", (hostName: string) => {
 });
 
 Given("host {string} exists", (hostName: string) => {
-  loginAsAdmin();
-  navigateTo("hosts");
-
-  cy.dataCy("hosts-button-add").click();
-  cy.dataCy("add-host-modal").should("exist");
-
-  typeInTextbox("modal-textbox-host-name", hostName);
-  cy.dataCy("modal-textbox-host-name").should("have.value", hostName);
-
-  cy.dataCy("modal-checkbox-force-host").check();
-  cy.dataCy("modal-checkbox-force-host").should("be.checked");
-
-  cy.dataCy("modal-button-add").click();
-  cy.dataCy("add-host-modal").should("not.exist");
-
-  searchForEntry(hostName);
-  entryExists(hostName);
-  logout();
+  cy.ipa({
+    command: "host-add --force",
+    name: hostName,
+  }).then((result) => {
+    cy.log(result.stderr);
+    cy.log(result.stdout);
+  });
 });

--- a/cypress/e2e/common/sudo_rules_management.ts
+++ b/cypress/e2e/common/sudo_rules_management.ts
@@ -4,7 +4,6 @@ import {
   entryDoesNotExist,
   searchForEntry,
   selectEntry,
-  validateEntry,
 } from "../common/data_tables";
 import { navigateTo } from "../common/navigation";
 import { typeInTextbox } from "../common/ui/textbox";
@@ -21,11 +20,13 @@ export const addSudoRule = (ruleName: string) => {
 };
 
 Given("sudo rule {string} exists", (ruleName: string) => {
-  loginAsAdmin();
-  navigateTo("sudo-rules");
-  addSudoRule(ruleName);
-  validateEntry(ruleName);
-  logout();
+  cy.ipa({
+    command: "sudorule-add",
+    name: ruleName,
+  }).then((result) => {
+    cy.log(result.stderr);
+    cy.log(result.stdout);
+  });
 });
 
 Given("I delete sudo rule {string}", (ruleName: string) => {

--- a/cypress/e2e/dns/dnszones.ts
+++ b/cypress/e2e/dns/dnszones.ts
@@ -172,14 +172,13 @@ Then("I should not see DNS zone {string} in the list", (zoneName: string) => {
 });
 
 Given("DNS zone {string} exists", (zoneName: string) => {
-  loginAsAdmin();
-  navigateTo("dns-zones");
-
-  createDnsZone(zoneName);
-
-  searchForEntry(parseZoneName(zoneName));
-  entryExists(parseZoneName(zoneName));
-  logout();
+  cy.ipa({
+    command: "dnszone-add",
+    name: zoneName,
+  }).then((result) => {
+    cy.log(result.stderr);
+    cy.log(result.stdout);
+  });
 });
 
 Then(

--- a/cypress/e2e/hbac/hbac_rule/hbac_rule_settings.feature
+++ b/cypress/e2e/hbac/hbac_rule/hbac_rule_settings.feature
@@ -1,12 +1,11 @@
 Feature: Hbac rule settings manipulation
   Modify a Hbac rule
 
-  @seed
-  Scenario: Add a new rule
-    Given hbac rule "rule1" exists
 
   @test
   Scenario: Add user to Who category
+    Given hbac rule "rule1" exists
+
     Given I am logged in as admin
     And I am on "hbac-rules/rule1" page
 
@@ -29,16 +28,11 @@ Feature: Hbac rule settings manipulation
     And I should see "add-member-success" alert
     Then I should see "admin" entry in the data table
 
-  @cleanup
-  Scenario: Delete the user for cleanup
-    Given I delete element "user" named "admin" from rule "rule1"
-
-  @seed
-  Scenario: Add a user to the rule
-    Given I have element "user" named "admin" in rule "rule1"
-
   @test
   Scenario: Remove user from Who category
+    Given hbac rule "rule1" exists
+    Given I have element "user" named "admin" in rule "rule1"
+
     Given I am logged in as admin
     And I am on "hbac-rules/rule1" page
 
@@ -54,6 +48,7 @@ Feature: Hbac rule settings manipulation
 
   @test
   Scenario: Add group to Who category
+    Given hbac rule "rule1" exists
     Given I am logged in as admin
     And I am on "hbac-rules/rule1" page
 
@@ -75,16 +70,10 @@ Feature: Hbac rule settings manipulation
     And I should see "add-member-success" alert
     Then I should see "admins" entry in the data table
 
-  @cleanup
-  Scenario: Delete the group for cleanup
-    Given I delete element "group" named "admins" from rule "rule1"
-
-  @seed
-  Scenario: Add a group to the rule
-    Given I have element "group" named "admins" in rule "rule1"
-
   @test
   Scenario: Remove group from Who category
+    Given hbac rule "rule1" exists
+    Given I have element "group" named "admins" in rule "rule1"
     Given I am logged in as admin
     And I am on "hbac-rules/rule1" page
 
@@ -103,6 +92,8 @@ Feature: Hbac rule settings manipulation
     # When enabling "Allow anyone" all members need to be removed otherwise
     # the update fails
     # 1) Add a user and group to the tables
+    Given hbac rule "rule1" exists
+
     Given I am logged in as admin
     And I am on "hbac-rules/rule1" page
     When I click on the "hbac-rules-tab-settings-tab-users" tab
@@ -145,12 +136,11 @@ Feature: Hbac rule settings manipulation
     Then I should not see "hbac-rules-tab-settings-tab-users" tab
     Then I should not see "hbac-rules-tab-settings-tab-groups" tab
 
-  @seed
-  Scenario: Add a new host that will be used in the tests
-    Given host "my-new-host.ipa.test" exists
-
   @test
   Scenario: Add host to Host category
+    Given host "my-new-host.ipa.test" exists
+    Given hbac rule "rule1" exists
+
     Given I am logged in as admin
     And I am on "hbac-rules/rule1" page
 
@@ -172,12 +162,11 @@ Feature: Hbac rule settings manipulation
     And I should see "add-member-success" alert
     Then I should see "my-new-host.ipa.test" entry in the data table
 
-  @cleanup
-  Scenario: Delete the host from the rule
-    Given I delete host "my-new-host" from rule "rule1"
-
-  @seed
+  @test
   Scenario: Add a host to the rule
+    Given host "my-new-host.ipa.test" exists
+    Given hbac rule "rule1" exists
+
     Given I am logged in as admin
     And I am on "hbac-rules/rule1" page
 
@@ -201,6 +190,10 @@ Feature: Hbac rule settings manipulation
 
   @test
   Scenario: Remove host from Host category
+    Given host "my-new-host.ipa.test" exists
+    Given hbac rule "rule1" exists
+    Given I have element "host" named "my-new-host.ipa.test" in rule "rule1"
+
     Given I am logged in as admin
     And I am on "hbac-rules/rule1" page
 
@@ -216,6 +209,8 @@ Feature: Hbac rule settings manipulation
 
   @test
   Scenario: Add hostgroup to Host category
+    Given hbac rule "rule1" exists
+
     Given I am logged in as admin
     And I am on "hbac-rules/rule1" page
 
@@ -237,16 +232,11 @@ Feature: Hbac rule settings manipulation
     And I should see "add-member-success" alert
     Then I should see "ipaservers" entry in the data table
 
-  @cleanup
-  Scenario: Delete the hostgroup from the rule
-    Given I delete element "hostgroup" named "ipaservers" from rule "rule1"
-
-  @seed
-  Scenario: Add a hostgroup to the rule
-    Given I have element "hostgroup" named "ipaservers" in rule "rule1"
-
   @test
   Scenario: Remove hostgroup from Host category
+    Given hbac rule "rule1" exists
+    Given I have element "hostgroup" named "ipaservers" in rule "rule1"
+
     Given I am logged in as admin
     And I am on "hbac-rules/rule1" page
 
@@ -263,6 +253,9 @@ Feature: Hbac rule settings manipulation
   @test
   Scenario: Set Host category to allow all hosts
     # This is the same test as above but for the host category
+    Given hbac rule "rule1" exists
+    Given host "my-new-host.ipa.test" exists
+
     # 1) Add a host and host group to the tables
     Given I am logged in as admin
     And I am on "hbac-rules/rule1" page
@@ -308,12 +301,9 @@ Feature: Hbac rule settings manipulation
     Then I should not see "hbac-rules-tab-settings-tab-hosts" tab
     Then I should not see "hbac-rules-tab-settings-tab-hostgroups" tab
 
-  @cleanup
-  Scenario: Delete host for cleanup
-    Given I delete host "my-new-host.ipa.test"
-
   @test
   Scenario: Add service to Service category
+    Given hbac rule "rule1" exists
     Given I am logged in as admin
     And I am on "hbac-rules/rule1" page
 
@@ -335,16 +325,11 @@ Feature: Hbac rule settings manipulation
     And I should see "add-member-success" alert
     Then I should see "crond" entry in the data table
 
-  @cleanup
-  Scenario: Delete the service from the rule
-    Given I delete service "crond" from rule "rule1"
-
-  @seed
-  Scenario: Add a service to the rule
-    Given I have service "crond" in rule "rule1"
-
   @test
   Scenario: Remove service from Service category
+    Given hbac rule "rule1" exists
+    Given I have service "crond" in rule "rule1"
+
     Given I am logged in as admin
     And I am on "hbac-rules/rule1" page
 
@@ -360,6 +345,7 @@ Feature: Hbac rule settings manipulation
 
   @test
   Scenario: Add service group to Service category
+    Given hbac rule "rule1" exists
     Given I am logged in as admin
     And I am on "hbac-rules/rule1" page
 
@@ -381,16 +367,11 @@ Feature: Hbac rule settings manipulation
     And I should see "add-member-success" alert
     Then I should see "ftp" entry in the data table
 
-  @cleanup
-  Scenario: Delete the service group from the rule
-    Given I delete servicegroup "ftp" from rule "rule1"
-
-  @seed
-  Scenario: Add a service group to the rule
-    Given I have servicegroup "ftp" in rule "rule1"
-
   @test
   Scenario: Remove service group from Service category
+    Given hbac rule "rule1" exists
+    Given I have servicegroup "ftp" in rule "rule1"
+
     Given I am logged in as admin
     And I am on "hbac-rules/rule1" page
 
@@ -407,6 +388,7 @@ Feature: Hbac rule settings manipulation
   @test
   Scenario: Set Service category to allow all services
     # 1) Add a service and service group to the tables
+    Given hbac rule "rule1" exists
     Given I am logged in as admin
     And I am on "hbac-rules/rule1" page
 
@@ -450,6 +432,3 @@ Feature: Hbac rule settings manipulation
     Then I should not see "hbac-rules-tab-settings-tab-services" tab
     Then I should not see "hbac-rules-tab-settings-tab-servicegroups" tab
 
-  @cleanup
-  Scenario: Delete the HBAC rule for cleanup
-    Given I delete hbac rule "rule1"

--- a/cypress/e2e/hbac/hbac_service/hbac_service.ts
+++ b/cypress/e2e/hbac/hbac_service/hbac_service.ts
@@ -7,7 +7,6 @@ import {
   searchForEntry,
   selectEntry,
 } from "../../common/data_tables";
-import { typeInTextbox } from "cypress/e2e/common/ui/textbox";
 import { addItemToRightList } from "cypress/e2e/common/ui/dual_list";
 import {
   searchForMembersEntry,
@@ -15,24 +14,13 @@ import {
 } from "cypress/e2e/common/members_table";
 
 Given("HBAC service {string} exists", (serviceName: string) => {
-  loginAsAdmin();
-  navigateTo("hbac-services");
-
-  searchForEntry(serviceName);
-  cy.dataCy("hbac-services-button-add").click();
-  cy.dataCy("add-hbac-service-modal").should("exist");
-
-  typeInTextbox("modal-textbox-service-name", serviceName);
-  cy.dataCy("modal-textbox-service-name").should("have.value", serviceName);
-
-  cy.dataCy("modal-button-add").click();
-  cy.dataCy("add-hbac-service-modal").should("not.exist");
-  cy.dataCy("add-hbacservice-success").should("exist");
-
-  searchForEntry(serviceName);
-  entryExists(serviceName);
-
-  logout();
+  cy.ipa({
+    command: "hbacsvc-add",
+    name: serviceName,
+  }).then((result) => {
+    cy.log(result.stderr);
+    cy.log(result.stdout);
+  });
 });
 
 Given("I delete service {string}", (serviceName: string) => {

--- a/cypress/e2e/hbac/hbac_service_group/hbac_service_group.ts
+++ b/cypress/e2e/hbac/hbac_service_group/hbac_service_group.ts
@@ -7,7 +7,6 @@ import {
   searchForEntry,
   selectEntry,
 } from "../../common/data_tables";
-import { typeInTextbox } from "../../common/ui/textbox";
 import { addItemToRightList } from "cypress/e2e/common/ui/dual_list";
 import {
   searchForMembersEntry,
@@ -15,25 +14,13 @@ import {
 } from "cypress/e2e/common/members_table";
 
 Given("HBAC service group {string} exists", (groupName: string) => {
-  loginAsAdmin();
-  navigateTo("hbac-service-groups");
-
-  searchForEntry(groupName);
-
-  cy.dataCy("hbac-service-groups-button-add").click();
-  cy.dataCy("add-hbac-service-group-modal").should("exist");
-
-  typeInTextbox("modal-textbox-service-group-name", groupName);
-  cy.dataCy("modal-textbox-service-group-name").should("have.value", groupName);
-
-  cy.dataCy("modal-button-add").click();
-  cy.dataCy("add-hbac-service-group-modal").should("not.exist");
-  cy.dataCy("add-hbacservicegroup-success").should("exist");
-
-  searchForEntry(groupName);
-  entryExists(groupName);
-
-  logout();
+  cy.ipa({
+    command: "hbacsvcgroup-add",
+    name: groupName,
+  }).then((result) => {
+    cy.log(result.stderr);
+    cy.log(result.stdout);
+  });
 });
 
 Given("I delete service group {string}", (groupName: string) => {

--- a/cypress/e2e/hostgroups/hostgroup.feature
+++ b/cypress/e2e/hostgroups/hostgroup.feature
@@ -8,16 +8,11 @@ Feature: Hostgroup management
         When I create hostgroup "my_automember_hostgroup" with description "test"
         Then I should see hostgroup "my_automember_hostgroup" in the data table
 
-    @cleanup
-    Scenario: Delete host group
-        Given I delete hostgroup "my_automember_hostgroup"
-
-    @seed
-    Scenario: Create new host group
-        Given Hostgroup "my_automember_hostgroup" with description "test" exists
 
     @test
     Scenario: Delete host group
+        Given Hostgroup "my_automember_hostgroup" with description "test" exists
+
         Given I am logged in as admin
         And I am on "host-groups" page
 

--- a/cypress/e2e/hostgroups/hostgroup.ts
+++ b/cypress/e2e/hostgroups/hostgroup.ts
@@ -75,13 +75,18 @@ Then(
 Given(
   "Hostgroup {string} with description {string} exists",
   (hostgroupName: string, hostgroupDescription: string) => {
-    loginAsAdmin();
-    navigateTo("host-groups");
-
-    createHostgroup(hostgroupName, hostgroupDescription);
-    validateHostgroup(hostgroupName);
-
-    logout();
+    try {
+      cy.ipa({
+        command: "hostgroup-add",
+        name: hostgroupName,
+        specificOptions: `--desc="${hostgroupDescription}"`,
+      }).then((result) => {
+        cy.log(result.stderr);
+        cy.log(result.stdout);
+      });
+    } catch (e) {
+      console.log("error in ipa command: " + String(e));
+    }
   }
 );
 

--- a/cypress/e2e/id_views/id_views.feature
+++ b/cypress/e2e/id_views/id_views.feature
@@ -19,10 +19,6 @@ Feature: ID View manipulation
     When I search for "a_new_view" in the data table
     Then I should see "a_new_view" entry in the data table
 
-  @cleanup
-  Scenario: Delete a view
-    Given I delete view "a_new_view"
-
   @test
   Scenario: Add a new view with description
     Given I am logged in as admin
@@ -45,16 +41,11 @@ Feature: ID View manipulation
     Then I should see "a_new_view" entry in the data table
     And I should see "a_new_view" entry in the data table with attribute "Description" set to "my description"
 
-  @cleanup
-  Scenario: Delete a view
-    Given I delete view "a_new_view"
-
-  @seed
-  Scenario: Create views
-    Given view "a_new_view" exists
 
   @test
   Scenario: Unapply views from hosts
+    Given view "a_new_view" exists
+
     Given I am logged in as admin
     And I am on "id-views" page
 
@@ -80,6 +71,8 @@ Feature: ID View manipulation
 
   @test
   Scenario: Unapply views from host groups
+    Given view "a_new_view" exists
+
     Given I am logged in as admin
     And I am on "id-views" page
 
@@ -103,16 +96,9 @@ Feature: ID View manipulation
     Then I should not see "dual-list-modal" modal
     And I should see "unapply-id-views-hosts-success" alert
 
-  @cleanup
-  Scenario: Delete a view
-    Given I delete view "a_new_view"
-
-  @seed
-  Scenario: Create view "a_new_view"
-    Given view "a_new_view" exists
-
   @test
   Scenario: Delete a view
+    Given view "a_new_view" exists
     Given I am logged in as admin
     And I am on "id-views" page
 
@@ -132,13 +118,10 @@ Feature: ID View manipulation
     When I search for "a_new_view" in the data table
     Then I should not see "a_new_view" entry in the data table
 
-  @seed
-  Scenario: Create views
-    Given view "a_new_view" exists
-    Given view "b_new_view" exists
-
   @test
   Scenario: Delete many views
+    Given view "a_new_view" exists
+    Given view "b_new_view" exists
     Given I am logged in as admin
     And I am on "id-views" page
 

--- a/cypress/e2e/id_views/id_views.ts
+++ b/cypress/e2e/id_views/id_views.ts
@@ -4,10 +4,8 @@ import {
   selectEntry,
   searchForEntry,
   entryDoesNotExist,
-  entryExists,
 } from "../common/data_tables";
 import { navigateTo } from "../common/navigation";
-import { typeInTextbox } from "../common/ui/textbox";
 
 Given("I delete view {string}", (viewName: string) => {
   loginAsAdmin();
@@ -26,19 +24,12 @@ Given("I delete view {string}", (viewName: string) => {
 });
 
 Given("view {string} exists", (viewName: string) => {
-  loginAsAdmin();
-  navigateTo("id-views");
-
-  cy.dataCy("id-views-button-add").click();
-  cy.dataCy("add-id-view-modal").should("exist");
-
-  typeInTextbox("modal-textbox-id-view-name", viewName);
-  cy.dataCy("modal-textbox-id-view-name").should("have.value", viewName);
-
-  cy.dataCy("modal-button-add").click();
-  cy.dataCy("add-id-view-modal").should("not.exist");
-
-  searchForEntry(viewName);
-  entryExists(viewName);
-  logout();
+  cy.log(`Ensuring view ${viewName} exists`);
+  cy.ipa({
+    command: "idview-add",
+    name: viewName,
+  }).then((result) => {
+    cy.log(result.stderr);
+    cy.log(result.stdout);
+  });
 });

--- a/cypress/e2e/netgroup/netgroup.ts
+++ b/cypress/e2e/netgroup/netgroup.ts
@@ -14,22 +14,13 @@ import { MemberEntity, assertMemberEntity } from "../common/member_of";
 import { searchForMembersEntry } from "../common/members_table";
 
 Given("netgroup {string} exists", (groupName: string) => {
-  loginAsAdmin();
-  navigateTo("netgroups");
-
-  cy.dataCy("netgroups-button-add").click();
-  cy.dataCy("add-netgroup-modal").should("exist");
-
-  typeInTextbox("modal-textbox-netgroup-name", groupName);
-  cy.dataCy("modal-textbox-netgroup-name").should("have.value", groupName);
-
-  cy.dataCy("modal-button-add").click();
-  cy.dataCy("add-netgroup-modal").should("not.exist");
-  cy.dataCy("add-netgroup-success").should("exist");
-
-  searchForMembersEntry(groupName);
-  entryExists(groupName);
-  logout();
+  cy.ipa({
+    command: "netgroup-add",
+    name: groupName,
+  }).then((result) => {
+    cy.log(result.stderr);
+    cy.log(result.stdout);
+  });
 });
 
 Given("I delete netgroup {string}", (groupName: string) => {

--- a/cypress/support/cleanupSpecs.ts
+++ b/cypress/support/cleanupSpecs.ts
@@ -1,0 +1,131 @@
+import { CleanupMetadata } from "./ipaCleanup";
+
+export const CLEANUP_SPECS: CleanupMetadata[] = [
+  // TODO: Check - "Could not get Grouping Type interactively" error
+  // {
+  //   find: ["automember-find", "--pkey-only"],
+  //   del: ["automember-del"],
+  // },
+  {
+    find: ["certmaprule-find", "--pkey-only"],
+    del: ["certmaprule-del"],
+  },
+  {
+    find: ["dnsforwardzone-find", "--pkey-only"],
+    del: ["dnsforwardzone-del"],
+  },
+  // TODO: Check - "Could not get Zone name interactively" error
+  // {
+  //   find: ["dnsrecord-find", "--pkey-only"],
+  //   del: ["dnsrecord-del"],
+  // },
+  {
+    find: ["dnszone-find", "--pkey-only"],
+    del: ["dnszone-del"],
+    omit: ["ipa.test.", "my-new-host.ipa.test"],
+  },
+  {
+    find: ["group-find", "--pkey-only"],
+    del: ["group-del"],
+    omit: ["admins", "editors", "ipausers", "trust admins"],
+  },
+  {
+    find: ["hbacrule-find", "--pkey-only"],
+    del: ["hbacrule-del"],
+    omit: ["allow_all", "allow_systemd-user"],
+  },
+  {
+    find: ["hbacsvc-find", "--pkey-only"],
+    del: ["hbacsvc-del"],
+    omit: [
+      "gdm",
+      "gdm-password",
+      "gssftp",
+      "kdm",
+      "login",
+      "proftpd",
+      "pure-ftpd",
+      "sshd",
+      "su",
+      "su-l",
+      "sudo",
+      "sudo-i",
+      "systemd-user",
+      "vsftpd",
+      "crond",
+      "ftp",
+    ],
+  },
+  {
+    find: ["hbacsvcgroup-find", "--pkey-only"],
+    del: ["hbacsvcgroup-del"],
+    omit: ["ftp", "Sudo"],
+  },
+  {
+    find: ["host-find", "--pkey-only"],
+    del: ["host-del"],
+    omit: ["webui.ipa.test"],
+  },
+  {
+    find: ["hostgroup-find", "--pkey-only"],
+    del: ["hostgroup-del"],
+    omit: ["ipaservers"],
+  },
+  // TODO: Check - "Could not get ID View Name interactively" error
+  // {
+  //   find: ["idoverridegroup-find", "--pkey-only"],
+  //   del: ["idoverridegroup-del"],
+  // },
+  // TODO: Check - "Could not get ID View Name interactively" error
+  // {
+  //   find: ["idoverrideuser-find", "--pkey-only"],
+  //   del: ["idoverrideuser-del"],
+  // },
+  {
+    find: ["idp-find", "--pkey-only"],
+    del: ["idp-del"],
+  },
+  {
+    find: ["idrange-find", "--pkey-only"],
+    del: ["idrange-del"],
+    omit: ["IPA.TEST_id_range", "IPA.TEST_subid_range"],
+  },
+  {
+    find: ["idview-find", "--pkey-only"],
+    del: ["idview-del"],
+  },
+  {
+    find: ["netgroup-find", "--pkey-only"],
+    del: ["netgroup-del"],
+  },
+  {
+    find: ["pwpolicy-find", "--pkey-only"],
+    del: ["pwpolicy-del"],
+    omit: ["global_policy"],
+  },
+  {
+    find: ["stageuser-find", "--pkey-only"],
+    del: ["stageuser-del"],
+  },
+  {
+    find: ["sudocmd-find", "--pkey-only"],
+    del: ["sudocmd-del"],
+  },
+  {
+    find: ["sudocmdgroup-find", "--pkey-only"],
+    del: ["sudocmdgroup-del"],
+  },
+  {
+    find: ["sudorule-find", "--pkey-only"],
+    del: ["sudorule-del"],
+  },
+  {
+    find: ["trust-find", "--pkey-only"],
+    del: ["trust-del"],
+  },
+  {
+    find: ["user-find", "--pkey-only"],
+    del: ["user-del"],
+    omit: ["admin"],
+  },
+];

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -25,6 +25,38 @@
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 //
 
+import { IPA_PREFIX } from "./utils";
+
 Cypress.Commands.add("dataCy", (value: string) => {
   return cy.get(`[data-cy='${value}']`);
 });
+
+export type IpaCommandParams = {
+  command: string;
+  name: string;
+  specificOptions?: string;
+  options?: Partial<Cypress.ExecOptions>;
+};
+
+// Register a helper to run IPA commands inside the webui container.
+// Automatically runs kinit before each IPA command.
+// Usage:
+//   cy.ipa("hbacsvc-show", "my_service", { failOnNonZeroExit: false })
+//   cy.ipa("hbacsvc-add", "my_service")
+// Returns the result of cy.exec so you can inspect code/stdout/stderr.
+Cypress.Commands.add(
+  "ipa",
+  ({
+    command,
+    name,
+    specificOptions,
+  }: IpaCommandParams): Cypress.Chainable<Cypress.Exec> => {
+    const safeName = name.replace(/"/g, '\\"');
+    let ipaCmd = `${IPA_PREFIX} ${command} "${safeName}"`;
+    if (specificOptions) {
+      ipaCmd = `${IPA_PREFIX} ${command} "${safeName}" ${specificOptions}`;
+    }
+
+    return cy.exec(ipaCmd, { failOnNonZeroExit: false });
+  }
+);

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -20,3 +20,10 @@ import { addCustomCommand } from "cy-verify-downloads";
 addCustomCommand();
 
 import "./commands";
+
+// Authenticate with Kerberos once before running any tests
+before(() => {
+  const password = Cypress.env("ADMIN_PASSWORD");
+  const kinitCmd = `echo "${password}" | podman exec -i webui kinit admin`;
+  cy.exec(kinitCmd, { failOnNonZeroExit: true });
+});

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -3,5 +3,6 @@
 declare namespace Cypress {
   interface Chainable<Subject> {
     dataCy(value: string): Chainable<Subject>;
+    ipa(IpaCommandParams): Chainable<Cypress.Exec>;
   }
 }

--- a/cypress/support/ipaCleanup.ts
+++ b/cypress/support/ipaCleanup.ts
@@ -1,0 +1,134 @@
+import { ExecOptions } from "child_process";
+import { exec, IPA_PREFIX } from "./utils";
+import { CLEANUP_SPECS } from "./cleanupSpecs";
+
+export type CleanupMetadata = {
+  find: string[];
+  del: string[];
+  omit?: string[];
+};
+
+type IpaCleanupParams = {
+  serverName: string;
+  adminLogin: string;
+  adminPassword: string;
+};
+
+export async function ipaCleanup({
+  serverName,
+  adminLogin,
+  adminPassword,
+}: IpaCleanupParams) {
+  const EXEC_OPTIONS: Readonly<ExecOptions> = {
+    maxBuffer: 20 * 1024 * 1024,
+    env: {
+      ...process.env,
+      CYPRESS_ADMIN_LOGIN: adminLogin,
+      CYPRESS_ADMIN_PASSWORD: adminPassword,
+    },
+  };
+
+  const standardPromises = CLEANUP_SPECS.map((spec) =>
+    runStandardCleanup({ cleanupMetadata: spec }, EXEC_OPTIONS)
+  );
+
+  const allPromises = [
+    ...standardPromises,
+    runServiceCleanup(serverName, EXEC_OPTIONS),
+  ];
+
+  await Promise.all(allPromises);
+
+  return null;
+}
+
+function logError(message: string) {
+  process.stderr.write(`${message}\n`);
+}
+
+function logWarning(message: string) {
+  process.stdout.write(`CLEANUP: ${message}\n`);
+}
+
+function parseItems(stdout: string): string[] {
+  return stdout
+    .split("\n")
+    .map((line) => line.split(":")[1]?.trim() || "")
+    .filter((u) => u.length > 0);
+}
+
+async function ipaFind(
+  findArgs: string[],
+  EXEC_OPTIONS: Readonly<ExecOptions>
+): Promise<string[]> {
+  const cmd = `${IPA_PREFIX} ${findArgs.join(" ")}`;
+
+  try {
+    const { stdout } = await exec(cmd, EXEC_OPTIONS);
+    return parseItems(String(stdout));
+  } catch {
+    return [];
+  }
+}
+
+async function ipaDel(
+  delArgs: string[],
+  items: string[],
+  EXEC_OPTIONS: Readonly<ExecOptions>
+): Promise<void> {
+  const deleted: string[] = [];
+
+  for (const item of items) {
+    const cmd = `${IPA_PREFIX} ${delArgs.join(" ")} "${item}"`;
+
+    try {
+      await exec(cmd, EXEC_OPTIONS);
+      deleted.push(item);
+    } catch (e) {
+      logError(`SKIP: cannot delete "${item}" – reason: ${e ?? String(e)}`);
+    }
+  }
+  if (deleted.length > 0) {
+    logWarning(`DELETED: ${deleted.join(", ")}`);
+  }
+}
+
+async function runStandardCleanup(
+  spec: {
+    cleanupMetadata: CleanupMetadata;
+  },
+  EXEC_OPTIONS: Readonly<ExecOptions>
+) {
+  const { find, del, omit = [] } = spec.cleanupMetadata;
+
+  const allItems = await ipaFind(find, EXEC_OPTIONS);
+  const items = allItems.filter((u) => !omit.includes(u));
+
+  await ipaDel(del, items, EXEC_OPTIONS);
+}
+
+async function runServiceCleanup(
+  serverName: string,
+  EXEC_OPTIONS: Readonly<ExecOptions>
+) {
+  const host = serverName;
+
+  const keepPrefixes = [
+    `HTTP/${host}`,
+    `DNS/${host}`,
+    `dogtag/${host}`,
+    `ipa-dnskeysyncd/${host}`,
+    `ldap/${host}`,
+  ];
+
+  const allItems = await ipaFind(["service-find", "--pkey-only"], EXEC_OPTIONS);
+  const items = allItems.filter(
+    (u) => u.length > 0 && !keepPrefixes.some((prefix) => u.startsWith(prefix))
+  );
+
+  if (items.length === 0) {
+    return;
+  }
+
+  await ipaDel(["service-del"], items, EXEC_OPTIONS);
+}

--- a/cypress/support/utils.ts
+++ b/cypress/support/utils.ts
@@ -1,0 +1,6 @@
+import { exec as cpExec } from "child_process";
+import util from "util";
+
+export const exec = util.promisify(cpExec);
+
+export const IPA_PREFIX = "podman exec webui ipa";


### PR DESCRIPTION
The cleanup uses a Before hook, this runs before each scenario. In this hook, a cy.task is run in order to paralelize the deletion calls. I also had to run kinit before both deletion or adding elements.

The seed adds a new cy.ipa calls which runs podman exec webui ipa via cy.exec(). The seed call has to be inside the scenarios, in the begining, otherwise the cleanup call would delete it.

The integration tests are failing now because of the seed calls mentioned above. This will be corrected in a new PR that will implement the changes thoroughly for all the tests.

## Summary by Sourcery

Replace UI-driven Cypress setup steps with direct IPA CLI calls and introduce a reusable IPA command helper and test environment cleanup hook.

New Features:
- Add a custom Cypress ipa command to run IPA CLI operations inside the web UI container.
- Introduce a global cleanup hook that removes most IPA test data before scenarios run, with special handling for core services.

Enhancements:
- Refactor various Given "... exists" steps to create resources via IPA CLI instead of navigating the UI flows.
- Extend Cypress type definitions to include the new ipa command for better TypeScript support.