### PR TITLE
Fix: 'add' form buttons stuck on duplicates

### DIFF
--- a/src/components/modals/IdpReferences/AddModal.tsx
+++ b/src/components/modals/IdpReferences/AddModal.tsx
@@ -196,43 +196,45 @@ const AddModal = (props: PropsToAddModal) => {
       payload.customFields = customData;
     }
 
-    addIdp(payload).then((result) => {
-      if ("data" in result) {
-        const data = result.data?.result;
-        const error = result.data?.error as SerializedError;
+    addIdp(payload)
+      .then((result) => {
+        if ("data" in result) {
+          const data = result.data?.result;
+          const error = result.data?.error as SerializedError;
 
-        if (error) {
-          dispatch(
-            addAlert({
-              name: "add-idp-error",
-              title: error.message,
-              variant: "danger",
-            })
-          );
-        }
-
-        if (data) {
-          dispatch(
-            addAlert({
-              name: "add-idp-success",
-              title: "Identity provider successfully added",
-              variant: "success",
-            })
-          );
-          // Reset selected item
-          clearAllFields();
-          // Update data
-          props.onRefresh();
-          // 'Add and add another' will keep the modal open
-          if (!keepModalOpen) {
-            props.onCloseModal();
+          if (error) {
+            dispatch(
+              addAlert({
+                name: "add-idp-error",
+                title: error.message,
+                variant: "danger",
+              })
+            );
           }
-          // Reset button spinners
-          setIsAddButtonSpinning(false);
-          setIsAddAnotherButtonSpinning(false);
+
+          if (data) {
+            dispatch(
+              addAlert({
+                name: "add-idp-success",
+                title: "Identity provider successfully added",
+                variant: "success",
+              })
+            );
+            // Reset selected item
+            clearAllFields();
+            // Update data
+            props.onRefresh();
+            // 'Add and add another' will keep the modal open
+            if (!keepModalOpen) {
+              props.onCloseModal();
+            }
+          }
         }
-      }
-    });
+      })
+      .finally(() => {
+        setIsAddButtonSpinning(false);
+        setIsAddAnotherButtonSpinning(false);
+      });
   };
 
   // Clean and close modal


### PR DESCRIPTION
The 'Add' buttons located in Identity Provider References page > 'Add' form are kept disabled when a duplicate entry is introduced. This is due to the missing `finally` check that should re-enable those buttons again.

Fixes: https://github.com/freeipa/freeipa-webui/issues/996

## Summary by Sourcery

Bug Fixes:
- Prevent 'Add' form buttons in the Identity Provider References modal from remaining disabled after failed or duplicate submissions by resetting their loading state in a finalizer.