### PR TITLE
Password expiration field must be read-only 

### DIFF
--- a/src/components/Form/IpaCalendar/IpaCalendar.tsx
+++ b/src/components/Form/IpaCalendar/IpaCalendar.tsx
@@ -23,6 +23,7 @@ interface ParamPropertiesDateTime {
 
 export interface IpaCalendarProps extends IPAParamDefinition {
   dataCy: string;
+  isDisabled?: boolean;
 }
 
 function getParamPropertiesDateTime(
@@ -64,7 +65,7 @@ const IpaCalendar = (props: IpaCalendarProps) => {
       onChange={onDateChange}
       name={props.name}
       ariaLabel={props.ariaLabel}
-      isDisabled={readOnly}
+      isDisabled={props.isDisabled || readOnly}
     />
   );
 };

--- a/src/components/UsersSections/UsersAccountSettings.tsx
+++ b/src/components/UsersSections/UsersAccountSettings.tsx
@@ -168,6 +168,7 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
                 objectName="user"
                 metadata={props.metadata}
                 dataCy="user-tab-settings-calendar-krbpasswordexpiration"
+                isDisabled={true}
               />
             </FormGroup>
             <FormGroup label="UID" fieldId="uidnumber">


### PR DESCRIPTION
The `Password expiration` field must be read-only
in all cases to prevent users to modify passwords
to any date.

Fixes: https://github.com/freeipa/freeipa-webui/issues/985

## Summary by Sourcery

Bug Fixes:
- Prevent setting a Kerberos password expiration date to a past date via the DateTimeSelector date picker.