### PR TITLE
dev-env.sh: Fix handling of extra options

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,10 +195,10 @@ Run the integration tests in headless mode with:
 ./developer/dev-env.sh -c
 ```
 
-You can provide arguments to Cypress using the _long options_. For example, you can run only the hosts tests with:
+You can provide arguments to Cypress using the _long options_. Altough not specifically required, it is suggested that these extra options are added after '--'. For example, you can run only the hosts tests with:
 
 ```
-./developer/dev-env.sh -c --spec cypress/e2e/hosts/hosts.feature
+./developer/dev-env.sh -c --  --spec cypress/e2e/hosts/hosts.feature
 ```
 
 If you want to open the graphical debugger use:

--- a/developer/containerfiles/centos
+++ b/developer/containerfiles/centos
@@ -1,4 +1,4 @@
-ARG distro_tag=latest
+ARG distro_tag=stream10
 FROM quay.io/centos/centos:${distro_tag}
 
 ENV container=podman

--- a/developer/dev-env.sh
+++ b/developer/dev-env.sh
@@ -327,13 +327,14 @@ do
         "p") action="build" ;;
         "r") action="restart" ;;
         "s") action="start" ;;
-        "-") break ;;
+        "-") OPTIND=$((OPTIND - 1)) ; break ;;
         *) die "Invalid option: ${OPTARG}" ;;
     esac
 done
 
 shift $((OPTIND - 1))
-if [ "${1:-}" != "--" ]
+
+if [[ ! "${1:-}" =~ ^-- ]]
 then
     scenario="${1:-"single-server"}"
     shift ||:
@@ -342,10 +343,8 @@ fi
 # Skip "--" and get extra arguments
 if [[ -n "${1:-}" ]]
 then
-    if [[ "${1}" == "--" ]]
+    if [[ ! "${1}" =~ ^--.* ]]
     then
-        shift
-    else
         die "Unexpected option: ${1}"
     fi
 fi


### PR DESCRIPTION
When using extra options after '--' in the CLI call to dev-env.sh the list is not being correctly parsed and the first extra option is lost. This causes issues, for example, when running a single feature test where the feature file (--spec) is defined as an extra option.

## Summary by Sourcery

Fix handling of extra CLI options passed to developer/dev-env.sh, ensuring arguments after "--" are preserved and validated correctly.

Bug Fixes:
- Preserve and correctly parse the first extra option after "--" when invoking developer/dev-env.sh.
- Tighten validation of initial and extra command-line arguments to prevent unexpected options from being silently misinterpreted.