### PR TITLE
Fix background image

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -30,12 +30,12 @@ code {
       var(--settings-tabs-height) - 72px
   );
   --idview-appliedto-toolbar-height: 53px;
-  background-color: var(--pf-t--color--gray--10);
 }
 
 .pf-v6-c-background-image {
   --pf-v6-c-background-image--BackgroundSize: cover;
   --pf-v6-c-background-image--BackgroundPosition: center;
+  --pf-v6-c-background-image--BackgroundColor: var(--pf-t--color--gray--10);
 }
 
 code {


### PR DESCRIPTION
Sadly the background image change introduced in #1043 doesn't work. We have to explicitly set color of the background-image.

You can test this by manually editing the image url to a non-sense, so the browser has to fallback to a color.
`<div class="pf-v6-c-background-image" style="--pf-v6-c-background-image--BackgroundImage: url(nonsense);"></div>`

## Summary by Sourcery

Bug Fixes:
- Ensure the background image container falls back to the intended gray background color when the image is missing or invalid.