### PR TITLE
Fix: indexes not reflecting real values

### DIFF
--- a/src/components/layouts/PaginationLayout.tsx
+++ b/src/components/layouts/PaginationLayout.tsx
@@ -23,8 +23,6 @@ interface PropsToPaginationPrep {
 }
 
 const PaginationLayout = (props: PropsToPaginationPrep) => {
-  // Handle content on 'setPage'
-
   let perPageOptions = [
     { title: "10", value: 10 },
     { title: "20", value: 20 },
@@ -81,17 +79,21 @@ const PaginationLayout = (props: PropsToPaginationPrep) => {
     ];
   }
 
+  // Ensure page is always at least 1 to prevent negative display values
+  const safePage = Math.max(1, props.paginationData.page);
+
+  const itemCount =
+    props.paginationData.totalCount > 0
+      ? props.paginationData.totalCount
+      : props.list.length;
+
   return (
     <Pagination
       className={props.className}
-      itemCount={
-        props.paginationData.totalCount
-          ? props.paginationData.totalCount
-          : props.list.length
-      }
+      itemCount={itemCount}
       widgetId={props.widgetId}
       perPage={props.paginationData.perPage}
-      page={props.paginationData.page}
+      page={safePage}
       variant={props.variant}
       onSetPage={handleSetPage}
       onPerPageSelect={handlePerPageSelect}

--- a/src/hooks/useListPageSearchParams.tsx
+++ b/src/hooks/useListPageSearchParams.tsx
@@ -13,7 +13,7 @@ const useListPageSearchParams = () => {
     if (pageParam && (parseInt(pageParam) < 1 || isNaN(parseInt(pageParam)))) {
       return 1;
     } else {
-      return parseInt(pageParam || "1");
+      return Math.max(1, parseInt(pageParam || "1"));
     }
   };
 
@@ -22,12 +22,22 @@ const useListPageSearchParams = () => {
     if (pageParam && (parseInt(pageParam) < 1 || isNaN(parseInt(pageParam)))) {
       return 10;
     } else {
-      return parseInt(pageParam || "10");
+      return Math.max(10, parseInt(pageParam || "10"));
     }
   };
 
-  const [page, setPage] = React.useState(getPageParam());
-  const [perPage, setPerPage] = React.useState(getPerPageParam());
+  const [page, _setPage] = React.useState(getPageParam());
+  const [perPage, _setPerPage] = React.useState(getPerPageParam());
+
+  // Ensure 'page' is always >= 1
+  const setPage = (newPage: number) => {
+    _setPage(Math.max(1, newPage));
+  };
+
+  // Ensure 'perPage' is always >= 1
+  const setPerPage = (newPerPage: number) => {
+    _setPerPage(Math.max(1, newPerPage));
+  };
 
   // Search value
   const [searchValue, setSearchValue] = React.useState(

--- a/src/pages/ActiveUsers/ActiveUsers.tsx
+++ b/src/pages/ActiveUsers/ActiveUsers.tsx
@@ -92,7 +92,8 @@ const ActiveUsers = () => {
   const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
   // Page indexes
-  const firstUserIdx = (page - 1) * perPage;
+  // - Ensure 'firstUserIdx' is always >= 0
+  const firstUserIdx = Math.max(0, (page - 1) * perPage);
   const lastUserIdx = page * perPage;
 
   // Derived states - what we get from API

--- a/src/services/rpc.ts
+++ b/src/services/rpc.ts
@@ -293,6 +293,9 @@ export const api = createApi({
         } = payloadData;
         let objName = payloadData.objName;
 
+        // startIdx cannot contain negative values
+        const startIdxValue = Math.max(startIdx, 0);
+
         if (objAttr === undefined || objName === undefined) {
           return {
             error: {
@@ -398,7 +401,7 @@ export const api = createApi({
         const idResponseData = getGroupIDsResult.data as FindRPCResponse;
         const ids: string[] = [];
         const itemsCount = idResponseData.result.result.length as number;
-        for (let i = startIdx; i < itemsCount && i < stopIdx; i++) {
+        for (let i = startIdxValue; i < itemsCount && i < stopIdx; i++) {
           let id;
           if (objName === "host") {
             id = idResponseData.result.result[i] as fqdnType;
@@ -433,7 +436,10 @@ export const api = createApi({
               } as FetchBaseQueryError,
             };
           }
-          ids.push(id[objAttr][0] as string);
+
+          if (id !== undefined) {
+            ids.push(id[objAttr][0] as string);
+          }
         }
 
         // 2ND CALL - GET PARTIAL INFO


### PR DESCRIPTION
The pagination parameters are not reflecting
the right data in Active users' page. Due to
this, table entries are not being shown
correctly.

Fixes: https://github.com/freeipa/freeipa-webui/issues/917

## Summary by Sourcery

Ensure pagination and index calculations never use negative values so that Active Users listings and related RPC calls correctly reflect available data.

Bug Fixes:
- Prevent Pagination component from displaying invalid pages by clamping the current page to a minimum of 1 and using a safe total item count.
- Guard list page search params so page and per-page values can never be less than 1 when updated from URL or user actions.
- Avoid negative start indices and undefined IDs in RPC list fetching to keep index-based iteration within valid bounds.
- Normalize Active Users index calculations to start at zero when a negative first index is derived, keeping the visible slice aligned with the requested page.