### PR TITLE
Filter Sudo Cmd data for sudo Cmd Groups

### DIFF
--- a/src/components/Members/MembersSudoCommands.tsx
+++ b/src/components/Members/MembersSudoCommands.tsx
@@ -32,7 +32,6 @@ interface PropsToMembersSudoGroups {
   from: string;
   isDataLoading: boolean;
   onRefreshData: () => void;
-  member_sudocmd: string[];
 }
 
 const MembersSudoCommands = (props: PropsToMembersSudoGroups) => {
@@ -45,56 +44,41 @@ const MembersSudoCommands = (props: PropsToMembersSudoGroups) => {
   // Other states
   const [membersSelected, setMembersSelected] = React.useState<string[]>([]);
 
-  // Loaded members based on paging and member attributes
-  const [members, setMembers] = React.useState<SudoCmd[]>([]);
+  const memberNamesToLoad = React.useMemo(() => {
+    const rawMembers = props.entity.member_sudocmd || [];
+    if (rawMembers.length === 0) return [];
 
-  const getCmdNamesToLoad = (): string[] => {
-    let toLoad = [...props.member_sudocmd];
-    toLoad.sort();
+    let toLoad = [...rawMembers].sort();
 
-    // Filter by search
     if (searchValue) {
       toLoad = toLoad.filter((name) =>
         name.toLowerCase().includes(searchValue.toLowerCase())
       );
     }
 
-    // Apply paging
-    toLoad = paginate(toLoad, page, perPage);
-
-    return toLoad;
-  };
-
-  const [memberNamesToLoad, setMemberNamesToLoad] =
-    React.useState<string[]>(getCmdNamesToLoad());
+    return paginate(toLoad, page, perPage);
+  }, [props.entity.member_sudocmd, searchValue, page, perPage]);
 
   // Load services
-  const fullServicesQuery = useGetSudoCmdsInfoByNameQuery({
-    sudoCmdNamesList: memberNamesToLoad,
-    no_members: true,
-    version: API_VERSION_BACKUP,
-  });
-
-  // Refresh services
-  React.useEffect(() => {
-    const serviceNames = getCmdNamesToLoad();
-    setMemberNamesToLoad(serviceNames);
-  }, [props.entity, searchValue, page, perPage]);
-
-  React.useEffect(() => {
-    if (memberNamesToLoad.length > 0) {
-      fullServicesQuery.refetch();
+  const fullSudoCmdsQuery = useGetSudoCmdsInfoByNameQuery(
+    {
+      sudoCmdNamesList: memberNamesToLoad,
+      no_members: true,
+      version: API_VERSION_BACKUP,
+    },
+    {
+      skip: memberNamesToLoad.length === 0 || props.isDataLoading,
+      refetchOnMountOrArgChange: true, // Ensures data is always updated when the component is mounted, ignoring the cache.
     }
-  }, [memberNamesToLoad]);
+  );
 
-  React.useEffect(() => {
-    if (fullServicesQuery.data && !fullServicesQuery.isFetching) {
-      setMembers(fullServicesQuery.data);
-    }
-  }, [fullServicesQuery.data, fullServicesQuery.isFetching]);
+  const members = React.useMemo(() => {
+    if (!fullSudoCmdsQuery.data) return [];
+    return fullSudoCmdsQuery.data.filter((m) => m.sudocmd && m.sudocmd !== "");
+  }, [fullSudoCmdsQuery.data]);
 
   // Computed "states"
-  const showTableRows = members.length > 0;
+  const showTableRows = !fullSudoCmdsQuery.isFetching && !props.isDataLoading;
   const columnNames = ["Sudo command", "Description"];
   const properties = ["cn", "description"];
 
@@ -105,7 +89,7 @@ const MembersSudoCommands = (props: PropsToMembersSudoGroups) => {
 
   // Buttons functionality
   const isRefreshButtonEnabled =
-    !fullServicesQuery.isFetching && !props.isDataLoading;
+    !fullSudoCmdsQuery.isFetching && !props.isDataLoading;
   const isAddButtonEnabled = isRefreshButtonEnabled;
 
   // API calls
@@ -150,9 +134,9 @@ const MembersSudoCommands = (props: PropsToMembersSudoGroups) => {
           title: cmd.sudocmd,
         });
       }
+
       items = items.filter(
-        (item) =>
-          !props.member_sudocmd.includes(item.key) && item.key !== props.id
+        (item) => !props.entity?.member_sudocmd?.includes(item.key)
       );
 
       setAvailableServices(avalCmds);
@@ -262,7 +246,7 @@ const MembersSudoCommands = (props: PropsToMembersSudoGroups) => {
         addButtonEnabled={isAddButtonEnabled}
         onAddButtonClick={() => setShowAddModal(true)}
         helpIconEnabled={true}
-        totalItems={props.member_sudocmd.length}
+        totalItems={props.entity?.member_sudocmd?.length || 0}
         perPage={perPage}
         page={page}
         onPerPageChange={setPerPage}
@@ -280,7 +264,7 @@ const MembersSudoCommands = (props: PropsToMembersSudoGroups) => {
       />
       <Pagination
         className="pf-v6-u-pb-0 pf-v6-u-pr-md"
-        itemCount={props.member_sudocmd.length}
+        itemCount={props.entity?.member_sudocmd?.length || 0}
         widgetId="pagination-options-menu-bottom"
         perPage={perPage}
         page={page}

--- a/src/pages/SudoCmdGroups/SudoCmdGroupsMembers.tsx
+++ b/src/pages/SudoCmdGroups/SudoCmdGroupsMembers.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 // PatternFly
 import { Badge, Tab, Tabs, TabTitleText } from "@patternfly/react-core";
 // Data types
@@ -22,18 +22,17 @@ interface PropsToSudoGroupsMembers {
 const SudoCmdGroupMembers = (props: PropsToSudoGroupsMembers) => {
   const navigate = useNavigate();
 
-  const groupQuery = useGetSudoCmdGroupByIdQuery(props.sudocmdgroup.cn);
-  const groupData = groupQuery.data || {};
-  const [cmdGroup, setCmdGroup] = useState<Partial<SudoCmdGroup>>({});
+  const {
+    data: cmdGroup,
+    isFetching,
+    refetch,
+  } = useGetSudoCmdGroupByIdQuery(props.sudocmdgroup.cn);
 
-  React.useEffect(() => {
-    if (!groupQuery.isFetching && groupData) {
-      setCmdGroup({ ...groupData });
-    }
-  }, [groupData, groupQuery.isFetching]);
+  // Fallback to props.sudocmdgroup if cmdGroup is not available
+  const displayEntity = cmdGroup || props.sudocmdgroup || {};
 
   const onRefreshSudoCmdData = () => {
-    groupQuery.refetch();
+    refetch();
   };
 
   // Update current route data to Redux and highlight the current page in the Nav bar
@@ -67,20 +66,19 @@ const SudoCmdGroupMembers = (props: PropsToSudoGroupsMembers) => {
               <TabTitleText>
                 Sudo commands{" "}
                 <Badge key={0} id="cmd_count" isRead>
-                  {cmdGroup && cmdGroup.member_sudocmd
-                    ? cmdGroup.member_sudocmd.length
+                  {cmdGroup?.member_sudocmd
+                    ? cmdGroup?.member_sudocmd?.length
                     : 0}
                 </Badge>
               </TabTitleText>
             }
           >
             <MembersSudoCommands
-              entity={cmdGroup}
-              id={cmdGroup.cn as string}
+              entity={displayEntity}
+              id={props.sudocmdgroup.cn}
               from="sudo-command-groups"
-              isDataLoading={groupQuery.isFetching}
+              isDataLoading={isFetching}
               onRefreshData={onRefreshSudoCmdData}
-              member_sudocmd={cmdGroup.member_sudocmd || []}
             />
           </Tab>
         </Tabs>

--- a/src/services/rpcSudoCmdGroups.ts
+++ b/src/services/rpcSudoCmdGroups.ts
@@ -135,7 +135,6 @@ const extendedApi = api.injectEndpoints({
           group: groupObject,
         };
       },
-      providesTags: ["FullSudoCmdGroup"],
     }),
     saveSudoCmdGroup: build.mutation<FindRPCResponse, Partial<SudoCmdGroup>>({
       query: (cmd) => {

--- a/src/services/rpcSudoCmds.ts
+++ b/src/services/rpcSudoCmds.ts
@@ -55,11 +55,26 @@ const extendedApi = api.injectEndpoints({
       },
       transformResponse: (response: BatchRPCResponse): SudoCmd[] => {
         const sudoRulesList: SudoCmd[] = [];
+
+        if (!response?.result?.results) return [];
+
         const results = response.result.results;
         const count = response.result.count;
+
         for (let i = 0; i < count; i++) {
-          const sudoRuleData = apiToSudoCmd(results[i].result);
-          sudoRulesList.push(sudoRuleData);
+          const currentResult = results[i];
+
+          if (
+            !currentResult ||
+            ("error" in currentResult && currentResult.error)
+          ) {
+            continue;
+          }
+
+          if (currentResult.result) {
+            const sudoRuleData = apiToSudoCmd(currentResult.result);
+            sudoRulesList.push(sudoRuleData);
+          }
         }
         return sudoRulesList;
       },


### PR DESCRIPTION
The Sudo command groups data is not properly
filtered in the code, hence some data (i.e.
Sudo commands associated as members) that has
been deleted is still showing in the table.
This is something that is also happening in
the old WebUI, but in the modern one the data
has been filtered to show only those Sudo
commands that are available in the table.
However, and due to the API data, if a given
Sudo command is restored, it will be displayed
again in the Members table if it has been
assigned in the past. This is a limitation
on the API side and there is no much we can do
to prevent this.
Fixes: https://github.com/freeipa/freeipa-webui/issues/923
