### PR TITLE
Remove certificate field for stage and preserved users

### DIFF
--- a/src/components/UsersSections/UsersAccountSettings.tsx
+++ b/src/components/UsersSections/UsersAccountSettings.tsx
@@ -260,21 +260,23 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
                 from={props.from}
               />
             </FormGroup>
-            <FormGroup
-              label="Certificates"
-              fieldId="usercertificate"
-              role="group"
-            >
-              <IpaCertificates
-                dataCy="user-tab-settings-certificates"
-                ipaObject={ipaObject}
-                objectType="user"
-                onChange={recordOnChange}
-                metadata={props.metadata}
-                certificates={props.certData}
-                onRefresh={props.onRefresh}
-              />
-            </FormGroup>
+            {props.from === "active-users" && (
+              <FormGroup
+                label="Certificates"
+                fieldId="usercertificate"
+                role="group"
+              >
+                <IpaCertificates
+                  dataCy="user-tab-settings-certificates"
+                  ipaObject={ipaObject}
+                  objectType="user"
+                  onChange={recordOnChange}
+                  metadata={props.metadata}
+                  certificates={props.certData}
+                  onRefresh={props.onRefresh}
+                />
+              </FormGroup>
+            )}
             <FormGroup
               label="Certificate mapping data"
               fieldId="ipacertmapdata"


### PR DESCRIPTION
'Certificate' field in 'Settings' page should be only available in Active users, so it must be removed in the rest of the user pages.

Fixes: https://github.com/freeipa/freeipa-webui/issues/999