### PR TITLE
Adjusting the offset for better jumplinks alignment

### DIFF
--- a/src/components/UsersSections/UserSettings.tsx
+++ b/src/components/UsersSections/UserSettings.tsx
@@ -528,7 +528,6 @@ const UserSettings = (props: PropsToUserSettings) => {
             isVertical
             label="Jump to section"
             scrollableSelector="#settings-page"
-            offset={220} // for masthead
             expandable={{ default: "expandable", md: "nonExpandable" }}
           >
             <JumpLinksItem key={0} href="#identity-settings">

--- a/src/components/layouts/SidebarLayout/SidebarLayout.tsx
+++ b/src/components/layouts/SidebarLayout/SidebarLayout.tsx
@@ -30,7 +30,6 @@ const SidebarLayout = (props: SidebarLayoutProps) => {
             isVertical
             label="Jump to section"
             scrollableSelector="#settings-page"
-            offset={220} // for masthead
             expandable={{ default: "expandable", md: "nonExpandable" }}
           >
             {props.itemNames.map((item, index) => (

--- a/src/pages/AutoMemUserRules/AutoMemSettings.tsx
+++ b/src/pages/AutoMemUserRules/AutoMemSettings.tsx
@@ -224,7 +224,6 @@ const AutoMemSettings = (props: PropsToSettings) => {
             isVertical
             label="Jump to section"
             scrollableSelector="#settings-page"
-            offset={220} // for masthead
             expandable={{ default: "expandable", md: "nonExpandable" }}
           >
             <JumpLinksItem key={0} href="#rule-general">

--- a/src/pages/Configuration/Configuration.tsx
+++ b/src/pages/Configuration/Configuration.tsx
@@ -273,7 +273,6 @@ const Configuration = () => {
               isVertical
               label="Jump to section"
               scrollableSelector="#settings-page"
-              offset={220} // for masthead
               expandable={{ default: "expandable", md: "nonExpandable" }}
             >
               <JumpLinksItem key={0} href="#search-options">

--- a/src/pages/HBACRules/HBACRulesSettings.tsx
+++ b/src/pages/HBACRules/HBACRulesSettings.tsx
@@ -256,7 +256,6 @@ const HBACRulesSettings = (props: PropsToSettings) => {
             isVertical
             label="Jump to section"
             scrollableSelector="#settings-page"
-            offset={220} // for masthead
             expandable={{ default: "expandable", md: "nonExpandable" }}
           >
             <JumpLinksItem key={0} href="#hbacrule-settings">

--- a/src/pages/Hosts/HostsSettings.tsx
+++ b/src/pages/Hosts/HostsSettings.tsx
@@ -425,7 +425,6 @@ const HostsSettings = (props: PropsToHostsSettings) => {
             isVertical
             label="Jump to section"
             scrollableSelector="#settings-page"
-            offset={220} // for masthead
             expandable={{ default: "expandable", md: "nonExpandable" }}
           >
             <JumpLinksItem key={0} href="#host-settings">

--- a/src/pages/IdPReferences/IdpReferencesSettings.tsx
+++ b/src/pages/IdPReferences/IdpReferencesSettings.tsx
@@ -237,7 +237,6 @@ const IdpRefSettings = (props: PropsToIdpRefSettings) => {
               isVertical
               label="Jump to section"
               scrollableSelector="#idp-reference-page"
-              offset={220} // for masthead
               expandable={{ default: "expandable", md: "nonExpandable" }}
               className="pf-v6-u-mt-md"
             >

--- a/src/pages/KrbTicketPolicy/KrbTicketPolicy.tsx
+++ b/src/pages/KrbTicketPolicy/KrbTicketPolicy.tsx
@@ -219,7 +219,6 @@ const KrbTicketPolicy = () => {
               isVertical
               label="Jump to section"
               scrollableSelector="#krb-ticket-policy-page"
-              offset={220} // for masthead
               expandable={{ default: "expandable", md: "nonExpandable" }}
               className="pf-v6-u-mt-md"
             >

--- a/src/pages/Services/ServicesSettings.tsx
+++ b/src/pages/Services/ServicesSettings.tsx
@@ -321,7 +321,6 @@ const ServicesSettings = (props: PropsToServicesSettings) => {
             isVertical
             label="Jump to section"
             scrollableSelector="#settings-page"
-            offset={220} // for masthead
             expandable={{ default: "expandable", md: "nonExpandable" }}
           >
             <JumpLinksItem key={0} href="#service-settings">

--- a/src/pages/Trusts/TrustsSettings.tsx
+++ b/src/pages/Trusts/TrustsSettings.tsx
@@ -183,7 +183,6 @@ const TrustsSettings = (props: TrustsSettingsProps) => {
             isVertical
             label="Jump to section"
             scrollableSelector="#settings-page"
-            offset={220} // for masthead
             expandable={{ default: "expandable", md: "nonExpandable" }}
           >
             <JumpLinksItem key={0} href="#trusts-settings">


### PR DESCRIPTION
Update: We decided to remove the offset altogether as it is redundant. 
 #943 and #940 should be marked as wontfix

A simple fix for the offset of Jumplinks. 


just a sidenote, I was thinking if there is a way to do this dynamically? As in, take the height of the MastHead? But Im not sure how to do this or if its a good approach. 


## Summary by Sourcery

Enhancements:
- Increase the jump link scroll offset in the sidebar layout to account for the masthead height and ensure correct section alignment.