### PR TITLE
Deletes warning rule- Must be at least 3 characters long for add user

### DIFF
--- a/src/components/modals/UserModals/AddUser.tsx
+++ b/src/components/modals/UserModals/AddUser.tsx
@@ -189,11 +189,6 @@ const AddUser = (props: PropsToAddUser) => {
           onChange={setUserLogin}
           rules={[
             {
-              id: "ruleLength",
-              message: "Must be at least 3 characters in length",
-              validate: (v: string) => v.length >= 3,
-            },
-            {
               id: "ruleCharacters",
               message: "Only alphanumeric and special characters _-.$",
               validate: (v: string) =>


### PR DESCRIPTION
I think this rule was added by a mistake, I looked into the old implementation and in the ipa call user-add, the user login doeasnt have this restriction. 

Fixes #937

## Summary by Sourcery

Bug Fixes:
- Drop the incorrect requirement that user logins must be at least three characters long when adding a user.