### PR TITLE
Implement 'No private group' checkbox functionality

### DIFF
--- a/src/services/rpcUsers.ts
+++ b/src/services/rpcUsers.ts
@@ -87,6 +87,17 @@ interface UserFindPayload {
   noMembers?: boolean;
 }
 
+export interface AddUserPayload {
+  type: "user" | "stageuser";
+  givenname: string;
+  sn: string;
+  uid?: string;
+  userclass?: string;
+  noprivate?: boolean;
+  gidnumber?: string;
+  userpassword?: string;
+}
+
 const extendedApi = api.injectEndpoints({
   endpoints: (build) => ({
     getGenericUsersFullData: build.query<UserFullData, object>({
@@ -536,6 +547,21 @@ const extendedApi = api.injectEndpoints({
         }
       },
     }),
+    /**
+     * Add new user
+     * @param {AddUserPayload} payload - Add user payload
+     * @returns {FindRPCResponse} - Find response
+     */
+    addUser: build.mutation<FindRPCResponse, AddUserPayload>({
+      query: (payload) => {
+        const { type, ...params } = payload;
+
+        return getCommand({
+          method: type === "user" ? "user_add" : "stageuser_add",
+          params: [[], params],
+        });
+      },
+    }),
   }),
   overrideExisting: false,
 });
@@ -604,4 +630,5 @@ export const {
   useGetUsersInfoByUidQuery,
   useGetUserDetailsByUidMutation,
   useUserFindQuery,
+  useAddUserMutation,
 } = extendedApi;


### PR DESCRIPTION
The 'No private group' checkbox functionality needs to be implemented based on the following:
- If checkbox is disabled, GID may be empty
- If checkbox is enabled, the UI must force to select a GID

In this solution, the `useAddUserMutation` has been implemented to replace the generic existing one used in user pages.

Fixes: https://github.com/freeipa/freeipa-webui/issues/997

Due to a vulnerability affecting `react-router` library, this PR depends on this one to be merged: https://github.com/freeipa/freeipa-webui/pull/1058

## Summary by Sourcery

Implement dedicated add-user RPC mutation and enforce GID selection when 'No private group' is enabled in the Add User modal.

New Features:
- Add an rpcUsers.addUser mutation hook to create users and stage users via typed payloads.
- Display contextual help for the 'No private group' option in the Add User modal via a popover icon.

Bug Fixes:
- Require a GID selection when 'No private group' is checked, preventing submission with an empty GID.
- Allow user creation without a GID when 'No private group' is not selected.

Enhancements:
- Refactor Add User modal to use the new useAddUserMutation instead of the generic mutation command and streamline success/error handling.