### PR TITLE
Fix issue 973 ,specific validation message

### DIFF
--- a/src/components/modals/Automember/AddRule.tsx
+++ b/src/components/modals/Automember/AddRule.tsx
@@ -178,7 +178,7 @@ const AddRule = (props: PropsToAddRule) => {
           dispatch(
             addAlert({
               name: "add-rule-success",
-              title: "Entry successfully added",
+              title: "User group rule successfully added",
               variant: "success",
             })
           );


### PR DESCRIPTION
Fix issue 973 ,specific validation message
This PR fixes the issue number 973, which says on adding new user group rules the validation message is 'Entry successfully added' which is not specific to the the action and it affects the consistency in UI.

changes: 'Entry successfully added' -> 'User group rule successfully added'
Fixes: https://github.com/freeipa/freeipa-webui/issues/973
Signed-off-by: Sami Shaikh <1694samishaikh@gmail.com>