### PR TITLE
Use exec calls for seeding

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -28,7 +28,10 @@ export default defineConfig({
           ],
         })
       );
-      on("task", verifyDownloadTasks);
+
+      on("task", {
+        ...verifyDownloadTasks,
+      });
 
       return config;
     },

--- a/cypress/e2e/automember/automember_hostgroup.feature
+++ b/cypress/e2e/automember/automember_hostgroup.feature
@@ -2,7 +2,7 @@ Feature: Automember hostgroup management
 
     @seed
     Scenario: Create new host group
-        Given Hostgroup "my_automember_hostgroup" with description "test" exists
+        Given hostgroup "my_automember_hostgroup" with description "test" exists
 
     @test
     Scenario: Create new hostgroup rule
@@ -24,13 +24,11 @@ Feature: Automember hostgroup management
     @cleanup
     Scenario: Delete host group rule
         Given I delete hostgroup rule "my_automember_hostgroup"
-
-    @cleanup
-    Scenario: Delete host group
         Given I delete hostgroup "my_automember_hostgroup"
 
     @seed
     Scenario: Create new automember host group
+        Given hostgroup "my_automember_hostgroup" with description "test" exists
         Given hostgroup rule "my_automember_hostgroup" exists
 
     @test
@@ -40,7 +38,7 @@ Feature: Automember hostgroup management
         When I try to delete hostgroup rule "my_automember_hostgroup"
         Then I should not see hostgroup rule "my_automember_hostgroup" in the hostgroup rule list
 
-        # Given I am on "host-groups" page
+        Given I am on "host-groups" page
         When I try to delete hostgroup "my_automember_hostgroup"
         Then I should not see hostgroup "my_automember_hostgroup" in the data table
 

--- a/cypress/e2e/automember/automember_hostgroup.ts
+++ b/cypress/e2e/automember/automember_hostgroup.ts
@@ -1,7 +1,6 @@
 import { When, Then, Given } from "@badeball/cypress-cucumber-preprocessor";
 import {
   entryDoesNotExist,
-  entryExists,
   searchForEntry,
   selectEntry,
   validateEntry,
@@ -10,7 +9,6 @@ import "../hostgroups/hostgroup";
 import "../common/data_tables";
 import { navigateTo } from "../common/navigation";
 import { loginAsAdmin, logout } from "../common/authentication";
-import { createHostgroup } from "../hostgroups/hostgroup";
 import { isOptionSelected, selectOption } from "../common/ui/select";
 
 const fillHostgroupRule = (hostgroupName: string) => {
@@ -18,7 +16,7 @@ const fillHostgroupRule = (hostgroupName: string) => {
   isOptionSelected(hostgroupName, "modal-select-automember");
 };
 
-export const createHostgroupRule = (hostgroupName: string) => {
+const createHostgroupRule = (hostgroupName: string) => {
   cy.dataCy("auto-member-host-rules-button-add").click();
   cy.dataCy("add-rule-modal").should("exist");
 
@@ -26,6 +24,14 @@ export const createHostgroupRule = (hostgroupName: string) => {
 
   cy.dataCy("modal-button-add").click();
   cy.dataCy("add-hostgroup-rule-modal").should("not.exist");
+};
+
+export const createHostgroupRuleExec = (hostgroupName: string) => {
+  cy.ipa({
+    command: "automember-add",
+    name: hostgroupName,
+    specificOptions: "--type hostgroup",
+  });
 };
 
 const deleteHostgroupRule = (hostgroupName: string) => {
@@ -57,19 +63,7 @@ const setDefaultHostgroupRule = (hostgroupName: string) => {
 };
 
 Given("hostgroup rule {string} exists", (hostgroupName: string) => {
-  loginAsAdmin();
-  navigateTo("host-groups");
-
-  createHostgroup(hostgroupName, "test");
-  searchForEntry(hostgroupName);
-  entryExists(hostgroupName);
-
-  navigateTo("host-group-rules");
-  createHostgroupRule(hostgroupName);
-
-  searchForEntry(hostgroupName);
-  entryExists(hostgroupName);
-  logout();
+  createHostgroupRuleExec(hostgroupName);
 });
 
 When(

--- a/cypress/e2e/automember/automember_settings.feature
+++ b/cypress/e2e/automember/automember_settings.feature
@@ -3,6 +3,7 @@ Feature: Automember > Settings page
 
     @seed
     Scenario: Prep: Create a new user group to work with
+        Given user group "my_automember_usergroup" exists
         Given user group rule "my_automember_usergroup" exists
 
     @test
@@ -24,6 +25,7 @@ Feature: Automember > Settings page
 
     @seed
     Scenario: Prep: Create a new user group to work with
+        Given user group "my_automember_usergroup" exists
         Given user group rule "my_automember_usergroup" exists
 
     @test
@@ -51,6 +53,7 @@ Feature: Automember > Settings page
 
     @seed
     Scenario: Prep: Create a new user group to work with
+        Given user group "my_automember_usergroup" exists
         Given user group rule "my_automember_usergroup" exists
 
     @test
@@ -78,6 +81,7 @@ Feature: Automember > Settings page
 
     @seed
     Scenario: Prep: Create a new host group rule to work with
+        Given hostgroup "my_automember_hostgroup" with description "desc" exists
         Given hostgroup rule "my_automember_hostgroup" exists
 
     @test
@@ -99,9 +103,11 @@ Feature: Automember > Settings page
 
     @seed
     Scenario: Prep: Create a new host group to work with
+        Given hostgroup "my_automember_hostgroup" with description "desc" exists
         Given hostgroup rule "my_automember_hostgroup" exists
 
     # 'Inclusive' subsection
+    @test
     Scenario: Add a new inclusive host group rule
         Given I am logged in as admin
         And I am on "host-group-rules/my_automember_hostgroup" page
@@ -122,7 +128,6 @@ Feature: Automember > Settings page
     @cleanup
     Scenario: Delete host group rule
         Given I delete hostgroup rule "my_automember_hostgroup"
-        And I delete hostgroup "my_automember_hostgroup"
 
     @seed
     Scenario: Prep: Create a new host group to work with
@@ -153,6 +158,7 @@ Feature: Automember > Settings page
 
     @seed
     Scenario: Prep: Create a new host group to work with
+        Given hostgroup "my_automember_hostgroup" with description "desc" exists
         Given hostgroup rule "my_automember_hostgroup" exists and has inclusive entry "my-department" with category "businesscategory"
 
     @test
@@ -177,6 +183,7 @@ Feature: Automember > Settings page
 
     @seed
     Scenario: Prep: Create a new user group to work with
+        Given user group "my_automember_usergroup" exists
         Given user group rule "my_automember_usergroup" exists and has inclusive entry "my-department" with category "businesscategory"
 
     @test

--- a/cypress/e2e/automember/automember_settings.ts
+++ b/cypress/e2e/automember/automember_settings.ts
@@ -1,13 +1,10 @@
 import { Given } from "@badeball/cypress-cucumber-preprocessor";
 import { loginAsAdmin, logout } from "../common/authentication";
 import { navigateTo } from "../common/navigation";
-import { entryExists, searchForEntry } from "../common/data_tables";
-import { createHostgroup } from "../hostgroups/hostgroup";
-import { createHostgroupRule } from "./automember_hostgroup";
-import { createUserGroupRule } from "./automember_user_group";
+import { createHostgroupRuleExec } from "./automember_hostgroup";
+import { createUserGroupRuleExec } from "./automember_user_group";
 import { isOptionSelected } from "../common/ui/select";
 import { typeInTextbox } from "../common/ui/textbox";
-import { createUserGroup } from "../user_groups/user_groups";
 import { EntryType } from "./parameter_types";
 
 const addEntryTableToGroupRule = (
@@ -47,19 +44,8 @@ Given(
     entry: string,
     category: string
   ) => {
+    createHostgroupRuleExec(hostGroupName);
     loginAsAdmin();
-    navigateTo("host-groups");
-
-    createHostgroup(hostGroupName, "test");
-    searchForEntry(hostGroupName);
-    entryExists(hostGroupName);
-
-    navigateTo("host-group-rules");
-    createHostgroupRule(hostGroupName);
-
-    searchForEntry(hostGroupName);
-    entryExists(hostGroupName);
-
     navigateTo("host-group-rules/" + hostGroupName);
     addEntryTableToGroupRule(entryType, entry, category);
     logout();
@@ -74,17 +60,8 @@ Given(
     entry: string,
     category: string
   ) => {
+    createUserGroupRuleExec(userGroupName);
     loginAsAdmin();
-    navigateTo("user-groups");
-
-    createUserGroup(userGroupName);
-
-    navigateTo("user-group-rules");
-    createUserGroupRule(userGroupName);
-
-    searchForEntry(userGroupName);
-    entryExists(userGroupName);
-
     navigateTo("user-group-rules/" + userGroupName);
     addEntryTableToGroupRule(entryType, entry, category);
     logout();

--- a/cypress/e2e/automember/automember_user_group.feature
+++ b/cypress/e2e/automember/automember_user_group.feature
@@ -23,13 +23,11 @@ Feature: Automember user group management
     @cleanup
     Scenario: Delete user group rule
         Given I delete user group rule "my_automember_usergroup"
-
-    @cleanup
-    Scenario: Delete user group
         Given I delete user group "my_automember_usergroup"
 
     @seed
     Scenario: Create new automember user group
+        Given user group "my_automember_usergroup" exists
         Given user group rule "my_automember_usergroup" exists
 
     @test

--- a/cypress/e2e/automember/automember_user_group.ts
+++ b/cypress/e2e/automember/automember_user_group.ts
@@ -17,7 +17,7 @@ const fillUserGroupRule = (userGroupName: string, selector: string) => {
   isOptionSelected(userGroupName, selector);
 };
 
-export const createUserGroupRule = (userGroupName: string) => {
+const createUserGroupRule = (userGroupName: string) => {
   cy.dataCy("auto-member-user-rules-button-add").click();
   cy.dataCy("add-rule-modal").should("exist");
 
@@ -27,6 +27,14 @@ export const createUserGroupRule = (userGroupName: string) => {
   cy.dataCy("add-rule-modal").should("not.exist");
   searchForEntry(userGroupName);
   entryExists(userGroupName);
+};
+
+export const createUserGroupRuleExec = (userGroupName: string) => {
+  cy.ipa({
+    command: "automember-add",
+    name: userGroupName,
+    specificOptions: "--type group",
+  });
 };
 
 const deleteUserGroupRule = (userGroupName: string) => {
@@ -58,26 +66,7 @@ const setDefaultUserGroupRule = (userGroupName: string) => {
 };
 
 Given("user group rule {string} exists", (userGroupName: string) => {
-  loginAsAdmin();
-  navigateTo("user-groups");
-
-  cy.dataCy("user-groups-button-add").click();
-  cy.dataCy("add-user-group-modal").should("exist");
-
-  cy.dataCy("modal-textbox-group-name").type(userGroupName);
-  cy.dataCy("modal-textbox-group-name").should("have.value", userGroupName);
-
-  cy.dataCy("modal-button-add").click();
-  cy.dataCy("add-user-group-modal").should("not.exist");
-  searchForEntry(userGroupName);
-  entryExists(userGroupName);
-
-  navigateTo("user-group-rules");
-  createUserGroupRule(userGroupName);
-
-  searchForEntry(userGroupName);
-  entryExists(userGroupName);
-  logout();
+  createUserGroupRuleExec(userGroupName);
 });
 
 When(

--- a/cypress/e2e/common/hbac_rule_management.ts
+++ b/cypress/e2e/common/hbac_rule_management.ts
@@ -4,27 +4,14 @@ import {
   selectEntry,
   searchForEntry,
   entryDoesNotExist,
-  entryExists,
 } from "../common/data_tables";
 import { navigateTo } from "../common/navigation";
-import { typeInTextbox } from "../common/ui/textbox";
 
 Given("hbac rule {string} exists", (ruleName: string) => {
-  loginAsAdmin();
-  navigateTo("hbac-rules");
-
-  cy.dataCy("hbac-rules-button-add").click();
-  cy.dataCy("add-hbac-rule-modal").should("exist");
-
-  typeInTextbox("modal-textbox-rule-name", ruleName);
-  cy.dataCy("modal-textbox-rule-name").should("have.value", ruleName);
-
-  cy.dataCy("modal-button-add").click();
-  cy.dataCy("add-hbac-rule-modal").should("not.exist");
-
-  searchForEntry(ruleName);
-  entryExists(ruleName);
-  logout();
+  cy.ipa({
+    command: "hbacrule-add",
+    name: ruleName,
+  });
 });
 
 Given("I delete hbac rule {string}", (ruleName: string) => {

--- a/cypress/e2e/common/host_management.ts
+++ b/cypress/e2e/common/host_management.ts
@@ -1,13 +1,7 @@
 import { Given } from "@badeball/cypress-cucumber-preprocessor";
 import { loginAsAdmin, logout } from "./authentication";
-import {
-  selectEntry,
-  searchForEntry,
-  entryDoesNotExist,
-  entryExists,
-} from "./data_tables";
+import { selectEntry, searchForEntry, entryDoesNotExist } from "./data_tables";
 import { navigateTo } from "./navigation";
-import { typeInTextbox } from "./ui/textbox";
 
 Given("I delete host {string}", (hostName: string) => {
   loginAsAdmin();
@@ -26,22 +20,8 @@ Given("I delete host {string}", (hostName: string) => {
 });
 
 Given("host {string} exists", (hostName: string) => {
-  loginAsAdmin();
-  navigateTo("hosts");
-
-  cy.dataCy("hosts-button-add").click();
-  cy.dataCy("add-host-modal").should("exist");
-
-  typeInTextbox("modal-textbox-host-name", hostName);
-  cy.dataCy("modal-textbox-host-name").should("have.value", hostName);
-
-  cy.dataCy("modal-checkbox-force-host").check();
-  cy.dataCy("modal-checkbox-force-host").should("be.checked");
-
-  cy.dataCy("modal-button-add").click();
-  cy.dataCy("add-host-modal").should("not.exist");
-
-  searchForEntry(hostName);
-  entryExists(hostName);
-  logout();
+  cy.ipa({
+    command: "host-add --force",
+    name: hostName,
+  });
 });

--- a/cypress/e2e/common/sudo_rules_management.ts
+++ b/cypress/e2e/common/sudo_rules_management.ts
@@ -4,7 +4,6 @@ import {
   entryDoesNotExist,
   searchForEntry,
   selectEntry,
-  validateEntry,
 } from "../common/data_tables";
 import { navigateTo } from "../common/navigation";
 import { typeInTextbox } from "../common/ui/textbox";
@@ -21,11 +20,10 @@ export const addSudoRule = (ruleName: string) => {
 };
 
 Given("sudo rule {string} exists", (ruleName: string) => {
-  loginAsAdmin();
-  navigateTo("sudo-rules");
-  addSudoRule(ruleName);
-  validateEntry(ruleName);
-  logout();
+  cy.ipa({
+    command: "sudorule-add",
+    name: ruleName,
+  });
 });
 
 Given("I delete sudo rule {string}", (ruleName: string) => {

--- a/cypress/e2e/dns/dnsrecords.feature
+++ b/cypress/e2e/dns/dnsrecords.feature
@@ -297,8 +297,8 @@ Feature: DNS Records
 
     @seed
     Scenario: Create new DNS zone
-        Given DNS zone "my-other-dns-zone" exists and has record "A" with name "my-a-dns-record" and data "192.168.66.67"
-
+        Given DNS zone "my-other-dns-zone" exists
+        Given DNS zone "my-other-dns-zone" has record A with name "my-a-dns-record" and data "192.168.66.67"
     @test
     Scenario: Remove DNS record
         Given I am logged in as admin

--- a/cypress/e2e/dns/dnsrecords.ts
+++ b/cypress/e2e/dns/dnsrecords.ts
@@ -1,10 +1,7 @@
 import { Given, Then, When } from "@badeball/cypress-cucumber-preprocessor";
 import { DnsRecordType } from "src/utils/datatypes/globalDataTypes";
-import { checkEntry, entryExists, searchForEntry } from "../common/data_tables";
-import { navigateTo } from "../common/navigation";
-import { loginAsAdmin, logout } from "../common/authentication";
+import { checkEntry, searchForEntry } from "../common/data_tables";
 import { clearAndAddAdjustedNumberValue } from "./dnszones_settings";
-import { createDnsZone, parseZoneName } from "./dnszones";
 
 const checkNewDnsRecord = (
   dnsRecordName: string,
@@ -661,23 +658,12 @@ Then("I should not see DNS record {string}", (recordName: string) => {
 });
 
 Given(
-  "DNS zone {string} exists and has record {string} with name {string} and data {string}",
-  (
-    dnsZoneName: string,
-    recordType: DnsRecordType,
-    recordName: string,
-    recordData: string
-  ) => {
-    loginAsAdmin();
-    navigateTo("dns-zones");
-
-    createDnsZone(dnsZoneName);
-    searchForEntry(parseZoneName(dnsZoneName));
-    entryExists(parseZoneName(dnsZoneName));
-
-    navigateTo("dns-zones/" + dnsZoneName + "./dns-records");
-    createDnsRecord(recordName, recordType);
-    checkNewDnsRecord(recordName, recordType, recordData);
-    logout();
+  "DNS zone {string} has record A with name {string} and data {string}",
+  (dnsZoneName: string, recordName: string, recordData: string) => {
+    cy.ipa({
+      command: "dnsrecord-add",
+      name: dnsZoneName,
+      specificOptions: `${recordName} --a-ip-address "${recordData}"`,
+    });
   }
 );

--- a/cypress/e2e/dns/dnszones.feature
+++ b/cypress/e2e/dns/dnszones.feature
@@ -58,6 +58,7 @@ Feature: DNS Zones
         And I am on "dns-zones" page
         When I create an invalid DNS reverse zone that triggers a validation error
         Then I should see "add-dnszone-error" alert
+        And I close the add DNS zone modal
 
     @seed
     Scenario: Create a new DNS zone to disable/enable
@@ -69,6 +70,15 @@ Feature: DNS Zones
         And I am on "dns-zones" page
         When I disable DNS zone "my-dnszone."
         Then I should see DNS zone "my-dnszone." in the list disabled
+
+    @cleanup
+    Scenario: Delete DNS zones
+        Given I delete DNS zone "my-dnszone."
+
+    @seed
+    Scenario: my-dnszone is exists and is disabled
+        Given DNS zone "my-dnszone" exists
+        And DNS zone "my-dnszone" is disabled
 
     @test
     Scenario: Enable DNS zone

--- a/cypress/e2e/dns/dnszones.ts
+++ b/cypress/e2e/dns/dnszones.ts
@@ -30,7 +30,7 @@ const fillReversedDnsZoneWithSkipOverlapCheck = (ip: string) => {
   cy.dataCy("modal-checkbox-skip-overlap-check").should("be.checked");
 };
 
-export const createDnsZone = (zone: string) => {
+const createDnsZone = (zone: string) => {
   cy.dataCy("dns-zones-button-add").click();
   cy.dataCy("add-dns-zone-modal").should("exist");
 
@@ -96,13 +96,13 @@ const isDisabled = (name: string) => {
   );
 };
 
-export const isEnabled = (name: string) => {
+const isEnabled = (name: string) => {
   cy.get("tr[id='" + name + "'] td[data-label=idnszoneactive]").contains(
     "Enabled"
   );
 };
 
-export const disableDnsZone = (zoneName: string) => {
+const disableDnsZone = (zoneName: string) => {
   selectEntry(zoneName);
 
   cy.dataCy("dns-zones-button-disable").click();
@@ -122,11 +122,6 @@ const enableDnsZone = (zoneName: string) => {
   cy.dataCy("dns-zones-enable-disable-modal").should("not.exist");
 
   isEnabled(zoneName);
-};
-
-// E.g. "my-dnszone" -> "my-dnszone."
-export const parseZoneName = (zoneName: string) => {
-  return zoneName + ".";
 };
 
 When("I create a DNS zone {string}", (zoneName: string) => {
@@ -172,14 +167,10 @@ Then("I should not see DNS zone {string} in the list", (zoneName: string) => {
 });
 
 Given("DNS zone {string} exists", (zoneName: string) => {
-  loginAsAdmin();
-  navigateTo("dns-zones");
-
-  createDnsZone(zoneName);
-
-  searchForEntry(parseZoneName(zoneName));
-  entryExists(parseZoneName(zoneName));
-  logout();
+  cy.ipa({
+    command: "dnszone-add",
+    name: zoneName,
+  });
 });
 
 Then(

--- a/cypress/e2e/dns/dnszones_settings_kebab.feature
+++ b/cypress/e2e/dns/dnszones_settings_kebab.feature
@@ -3,7 +3,8 @@ Feature: DNS Zones Settings > Kebab
 
     @seed
     Scenario: Create DNS zone 'my-dns-zone' for settings testing
-        Given DNS zone "my-dns-zone" exists and it is enabled
+        Given DNS zone "my-dns-zone" exists
+        And DNS zone "my-dns-zone" is enabled
 
     @test
     Scenario: Disable DNS zone from settings page kebab menu
@@ -25,7 +26,8 @@ Feature: DNS Zones Settings > Kebab
 
     @seed
     Scenario: Create DNS zone 'my-dns-zone-2' for settings testing
-        Given DNS zone "my-dns-zone-2" exists and it is disabled
+        Given DNS zone "my-dns-zone-2" exists
+        And DNS zone "my-dns-zone-2" is disabled
 
     @test
     Scenario: Enable DNS zone from settings page kebab menu
@@ -47,7 +49,8 @@ Feature: DNS Zones Settings > Kebab
 
     @seed
     Scenario: Create DNS zone 'my-dns-zone' for settings testing
-        Given DNS zone "my-dns-zone" exists and it is enabled
+        Given DNS zone "my-dns-zone" exists
+        Given DNS zone "my-dns-zone" is enabled
 
     @test
     Scenario: Add permission to DNS zone from settings page kebab menu
@@ -69,7 +72,8 @@ Feature: DNS Zones Settings > Kebab
 
     @seed
     Scenario: Create DNS zone 'my-dns-zone' for settings testing
-        Given DNS zone "my-dns-zone" exists and has permission
+        Given DNS zone "my-dns-zone" exists
+        And DNS zone "my-dns-zone" has permission
 
     @test
     Scenario: Remove permission from DNS zone from settings page kebab menu
@@ -91,7 +95,8 @@ Feature: DNS Zones Settings > Kebab
 
     @seed
     Scenario: Create DNS zone 'my-dns-zone' for settings testing
-        Given DNS zone "my-dns-zone" exists and it is enabled
+        Given DNS zone "my-dns-zone" exists
+        And DNS zone "my-dns-zone" is enabled
 
     @test
     Scenario: Delete DNS zone from settings page kebab menu

--- a/cypress/e2e/dns/dnszones_settings_kebab.ts
+++ b/cypress/e2e/dns/dnszones_settings_kebab.ts
@@ -1,65 +1,22 @@
 import { Given } from "@badeball/cypress-cucumber-preprocessor";
-import { entryExists, searchForEntry } from "../common/data_tables";
-import { navigateTo } from "../common/navigation";
-import { loginAsAdmin, logout } from "../common/authentication";
-import {
-  createDnsZone,
-  disableDnsZone,
-  isEnabled,
-  parseZoneName,
-} from "./dnszones";
 
-const addPermissionToDnsZone = (dnsZoneName: string) => {
-  navigateTo("dns-zones/" + dnsZoneName);
-
-  cy.dataCy("dns-zones-settings").should("be.visible");
-  cy.dataCy("dns-zones-tab-settings-kebab").click();
-  cy.dataCy("dns-zones-tab-settings-kebab-kebab").should("be.visible");
-
-  cy.dataCy("dns-zones-tab-settings-kebab-add-permission")
-    .find("button")
-    .click();
-  cy.dataCy("dns-zones-add-remove-permission-modal").should("be.visible");
-
-  cy.dataCy("modal-button-ok").click();
-  cy.dataCy("dns-zones-add-remove-permission-modal").should("not.exist");
-  cy.dataCy("success").should("be.visible");
-};
-
-Given("DNS zone {string} exists and it is enabled", (dnsZoneName: string) => {
-  loginAsAdmin();
-  navigateTo("dns-zones");
-
-  createDnsZone(dnsZoneName);
-
-  searchForEntry(parseZoneName(dnsZoneName));
-  entryExists(parseZoneName(dnsZoneName));
-  isEnabled(parseZoneName(dnsZoneName));
-  logout();
+Given("DNS zone {string} is enabled", (dnsZoneName: string) => {
+  cy.ipa({
+    command: "dnszone-enable",
+    name: dnsZoneName,
+  });
 });
 
-Given("DNS zone {string} exists and it is disabled", (dnsZoneName: string) => {
-  loginAsAdmin();
-  navigateTo("dns-zones");
-
-  createDnsZone(dnsZoneName);
-
-  searchForEntry(parseZoneName(dnsZoneName));
-  entryExists(parseZoneName(dnsZoneName));
-  // When creating a DNS zone, it is enabled by default
-  disableDnsZone(parseZoneName(dnsZoneName));
-  logout();
+Given("DNS zone {string} is disabled", (dnsZoneName: string) => {
+  cy.ipa({
+    command: "dnszone-disable",
+    name: dnsZoneName,
+  });
 });
 
-Given("DNS zone {string} exists and has permission", (dnsZoneName: string) => {
-  loginAsAdmin();
-  navigateTo("dns-zones");
-
-  createDnsZone(dnsZoneName);
-
-  searchForEntry(parseZoneName(dnsZoneName));
-  entryExists(parseZoneName(dnsZoneName));
-  navigateTo("dns-zones/" + dnsZoneName);
-  addPermissionToDnsZone(dnsZoneName);
-  logout();
+Given("DNS zone {string} has permission", (dnsZoneName: string) => {
+  cy.ipa({
+    command: "dnszone-add-permission",
+    name: dnsZoneName,
+  });
 });

--- a/cypress/e2e/hbac/hbac_rule/hbac_rule.feature
+++ b/cypress/e2e/hbac/hbac_rule/hbac_rule.feature
@@ -24,7 +24,7 @@ Feature: HBAC rules manipulation
     And I should see "rule1" entry in the data table with attribute "Description" set to "my description"
 
   @cleanup
-    Scenario: Delete a rule
+  Scenario: Delete a rule
     Given I delete hbac rule "rule1"
 
   @seed
@@ -39,17 +39,17 @@ Feature: HBAC rules manipulation
     When I search for "rule1" in the data table
     Then I should see "rule1" entry in the data table
     And I should not see "rule2" entry in the data table
-  
+
   @cleanup
   Scenario: Delete a rule
     Given I delete hbac rule "rule1"
 
-  @seed 
+  @seed
   Scenario: Create a rule
     Given hbac rule "rule4" exists
 
   @test
-    Scenario: Disable a rule
+  Scenario: Disable a rule
     Given I am logged in as admin
     And I am on "hbac-rules" page
 
@@ -67,6 +67,7 @@ Feature: HBAC rules manipulation
     Then I should see "rule4" entry in the data table
     Then I should see "rule4" entry in the data table with attribute "Status" set to "Disabled"
 
+  @test
   Scenario: Re-enable a rule
     Given I am logged in as admin
     And I am on "hbac-rules" page
@@ -89,7 +90,7 @@ Feature: HBAC rules manipulation
   Scenario: Delete a rule
     Given I delete hbac rule "rule4"
 
-  @seed 
+  @seed
   Scenario: Create a rule
     Given hbac rule "rule1" exists
 
@@ -99,7 +100,7 @@ Feature: HBAC rules manipulation
     And I am on "hbac-rules" page
 
     When I search for "rule1" in the data table
-    Then I should see "rule1" entry in the data table  
+    Then I should see "rule1" entry in the data table
     When I select entry "rule1" in the data table
     Then I should see "rule1" entry selected in the data table
     When I click on the "hbac-rules-button-delete" button

--- a/cypress/e2e/hbac/hbac_rule/hbac_rule_settings.feature
+++ b/cypress/e2e/hbac/hbac_rule/hbac_rule_settings.feature
@@ -31,10 +31,11 @@ Feature: Hbac rule settings manipulation
 
   @cleanup
   Scenario: Delete the user for cleanup
-    Given I delete element "user" named "admin" from rule "rule1"
+    Given I delete hbac rule "rule1"
 
   @seed
   Scenario: Add a user to the rule
+    Given hbac rule "rule1" exists
     Given I have element "user" named "admin" in rule "rule1"
 
   @test
@@ -78,9 +79,11 @@ Feature: Hbac rule settings manipulation
   @cleanup
   Scenario: Delete the group for cleanup
     Given I delete element "group" named "admins" from rule "rule1"
+    Given I delete hbac rule "rule1"
 
   @seed
   Scenario: Add a group to the rule
+    Given hbac rule "rule1" exists
     Given I have element "group" named "admins" in rule "rule1"
 
   @test
@@ -145,9 +148,14 @@ Feature: Hbac rule settings manipulation
     Then I should not see "hbac-rules-tab-settings-tab-users" tab
     Then I should not see "hbac-rules-tab-settings-tab-groups" tab
 
+  @cleanup
+  Scenario: Delete the group for cleanup
+    Given I delete hbac rule "rule1"
+
   @seed
   Scenario: Add a new host that will be used in the tests
     Given host "my-new-host.ipa.test" exists
+    Given hbac rule "rule1" exists
 
   @test
   Scenario: Add host to Host category
@@ -174,9 +182,15 @@ Feature: Hbac rule settings manipulation
 
   @cleanup
   Scenario: Delete the host from the rule
-    Given I delete host "my-new-host" from rule "rule1"
+    Given I delete host "my-new-host.ipa.test"
+    Given I delete hbac rule "rule1"
 
   @seed
+  Scenario: Prep: Create rule and host
+    Given hbac rule "rule1" exists
+    Given host "my-new-host.ipa.test" exists
+
+  @test
   Scenario: Add a host to the rule
     Given I am logged in as admin
     And I am on "hbac-rules/rule1" page
@@ -199,6 +213,17 @@ Feature: Hbac rule settings manipulation
     And I should see "add-member-success" alert
     Then I should see "my-new-host.ipa.test" entry in the data table
 
+  @cleanup
+  Scenario: Delete the host from the rule
+    Given I delete host "my-new-host.ipa.test"
+    Given I delete hbac rule "rule1"
+
+  @seed
+  Scenario: Prep: Create rule and host
+    Given host "my-new-host.ipa.test" exists
+    Given hbac rule "rule1" exists
+    Given I have element "host" named "my-new-host.ipa.test" in rule "rule1"
+
   @test
   Scenario: Remove host from Host category
     Given I am logged in as admin
@@ -213,6 +238,16 @@ Feature: Hbac rule settings manipulation
     When I click on the "modal-button-delete" button
     Then I should see "remove-member-success" alert
     Then I should not see "my-new-host.ipa.test" entry in the data table
+
+  @cleanup
+  Scenario: Delete the host from the rule
+    Given I delete host "my-new-host.ipa.test"
+    Given I delete hbac rule "rule1"
+
+  @seed
+  Scenario: Prep: Create rule and host
+    Given host "my-new-host.ipa.test" exists
+    Given hbac rule "rule1" exists
 
   @test
   Scenario: Add hostgroup to Host category
@@ -239,10 +274,11 @@ Feature: Hbac rule settings manipulation
 
   @cleanup
   Scenario: Delete the hostgroup from the rule
-    Given I delete element "hostgroup" named "ipaservers" from rule "rule1"
+    Given I delete hbac rule "rule1"
 
   @seed
   Scenario: Add a hostgroup to the rule
+    Given hbac rule "rule1" exists
     Given I have element "hostgroup" named "ipaservers" in rule "rule1"
 
   @test
@@ -259,6 +295,16 @@ Feature: Hbac rule settings manipulation
     When I click on the "modal-button-delete" button
     Then I should see "remove-member-success" alert
     Then I should not see "ipaservers" entry in the data table
+
+  @cleanup
+  Scenario: Delete the hostgroup from the rule
+    Given I delete hbac rule "rule1"
+    Given I delete host "my-new-host.ipa.test"
+
+  @seed
+  Scenario: Add a new host that will be used in the tests
+    Given hbac rule "rule1" exists
+    Given host "my-new-host.ipa.test" exists
 
   @test
   Scenario: Set Host category to allow all hosts
@@ -310,7 +356,12 @@ Feature: Hbac rule settings manipulation
 
   @cleanup
   Scenario: Delete host for cleanup
+    Given I delete hbac rule "rule1"
     Given I delete host "my-new-host.ipa.test"
+
+  @seed
+  Scenario: Add a service to the rule
+    Given hbac rule "rule1" exists
 
   @test
   Scenario: Add service to Service category
@@ -337,10 +388,11 @@ Feature: Hbac rule settings manipulation
 
   @cleanup
   Scenario: Delete the service from the rule
-    Given I delete service "crond" from rule "rule1"
+    And I delete hbac rule "rule1"
 
   @seed
   Scenario: Add a service to the rule
+    Given hbac rule "rule1" exists
     Given I have service "crond" in rule "rule1"
 
   @test
@@ -357,6 +409,14 @@ Feature: Hbac rule settings manipulation
     When I click on the "modal-button-delete" button
     Then I should see "remove-member-success" alert
     Then I should not see "crond" entry in the data table
+
+  @cleanup
+  Scenario: Delete the service from the rule
+    And I delete hbac rule "rule1"
+
+  @seed
+  Scenario: Prep: Create rule
+    Given hbac rule "rule1" exists
 
   @test
   Scenario: Add service group to Service category
@@ -383,10 +443,11 @@ Feature: Hbac rule settings manipulation
 
   @cleanup
   Scenario: Delete the service group from the rule
-    Given I delete servicegroup "ftp" from rule "rule1"
+    Given I delete hbac rule "rule1"
 
   @seed
   Scenario: Add a service group to the rule
+    Given hbac rule "rule1" exists
     Given I have servicegroup "ftp" in rule "rule1"
 
   @test
@@ -403,6 +464,14 @@ Feature: Hbac rule settings manipulation
     When I click on the "modal-button-delete" button
     Then I should see "remove-member-success" alert
     Then I should not see "ftp" entry in the data table
+
+  @cleanup
+  Scenario: Delete the service group from the rule
+    Given I delete hbac rule "rule1"
+
+  @seed
+  Scenario: Prep: Create rule
+    Given hbac rule "rule1" exists
 
   @test
   Scenario: Set Service category to allow all services

--- a/cypress/e2e/hbac/hbac_service/hbac_service.feature
+++ b/cypress/e2e/hbac/hbac_service/hbac_service.feature
@@ -29,7 +29,7 @@ Feature: HBAC services manipulation
 
   @seed
   Scenario: Seed: Create HBAC services used in tests
-      Given HBAC service "a_service2" exists
+    Given HBAC service "a_service2" exists
 
   @test
   Scenario: Search for a service
@@ -41,7 +41,7 @@ Feature: HBAC services manipulation
     And I should not see "a_service1" entry in the data table
 
   @cleanup
-    Scenario: Cleanup: Delete seeded services
+  Scenario: Cleanup: Delete seeded services
     Given I delete service "a_service2"
 
   @seed

--- a/cypress/e2e/hbac/hbac_service/hbac_service.ts
+++ b/cypress/e2e/hbac/hbac_service/hbac_service.ts
@@ -7,7 +7,6 @@ import {
   searchForEntry,
   selectEntry,
 } from "../../common/data_tables";
-import { typeInTextbox } from "cypress/e2e/common/ui/textbox";
 import { addItemToRightList } from "cypress/e2e/common/ui/dual_list";
 import {
   searchForMembersEntry,
@@ -15,24 +14,10 @@ import {
 } from "cypress/e2e/common/members_table";
 
 Given("HBAC service {string} exists", (serviceName: string) => {
-  loginAsAdmin();
-  navigateTo("hbac-services");
-
-  searchForEntry(serviceName);
-  cy.dataCy("hbac-services-button-add").click();
-  cy.dataCy("add-hbac-service-modal").should("exist");
-
-  typeInTextbox("modal-textbox-service-name", serviceName);
-  cy.dataCy("modal-textbox-service-name").should("have.value", serviceName);
-
-  cy.dataCy("modal-button-add").click();
-  cy.dataCy("add-hbac-service-modal").should("not.exist");
-  cy.dataCy("add-hbacservice-success").should("exist");
-
-  searchForEntry(serviceName);
-  entryExists(serviceName);
-
-  logout();
+  cy.ipa({
+    command: "hbacsvc-add",
+    name: serviceName,
+  });
 });
 
 Given("I delete service {string}", (serviceName: string) => {

--- a/cypress/e2e/hbac/hbac_service_group/hbac_service_group.feature
+++ b/cypress/e2e/hbac/hbac_service_group/hbac_service_group.feature
@@ -27,8 +27,8 @@ Feature: HBAC service groups manipulation
   Scenario: Cleanup: Delete a service group
     Given I delete service group "a_service_group1"
 
-  @seed
-  Scenario: Seed: Ensure service group exists
+  @test
+  Scenario: Search for a service group
     Given HBAC service group "a_service_group2" exists
 
   @test

--- a/cypress/e2e/hbac/hbac_service_group/hbac_service_group.ts
+++ b/cypress/e2e/hbac/hbac_service_group/hbac_service_group.ts
@@ -7,7 +7,6 @@ import {
   searchForEntry,
   selectEntry,
 } from "../../common/data_tables";
-import { typeInTextbox } from "../../common/ui/textbox";
 import { addItemToRightList } from "cypress/e2e/common/ui/dual_list";
 import {
   searchForMembersEntry,
@@ -15,25 +14,10 @@ import {
 } from "cypress/e2e/common/members_table";
 
 Given("HBAC service group {string} exists", (groupName: string) => {
-  loginAsAdmin();
-  navigateTo("hbac-service-groups");
-
-  searchForEntry(groupName);
-
-  cy.dataCy("hbac-service-groups-button-add").click();
-  cy.dataCy("add-hbac-service-group-modal").should("exist");
-
-  typeInTextbox("modal-textbox-service-group-name", groupName);
-  cy.dataCy("modal-textbox-service-group-name").should("have.value", groupName);
-
-  cy.dataCy("modal-button-add").click();
-  cy.dataCy("add-hbac-service-group-modal").should("not.exist");
-  cy.dataCy("add-hbacservicegroup-success").should("exist");
-
-  searchForEntry(groupName);
-  entryExists(groupName);
-
-  logout();
+  cy.ipa({
+    command: "hbacsvcgroup-add",
+    name: groupName,
+  });
 });
 
 Given("I delete service group {string}", (groupName: string) => {

--- a/cypress/e2e/hostgroups/hostgroup.feature
+++ b/cypress/e2e/hostgroups/hostgroup.feature
@@ -14,7 +14,7 @@ Feature: Hostgroup management
 
     @seed
     Scenario: Create new host group
-        Given Hostgroup "my_automember_hostgroup" with description "test" exists
+        Given hostgroup "my_automember_hostgroup" with description "test" exists
 
     @test
     Scenario: Delete host group

--- a/cypress/e2e/hostgroups/hostgroup.ts
+++ b/cypress/e2e/hostgroups/hostgroup.ts
@@ -19,7 +19,7 @@ const fillHostgroup = (hostgroupName: string, hostgroupDescription: string) => {
   );
 };
 
-export const createHostgroup = (
+const createHostgroup = (
   hostgroupName: string,
   hostgroupDescription: string
 ) => {
@@ -73,15 +73,13 @@ Then(
 );
 
 Given(
-  "Hostgroup {string} with description {string} exists",
+  "hostgroup {string} with description {string} exists",
   (hostgroupName: string, hostgroupDescription: string) => {
-    loginAsAdmin();
-    navigateTo("host-groups");
-
-    createHostgroup(hostgroupName, hostgroupDescription);
-    validateHostgroup(hostgroupName);
-
-    logout();
+    cy.ipa({
+      command: "hostgroup-add",
+      name: hostgroupName,
+      specificOptions: `--desc="${hostgroupDescription}"`,
+    });
   }
 );
 

--- a/cypress/e2e/id_views/id_views.feature
+++ b/cypress/e2e/id_views/id_views.feature
@@ -49,12 +49,10 @@ Feature: ID View manipulation
   Scenario: Delete a view
     Given I delete view "a_new_view"
 
-  @seed
-  Scenario: Create views
-    Given view "a_new_view" exists
-
   @test
   Scenario: Unapply views from hosts
+    Given view "a_new_view" exists
+
     Given I am logged in as admin
     And I am on "id-views" page
 

--- a/cypress/e2e/id_views/id_views.ts
+++ b/cypress/e2e/id_views/id_views.ts
@@ -4,10 +4,8 @@ import {
   selectEntry,
   searchForEntry,
   entryDoesNotExist,
-  entryExists,
 } from "../common/data_tables";
 import { navigateTo } from "../common/navigation";
-import { typeInTextbox } from "../common/ui/textbox";
 
 Given("I delete view {string}", (viewName: string) => {
   loginAsAdmin();
@@ -26,19 +24,8 @@ Given("I delete view {string}", (viewName: string) => {
 });
 
 Given("view {string} exists", (viewName: string) => {
-  loginAsAdmin();
-  navigateTo("id-views");
-
-  cy.dataCy("id-views-button-add").click();
-  cy.dataCy("add-id-view-modal").should("exist");
-
-  typeInTextbox("modal-textbox-id-view-name", viewName);
-  cy.dataCy("modal-textbox-id-view-name").should("have.value", viewName);
-
-  cy.dataCy("modal-button-add").click();
-  cy.dataCy("add-id-view-modal").should("not.exist");
-
-  searchForEntry(viewName);
-  entryExists(viewName);
-  logout();
+  cy.ipa({
+    command: "idview-add",
+    name: viewName,
+  });
 });

--- a/cypress/e2e/netgroup/netgroup.ts
+++ b/cypress/e2e/netgroup/netgroup.ts
@@ -14,22 +14,10 @@ import { MemberEntity, assertMemberEntity } from "../common/member_of";
 import { searchForMembersEntry } from "../common/members_table";
 
 Given("netgroup {string} exists", (groupName: string) => {
-  loginAsAdmin();
-  navigateTo("netgroups");
-
-  cy.dataCy("netgroups-button-add").click();
-  cy.dataCy("add-netgroup-modal").should("exist");
-
-  typeInTextbox("modal-textbox-netgroup-name", groupName);
-  cy.dataCy("modal-textbox-netgroup-name").should("have.value", groupName);
-
-  cy.dataCy("modal-button-add").click();
-  cy.dataCy("add-netgroup-modal").should("not.exist");
-  cy.dataCy("add-netgroup-success").should("exist");
-
-  searchForMembersEntry(groupName);
-  entryExists(groupName);
-  logout();
+  cy.ipa({
+    command: "netgroup-add",
+    name: groupName,
+  });
 });
 
 Given("I delete netgroup {string}", (groupName: string) => {

--- a/cypress/e2e/user_groups/user_groups.ts
+++ b/cypress/e2e/user_groups/user_groups.ts
@@ -9,19 +9,12 @@ import {
 import { navigateTo } from "../common/navigation";
 import { selectOption } from "../common/ui/select";
 import { isOptionSelected } from "../common/ui/select";
-import { addItemToRightList } from "../common/ui/dual_list";
 
-export const createUserGroup = (groupName: string) => {
-  cy.dataCy("user-groups-button-add").click();
-  cy.dataCy("add-user-group-modal").should("exist");
-
-  cy.dataCy("modal-textbox-group-name").type(groupName);
-  cy.dataCy("modal-textbox-group-name").should("have.value", groupName);
-
-  cy.dataCy("modal-button-add").click();
-  cy.dataCy("add-user-group-modal").should("not.exist");
-  searchForEntry(groupName);
-  entryExists(groupName);
+const createUserGroupExec = (groupName: string) => {
+  cy.ipa({
+    command: "group-add",
+    name: groupName,
+  });
 };
 
 Given("I delete user group {string}", (groupName: string) => {
@@ -41,11 +34,7 @@ Given("I delete user group {string}", (groupName: string) => {
 });
 
 Given("user group {string} exists", (groupName: string) => {
-  loginAsAdmin();
-  navigateTo("user-groups");
-
-  createUserGroup(groupName);
-  logout();
+  createUserGroupExec(groupName);
 });
 
 type MemberType = "member_user" | "member_group" | "member_service";
@@ -64,20 +53,78 @@ const addMember = (
   member: string,
   group: string
 ) => {
-  loginAsAdmin();
-  navigateTo("user-groups/" + group + "/" + type);
-
-  cy.dataCy("member-of-button-add").click();
-  cy.dataCy("member-of-add-modal").should("exist");
-
-  addItemToRightList(member);
-
-  cy.dataCy("modal-button-add").click();
-  cy.dataCy("member-of-add-modal").should("not.exist");
-
-  searchForEntry(member);
-  entryExists(member);
-  logout();
+  switch (type) {
+    case "member_user":
+      cy.ipa({
+        command: "group-add-member",
+        name: group,
+        specificOptions: `--users=${member}`,
+      });
+      break;
+    case "member_group":
+      cy.ipa({
+        command: "group-add-member",
+        name: group,
+        specificOptions: `--groups=${member}`,
+      });
+      break;
+    case "member_service":
+      cy.ipa({
+        command: "group-add-member",
+        name: group,
+        specificOptions: `--services=${member}`,
+      });
+      break;
+    case "manager_user":
+      cy.ipa({
+        command: "group-add-member-manager",
+        name: group,
+        specificOptions: `--users=${member}`,
+      });
+      break;
+    case "manager_group":
+      cy.ipa({
+        command: "group-add-member-manager",
+        name: group,
+        specificOptions: `--groups=${member}`,
+      });
+      break;
+    case "memberof_usergroup":
+      cy.ipa({
+        command: "group-add-member",
+        name: member,
+        specificOptions: `--groups=${group}`,
+      });
+      break;
+    case "memberof_netgroup":
+      cy.ipa({
+        command: "netgroup-add-member",
+        name: member,
+        specificOptions: `--groups=${group}`,
+      });
+      break;
+    case "memberof_role":
+      cy.ipa({
+        command: "role-add-member",
+        name: member,
+        specificOptions: `--groups=${group}`,
+      });
+      break;
+    case "memberof_hbacrule":
+      cy.ipa({
+        command: "hbacrule-add-user",
+        name: member,
+        specificOptions: `--groups=${group}`,
+      });
+      break;
+    case "memberof_sudorule":
+      cy.ipa({
+        command: "sudorule-add-user",
+        name: member,
+        specificOptions: `--groups=${group}`,
+      });
+      break;
+  }
 };
 
 Given(

--- a/cypress/e2e/user_groups/user_groups_memberof.feature
+++ b/cypress/e2e/user_groups/user_groups_memberof.feature
@@ -114,7 +114,7 @@ Feature: Usergroup is a member of
   @cleanup
   Scenario: Cleanup seed data
     Given I delete user group "a-group"
-  
+
   @seed
   Scenario: Create seed data (User group and HBAC rule)
     Given hbac rule "test" exists
@@ -175,4 +175,4 @@ Feature: Usergroup is a member of
     Given I delete user group "a-group"
     And I delete hbac rule "test"
 
-  # Add Sudo rules
+# Add Sudo rules

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -25,6 +25,38 @@
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 //
 
+import { IPA_PREFIX } from "./utils";
+
 Cypress.Commands.add("dataCy", (value: string) => {
   return cy.get(`[data-cy='${value}']`);
 });
+
+export type IpaCommandParams = {
+  command: string;
+  name: string;
+  specificOptions?: string;
+  options?: Partial<Cypress.ExecOptions>;
+};
+
+// Register a helper to run IPA commands inside the webui container.
+// Automatically runs kinit before each IPA command.
+// Usage:
+//   cy.ipa("hbacsvc-show", "my_service", { failOnNonZeroExit: false })
+//   cy.ipa("hbacsvc-add", "my_service")
+// Returns the result of cy.exec so you can inspect code/stdout/stderr.
+Cypress.Commands.add(
+  "ipa",
+  ({
+    command,
+    name,
+    specificOptions,
+  }: IpaCommandParams): Cypress.Chainable<Cypress.Exec> => {
+    const safeName = name.replace(/"/g, '\\"');
+    let ipaCmd = `${IPA_PREFIX} ${command} "${safeName}"`;
+    if (specificOptions) {
+      ipaCmd = `${IPA_PREFIX} ${command} "${safeName}" ${specificOptions}`;
+    }
+
+    return cy.exec(ipaCmd);
+  }
+);

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -20,3 +20,10 @@ import { addCustomCommand } from "cy-verify-downloads";
 addCustomCommand();
 
 import "./commands";
+
+// Authenticate with Kerberos once before running any tests
+before(() => {
+  const password = Cypress.env("ADMIN_PASSWORD");
+  const kinitCmd = `echo "${password}" | podman exec -i webui kinit admin`;
+  cy.exec(kinitCmd, { failOnNonZeroExit: true });
+});

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -3,5 +3,6 @@
 declare namespace Cypress {
   interface Chainable<Subject> {
     dataCy(value: string): Chainable<Subject>;
+    ipa(IpaCommandParams): Chainable<Cypress.Exec>;
   }
 }

--- a/cypress/support/utils.ts
+++ b/cypress/support/utils.ts
@@ -1,0 +1,6 @@
+import { exec as cpExec } from "child_process";
+import { promisify } from "util";
+
+export const exec = promisify(cpExec);
+
+export const IPA_PREFIX = "podman exec webui ipa";


### PR DESCRIPTION
The seed adds a new cy.ipa calls which runs podman exec webui ipa via cy.exec(). 

## Summary by Sourcery

Refactor Cypress E2E test setup and cleanup to use IPA CLI exec helpers instead of UI-driven flows, simplifying seed data management across DNS, HBAC, automember, host, hostgroup, sudo rule, ID view, and related scenarios.

Enhancements:
- Introduce a reusable Cypress ipa command and shared IPA_PREFIX utility for executing IPA CLI commands inside the web UI container.
- Streamline DNS zone-related helpers by removing UI-centric helpers such as parseZoneName and narrowing create/enable/disable/permission helpers to CLI-backed steps.
- Adjust HBAC, automember, hostgroup, host, ID view, and sudo rule step definitions to create and manage entities via IPA CLI rather than navigating the UI.
- Simplify Cypress plugin task registration for download verification by spreading verifyDownloadTasks into the task map.

Tests:
- Update multiple Gherkin feature files to rely on inline Given seed steps instead of separate @seed/@cleanup scenarios, aligning them with the new CLI-backed helpers for records, zones, HBAC services/groups, automember rules, and hostgroups.
- Revise DNS, HBAC, automember, hostgroup, and ID view tests to expect the new setup/teardown behavior (e.g., closing modals instead of checking specific alerts, using existence steps inside @test scenarios, and changing some deletion flows).