### PR TITLE
Fix: rebuild auto memberhip fails

### DIFF
--- a/src/pages/ActiveUsers/ActiveUsers.tsx
+++ b/src/pages/ActiveUsers/ActiveUsers.tsx
@@ -326,7 +326,10 @@ const ActiveUsers = () => {
       })
     );
 
-    executeAutoMemberRebuild(selectedUsers).then((result) => {
+    // Prepare payload
+    const userList = selectedUsers.map((user) => user.uid[0]);
+
+    executeAutoMemberRebuild(userList).then((result) => {
       if ("data" in result) {
         const automemberError = result.data?.error as
           | FetchBaseQueryError

--- a/src/services/rpcUsers.ts
+++ b/src/services/rpcUsers.ts
@@ -269,20 +269,16 @@ const extendedApi = api.injectEndpoints({
         response.result.result as unknown as User[],
       providesTags: ["ActiveUsers"],
     }),
-    // Autommeber Users
-    autoMemberRebuildUsers: build.mutation<FindRPCResponse, any[]>({
+    // Automember Users
+    autoMemberRebuildUsers: build.mutation<FindRPCResponse, string[]>({
       query: (users) => {
-        let user_list = users.map((user) => user.uid);
-        // user.uid might be an array
-        if (users.length > 0 && Array.isArray(users[0].uid)) {
-          user_list = users.map((user) => user.uid[0]);
-        }
-
         const paramArgs =
           users.length === 0
-            ? { type: "group", version: API_VERSION_BACKUP }
-            : {
-                users: user_list,
+            ? // from user's main page
+              { type: "group", version: API_VERSION_BACKUP }
+            : // from user's settings page
+              {
+                users: users,
                 version: API_VERSION_BACKUP,
               };
 


### PR DESCRIPTION
Rebuild auto membership works fine when it is done in bulk (e.g. from Active users page), but fails when it is done in a specific entity from its Setting page.

This has been fixed by adjusting how the data is sent to the endpoint.

Fixes: https://github.com/freeipa/freeipa-webui/issues/1017

## Summary by Sourcery

Fix auto-membership rebuild behavior for users triggered from different UI entry points.

Bug Fixes:
- Correct auto-membership rebuild payload so rebuilding from a user's settings page succeeds instead of failing.

Enhancements:
- Align auto-membership rebuild RPC to always receive a list of user identifiers, centralizing UID extraction in the Active Users page.