### PR TITLE
Adjust logo height settings

### DIFF
--- a/src/AppLayout.tsx
+++ b/src/AppLayout.tsx
@@ -181,12 +181,12 @@ const AppLayout = (props: PropsToAppLayout) => {
           />
         </MastheadToggle>
         <MastheadBrand>
-          <MastheadLogo className="pf-v6-u-mt-sm">
-            <MastheadBrand>
-              <MastheadLogo>
-                <Brand src={headerLogo} alt="FreeIPA Logo" />
-              </MastheadLogo>
-            </MastheadBrand>
+          <MastheadLogo className="pf-v6-u-display-flex">
+            <Brand
+              src={headerLogo}
+              alt="IPA Logo"
+              className="pf-v6-u-my-auto"
+            />
           </MastheadLogo>
         </MastheadBrand>
       </MastheadMain>


### PR DESCRIPTION
Removing unnecessary padding and adjusting masthead settings that affect logo height.

Making the logo bigger will deform the image, so I opted to remove unnecessary components (they were some duplicates, most likely due to PF6 codemods during migration) and set some parameters.

This PR depends on this one to be merged: https://github.com/freeipa/freeipa-webui/pull/1050

## Summary by Sourcery

Adjust layout styling for the masthead logo and navigation toggle.

Enhancements:
- Simplify the masthead brand/logo structure and switch the navigation toggle to use a standard hamburger button.
- Align the masthead brand area using flex layout to keep the logo vertically centered.
