### PR TITLE
[WIP] Generic main page component

### DIFF
--- a/src/components/GenericMainPage.tsx
+++ b/src/components/GenericMainPage.tsx
@@ -1,0 +1,1058 @@
+/**
+ * GenericMainPage - A reusable layout component for WebUI's main pages.
+ *
+ * This component extracts the common patterns found across all main page
+ * components (e.g.: ActiveUsers, Hosts, Services, UserGroups, HostGroups,
+ * Netgroups, IDViews, HBACRules, SubordinateIDs, AutoMemRules, etc.)
+ * and provides:
+ *
+ * 1. `useMainPageState<T>` - A custom hook encapsulating all common state logic
+ * 2. `GenericMainPage<T>` - A layout component providing the common UI structure
+ *
+ * USAGE EXAMPLE:
+ * ```tsx
+ * const MyPage = () => {
+ *   const state = useMainPageState<MyType>({
+ *     pathname: "my-items",
+ *     searchEntryType: "myitem",
+ *     nameAttr: "cn",
+ *     getKeyValue: (item) => item.cn,
+ *     isSelectable: isMyItemSelectable,
+ *   });
+ *
+ *   // Use your own RTK Query hook
+ *   const dataResponse = useGettingMyItemsQuery({
+ *     searchValue: state.searchValue,
+ *     sizeLimit: 0,
+ *     apiVersion: state.apiVersion,
+ *     startIdx: state.firstIdx,
+ *     stopIdx: state.lastIdx,
+ *   } as GenericPayload);
+ *
+ *   // Connect the query response to the state
+ *   useDataResponseEffect(dataResponse, state);
+ *
+ *   return (
+ *     <GenericMainPage
+ *       state={state}
+ *       pageTitle="My Items"
+ *       batchError={dataResponse.error}
+ *       onRefresh={() => state.refreshData(() => dataResponse.refetch())}
+ *       onAddClick={() => setShowAddModal(true)}
+ *       onDeleteClick={() => setShowDeleteModal(true)}
+ *       renderTable={(s) => <MyTable elementsList={s.elementsList} ... />}
+ *     >
+ *       <AddMyItem show={...} />
+ *       <DeleteMyItems show={...} />
+ *     </GenericMainPage>
+ *   );
+ * };
+ * ```
+ */
+
+import React, {
+  useEffect,
+  useState,
+  useCallback,
+  useMemo,
+  useRef,
+} from "react";
+// PatternFly
+import {
+  Flex,
+  FlexItem,
+  PageSection,
+  PaginationVariant,
+  ToolbarItemVariant,
+} from "@patternfly/react-core";
+import {
+  InnerScrollContainer,
+  OuterScrollContainer,
+} from "@patternfly/react-table";
+// Redux
+import { useAppSelector, useAppDispatch } from "src/store/hooks";
+// Layouts
+import TitleLayout from "src/components/layouts/TitleLayout";
+import ToolbarLayout, {
+  ToolbarItem,
+} from "src/components/layouts/ToolbarLayout";
+import SearchInputLayout from "src/components/layouts/SearchInputLayout";
+import SecondaryButton from "src/components/layouts/SecondaryButton";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
+import BulkSelectorPrep from "src/components/BulkSelectorPrep";
+// Components
+import ContextualHelpPanel from "src/components/ContextualHelpPanel/ContextualHelpPanel";
+// Hooks
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
+import useUpdateRoute from "src/hooks/useUpdateRoute";
+import useApiError from "src/hooks/useApiError";
+import { addAlert } from "src/store/Global/alerts-slice";
+// Errors
+import GlobalErrors from "src/components/errors/GlobalErrors";
+import ModalErrors from "src/components/errors/ModalErrors";
+// Utils
+import { API_VERSION_BACKUP } from "src/utils/utils";
+// RPC
+import {
+  BatchRPCResponse,
+  GenericPayload,
+  useSearchEntriesMutation,
+} from "src/services/rpc";
+// Types
+import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
+import { SerializedError } from "@reduxjs/toolkit";
+
+// ============================================================================
+// Type definitions
+// ============================================================================
+
+/**
+ * Configuration required to initialize `useMainPageState`.
+ * Each main page provides its own configuration values.
+ */
+export interface MainPageConfig<T> {
+  /** Route pathname used by `useUpdateRoute` (e.g., "active-users", "hosts") */
+  pathname: string;
+
+  /**
+   * Entry type used for the `useSearchEntriesMutation` search call.
+   * Corresponds to `GenericPayload.entryType`.
+   * For pages that use a custom search mutation, this can be left empty.
+   */
+  searchEntryType?: GenericPayload["entryType"];
+
+  /**
+   * The attribute name used to identify each item in the list.
+   * Used by BulkSelectorPrep and the selection logic.
+   * Examples: "uid" (users), "fqdn" (hosts), "cn" (groups), "krbcanonicalname" (services)
+   */
+  nameAttr: string;
+
+  /**
+   * Function to extract the primary key value from an item.
+   * Used for comparing items during selection.
+   * Example: `(user) => user.uid` or `(host) => host.fqdn`
+   */
+  getKeyValue: (item: T) => string;
+
+  /**
+   * Predicate function to determine if an item can be selected.
+   * Example: `isUserSelectable`, `isHostSelectable`
+   */
+  isSelectable: (item: T) => boolean;
+}
+
+/**
+ * The complete state object returned by `useMainPageState`.
+ * Provides all state values and callbacks needed by the generic page
+ * and by page-specific components (tables, modals, etc.).
+ */
+export interface MainPageState<T> {
+  // -- API --
+  /** Current API version string from Redux store */
+  apiVersion: string;
+  /** Redux dispatch function */
+  dispatch: ReturnType<typeof useAppDispatch>;
+
+  // -- List data --
+  /** Current list of elements displayed in the table */
+  elementsList: T[];
+  /** Setter for the elements list */
+  setElementsList: React.Dispatch<React.SetStateAction<T[]>>;
+  /** Total count of elements matching the current query */
+  totalCount: number;
+  /** Setter for the total count */
+  setTotalCount: React.Dispatch<React.SetStateAction<number>>;
+  /** Whether the table rows should be visible */
+  showTableRows: boolean;
+  /** Setter for showTableRows */
+  setShowTableRows: React.Dispatch<React.SetStateAction<boolean>>;
+
+  // -- Pagination --
+  /** Current page number (1-based) */
+  page: number;
+  /** Setter for page */
+  setPage: (page: number) => void;
+  /** Number of items per page */
+  perPage: number;
+  /** Setter for perPage */
+  setPerPage: (perPage: number) => void;
+  /** Index of first item on current page */
+  firstIdx: number;
+  /** Index of last item on current page */
+  lastIdx: number;
+
+  // -- Search --
+  /** Current search input value */
+  searchValue: string;
+  /** Setter for search value */
+  setSearchValue: (value: string) => void;
+  /** Whether the search input is disabled (e.g., during a search request) */
+  searchDisabled: boolean;
+  /** Submit the current search value using the search mutation */
+  submitSearchValue: () => void;
+
+  // -- Selection --
+  /** Currently selected elements */
+  selectedElements: T[];
+  /** Filtered list of selectable elements from the current page */
+  selectableElements: T[];
+  /** Toggle selection of a single element */
+  setElementSelected: (element: T, isSelecting?: boolean) => void;
+  /** Update selection for multiple elements at once */
+  updateSelectedElements: (elements: T[], isSelected: boolean) => void;
+  /** Clear all selected elements */
+  clearSelectedElements: () => void;
+
+  // -- Button states --
+  /** Whether the delete button is disabled */
+  isDeleteButtonDisabled: boolean;
+  /** Update the delete button disabled state */
+  updateIsDeleteButtonDisabled: (value: boolean) => void;
+  /** Whether a deletion operation just occurred */
+  isDeletion: boolean;
+  /** Update the isDeletion state */
+  updateIsDeletion: (value: boolean) => void;
+
+  // -- Per-page selection tracking --
+  /** Number of elements selected on the current page */
+  selectedPerPage: number;
+  /** Update the per-page selection count */
+  updateSelectedPerPage: (selected: number) => void;
+
+  // -- Actions --
+  /** Refresh handler: hides table, clears selection, triggers refetch */
+  refreshData: (refetchFn: () => void) => void;
+
+  // -- Contextual help panel --
+  /** Whether the contextual help panel is expanded */
+  isContextualPanelExpanded: boolean;
+  /** Toggle the contextual help panel open/closed */
+  toggleContextualPanel: () => void;
+  /** Close the contextual help panel */
+  closeContextualPanel: () => void;
+
+  // -- Errors --
+  /** Global error handler for API responses */
+  globalErrors: ReturnType<typeof useApiError>;
+  /** Modal error handler */
+  modalErrors: ReturnType<typeof useApiError>;
+
+  // -- Pre-built data wrappers (for child components) --
+
+  /** Pre-built pagination data object for PaginationLayout */
+  paginationData: {
+    page: number;
+    perPage: number;
+    updatePage: (newPage: number) => void;
+    updatePerPage: (newSetPerPage: number) => void;
+    updateSelectedPerPage: (selected: number) => void;
+    updateShownElementsList: (newShownElementsList: T[]) => void;
+    totalCount: number;
+  };
+
+  /** Pre-built search value data object for SearchInputLayout */
+  searchValueData: {
+    searchValue: string;
+    updateSearchValue: (value: string) => void;
+    submitSearchValue: () => void;
+  };
+
+  /** Pre-built bulk selector data object for BulkSelectorPrep */
+  bulkSelectorData: {
+    selected: T[];
+    updateSelected: (elements: T[], isSelected: boolean) => void;
+    selectableTable: T[];
+    nameAttr: string;
+  };
+
+  /** Pre-built selected per page data object */
+  selectedPerPageData: {
+    selectedPerPage: number;
+    updateSelectedPerPage: (selected: number) => void;
+  };
+
+  /** Pre-built buttons data (for BulkSelectorPrep) */
+  buttonsData: {
+    updateIsDeleteButtonDisabled: (value: boolean) => void;
+  };
+
+  /** Pre-built delete buttons data (for delete modals) */
+  deleteButtonsData: {
+    updateIsDeleteButtonDisabled: (value: boolean) => void;
+    updateIsDeletion: (value: boolean) => void;
+  };
+
+  // -- Configuration --
+  /** Original configuration passed to the hook */
+  config: MainPageConfig<T>;
+}
+
+// ============================================================================
+// Custom Hook: useMainPageState
+// ============================================================================
+
+/**
+ * Custom hook that encapsulates all common state management logic
+ * shared across main page components.
+ *
+ * This hook manages:
+ * - Page routing and browser title
+ * - API version from Redux store
+ * - Pagination state (page, perPage, indexes)
+ * - Search state and submit logic
+ * - Element list and total count
+ * - Selection state and logic
+ * - Button states (delete, deletion tracking)
+ * - Error handling
+ * - Pre-built data wrapper objects for child components
+ *
+ * @param config - Configuration specific to each page
+ * @returns Complete state object with values and callbacks
+ */
+export function useMainPageState<T>(
+  config: MainPageConfig<T>
+): MainPageState<T> {
+  const dispatch = useAppDispatch();
+
+  // Stabilize config callbacks with refs to avoid unnecessary re-renders.
+  // This prevents `useMemo`/`useCallback` invalidation when the consumer
+  // passes an inline config object (new reference every render).
+  const getKeyValueRef = useRef(config.getKeyValue);
+  getKeyValueRef.current = config.getKeyValue;
+
+  const isSelectableRef = useRef(config.isSelectable);
+  isSelectableRef.current = config.isSelectable;
+
+  const nameAttrRef = useRef(config.nameAttr);
+  nameAttrRef.current = config.nameAttr;
+
+  // Route (useUpdateRoute already sets document.title internally)
+  useUpdateRoute({ pathname: config.pathname });
+
+  // API version
+  const apiVersion = useAppSelector(
+    (state) => state.global.environment.api_version
+  ) as string;
+
+  // URL parameters
+  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+    useListPageSearchParams();
+
+  // Error handling
+  const globalErrors = useApiError([]);
+  const modalErrors = useApiError([]);
+
+  // List data
+  const [elementsList, setElementsList] = useState<T[]>([]);
+  const [totalCount, setTotalCount] = useState<number>(0);
+  const [showTableRows, setShowTableRows] = useState<boolean>(false);
+
+  // Search
+  const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
+
+  // Selection
+  const [selectedElements, setSelectedElements] = useState<T[]>([]);
+  const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
+
+  // Button states
+  const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
+    useState<boolean>(true);
+  const [isDeletion, setIsDeletion] = useState<boolean>(false);
+
+  // Page indexes
+  const firstIdx = (page - 1) * perPage;
+  const lastIdx = page * perPage;
+
+  // -- Callbacks --
+
+  const updateSelectedPerPage = useCallback(
+    (selected: number) => setSelectedPerPage(selected),
+    []
+  );
+  const updateIsDeleteButtonDisabled = useCallback(
+    (value: boolean) => setIsDeleteButtonDisabled(value),
+    []
+  );
+  const updateIsDeletion = useCallback(
+    (value: boolean) => setIsDeletion(value),
+    []
+  );
+
+  const clearSelectedElements = useCallback(() => {
+    setSelectedElements([]);
+  }, []);
+
+  // Selectable elements (filtered from current list)
+  // Uses ref for `isSelectable` to avoid invalidating on every render
+  const selectableElements = useMemo(
+    () => elementsList.filter((item) => isSelectableRef.current(item)),
+    [elementsList]
+  );
+
+  // Update selection for multiple elements.
+  // Uses functional setState to avoid capturing `selectedElements` in the
+  // closure (which would cause this callback to be recreated on every
+  // selection change). Uses refs for config functions for the same reason.
+  const updateSelectedElements = useCallback(
+    (elements: T[], isSelected: boolean) => {
+      setSelectedElements((prevSelected) => {
+        const getKey = getKeyValueRef.current;
+        let newSelected: T[];
+
+        if (isSelected) {
+          newSelected = structuredClone(prevSelected);
+          for (const elem of elements) {
+            const alreadySelected = prevSelected.some(
+              (sel) => getKey(sel) === getKey(elem)
+            );
+            if (!alreadySelected) {
+              newSelected.push(elem);
+            }
+          }
+        } else {
+          const keysToRemove = new Set(elements.map(getKey));
+          newSelected = prevSelected.filter(
+            (sel) => !keysToRemove.has(getKey(sel))
+          );
+        }
+
+        setIsDeleteButtonDisabled(newSelected.length === 0);
+        return newSelected;
+      });
+    },
+    [] // stable: no external dependencies thanks to refs + functional update
+  );
+
+  // Toggle selection for a single element.
+  // Stable callback: uses ref for `isSelectable`, and `updateSelectedElements`
+  // is itself stable.
+  const setElementSelected = useCallback(
+    (element: T, isSelecting = true) => {
+      if (isSelectableRef.current(element)) {
+        updateSelectedElements([element], isSelecting);
+      }
+    },
+    [updateSelectedElements]
+  );
+
+  // Search mutation
+  const [retrieveEntries] = useSearchEntriesMutation({});
+
+  const submitSearchValue = useCallback(() => {
+    if (!config.searchEntryType) return;
+
+    setShowTableRows(false);
+    setTotalCount(0);
+    setSearchIsDisabled(true);
+
+    retrieveEntries({
+      searchValue: searchValue,
+      sizeLimit: 0,
+      apiVersion: apiVersion || API_VERSION_BACKUP,
+      startIdx: firstIdx,
+      stopIdx: lastIdx,
+      entryType: config.searchEntryType,
+    } as GenericPayload).then((result) => {
+      if ("data" in result) {
+        const searchError = result.data?.error as
+          | FetchBaseQueryError
+          | SerializedError;
+
+        if (searchError) {
+          let error: string | undefined = "";
+          if ("error" in searchError) {
+            error = searchError.error;
+          } else if ("message" in searchError) {
+            error = searchError.message;
+          }
+          dispatch(
+            addAlert({
+              name: "submit-search-value-error",
+              title:
+                error ||
+                `Error when searching for ${config.searchEntryType || "entries"}`,
+              variant: "danger",
+            })
+          );
+        } else {
+          const listResult = result.data?.result.results || [];
+          const listSize = result.data?.result.count || 0;
+          const resultTotalCount = result.data?.result.totalCount || 0;
+          const items: T[] = [];
+
+          for (let i = 0; i < listSize; i++) {
+            items.push(listResult[i].result);
+          }
+
+          setPage(1);
+          setElementsList(items);
+          setTotalCount(resultTotalCount);
+          setShowTableRows(true);
+        }
+        setSearchIsDisabled(false);
+      }
+    });
+  }, [
+    searchValue,
+    apiVersion,
+    firstIdx,
+    lastIdx,
+    config.searchEntryType,
+    dispatch,
+    retrieveEntries,
+    setPage,
+  ]);
+
+  // Refresh — does NOT reset page to 1 (user expects to stay on current page)
+  const refreshData = useCallback(
+    (refetchFn: () => void) => {
+      setShowTableRows(false);
+      setTotalCount(0);
+      clearSelectedElements();
+      refetchFn();
+    },
+    [clearSelectedElements]
+  );
+
+  // Contextual help panel
+  const [isContextualPanelExpanded, setIsContextualPanelExpanded] =
+    useState<boolean>(false);
+
+  const toggleContextualPanel = useCallback(() => {
+    setIsContextualPanelExpanded((prev) => !prev);
+  }, []);
+
+  const closeContextualPanel = useCallback(() => {
+    setIsContextualPanelExpanded(false);
+  }, []);
+
+  // -- Pre-built data wrapper objects --
+  // These provide the exact shapes expected by child components
+  // (PaginationLayout, SearchInputLayout, BulkSelectorPrep, etc.)
+
+  const paginationData = useMemo(
+    () => ({
+      page,
+      perPage,
+      updatePage: setPage,
+      updatePerPage: setPerPage,
+      updateSelectedPerPage,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      updateShownElementsList: setElementsList as (list: any[]) => void,
+      totalCount,
+    }),
+    [page, perPage, setPage, setPerPage, updateSelectedPerPage, totalCount]
+  );
+
+  const searchValueData = useMemo(
+    () => ({
+      searchValue,
+      updateSearchValue: setSearchValue,
+      submitSearchValue,
+    }),
+    [searchValue, setSearchValue, submitSearchValue]
+  );
+
+  const bulkSelectorData = useMemo(
+    () => ({
+      selected: selectedElements,
+      updateSelected: updateSelectedElements,
+      selectableTable: selectableElements,
+      nameAttr: nameAttrRef.current,
+    }),
+    [selectedElements, updateSelectedElements, selectableElements]
+  );
+
+  const selectedPerPageData = useMemo(
+    () => ({
+      selectedPerPage,
+      updateSelectedPerPage,
+    }),
+    [selectedPerPage, updateSelectedPerPage]
+  );
+
+  const buttonsData = useMemo(
+    () => ({
+      updateIsDeleteButtonDisabled,
+    }),
+    [updateIsDeleteButtonDisabled]
+  );
+
+  const deleteButtonsData = useMemo(
+    () => ({
+      updateIsDeleteButtonDisabled,
+      updateIsDeletion,
+    }),
+    [updateIsDeleteButtonDisabled, updateIsDeletion]
+  );
+
+  return {
+    apiVersion,
+    dispatch,
+    elementsList,
+    setElementsList,
+    totalCount,
+    setTotalCount,
+    showTableRows,
+    setShowTableRows,
+    page,
+    setPage,
+    perPage,
+    setPerPage,
+    firstIdx,
+    lastIdx,
+    searchValue,
+    setSearchValue,
+    searchDisabled,
+    submitSearchValue,
+    selectedElements,
+    selectableElements,
+    setElementSelected,
+    updateSelectedElements,
+    clearSelectedElements,
+    isDeleteButtonDisabled,
+    updateIsDeleteButtonDisabled,
+    isDeletion,
+    updateIsDeletion,
+    selectedPerPage,
+    updateSelectedPerPage,
+    refreshData,
+    isContextualPanelExpanded,
+    toggleContextualPanel,
+    closeContextualPanel,
+    globalErrors,
+    modalErrors,
+    paginationData,
+    searchValueData,
+    bulkSelectorData,
+    selectedPerPageData,
+    buttonsData,
+    deleteButtonsData,
+    config,
+  };
+}
+
+// ============================================================================
+// Helper: useDataResponseEffect
+// ============================================================================
+
+/**
+ * Helper hook that connects an RTK Query response to the GenericMainPage state.
+ * This handles the common pattern of:
+ * - Hiding the table during fetch
+ * - Parsing the batch response on success
+ * - Dispatching an error alert on failure
+ *
+ * @param dataResponse - The RTK Query hook return value
+ * @param state - The MainPageState from useMainPageState
+ * @param onSuccess - Optional callback after successful data load
+ */
+export function useDataResponseEffect<T>(
+  dataResponse: {
+    data?: BatchRPCResponse;
+    isLoading: boolean;
+    isFetching: boolean;
+    isSuccess: boolean;
+    isError: boolean;
+    error?: unknown;
+    refetch: () => void;
+  },
+  state: MainPageState<T>,
+  onSuccess?: (items: T[]) => void
+) {
+  // Stabilize the onSuccess callback with a ref so it doesn't
+  // need to be in the dependency array
+  const onSuccessRef = useRef(onSuccess);
+  onSuccessRef.current = onSuccess;
+
+  // Destructure primitive/stable values for use as dependencies
+  const {
+    data: batchResponse,
+    isLoading,
+    isFetching,
+    isSuccess,
+    isError,
+    error,
+  } = dataResponse;
+
+  // Process API response — dependencies are primitive values (booleans),
+  // plus `batchResponse` which is reference-stable from RTK Query when unchanged.
+  useEffect(() => {
+    if (isFetching) {
+      state.setShowTableRows(false);
+      state.setTotalCount(0);
+      state.globalErrors.clear();
+      return;
+    }
+
+    // Success
+    if (isSuccess && batchResponse !== undefined) {
+      // BatchRPCResponse.result.results is typed as a single object but is
+      // actually an array at runtime. Cast to the expected shape.
+      const listResult = batchResponse.result.results as unknown as {
+        result: T;
+      }[];
+      const resultTotalCount = batchResponse.result.totalCount;
+      const listSize = batchResponse.result.count;
+      const items: T[] = [];
+
+      for (let i = 0; i < listSize; i++) {
+        items.push(listResult[i].result);
+      }
+
+      state.setElementsList(items);
+      state.setTotalCount(resultTotalCount);
+      state.setShowTableRows(true);
+
+      onSuccessRef.current?.(items);
+    }
+
+    // Error — dispatch an alert instead of forcing a full page reload,
+    // which would bypass React error boundaries and lose client-side state.
+    if (!isLoading && isError && error !== undefined) {
+      state.dispatch(
+        addAlert({
+          name: "batch-query-error",
+          title: "An error occurred while loading data. Please try refreshing.",
+          variant: "danger",
+        })
+      );
+    }
+  }, [isFetching, isSuccess, isError, batchResponse]);
+
+  // Sync showTableRows with loading state
+  useEffect(() => {
+    state.setShowTableRows(!isLoading);
+  }, [isLoading]);
+}
+
+// ============================================================================
+// Component: GenericMainPage
+// ============================================================================
+
+/**
+ * Props for the GenericMainPage layout component.
+ *
+ * Most props are optional and derived from `state.config` by default.
+ * Only `state`, `pageTitle`, `onRefresh`, and `renderTable` are required.
+ *
+ * Feature buttons (Add, Delete) are shown automatically when their
+ * click handlers are provided — no separate boolean flag needed.
+ */
+export interface GenericMainPageProps<T> {
+  // ---- Required ----
+
+  /** The state object from `useMainPageState` */
+  state: MainPageState<T>;
+
+  /** Page title displayed at the top of the page */
+  pageTitle: string;
+
+  /** Handler for the Refresh button click */
+  onRefresh: () => void;
+
+  /**
+   * Render function for the table component.
+   * The function receives the current page state.
+   */
+  renderTable: (state: MainPageState<T>) => React.ReactNode;
+
+  // ---- Feature toggles (presence-based) ----
+
+  /**
+   * Handler for the Add button click.
+   * If provided, the Add button is shown; if omitted, it is hidden.
+   */
+  onAddClick?: () => void;
+
+  /**
+   * Handler for the Delete button click.
+   * If provided, the Delete button is shown; if omitted, it is hidden.
+   */
+  onDeleteClick?: () => void;
+
+  /**
+   * The `fromPage` identifier for the ContextualHelpPanel.
+   * If provided, the contextual help panel is enabled.
+   * If omitted, no help panel is rendered.
+   */
+  contextualPanelPage?: string;
+
+  // ---- Optional ----
+
+  /** Error from the batch data query (to show GlobalErrors) */
+  batchError?: unknown;
+
+  /**
+   * Additional toolbar items to insert after the standard buttons.
+   * Useful for Enable/Disable buttons, Kebab menus, etc.
+   */
+  extraToolbarItems?: ToolbarItem[];
+
+  /**
+   * Whether the Add button should be disabled due to an error.
+   * @default false
+   */
+  isAddDisabledDueError?: boolean;
+
+  /**
+   * Whether to show the bulk selector.
+   * @default true
+   */
+  hasBulkSelector?: boolean;
+
+  /**
+   * Children to render after the page sections (modals, etc.)
+   */
+  children?: React.ReactNode;
+
+  // ---- Overrides (derived by default, pass only to customize) ----
+
+  /**
+   * Override the page title ID.
+   * @default derived from `pageTitle` as `${pageTitle.toLowerCase()} title`
+   */
+  pageTitleId?: string;
+
+  /**
+   * Override the data-cy prefix for toolbar elements.
+   * @default `state.config.pathname`
+   */
+  dataCyPrefix?: string;
+
+  /**
+   * Override the aria label for the search input.
+   * @default `"Search " + pageTitle.toLowerCase()`
+   */
+  searchAriaLabel?: string;
+
+  /**
+   * Override the data-cy value for the modal errors component.
+   * @default `${dataCyPrefix}-modal-error`
+   */
+  modalErrorsDataCy?: string;
+}
+
+/**
+ * GenericMainPage - Layout component for main list pages.
+ *
+ * Provides the common UI structure shared by all main pages:
+ * - Page title section
+ * - Toolbar with BulkSelector, Search, Refresh, Delete, Add, Help, Pagination
+ * - Table area with error handling
+ * - Bottom pagination
+ * - Modal error display
+ *
+ * Page-specific elements (table, modals, extra buttons) are provided via
+ * render props and children.
+ *
+ * @typeParam T - The data type for the page's list items
+ */
+const EMPTY_TOOLBAR_ITEMS: ToolbarItem[] = [];
+
+export function GenericMainPage<T>(props: GenericMainPageProps<T>) {
+  const {
+    state,
+    pageTitle,
+    onRefresh,
+    renderTable,
+    onAddClick,
+    onDeleteClick,
+    contextualPanelPage,
+    batchError,
+    extraToolbarItems = EMPTY_TOOLBAR_ITEMS,
+    isAddDisabledDueError = false,
+    hasBulkSelector = true,
+    children,
+  } = props;
+
+  // Derive defaults from state.config and pageTitle
+  const dataCyPrefix = props.dataCyPrefix ?? state.config.pathname;
+  const pageTitleId = props.pageTitleId ?? pageTitle.toLowerCase() + " title";
+  const searchAriaLabel =
+    props.searchAriaLabel ?? "Search " + pageTitle.toLowerCase();
+  const modalErrorsDataCy =
+    props.modalErrorsDataCy ?? dataCyPrefix + "-modal-error";
+
+  // Feature flags derived from handler presence
+  const hasContextualPanel = !!contextualPanelPage;
+
+  // Build toolbar items — uses stable string keys instead of a mutable counter
+  // to prevent unnecessary unmount/remount when items are conditionally shown.
+  const toolbarItems = useMemo(() => {
+    const items: ToolbarItem[] = [];
+
+    // 1. Bulk Selector
+    if (hasBulkSelector) {
+      items.push({
+        key: "bulk-selector",
+        element: (
+          <BulkSelectorPrep
+            list={state.elementsList}
+            shownElementsList={state.elementsList}
+            elementData={state.bulkSelectorData}
+            buttonsData={state.buttonsData}
+            selectedPerPageData={state.selectedPerPageData}
+          />
+        ),
+      });
+    }
+
+    // 2. Search Input
+    items.push({
+      key: "search",
+      element: (
+        <SearchInputLayout
+          dataCy="search"
+          name="search"
+          ariaLabel={searchAriaLabel}
+          placeholder="Search"
+          searchValueData={state.searchValueData}
+          isDisabled={state.searchDisabled}
+        />
+      ),
+      toolbarItemVariant: ToolbarItemVariant.label,
+      toolbarItemGap: { default: "gapMd" },
+    });
+
+    // 3. Separator
+    items.push({
+      key: "separator-1",
+      toolbarItemVariant: ToolbarItemVariant.separator,
+    });
+
+    // 4. Refresh button
+    items.push({
+      key: "refresh",
+      element: (
+        <SecondaryButton
+          dataCy={`${dataCyPrefix}-button-refresh`}
+          onClickHandler={onRefresh}
+          isDisabled={!state.showTableRows}
+        >
+          Refresh
+        </SecondaryButton>
+      ),
+    });
+
+    // 5. Delete button (shown when onDeleteClick handler is provided)
+    if (onDeleteClick) {
+      items.push({
+        key: "delete",
+        element: (
+          <SecondaryButton
+            dataCy={`${dataCyPrefix}-button-delete`}
+            isDisabled={state.isDeleteButtonDisabled || !state.showTableRows}
+            onClickHandler={onDeleteClick}
+          >
+            Delete
+          </SecondaryButton>
+        ),
+      });
+    }
+
+    // 6. Add button (shown when onAddClick handler is provided)
+    if (onAddClick) {
+      items.push({
+        key: "add",
+        element: (
+          <SecondaryButton
+            dataCy={`${dataCyPrefix}-button-add`}
+            onClickHandler={onAddClick}
+            isDisabled={!state.showTableRows || isAddDisabledDueError}
+          >
+            Add
+          </SecondaryButton>
+        ),
+      });
+    }
+
+    // 7. Extra toolbar items (Enable/Disable, Kebab, Separator, Help,
+    //    Pagination, etc.) — provided by each page via extraToolbarItems
+    for (let i = 0; i < extraToolbarItems.length; i++) {
+      items.push({
+        ...extraToolbarItems[i],
+        key: extraToolbarItems[i].key ?? `extra-${i}`,
+      });
+    }
+
+    return items;
+  }, [
+    hasBulkSelector,
+    searchAriaLabel,
+    dataCyPrefix,
+    isAddDisabledDueError,
+    onRefresh,
+    onDeleteClick,
+    onAddClick,
+    extraToolbarItems,
+    state.elementsList,
+    state.bulkSelectorData,
+    state.buttonsData,
+    state.selectedPerPageData,
+    state.searchValueData,
+    state.searchDisabled,
+    state.showTableRows,
+    state.isDeleteButtonDisabled,
+  ]);
+
+  // Page content
+  const pageContent = (
+    <div>
+      <PageSection hasBodyWrapper={false}>
+        <TitleLayout id={pageTitleId} headingLevel="h1" text={pageTitle} />
+      </PageSection>
+      <PageSection hasBodyWrapper={false} isFilled={false}>
+        <Flex direction={{ default: "column" }}>
+          <FlexItem>
+            <ToolbarLayout toolbarItems={toolbarItems} />
+          </FlexItem>
+          <FlexItem style={{ flex: "0 0 auto" }}>
+            <OuterScrollContainer>
+              <InnerScrollContainer
+                style={{ height: "60vh", overflow: "auto" }}
+              >
+                {batchError !== undefined && batchError ? (
+                  <GlobalErrors errors={state.globalErrors.getAll()} />
+                ) : (
+                  renderTable(state)
+                )}
+              </InnerScrollContainer>
+            </OuterScrollContainer>
+          </FlexItem>
+          <FlexItem style={{ flex: "0 0 auto", position: "sticky", bottom: 0 }}>
+            <PaginationLayout
+              list={state.elementsList}
+              paginationData={state.paginationData}
+              variant={PaginationVariant.bottom}
+              widgetId="pagination-options-menu-bottom"
+            />
+          </FlexItem>
+        </Flex>
+      </PageSection>
+      <ModalErrors
+        errors={state.modalErrors.getAll()}
+        dataCy={modalErrorsDataCy}
+      />
+      {children}
+    </div>
+  );
+
+  // Wrap with contextual panel if enabled
+  if (hasContextualPanel && contextualPanelPage) {
+    return (
+      <ContextualHelpPanel
+        fromPage={contextualPanelPage}
+        isExpanded={state.isContextualPanelExpanded}
+        onClose={state.closeContextualPanel}
+      >
+        {pageContent}
+      </ContextualHelpPanel>
+    );
+  }
+
+  return pageContent;
+}
+
+export default GenericMainPage;

--- a/src/components/layouts/ToolbarLayout/ToolbarLayout.tsx
+++ b/src/components/layouts/ToolbarLayout/ToolbarLayout.tsx
@@ -12,7 +12,7 @@ type ToolbarItemGap = ToolbarItemProps["gap"];
 type ToolbarItemAlignment = ToolbarItemProps["align"];
 
 export interface ToolbarItem {
-  key: number;
+  key: number | string;
   id?: string;
   element?: JSX.Element;
   toolbarItemVariant?: ToolbarItemVariant;

--- a/src/pages/ActiveUsers/ActiveUsers.tsx
+++ b/src/pages/ActiveUsers/ActiveUsers.tsx
@@ -1,52 +1,32 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 // PatternFly
 import {
-  PageSection,
-  PaginationVariant,
   Button,
   DropdownItem,
-  ToolbarItemVariant,
-  PageSectionVariants,
-  FlexItem,
-  Flex,
   Content,
+  ToolbarItemVariant,
 } from "@patternfly/react-core";
-// PatternFly table
-import {
-  InnerScrollContainer,
-  OuterScrollContainer,
-} from "@patternfly/react-table";
 // Data types
 import { User } from "src/utils/datatypes/globalDataTypes";
 import { ToolbarItem } from "src/components/layouts/ToolbarLayout";
-// Redux
-import { useAppSelector, useAppDispatch } from "src/store/hooks";
 // Layouts
-import TitleLayout from "src/components/layouts/TitleLayout";
-import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
-import KebabLayout from "src/components/layouts/KebabLayout";
 import SecondaryButton from "src/components/layouts/SecondaryButton";
-import ToolbarLayout from "src/components/layouts/ToolbarLayout";
-import SearchInputLayout from "src/components/layouts/SearchInputLayout";
+import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
+import KebabLayout from "src/components/layouts/KebabLayout";
 import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
 // Tables
 import UsersTable from "../../components/tables/UsersTable";
-// Components
-import PaginationLayout from "../../components/layouts/PaginationLayout";
-import BulkSelectorPrep from "src/components/BulkSelectorPrep";
-import ContextualHelpPanel from "src/components/ContextualHelpPanel/ContextualHelpPanel";
 // Modals
 import AddUser from "src/components/modals/UserModals/AddUser";
 import DeleteUsers from "src/components/modals/UserModals/DeleteUsers";
 import DisableEnableUsers from "src/components/modals/UserModals/DisableEnableUsers";
 // Hooks
 import { addAlert } from "src/store/Global/alerts-slice";
-import useUpdateRoute from "src/hooks/useUpdateRoute";
-import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 // Utils
 import { API_VERSION_BACKUP, isUserSelectable } from "src/utils/utils";
-// RPC client
-import { GenericPayload, useSearchEntriesMutation } from "src/services/rpc";
+// RPC
+import { GenericPayload } from "src/services/rpc";
 import {
   useGettingActiveUserQuery,
   useAutoMemberRebuildUsersMutation,
@@ -54,117 +34,34 @@ import {
 // Errors
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import { SerializedError } from "@reduxjs/toolkit";
-import useApiError from "src/hooks/useApiError";
-import GlobalErrors from "src/components/errors/GlobalErrors";
-import ModalErrors from "src/components/errors/ModalErrors";
+// Generic main page
+import {
+  useMainPageState,
+  useDataResponseEffect,
+  GenericMainPage,
+} from "src/components/GenericMainPage";
 
 const ActiveUsers = () => {
-  const dispatch = useAppDispatch();
+  // Common state via generic hook
+  const state = useMainPageState<User>({
+    pathname: "active-users",
+    searchEntryType: "user",
+    nameAttr: "uid",
+    getKeyValue: (user) => user.uid[0],
+    isSelectable: isUserSelectable,
+  });
 
-  // Update current route data to Redux and highlight the current page in the Nav bar
-  const { browserTitle } = useUpdateRoute({ pathname: "active-users" });
-
-  // Set the page title to be shown in the browser tab
-  React.useEffect(() => {
-    document.title = browserTitle;
-  }, [browserTitle]);
-
-  // Retrieve API version from environment data
-  const apiVersion = useAppSelector(
-    (state) => state.global.environment.api_version
-  ) as string;
-
-  const [activeUsersList, setActiveUsersList] = useState<User[]>([]);
-
-  // Define 'executeCommand' to execute simple commands (via Mutation)
   const [executeAutoMemberRebuild] = useAutoMemberRebuildUsersMutation();
 
-  // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
-    useListPageSearchParams();
-
-  // Handle API calls errors
-  const globalErrors = useApiError([]);
-  const modalErrors = useApiError([]);
-
-  // Main states - what user can define / what we could use in page URL
-  const [totalCount, setUsersTotalCount] = useState<number>(0);
-  const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
-
-  // Page indexes
-  const firstUserIdx = (page - 1) * perPage;
-  const lastUserIdx = page * perPage;
-
-  // Derived states - what we get from API
   const userDataResponse = useGettingActiveUserQuery({
-    searchValue: searchValue,
+    searchValue: state.searchValue,
     sizeLimit: 0,
-    apiVersion: apiVersion || API_VERSION_BACKUP,
-    startIdx: firstUserIdx,
-    stopIdx: lastUserIdx,
+    apiVersion: state.apiVersion || API_VERSION_BACKUP,
+    startIdx: state.firstIdx,
+    stopIdx: state.lastIdx,
   } as GenericPayload);
 
-  const {
-    data: batchResponse,
-    isLoading: isBatchLoading,
-    error: batchError,
-  } = userDataResponse;
-
-  // Handle data when the API call is finished
-  useEffect(() => {
-    if (userDataResponse.isFetching) {
-      setShowTableRows(false);
-      // Reset selected users on refresh
-      setUsersTotalCount(0);
-      globalErrors.clear();
-      return;
-    }
-
-    // API response: Success
-    if (
-      userDataResponse.isSuccess &&
-      userDataResponse.data &&
-      batchResponse !== undefined
-    ) {
-      const usersListResult = batchResponse.result.results;
-      const totalCount = batchResponse.result.totalCount;
-      const usersListSize = batchResponse.result.count;
-      const usersList: User[] = [];
-
-      for (let i = 0; i < usersListSize; i++) {
-        usersList.push(usersListResult[i].result);
-      }
-
-      setUsersTotalCount(totalCount);
-      // Update the list of users
-      setActiveUsersList(usersList);
-      // Show table elements
-      setShowTableRows(true);
-    }
-
-    // API response: Error
-    if (
-      !userDataResponse.isLoading &&
-      userDataResponse.isError &&
-      userDataResponse.error !== undefined
-    ) {
-      // This normally happens when the user is not authorized to view the data
-      // So instead of adding an error, refresh page
-      window.location.reload();
-    }
-  }, [userDataResponse]);
-
-  // Refresh button handling
-  const refreshUsersData = () => {
-    // Hide table
-    setShowTableRows(false);
-
-    // Reset selected users on refresh
-    setUsersTotalCount(0);
-    clearSelectedUsers();
-
-    userDataResponse.refetch();
-  };
+  useDataResponseEffect(userDataResponse, state);
 
   // Always refetch data when the component is loaded.
   // This ensures the data is always up-to-date.
@@ -172,22 +69,9 @@ const ActiveUsers = () => {
     userDataResponse.refetch();
   }, []);
 
-  // 'Delete' button state
-  const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
-    useState<boolean>(true);
+  const refreshData = () => state.refreshData(() => userDataResponse.refetch());
 
-  const updateIsDeleteButtonDisabled = (value: boolean) => {
-    setIsDeleteButtonDisabled(value);
-  };
-
-  // If some entries have been deleted, restore the selectedUsers list
-  const [isDeletion, setIsDeletion] = useState(false);
-
-  const updateIsDeletion = (value: boolean) => {
-    setIsDeletion(value);
-  };
-
-  // 'Enable' button state
+  // Page-specific states
   const [isEnableButtonDisabled, setIsEnableButtonDisabled] =
     useState<boolean>(true);
 
@@ -195,7 +79,6 @@ const ActiveUsers = () => {
     setIsEnableButtonDisabled(value);
   };
 
-  // 'Disable' button state
   const [isDisableButtonDisabled, setIsDisableButtonDisabled] =
     useState<boolean>(true);
 
@@ -210,114 +93,61 @@ const ActiveUsers = () => {
     setIsDisableEnableOp(value);
   };
 
-  // Elements selected (per page)
-  //  - This will help to calculate the remaining elements on a specific page (bulk selector)
-  const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
+  // Modals functionality
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [showEnableDisableModal, setShowEnableDisableModal] = useState(false);
+  const [enableDisableOptionSelected, setEnableDisableOptionSelected] =
+    useState(false);
 
-  const updateSelectedPerPage = (selected: number) => {
-    setSelectedPerPage(selected);
+  const onAddClickHandler = () => {
+    setShowAddModal(true);
   };
 
-  // Pagination
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
+  const onCloseAddModal = () => {
+    setShowAddModal(false);
   };
 
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
+  const onAddModalToggle = () => {
+    setShowAddModal(!showAddModal);
   };
 
-  // Users displayed on the first page
-  const updateShownUsersList = (newShownUsersList: User[]) => {
-    setActiveUsersList(newShownUsersList);
+  const onDeleteHandler = () => {
+    setShowDeleteModal(true);
   };
 
-  // Update search input valie
-  const updateSearchValue = (value: string) => {
-    setSearchValue(value);
+  const onOpenDeleteModal = () => {
+    setShowDeleteModal(true);
   };
 
-  const [selectedUsers, setSelectedUsers] = useState<User[]>([]);
-
-  const clearSelectedUsers = () => {
-    const emptyList: User[] = [];
-    setSelectedUsers(emptyList);
+  const onCloseDeleteModal = () => {
+    setShowDeleteModal(false);
   };
 
-  const [retrieveUser] = useSearchEntriesMutation({});
-
-  // Issue a search using a specific search value
-  const submitSearchValue = () => {
-    setShowTableRows(false);
-    setSearchIsDisabled(true);
-    setUsersTotalCount(0);
-
-    // Make search via API call
-    retrieveUser({
-      searchValue: searchValue,
-      sizeLimit: 0,
-      apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: firstUserIdx,
-      stopIdx: lastUserIdx,
-      entryType: "user",
-    } as GenericPayload).then((result) => {
-      // Manage new response here
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for users",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success
-          const usersListResult = result.data?.result.results || [];
-          const usersListSize = result.data?.result.count || 0;
-          const totalCount = result.data?.result.totalCount || 0;
-          const usersList: User[] = [];
-
-          for (let i = 0; i < usersListSize; i++) {
-            usersList.push(usersListResult[i].result);
-          }
-
-          setUsersTotalCount(totalCount);
-          setActiveUsersList(usersList);
-          // Show table elements
-          setShowTableRows(true);
-        }
-        setSearchIsDisabled(false);
-      }
-    });
+  const onDeleteModalToggle = () => {
+    setShowDeleteModal(!showDeleteModal);
   };
 
-  // Show table rows
-  const [showTableRows, setShowTableRows] = useState(!isBatchLoading);
+  const onEnableDisableHandler = (optionClicked: boolean) => {
+    state.updateIsDeleteButtonDisabled(true);
+    setIsEnableButtonDisabled(true);
+    setIsDisableButtonDisabled(true);
+    setEnableDisableOptionSelected(optionClicked);
+    setShowEnableDisableModal(true);
+  };
 
-  // Show table rows only when data is fully retrieved
-  useEffect(() => {
-    if (showTableRows !== !isBatchLoading) {
-      setShowTableRows(!isBatchLoading);
-    }
-  }, [isBatchLoading]);
+  const onEnableDisableModalToggle = () => {
+    setIsEnableButtonDisabled(true);
+    setIsDisableButtonDisabled(true);
+    setShowEnableDisableModal(!showEnableDisableModal);
+  };
 
-  // [API call] 'Rebuild auto membership'
+  const [isMembershipModalOpen, setIsMembershipModalOpen] = useState(false);
+
   const onRebuildAutoMembership = () => {
     // Task can potentially run for a very long time, give feed back that we
     // at least started the task
-    dispatch(
+    state.dispatch(
       addAlert({
         name: "rebuild-automember-start",
         title:
@@ -327,7 +157,7 @@ const ActiveUsers = () => {
     );
 
     // Prepare payload
-    const userList = selectedUsers.map((user) => user.uid[0]);
+    const userList = state.selectedElements.map((user) => user.uid[0]);
 
     executeAutoMemberRebuild(userList).then((result) => {
       if ("data" in result) {
@@ -344,7 +174,7 @@ const ActiveUsers = () => {
             error = automemberError.message;
           }
 
-          dispatch(
+          state.dispatch(
             addAlert({
               name: "rebuild-automember-error",
               title: error || "Error when rebuilding membership",
@@ -353,7 +183,7 @@ const ActiveUsers = () => {
           );
         } else {
           // alert: success
-          dispatch(
+          state.dispatch(
             addAlert({
               name: "rebuild-automember-success",
               title: "Automember rebuild membership task completed",
@@ -368,8 +198,6 @@ const ActiveUsers = () => {
   };
 
   // 'Rebuild auto membership' modal
-  const [isMembershipModalOpen, setIsMembershipModalOpen] = useState(false);
-
   const membershipModalActions: JSX.Element[] = [
     <Button
       data-cy="modal-button-ok"
@@ -426,270 +254,49 @@ const ActiveUsers = () => {
 
   const onDropdownSelect = (
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    event?: React.MouseEvent<Element, MouseEvent> | undefined
+    _event?: React.MouseEvent<Element, MouseEvent> | undefined
   ) => {
     setKebabIsOpen(!kebabIsOpen);
   };
 
-  // Modals functionality
-  const [showAddModal, setShowAddModal] = useState(false);
-  const [showDeleteModal, setShowDeleteModal] = useState(false);
-  const [showEnableDisableModal, setShowEnableDisableModal] = useState(false);
-  const [enableDisableOptionSelected, setEnableDisableOptionSelected] =
-    useState(false);
-  const onAddClickHandler = () => {
-    setShowAddModal(true);
+  // Data wrappers for child components
+  const selectedUsersData = {
+    selectedUsers: state.selectedElements,
+    clearSelectedUsers: state.clearSelectedElements,
   };
 
-  const onCloseAddModal = () => {
-    setShowAddModal(false);
+  const usersTableData = {
+    isUserSelectable,
+    selectedUsers: state.selectedElements,
+    selectableUsersTable: state.selectableElements,
+    setUserSelected: state.setElementSelected,
+    clearSelectedUsers: state.clearSelectedElements,
   };
 
-  const onAddModalToggle = () => {
-    setShowAddModal(!showAddModal);
-  };
-
-  const onDeleteHandler = () => {
-    setShowDeleteModal(true);
-  };
-
-  const onOpenDeleteModal = () => {
-    setShowDeleteModal(true);
-  };
-
-  const onCloseDeleteModal = () => {
-    setShowDeleteModal(false);
-  };
-
-  const onDeleteModalToggle = () => {
-    setShowDeleteModal(!showDeleteModal);
-  };
-
-  const onEnableDisableHandler = (optionClicked: boolean) => {
-    setIsDeleteButtonDisabled(true); // prevents 'Delete' button to be enabled
-    setIsEnableButtonDisabled(true); // prevents 'Enable' button to be enabled
-    setIsDisableButtonDisabled(true); // prevents 'Disable' button to be enabled
-    setEnableDisableOptionSelected(optionClicked);
-    setShowEnableDisableModal(true);
-  };
-
-  const onEnableDisableModalToggle = () => {
-    setIsEnableButtonDisabled(true); // prevents 'Enable' button to be enabled
-    setIsDisableButtonDisabled(true); // prevents 'Disable' button to be enabled
-    setShowEnableDisableModal(!showEnableDisableModal);
-  };
-
-  // Table-related shared functionality
-  // - Selectable checkboxes on table
-  const selectableUsersTable = activeUsersList.filter(isUserSelectable); // elements per Table
-
-  const updateSelectedUsers = (users: User[], isSelected: boolean) => {
-    let newSelectedUsers: User[] = [];
-    if (isSelected) {
-      newSelectedUsers = JSON.parse(JSON.stringify(selectedUsers));
-      for (let i = 0; i < users.length; i++) {
-        if (
-          selectedUsers.find(
-            (selectedUser) => selectedUser.uid[0] === users[i].uid[0]
-          )
-        ) {
-          // Already in the list
-          continue;
-        }
-        // Add user to list
-        newSelectedUsers.push(users[i]);
-      }
-    } else {
-      // Remove user
-      for (let i = 0; i < selectedUsers.length; i++) {
-        let found = false;
-        for (let ii = 0; ii < users.length; ii++) {
-          if (selectedUsers[i].uid[0] === users[ii].uid[0]) {
-            found = true;
-            break;
-          }
-        }
-        if (!found) {
-          // Keep this valid selected entry
-          newSelectedUsers.push(selectedUsers[i]);
-        }
-      }
-    }
-    setSelectedUsers(newSelectedUsers);
-    setIsDeleteButtonDisabled(newSelectedUsers.length === 0);
-  };
-
-  // - Helper method to set the selected users from the table
-  const setUserSelected = (user: User, isSelecting = true) => {
-    if (isUserSelectable(user)) {
-      updateSelectedUsers([user], isSelecting);
-    }
-  };
-
-  // Data wrappers
-  // TODO: Better separation of concerts
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList: updateShownUsersList,
-    totalCount,
-  };
-
-  // - 'BulkSelectorUsersPrep'
-  const usersBulkSelectorData = {
-    selected: selectedUsers,
-    updateSelected: updateSelectedUsers,
-    selectableTable: selectableUsersTable,
-    nameAttr: "uid",
-  };
-
-  const buttonsData = {
-    updateIsDeleteButtonDisabled,
+  const usersTableButtonsData = {
+    updateIsDeleteButtonDisabled: state.updateIsDeleteButtonDisabled,
     updateIsEnableButtonDisabled,
     updateIsDisableButtonDisabled,
+    isDeletion: state.isDeletion,
+    updateIsDeletion: state.updateIsDeletion,
+    isDisableEnableOp,
     updateIsDisableEnableOp,
   };
 
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage,
-  };
-
-  // 'DeleteUsers'
-  const deleteUsersButtonsData = {
-    updateIsDeleteButtonDisabled,
-    updateIsDeletion,
-  };
-
-  const selectedUsersData = {
-    selectedUsers,
-    clearSelectedUsers,
-  };
-
-  // 'DisableEnableUsers'
   const disableEnableButtonsData = {
     updateIsEnableButtonDisabled,
     updateIsDisableButtonDisabled,
     updateIsDisableEnableOp,
   };
 
-  // 'UsersTable'
-  const usersTableData = {
-    isUserSelectable,
-    selectedUsers,
-    selectableUsersTable,
-    setUserSelected,
-    clearSelectedUsers,
-  };
-
-  const usersTableButtonsData = {
-    updateIsDeleteButtonDisabled,
-    updateIsEnableButtonDisabled,
-    updateIsDisableButtonDisabled,
-    isDeletion,
-    updateIsDeletion,
-    isDisableEnableOp,
-    updateIsDisableEnableOp,
-  };
-
-  // SearchInputLayout
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
-  };
-
-  // Contextual links panel
-  const [isContextualPanelExpanded, setIsContextualPanelExpanded] =
-    React.useState(false);
-
-  const onOpenContextualPanel = () => {
-    setIsContextualPanelExpanded(!isContextualPanelExpanded);
-  };
-
-  const onCloseContextualPanel = () => {
-    setIsContextualPanelExpanded(false);
-  };
-
-  // List of Toolbar items
-  const toolbarItems: ToolbarItem[] = [
+  // Toolbar items
+  const extraToolbarItems: ToolbarItem[] = [
     {
-      key: 0,
-      element: (
-        <BulkSelectorPrep
-          list={activeUsersList}
-          shownElementsList={activeUsersList}
-          elementData={usersBulkSelectorData}
-          buttonsData={buttonsData}
-          selectedPerPageData={selectedPerPageData}
-        />
-      ),
-    },
-    {
-      key: 1,
-      element: (
-        <SearchInputLayout
-          dataCy="search"
-          name="search"
-          ariaLabel="Search user"
-          placeholder="Search"
-          searchValueData={searchValueData}
-          isDisabled={searchDisabled}
-        />
-      ),
-      toolbarItemVariant: ToolbarItemVariant.label,
-      toolbarItemGap: { default: "gapMd" },
-    },
-    {
-      key: 2,
-      toolbarItemVariant: ToolbarItemVariant.separator,
-    },
-    {
-      key: 3,
-      element: (
-        <SecondaryButton
-          dataCy="active-users-button-refresh"
-          onClickHandler={refreshUsersData}
-          isDisabled={!showTableRows}
-        >
-          Refresh
-        </SecondaryButton>
-      ),
-    },
-    {
-      key: 4,
-      element: (
-        <SecondaryButton
-          dataCy="active-users-button-delete"
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
-          onClickHandler={onDeleteHandler}
-        >
-          Delete
-        </SecondaryButton>
-      ),
-    },
-    {
-      key: 5,
-      element: (
-        <SecondaryButton
-          dataCy="active-users-button-add"
-          onClickHandler={onAddClickHandler}
-          isDisabled={!showTableRows}
-        >
-          Add
-        </SecondaryButton>
-      ),
-    },
-    {
-      key: 6,
+      key: "disable",
       element: (
         <SecondaryButton
           dataCy="active-users-button-disable"
-          isDisabled={isDisableButtonDisabled || !showTableRows}
+          isDisabled={isDisableButtonDisabled || !state.showTableRows}
           onClickHandler={() => onEnableDisableHandler(true)}
         >
           Disable
@@ -697,11 +304,11 @@ const ActiveUsers = () => {
       ),
     },
     {
-      key: 7,
+      key: "enable",
       element: (
         <SecondaryButton
           dataCy="active-users-button-enable"
-          isDisabled={isEnableButtonDisabled || !showTableRows}
+          isDisabled={isEnableButtonDisabled || !state.showTableRows}
           onClickHandler={() => onEnableDisableHandler(false)}
         >
           Enable
@@ -709,7 +316,7 @@ const ActiveUsers = () => {
       ),
     },
     {
-      key: 8,
+      key: "kebab",
       element: (
         <KebabLayout
           dataCy="active-users-kebab"
@@ -717,30 +324,30 @@ const ActiveUsers = () => {
           onKebabToggle={onKebabToggle}
           idKebab="main-dropdown-kebab"
           isKebabOpen={kebabIsOpen}
-          dropdownItems={showTableRows ? dropdownItems : []}
-          isDisabled={!showTableRows}
+          dropdownItems={state.showTableRows ? dropdownItems : []}
+          isDisabled={!state.showTableRows}
         />
       ),
     },
     {
-      key: 9,
+      key: "separator",
       toolbarItemVariant: ToolbarItemVariant.separator,
     },
     {
-      key: 10,
+      key: "help",
       element: (
         <HelpTextWithIconLayout
           textContent="Help"
-          onClick={onOpenContextualPanel}
+          onClick={state.toggleContextualPanel}
         />
       ),
     },
     {
-      key: 11,
+      key: "pagination-top",
       element: (
         <PaginationLayout
-          list={activeUsersList}
-          paginationData={paginationData}
+          list={state.elementsList}
+          paginationData={state.paginationData}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -749,107 +356,70 @@ const ActiveUsers = () => {
     },
   ];
 
-  // Render 'Active users'
   return (
-    <ContextualHelpPanel
-      fromPage="active-users"
-      isExpanded={isContextualPanelExpanded}
-      onClose={onCloseContextualPanel}
+    <GenericMainPage
+      state={state}
+      pageTitle="Active Users"
+      batchError={userDataResponse.error}
+      onRefresh={refreshData}
+      onAddClick={onAddClickHandler}
+      onDeleteClick={onDeleteHandler}
+      extraToolbarItems={extraToolbarItems}
+      contextualPanelPage="active-users"
+      renderTable={(s) => (
+        <UsersTable
+          shownElementsList={s.elementsList}
+          from="active-users"
+          showTableRows={s.showTableRows}
+          usersData={usersTableData}
+          buttonsData={usersTableButtonsData}
+          paginationData={s.selectedPerPageData}
+          searchValue={s.searchValue}
+        />
+      )}
     >
-      <div>
-        <PageSection
-          hasBodyWrapper={false}
-          variant={PageSectionVariants.default}
-        >
-          <TitleLayout
-            id="active users title"
-            headingLevel="h1"
-            text="Active Users"
-          />
-        </PageSection>
-        <PageSection hasBodyWrapper={false} isFilled={false}>
-          <Flex direction={{ default: "column" }}>
-            <FlexItem>
-              <ToolbarLayout toolbarItems={toolbarItems} />
-            </FlexItem>
-            <FlexItem>
-              <OuterScrollContainer>
-                <InnerScrollContainer>
-                  {batchError !== undefined && batchError ? (
-                    <GlobalErrors errors={globalErrors.getAll()} />
-                  ) : (
-                    <UsersTable
-                      shownElementsList={activeUsersList}
-                      from="active-users"
-                      showTableRows={showTableRows}
-                      usersData={usersTableData}
-                      buttonsData={usersTableButtonsData}
-                      paginationData={selectedPerPageData}
-                      searchValue={searchValue}
-                    />
-                  )}
-                </InnerScrollContainer>
-              </OuterScrollContainer>
-            </FlexItem>
-            <FlexItem
-              style={{ flex: "0 0 auto", position: "sticky", bottom: 0 }}
-            >
-              <PaginationLayout
-                list={activeUsersList}
-                paginationData={paginationData}
-                variant={PaginationVariant.bottom}
-                widgetId="pagination-options-menu-bottom"
-              />
-            </FlexItem>
-          </Flex>
-        </PageSection>
-        <AddUser
-          show={showAddModal}
-          from="active-users"
-          handleModalToggle={onAddModalToggle}
-          onOpenAddModal={onAddClickHandler}
-          onCloseAddModal={onCloseAddModal}
-          onRefresh={refreshUsersData}
+      <AddUser
+        show={showAddModal}
+        from="active-users"
+        handleModalToggle={onAddModalToggle}
+        onOpenAddModal={onAddClickHandler}
+        onCloseAddModal={onCloseAddModal}
+        onRefresh={refreshData}
+      />
+      <DeleteUsers
+        show={showDeleteModal}
+        from="active-users"
+        handleModalToggle={onDeleteModalToggle}
+        selectedUsersData={selectedUsersData}
+        buttonsData={state.deleteButtonsData}
+        onRefresh={refreshData}
+        onCloseDeleteModal={onCloseDeleteModal}
+        onOpenDeleteModal={onOpenDeleteModal}
+      />
+      <DisableEnableUsers
+        show={showEnableDisableModal}
+        from="active-users"
+        handleModalToggle={onEnableDisableModalToggle}
+        optionSelected={enableDisableOptionSelected}
+        selectedUsersData={selectedUsersData}
+        buttonsData={disableEnableButtonsData}
+        onRefresh={refreshData}
+      />
+      {isMembershipModalOpen && (
+        <ModalWithFormLayout
+          dataCy="rebuild-auto-membership-modal"
+          variantType="medium"
+          modalPosition="top"
+          offPosition="76px"
+          title="Confirmation"
+          formId="rebuild-auto-membership-modal"
+          fields={confirmationQuestion}
+          show={isMembershipModalOpen}
+          onClose={() => setIsMembershipModalOpen(!isMembershipModalOpen)}
+          actions={membershipModalActions}
         />
-        <DeleteUsers
-          show={showDeleteModal}
-          from="active-users"
-          handleModalToggle={onDeleteModalToggle}
-          selectedUsersData={selectedUsersData}
-          buttonsData={deleteUsersButtonsData}
-          onRefresh={refreshUsersData}
-          onCloseDeleteModal={onCloseDeleteModal}
-          onOpenDeleteModal={onOpenDeleteModal}
-        />
-        <DisableEnableUsers
-          show={showEnableDisableModal}
-          from="active-users"
-          handleModalToggle={onEnableDisableModalToggle}
-          optionSelected={enableDisableOptionSelected}
-          selectedUsersData={selectedUsersData}
-          buttonsData={disableEnableButtonsData}
-          onRefresh={refreshUsersData}
-        />
-        <ModalErrors
-          errors={modalErrors.getAll()}
-          dataCy="active-users-modal-error"
-        />
-        {isMembershipModalOpen && (
-          <ModalWithFormLayout
-            dataCy="rebuild-auto-membership-modal"
-            variantType="medium"
-            modalPosition="top"
-            offPosition="76px"
-            title="Confirmation"
-            formId="rebuild-auto-membership-modal"
-            fields={confirmationQuestion}
-            show={isMembershipModalOpen}
-            onClose={() => setIsMembershipModalOpen(!isMembershipModalOpen)}
-            actions={membershipModalActions}
-          />
-        )}
-      </div>
-    </ContextualHelpPanel>
+      )}
+    </GenericMainPage>
   );
 };
 

--- a/src/pages/Hosts/Hosts.tsx
+++ b/src/pages/Hosts/Hosts.tsx
@@ -4,187 +4,79 @@ import {
   Button,
   Content,
   DropdownItem,
-  Flex,
-  FlexItem,
-  PageSection,
-  PaginationVariant,
   ToolbarItemVariant,
 } from "@patternfly/react-core";
-import {
-  InnerScrollContainer,
-  OuterScrollContainer,
-} from "@patternfly/react-table";
 // Layouts
-import TitleLayout from "src/components/layouts/TitleLayout";
-import ToolbarLayout, {
-  ToolbarItem,
-} from "src/components/layouts/ToolbarLayout";
-import SearchInputLayout from "src/components/layouts/SearchInputLayout";
-import SecondaryButton from "src/components/layouts/SecondaryButton";
+import { ToolbarItem } from "src/components/layouts/ToolbarLayout";
 import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
 import KebabLayout from "src/components/layouts/KebabLayout";
 import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
-// Components
-import BulkSelectorPrep from "src/components/BulkSelectorPrep";
-import PaginationLayout from "src/components/layouts/PaginationLayout";
-import ContextualHelpPanel from "src/components/ContextualHelpPanel/ContextualHelpPanel";
 // Tables
 import HostsTable from "./HostsTable";
 // Modal
 import AddHost from "src/components/modals/HostModals/AddHost";
 import DeleteHosts from "src/components/modals/HostModals/DeleteHosts";
 // Redux
-import { useAppDispatch, useAppSelector } from "src/store/hooks";
+import { useAppDispatch } from "src/store/hooks";
 // Data types
 import { Host } from "src/utils/datatypes/globalDataTypes";
 // Utils
 import { API_VERSION_BACKUP, isHostSelectable } from "src/utils/utils";
 // Hooks
 import { addAlert } from "src/store/Global/alerts-slice";
-import useUpdateRoute from "src/hooks/useUpdateRoute";
-import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 // Errors
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import { SerializedError } from "@reduxjs/toolkit";
-import useApiError from "src/hooks/useApiError";
-import GlobalErrors from "src/components/errors/GlobalErrors";
-import ModalErrors from "src/components/errors/ModalErrors";
 // RPC client
-import { GenericPayload, useSearchEntriesMutation } from "../../services/rpc";
+import { GenericPayload } from "../../services/rpc";
 import {
   useGettingHostQuery,
   useAutoMemberRebuildHostsMutation,
 } from "../../services/rpcHosts";
+// Generic main page
+import {
+  useMainPageState,
+  useDataResponseEffect,
+  GenericMainPage,
+} from "src/components/GenericMainPage";
 
 const Hosts = () => {
   const dispatch = useAppDispatch();
 
-  // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
-    useListPageSearchParams();
-
-  // Update current route data to Redux and highlight the current page in the Nav bar
-  const { browserTitle } = useUpdateRoute({ pathname: "hosts" });
-
-  // Set the page title to be shown in the browser tab
-  React.useEffect(() => {
-    document.title = browserTitle;
-  }, [browserTitle]);
+  // Common state via generic hook
+  const state = useMainPageState<Host>({
+    pathname: "hosts",
+    searchEntryType: "host",
+    nameAttr: "fqdn",
+    getKeyValue: (host) => host.fqdn[0],
+    isSelectable: isHostSelectable,
+  });
 
   // Define 'executeCommand' to execute simple commands (via Mutation)
   const [executeAutoMemberRebuild] = useAutoMemberRebuildHostsMutation();
 
-  // Retrieve API version from environment data
-  const apiVersion = useAppSelector(
-    (state) => state.global.environment.api_version
-  ) as string;
-
-  // Initialize hosts list (Redux)
-  const [hostsList, setHostsList] = useState<Host[]>([]);
-
-  // Handle API calls errors
-  const globalErrors = useApiError([]);
-  const modalErrors = useApiError([]);
-
-  // Table comps
-  const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
-  const [totalCount, setHostsTotalCount] = useState<number>(0);
-  const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
-
-  const updateSelectedPerPage = (selected: number) => {
-    setSelectedPerPage(selected);
-  };
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
-  };
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
-  };
-
-  // 'Delete' button state
-  const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
-    useState<boolean>(true);
-
-  const updateIsDeleteButtonDisabled = (value: boolean) => {
-    setIsDeleteButtonDisabled(value);
-  };
-
-  // If some entries have been deleted, restore the selectedHosts list
-  const [isDeletion, setIsDeletion] = useState(false);
-
-  const updateIsDeletion = (value: boolean) => {
-    setIsDeletion(value);
-  };
-
-  const updateShownHostsList = (newShownHostsList: Host[]) => {
-    setHostsList(newShownHostsList);
-  };
-
   // Button disabled due to error
   const [isDisabledDueError, setIsDisabledDueError] = useState<boolean>(false);
 
-  // Page indexes
-  const firstHostIdx = (page - 1) * perPage;
-  const lastHostIdx = page * perPage;
-
   // Derived states - what we get from API
   const hostDataResponse = useGettingHostQuery({
-    searchValue: searchValue,
+    searchValue: state.searchValue,
     sizeLimit: 0,
-    apiVersion: apiVersion || API_VERSION_BACKUP,
-    startIdx: firstHostIdx,
-    stopIdx: lastHostIdx,
+    apiVersion: state.apiVersion || API_VERSION_BACKUP,
+    startIdx: state.firstIdx,
+    stopIdx: state.lastIdx,
   } as GenericPayload);
 
-  const {
-    data: batchResponse,
-    isLoading: isBatchLoading,
-    error: batchError,
-  } = hostDataResponse;
+  // Connect query response to state
+  useDataResponseEffect(hostDataResponse, state);
 
-  // Handle data when the API call is finished
+  // Reset isDisabledDueError when fetching
   useEffect(() => {
     if (hostDataResponse.isFetching) {
-      setShowTableRows(false);
-      // Reset selected users on refresh
-      setHostsTotalCount(0);
-      globalErrors.clear();
       setIsDisabledDueError(false);
-      return;
     }
-
-    // API response: Success
-    if (
-      hostDataResponse.isSuccess &&
-      hostDataResponse.data &&
-      batchResponse !== undefined
-    ) {
-      const hostsListResult = batchResponse.result.results;
-      const totalCount = batchResponse.result.totalCount;
-      const hostsListSize = batchResponse.result.count;
-      const hostsList: Host[] = [];
-
-      for (let i = 0; i < hostsListSize; i++) {
-        hostsList.push(hostsListResult[i].result);
-      }
-
-      setHostsList(hostsList);
-      setHostsTotalCount(totalCount);
-      // Show table elements
-      setShowTableRows(true);
-    }
-
-    // API response: Error
-    if (
-      !hostDataResponse.isLoading &&
-      hostDataResponse.isError &&
-      hostDataResponse.error !== undefined
-    ) {
-      // This normally happens when the user is not authorized to view the data
-      // So instead of adding an error, refresh page
-      window.location.reload();
-    }
-  }, [hostDataResponse]);
+  }, [hostDataResponse.isFetching]);
 
   // Always refetch data when the component is loaded.
   // This ensures the data is always up-to-date.
@@ -192,137 +84,10 @@ const Hosts = () => {
     hostDataResponse.refetch();
   }, []);
 
-  // Refresh button handling
-  const refreshHostsData = () => {
-    // Hide table
-    setShowTableRows(false);
+  // Refresh handler
+  const refreshData = () => state.refreshData(() => hostDataResponse.refetch());
 
-    // Reset selected hosts on refresh
-    setHostsTotalCount(0);
-    clearSelectedHosts();
-
-    hostDataResponse.refetch();
-  };
-
-  const updateSearchValue = (value: string) => {
-    setSearchValue(value);
-  };
-
-  const [selectedHosts, setSelectedHostsList] = useState<Host[]>([]);
-  const clearSelectedHosts = () => {
-    const emptyList: Host[] = [];
-    setSelectedHostsList(emptyList);
-  };
-
-  const [retrieveHost] = useSearchEntriesMutation({});
-
-  // Issue a search using a specific search value
-  const submitSearchValue = () => {
-    setShowTableRows(false);
-    setHostsTotalCount(0);
-    setSearchIsDisabled(true);
-    retrieveHost({
-      searchValue: searchValue,
-      sizeLimit: 0,
-      apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: firstHostIdx,
-      stopIdx: lastHostIdx,
-      entryType: "host",
-    } as GenericPayload).then((result) => {
-      // Manage new response here
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for hosts",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success
-          const hostsListResult = result.data?.result.results || [];
-          const hostsListSize = result.data?.result.count || 0;
-          const totalCount = result.data?.result.totalCount || 0;
-          const hostsList: Host[] = [];
-
-          for (let i = 0; i < hostsListSize; i++) {
-            hostsList.push(hostsListResult[i].result);
-          }
-
-          setHostsList(hostsList);
-          setHostsTotalCount(totalCount);
-          // Show table elements
-          setShowTableRows(true);
-        }
-        setSearchIsDisabled(false);
-      }
-    });
-  };
-
-  // Show table rows
-  const [showTableRows, setShowTableRows] = useState(!isBatchLoading);
-
-  const updateSelectedHosts = (hosts: Host[], isSelected: boolean) => {
-    let newSelectedHosts: Host[] = [];
-    if (isSelected) {
-      newSelectedHosts = JSON.parse(JSON.stringify(selectedHosts));
-      for (let i = 0; i < hosts.length; i++) {
-        if (
-          selectedHosts.find(
-            (selectedUser) => selectedUser.fqdn[0] === hosts[i].fqdn[0]
-          )
-        ) {
-          // Already in the list
-          continue;
-        }
-        // Add user to list
-        newSelectedHosts.push(hosts[i]);
-      }
-    } else {
-      // Remove host
-      for (let i = 0; i < selectedHosts.length; i++) {
-        let found = false;
-        for (let ii = 0; ii < hosts.length; ii++) {
-          if (selectedHosts[i].fqdn[0] === hosts[ii].fqdn[0]) {
-            found = true;
-            break;
-          }
-        }
-        if (!found) {
-          // Keep this valid selected entry
-          newSelectedHosts.push(selectedHosts[i]);
-        }
-      }
-    }
-    setSelectedHostsList(newSelectedHosts);
-    setIsDeleteButtonDisabled(newSelectedHosts.length === 0);
-  };
-
-  // - Helper method to set the selected users from the table
-  const setHostSelected = (host: Host, isSelecting = true) => {
-    if (isHostSelectable(host)) {
-      updateSelectedHosts([host], isSelecting);
-    }
-  };
-
-  // Show table rows only when data is fully retrieved
-  useEffect(() => {
-    if (showTableRows !== !isBatchLoading) {
-      setShowTableRows(!isBatchLoading);
-    }
-  }, [isBatchLoading]);
+  // -- Page-specific state --
 
   // Dropdown kebab
   const [kebabIsOpen, setKebabIsOpen] = useState(false);
@@ -341,7 +106,7 @@ const Hosts = () => {
         variant: "info",
       })
     );
-    executeAutoMemberRebuild(selectedHosts).then((result) => {
+    executeAutoMemberRebuild(state.selectedElements).then((result) => {
       if ("data" in result) {
         const automemberError = result.data?.error as
           | FetchBaseQueryError
@@ -467,186 +232,62 @@ const Hosts = () => {
     setShowDeleteModal(!showDeleteModal);
   };
 
-  // Table-related shared functionality
-  // - Selectable checkboxes on table
-  const selectableHostsTable = hostsList.filter(isHostSelectable); // elements per Table
-
-  // Data wrappers
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList: updateShownHostsList,
-    totalCount,
-  };
-
-  // - 'BulkSelectorPrep'
-  const hostsBulkSelectorData = {
-    selected: selectedHosts,
-    updateSelected: updateSelectedHosts,
-    selectableTable: selectableHostsTable,
-    nameAttr: "fqdn",
-  };
-
-  const buttonsData = {
-    updateIsDeleteButtonDisabled,
-  };
-
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage,
-  };
-
-  // - 'DeleteHosts'
-  const deleteHostsButtonsData = {
-    updateIsDeleteButtonDisabled,
-    updateIsDeletion,
-  };
+  // -- Data wrappers for child components --
 
   const selectedHostsData = {
-    selectedHosts,
-    clearSelectedHosts,
+    selectedHosts: state.selectedElements,
+    clearSelectedHosts: state.clearSelectedElements,
   };
 
-  // - 'HostsTable'
   const hostsTableData = {
     isHostSelectable,
-    selectedHosts,
-    selectableHostsTable,
-    setHostSelected,
-    clearSelectedHosts,
+    selectedHosts: state.selectedElements,
+    selectableHostsTable: state.selectableElements,
+    setHostSelected: state.setElementSelected,
+    clearSelectedHosts: state.clearSelectedElements,
   };
 
   const hostsTableButtonsData = {
-    updateIsDeleteButtonDisabled,
-    isDeletion,
-    updateIsDeletion,
+    updateIsDeleteButtonDisabled: state.updateIsDeleteButtonDisabled,
+    isDeletion: state.isDeletion,
+    updateIsDeletion: state.updateIsDeletion,
   };
 
-  // - 'SearchInputLayout'
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
-  };
-
-  // Contextual links panel
-  const [isContextualPanelExpanded, setIsContextualPanelExpanded] =
-    React.useState(false);
-
-  const onOpenContextualPanel = () => {
-    setIsContextualPanelExpanded(!isContextualPanelExpanded);
-  };
-
-  const onCloseContextualPanel = () => {
-    setIsContextualPanelExpanded(false);
-  };
-
-  // List of toolbar items
-  const toolbarItems: ToolbarItem[] = [
+  // Extra toolbar items: Kebab, Separator, Help, Pagination
+  const extraToolbarItems: ToolbarItem[] = [
     {
-      key: 0,
-      element: (
-        <BulkSelectorPrep
-          list={hostsList}
-          shownElementsList={hostsList}
-          elementData={hostsBulkSelectorData}
-          buttonsData={buttonsData}
-          selectedPerPageData={selectedPerPageData}
-        />
-      ),
-    },
-    {
-      key: 1,
-      element: (
-        <SearchInputLayout
-          dataCy="search"
-          name="search"
-          ariaLabel="Search hosts"
-          placeholder="Search"
-          searchValueData={searchValueData}
-          isDisabled={searchDisabled}
-        />
-      ),
-      toolbarItemVariant: ToolbarItemVariant.label,
-      toolbarItemGap: { default: "gapMd" },
-    },
-    {
-      key: 2,
-      toolbarItemVariant: ToolbarItemVariant.separator,
-    },
-    {
-      key: 3,
-      element: (
-        <SecondaryButton
-          onClickHandler={refreshHostsData}
-          isDisabled={!showTableRows}
-          dataCy="hosts-button-refresh"
-        >
-          Refresh
-        </SecondaryButton>
-      ),
-    },
-    {
-      key: 4,
-      element: (
-        <SecondaryButton
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
-          onClickHandler={onDeleteHandler}
-          dataCy="hosts-button-delete"
-        >
-          Delete
-        </SecondaryButton>
-      ),
-    },
-    {
-      key: 5,
-      element: (
-        <SecondaryButton
-          onClickHandler={onAddClickHandler}
-          isDisabled={!showTableRows || isDisabledDueError}
-          dataCy="hosts-button-add"
-        >
-          Add
-        </SecondaryButton>
-      ),
-    },
-    {
-      key: 6,
+      key: "kebab",
       element: (
         <KebabLayout
           onDropdownSelect={onDropdownSelect}
           onKebabToggle={onKebabToggle}
           idKebab="main-dropdown-kebab"
           isKebabOpen={kebabIsOpen}
-          dropdownItems={!showTableRows ? [] : dropdownItems}
+          dropdownItems={!state.showTableRows ? [] : dropdownItems}
           dataCy="hosts-kebab"
-          isDisabled={!showTableRows}
+          isDisabled={!state.showTableRows}
         />
       ),
     },
     {
-      key: 7,
+      key: "separator",
       toolbarItemVariant: ToolbarItemVariant.separator,
     },
     {
-      key: 8,
+      key: "help",
       element: (
         <HelpTextWithIconLayout
           textContent="Help"
-          onClick={onOpenContextualPanel}
+          onClick={state.toggleContextualPanel}
         />
       ),
     },
     {
-      key: 9,
+      key: "pagination-top",
       element: (
         <PaginationLayout
-          list={hostsList}
-          paginationData={paginationData}
+          list={state.elementsList}
+          paginationData={state.paginationData}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -656,84 +297,57 @@ const Hosts = () => {
   ];
 
   return (
-    <ContextualHelpPanel
-      fromPage="hosts"
-      isExpanded={isContextualPanelExpanded}
-      onClose={onCloseContextualPanel}
+    <GenericMainPage
+      state={state}
+      pageTitle="Hosts"
+      batchError={hostDataResponse.error}
+      onRefresh={refreshData}
+      onAddClick={onAddClickHandler}
+      onDeleteClick={onDeleteHandler}
+      extraToolbarItems={extraToolbarItems}
+      contextualPanelPage="hosts"
+      isAddDisabledDueError={isDisabledDueError}
+      renderTable={(s) => (
+        <HostsTable
+          elementsList={s.elementsList}
+          shownElementsList={s.elementsList}
+          showTableRows={s.showTableRows}
+          hostsData={hostsTableData}
+          buttonsData={hostsTableButtonsData}
+          paginationData={s.selectedPerPageData}
+          searchValue={s.searchValue}
+        />
+      )}
     >
-      <div>
-        <PageSection hasBodyWrapper={false}>
-          <TitleLayout id="Hosts title" headingLevel="h1" text="Hosts" />
-        </PageSection>
-        <PageSection hasBodyWrapper={false} isFilled={false}>
-          <Flex direction={{ default: "column" }}>
-            <FlexItem>
-              <ToolbarLayout toolbarItems={toolbarItems} />
-            </FlexItem>
-            <FlexItem style={{ flex: "0 0 auto" }}>
-              <OuterScrollContainer>
-                <InnerScrollContainer
-                  style={{ height: "60vh", overflow: "auto" }}
-                >
-                  {batchError !== undefined && batchError ? (
-                    <GlobalErrors errors={globalErrors.getAll()} />
-                  ) : (
-                    <HostsTable
-                      elementsList={hostsList}
-                      shownElementsList={hostsList}
-                      showTableRows={showTableRows}
-                      hostsData={hostsTableData}
-                      buttonsData={hostsTableButtonsData}
-                      paginationData={selectedPerPageData}
-                      searchValue={searchValue}
-                    />
-                  )}
-                </InnerScrollContainer>
-              </OuterScrollContainer>
-            </FlexItem>
-            <FlexItem
-              style={{ flex: "0 0 auto", position: "sticky", bottom: 0 }}
-            >
-              <PaginationLayout
-                list={hostsList}
-                paginationData={paginationData}
-                variant={PaginationVariant.bottom}
-                widgetId="pagination-options-menu-bottom"
-              />
-            </FlexItem>
-          </Flex>
-        </PageSection>
-        <ModalErrors errors={modalErrors.getAll()} dataCy="hosts-modal-error" />
-        {isMembershipModalOpen && (
-          <ModalWithFormLayout
-            variantType="medium"
-            modalPosition="top"
-            offPosition="76px"
-            title="Confirmation"
-            formId="rebuild-auto-membership-modal"
-            fields={confirmationQuestion}
-            show={isMembershipModalOpen}
-            onClose={() => setIsMembershipModalOpen(!isMembershipModalOpen)}
-            actions={membershipModalActions}
-            dataCy="hosts-rebuild-auto-membership-modal"
-          />
-        )}
-        <AddHost
-          show={showAddModal}
-          handleModalToggle={onAddModalToggle}
-          onOpenAddModal={onAddClickHandler}
-          onCloseAddModal={onCloseAddModal}
-          onRefresh={refreshHostsData}
+      {isMembershipModalOpen && (
+        <ModalWithFormLayout
+          variantType="medium"
+          modalPosition="top"
+          offPosition="76px"
+          title="Confirmation"
+          formId="rebuild-auto-membership-modal"
+          fields={confirmationQuestion}
+          show={isMembershipModalOpen}
+          onClose={() => setIsMembershipModalOpen(!isMembershipModalOpen)}
+          actions={membershipModalActions}
+          dataCy="hosts-rebuild-auto-membership-modal"
         />
-        <DeleteHosts
-          show={showDeleteModal}
-          handleModalToggle={onDeleteModalToggle}
-          selectedHostsData={selectedHostsData}
-          buttonsData={deleteHostsButtonsData}
-          onRefresh={refreshHostsData}
-        />
-      </div>
-    </ContextualHelpPanel>
+      )}
+      <AddHost
+        show={showAddModal}
+        handleModalToggle={onAddModalToggle}
+        onOpenAddModal={onAddClickHandler}
+        onCloseAddModal={onCloseAddModal}
+        onRefresh={refreshData}
+      />
+      <DeleteHosts
+        show={showDeleteModal}
+        handleModalToggle={onDeleteModalToggle}
+        selectedHostsData={selectedHostsData}
+        buttonsData={state.deleteButtonsData}
+        onRefresh={refreshData}
+      />
+    </GenericMainPage>
   );
 };
 

--- a/src/pages/PreservedUsers/PreservedUsers.tsx
+++ b/src/pages/PreservedUsers/PreservedUsers.tsx
@@ -1,158 +1,49 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 // PatternFly
-import {
-  PaginationVariant,
-  PageSection,
-  ToolbarItemVariant,
-  Flex,
-  FlexItem,
-} from "@patternfly/react-core";
-// PatternFly table
-import {
-  InnerScrollContainer,
-  OuterScrollContainer,
-} from "@patternfly/react-table";
+import { ToolbarItemVariant } from "@patternfly/react-core";
 // Data types
 import { User } from "src/utils/datatypes/globalDataTypes";
 import { ToolbarItem } from "src/components/layouts/ToolbarLayout";
-// Redux
-import { useAppSelector, useAppDispatch } from "src/store/hooks";
 // Layouts
-import TitleLayout from "src/components/layouts/TitleLayout";
-import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
 import SecondaryButton from "src/components/layouts/SecondaryButton";
-import ToolbarLayout from "src/components/layouts/ToolbarLayout";
-import SearchInputLayout from "src/components/layouts/SearchInputLayout";
+import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
 // Tables
 import UsersTable from "../../components/tables/UsersTable";
-// Components
-import PaginationLayout from "src/components/layouts/PaginationLayout";
-import BulkSelectorPrep from "src/components/BulkSelectorPrep";
-import ContextualHelpPanel from "src/components/ContextualHelpPanel/ContextualHelpPanel";
 // Modals
 import DeleteUsers from "src/components/modals/UserModals/DeleteUsers";
 import StagePreservedUsers from "src/components/modals/UserModals/StagePreservedUsers";
 import RestorePreservedUsers from "src/components/modals/UserModals/RestorePreservedUsers";
-// Hooks
-import { addAlert } from "src/store/Global/alerts-slice";
-import useUpdateRoute from "src/hooks/useUpdateRoute";
-import useListPageSearchParams from "src/hooks/useListPageSearchParams";
-// Errors
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 // Utils
 import { API_VERSION_BACKUP, isUserSelectable } from "src/utils/utils";
-import { GenericPayload, useSearchEntriesMutation } from "../../services/rpc";
+// RPC client
+import { GenericPayload } from "../../services/rpc";
 import { useGettingPreservedUserQuery } from "../../services/rpcUsers";
-import useApiError from "src/hooks/useApiError";
-import GlobalErrors from "src/components/errors/GlobalErrors";
-import ModalErrors from "src/components/errors/ModalErrors";
+// Generic main page
+import {
+  useMainPageState,
+  useDataResponseEffect,
+  GenericMainPage,
+} from "src/components/GenericMainPage";
 
 const PreservedUsers = () => {
-  const dispatch = useAppDispatch();
+  const state = useMainPageState<User>({
+    pathname: "preserved-users",
+    searchEntryType: "preserved",
+    nameAttr: "uid",
+    getKeyValue: (user) => user.uid[0],
+    isSelectable: isUserSelectable,
+  });
 
-  // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
-    useListPageSearchParams();
-
-  // Update current route data to Redux and highlight the current page in the Nav bar
-  const { browserTitle } = useUpdateRoute({ pathname: "preserved-users" });
-
-  // Set the page title to be shown in the browser tab
-  React.useEffect(() => {
-    document.title = browserTitle;
-  }, [browserTitle]);
-
-  // Retrieve API version from environment data
-  const apiVersion = useAppSelector(
-    (state) => state.global.environment.api_version
-  ) as string;
-
-  // Preservered users list
-  const [preservedUsersList, setPreservedUsersList] = useState<User[]>([]);
-
-  // Handle API calls errors
-  const globalErrors = useApiError([]);
-  const modalErrors = useApiError([]);
-
-  // Main states - what user can define / what we could use in page URL
-  const [totalCount, setUsersTotalCount] = useState<number>(0);
-  const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
-
-  // Page indexes
-  const firstUserIdx = (page - 1) * perPage;
-  const lastUserIdx = page * perPage;
-
-  // Derived states - what we get from API
   const userDataResponse = useGettingPreservedUserQuery({
-    searchValue: searchValue,
+    searchValue: state.searchValue,
     sizeLimit: 0,
-    apiVersion: apiVersion || API_VERSION_BACKUP,
-    startIdx: firstUserIdx,
-    stopIdx: lastUserIdx,
+    apiVersion: state.apiVersion || API_VERSION_BACKUP,
+    startIdx: state.firstIdx,
+    stopIdx: state.lastIdx,
   } as GenericPayload);
 
-  const {
-    data: batchResponse,
-    isLoading: isBatchLoading,
-    error: batchError,
-  } = userDataResponse;
-
-  // Handle data when the API call is finished
-  useEffect(() => {
-    if (userDataResponse.isFetching) {
-      setShowTableRows(false);
-      // Reset selected users on refresh
-      setUsersTotalCount(0);
-      globalErrors.clear();
-      return;
-    }
-
-    // API response: Success
-    if (
-      userDataResponse.isSuccess &&
-      userDataResponse.data &&
-      batchResponse !== undefined
-    ) {
-      const usersListResult = batchResponse.result.results;
-      const usersListSize = batchResponse.result.count;
-      const totalCount = batchResponse.result.totalCount;
-      const usersList: User[] = [];
-
-      for (let i = 0; i < usersListSize; i++) {
-        usersList.push(usersListResult[i].result);
-      }
-
-      setUsersTotalCount(totalCount);
-      // Update the list of users
-      setPreservedUsersList(usersList);
-      // Show table elements
-      setShowTableRows(true);
-    }
-
-    // API response: Error
-    if (
-      !userDataResponse.isLoading &&
-      userDataResponse.isError &&
-      userDataResponse.error !== undefined
-    ) {
-      // This normally happens when the user is not authorized to view the data
-      // So instead of adding an error, refresh page
-      window.location.reload();
-    }
-  }, [userDataResponse]);
-
-  // Refresh button handling
-  const refreshUsersData = () => {
-    // Hide table
-    setShowTableRows(false);
-
-    // Reset selected users on refresh
-    setUsersTotalCount(0);
-    clearSelectedUsers();
-
-    userDataResponse.refetch();
-  };
+  useDataResponseEffect(userDataResponse, state);
 
   // Always refetch data when the component is loaded.
   // This ensures the data is always up-to-date.
@@ -160,174 +51,13 @@ const PreservedUsers = () => {
     userDataResponse.refetch();
   }, []);
 
-  // 'Delete' button state
-  const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
-    useState<boolean>(true);
+  const refreshData = () => state.refreshData(() => userDataResponse.refetch());
 
-  const updateIsDeleteButtonDisabled = (value: boolean) => {
-    setIsDeleteButtonDisabled(value);
-  };
-
-  // If some entries have been deleted, restore the selectedUsers list
-  const [isDeletion, setIsDeletion] = useState(false);
-
-  const updateIsDeletion = (value: boolean) => {
-    setIsDeletion(value);
-  };
-
-  // Elements selected (per page)
-  //  - This will help to calculate the remaining elements on a specific page (bulk selector)
-  const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
-
-  const updateSelectedPerPage = (selected: number) => {
-    setSelectedPerPage(selected);
-  };
-
-  // Pagination
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
-  };
-
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
-  };
-
-  // Users displayed on the first page
-  const updateShownUsersList = (newShownUsersList: User[]) => {
-    setPreservedUsersList(newShownUsersList);
-  };
-
-  // Filter (Input search)
-  const updateSearchValue = (value: string) => {
-    setSearchValue(value);
-  };
-
-  // Issue search with filter
-  const [retrieveUser] = useSearchEntriesMutation({});
-
-  // Issue a search using a specific search value
-  const submitSearchValue = () => {
-    setShowTableRows(false);
-    setUsersTotalCount(0);
-    setSearchIsDisabled(true);
-
-    retrieveUser({
-      searchValue: searchValue,
-      sizeLimit: 0,
-      apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: firstUserIdx,
-      stopIdx: lastUserIdx,
-      entryType: "preserved",
-    } as GenericPayload).then((result) => {
-      // Manage new response here
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for preserved users",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success
-          const usersListResult = result.data?.result.results || [];
-          const usersListSize = result.data?.result.count || 0;
-          const totalCount = result.data?.result.totalCount || 0;
-          const usersList: User[] = [];
-
-          for (let i = 0; i < usersListSize; i++) {
-            usersList.push(usersListResult[i].result);
-          }
-
-          setPreservedUsersList(usersList);
-          setUsersTotalCount(totalCount);
-          // Show table elements
-          setShowTableRows(true);
-        }
-        setSearchIsDisabled(false);
-      }
-    });
-  };
-
-  // Show table rows
-  const [showTableRows, setShowTableRows] = useState(!isBatchLoading);
-
-  // Show table rows only when data is fully retrieved
-  useEffect(() => {
-    if (showTableRows !== !isBatchLoading) {
-      setShowTableRows(!isBatchLoading);
-    }
-  }, [isBatchLoading]);
-
-  // Table-related shared functionality
-  // - Selectable checkboxes on table
-  const selectableUsersTable = preservedUsersList.filter(isUserSelectable); // elements per Table
-
-  const [selectedUsers, setSelectedUsers] = useState<User[]>([]);
-  const clearSelectedUsers = () => {
-    const emptyList: User[] = [];
-    setSelectedUsers(emptyList);
-  };
-
-  const updateSelectedUsers = (users: User[], isSelected: boolean) => {
-    let newSelectedUsers: User[] = [];
-    if (isSelected) {
-      newSelectedUsers = JSON.parse(JSON.stringify(selectedUsers));
-      for (let i = 0; i < users.length; i++) {
-        if (
-          selectedUsers.find(
-            (selectedUser) => selectedUser.uid[0] === users[i].uid[0]
-          )
-        ) {
-          // Already in the list
-          continue;
-        }
-        // Add user to list
-        newSelectedUsers.push(users[i]);
-      }
-    } else {
-      // Remove user
-      for (let i = 0; i < selectedUsers.length; i++) {
-        let found = false;
-        for (let ii = 0; ii < users.length; ii++) {
-          if (selectedUsers[i].uid[0] === users[ii].uid[0]) {
-            found = true;
-            break;
-          }
-        }
-        if (!found) {
-          // Keep this valid selected entry
-          newSelectedUsers.push(selectedUsers[i]);
-        }
-      }
-    }
-    setSelectedUsers(newSelectedUsers);
-    setIsDeleteButtonDisabled(newSelectedUsers.length === 0);
-  };
-
-  // - Helper method to set the selected users from the table
-  const setUserSelected = (user: User, isSelecting = true) => {
-    if (isUserSelectable(user)) {
-      updateSelectedUsers([user], isSelecting);
-    }
-  };
-
-  // Modals functionality
+  // Page-specific states
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showRestoreModal, setShowRestoreModal] = useState(false);
   const [showStageModal, setShowStageModal] = useState(false);
+
   const onDeleteHandler = () => {
     setShowDeleteModal(true);
   };
@@ -347,143 +77,36 @@ const PreservedUsers = () => {
     setShowStageModal(!showStageModal);
   };
 
-  // Data wrappers
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList: updateShownUsersList,
-    totalCount,
-  };
-
-  // - 'BulkSelectorPrep'
-  const usersBulkSelectorData = {
-    selected: selectedUsers,
-    updateSelected: updateSelectedUsers,
-    selectableTable: selectableUsersTable,
-    nameAttr: "uid",
-  };
-
-  const buttonsData = {
-    isDeleteButtonDisabled,
-    updateIsDeleteButtonDisabled,
-  };
-
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage,
-  };
-
-  // 'DeleteUsers'
-  const deleteUsersButtonsData = {
-    updateIsDeleteButtonDisabled,
-    updateIsDeletion,
-  };
+  // Data wrappers for child components
 
   const selectedUsersData = {
-    selectedUsers,
-    clearSelectedUsers,
+    selectedUsers: state.selectedElements,
+    clearSelectedUsers: state.clearSelectedElements,
   };
 
-  // 'UsersTable'
   const usersTableData = {
     isUserSelectable,
-    selectedUsers,
-    selectableUsersTable,
-    setUserSelected,
-    clearSelectedUsers,
+    selectedUsers: state.selectedElements,
+    selectableUsersTable: state.selectableElements,
+    setUserSelected: state.setElementSelected,
+    clearSelectedUsers: state.clearSelectedElements,
   };
 
   const usersTableButtonsData = {
-    updateIsDeleteButtonDisabled,
-    isDeletion,
-    updateIsDeletion,
+    updateIsDeleteButtonDisabled: state.updateIsDeleteButtonDisabled,
+    isDeletion: state.isDeletion,
+    updateIsDeletion: state.updateIsDeletion,
   };
 
-  // SearchInputLayout
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
-  };
-
-  // Contextual links panel
-  const [isContextualPanelExpanded, setIsContextualPanelExpanded] =
-    React.useState(false);
-
-  const onOpenContextualPanel = () => {
-    setIsContextualPanelExpanded(!isContextualPanelExpanded);
-  };
-
-  const onCloseContextualPanel = () => {
-    setIsContextualPanelExpanded(false);
-  };
-
-  // List of Toolbar items
-  const toolbarItems: ToolbarItem[] = [
+  // Extra toolbar items
+  const extraToolbarItems: ToolbarItem[] = [
     {
-      key: 0,
-      element: (
-        <BulkSelectorPrep
-          list={preservedUsersList}
-          shownElementsList={preservedUsersList}
-          elementData={usersBulkSelectorData}
-          buttonsData={buttonsData}
-          selectedPerPageData={selectedPerPageData}
-        />
-      ),
-    },
-    {
-      key: 1,
-      element: (
-        <SearchInputLayout
-          dataCy="search"
-          name="search"
-          ariaLabel="Search user"
-          placeholder="Search"
-          searchValueData={searchValueData}
-          isDisabled={searchDisabled}
-        />
-      ),
-      toolbarItemVariant: ToolbarItemVariant.label,
-      toolbarItemGap: { default: "gapMd" },
-    },
-    {
-      key: 2,
-      toolbarItemVariant: ToolbarItemVariant.separator,
-    },
-    {
-      key: 3,
+      key: "restore",
       element: (
         <SecondaryButton
-          onClickHandler={refreshUsersData}
-          isDisabled={!showTableRows}
-          dataCy="preserved-users-button-refresh"
-        >
-          Refresh
-        </SecondaryButton>
-      ),
-    },
-    {
-      key: 4,
-      element: (
-        <SecondaryButton
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
-          onClickHandler={onDeleteHandler}
-          dataCy="preserved-users-button-delete"
-        >
-          Delete
-        </SecondaryButton>
-      ),
-    },
-    {
-      key: 5,
-      element: (
-        <SecondaryButton
-          isDisabled={!showTableRows || selectedUsers.length === 0}
+          isDisabled={
+            !state.showTableRows || state.selectedElements.length === 0
+          }
           onClickHandler={onRestoreHandler}
           dataCy="preserved-users-button-restore"
         >
@@ -492,10 +115,12 @@ const PreservedUsers = () => {
       ),
     },
     {
-      key: 6,
+      key: "stage",
       element: (
         <SecondaryButton
-          isDisabled={!showTableRows || selectedUsers.length === 0}
+          isDisabled={
+            !state.showTableRows || state.selectedElements.length === 0
+          }
           onClickHandler={onStageHandler}
           dataCy="preserved-users-button-stage"
         >
@@ -504,24 +129,24 @@ const PreservedUsers = () => {
       ),
     },
     {
-      key: 7,
+      key: "separator",
       toolbarItemVariant: ToolbarItemVariant.separator,
     },
     {
-      key: 8,
+      key: "help",
       element: (
         <HelpTextWithIconLayout
           textContent="Help"
-          onClick={onOpenContextualPanel}
+          onClick={state.toggleContextualPanel}
         />
       ),
     },
     {
-      key: 9,
+      key: "pagination-top",
       element: (
         <PaginationLayout
-          list={preservedUsersList}
-          paginationData={paginationData}
+          list={state.elementsList}
+          paginationData={state.paginationData}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -530,87 +155,50 @@ const PreservedUsers = () => {
     },
   ];
 
-  // Render 'Preserved users'
   return (
-    <ContextualHelpPanel
-      fromPage="preserved-users"
-      isExpanded={isContextualPanelExpanded}
-      onClose={onCloseContextualPanel}
-    >
-      <div>
-        <PageSection hasBodyWrapper={false}>
-          <TitleLayout
-            id="preserved users title"
-            headingLevel="h1"
-            text="Preserved users"
-          />
-        </PageSection>
-        <PageSection hasBodyWrapper={false} isFilled={false}>
-          <Flex direction={{ default: "column" }}>
-            <FlexItem>
-              <ToolbarLayout toolbarItems={toolbarItems} />
-            </FlexItem>
-            <FlexItem style={{ flex: "0 0 auto" }}>
-              <OuterScrollContainer>
-                <InnerScrollContainer
-                  style={{ height: "60vh", overflow: "auto" }}
-                >
-                  {batchError !== undefined && batchError ? (
-                    <GlobalErrors errors={globalErrors.getAll()} />
-                  ) : (
-                    <UsersTable
-                      shownElementsList={preservedUsersList}
-                      from="preserved-users"
-                      showTableRows={showTableRows}
-                      usersData={usersTableData}
-                      buttonsData={usersTableButtonsData}
-                      paginationData={selectedPerPageData}
-                      searchValue={searchValue}
-                    />
-                  )}
-                </InnerScrollContainer>
-              </OuterScrollContainer>
-            </FlexItem>
-            <FlexItem
-              style={{ flex: "0 0 auto", position: "sticky", bottom: 0 }}
-            >
-              <PaginationLayout
-                list={preservedUsersList}
-                paginationData={paginationData}
-                variant={PaginationVariant.bottom}
-                widgetId="pagination-options-menu-bottom"
-              />
-            </FlexItem>
-          </Flex>
-        </PageSection>
-        <ModalErrors
-          errors={modalErrors.getAll()}
-          dataCy="preserved-users-modal-error"
-        />
-        <DeleteUsers
-          show={showDeleteModal}
+    <GenericMainPage
+      state={state}
+      pageTitle="Preserved users"
+      batchError={userDataResponse.error}
+      onRefresh={refreshData}
+      onDeleteClick={onDeleteHandler}
+      extraToolbarItems={extraToolbarItems}
+      contextualPanelPage="preserved-users"
+      renderTable={(s) => (
+        <UsersTable
+          shownElementsList={s.elementsList}
           from="preserved-users"
-          handleModalToggle={onDeleteModalToggle}
-          selectedUsersData={selectedUsersData}
-          buttonsData={deleteUsersButtonsData}
-          onRefresh={refreshUsersData}
+          showTableRows={s.showTableRows}
+          usersData={usersTableData}
+          buttonsData={usersTableButtonsData}
+          paginationData={s.selectedPerPageData}
+          searchValue={s.searchValue}
         />
-        <RestorePreservedUsers
-          show={showRestoreModal}
-          handleModalToggle={onRestoreModalToggle}
-          selectedUsers={selectedUsers}
-          clearSelectedUsers={clearSelectedUsers}
-          onSuccess={refreshUsersData}
-        />
-        <StagePreservedUsers
-          show={showStageModal}
-          handleModalToggle={onStageModalToggle}
-          selectedUsers={selectedUsers}
-          clearSelectedUsers={clearSelectedUsers}
-          onSuccess={refreshUsersData}
-        />
-      </div>
-    </ContextualHelpPanel>
+      )}
+    >
+      <DeleteUsers
+        show={showDeleteModal}
+        from="preserved-users"
+        handleModalToggle={onDeleteModalToggle}
+        selectedUsersData={selectedUsersData}
+        buttonsData={state.deleteButtonsData}
+        onRefresh={refreshData}
+      />
+      <RestorePreservedUsers
+        show={showRestoreModal}
+        handleModalToggle={onRestoreModalToggle}
+        selectedUsers={state.selectedElements}
+        clearSelectedUsers={state.clearSelectedElements}
+        onSuccess={refreshData}
+      />
+      <StagePreservedUsers
+        show={showStageModal}
+        handleModalToggle={onStageModalToggle}
+        selectedUsers={state.selectedElements}
+        clearSelectedUsers={state.clearSelectedElements}
+        onSuccess={refreshData}
+      />
+    </GenericMainPage>
   );
 };
 

--- a/src/pages/StageUsers/StageUsers.tsx
+++ b/src/pages/StageUsers/StageUsers.tsx
@@ -1,159 +1,49 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 // PatternFly
-import {
-  Flex,
-  FlexItem,
-  PageSection,
-  PaginationVariant,
-  ToolbarItemVariant,
-} from "@patternfly/react-core";
-// PatternFly table
-import {
-  InnerScrollContainer,
-  OuterScrollContainer,
-} from "@patternfly/react-table";
+import { ToolbarItemVariant } from "@patternfly/react-core";
 // Data types
 import { User } from "src/utils/datatypes/globalDataTypes";
 import { ToolbarItem } from "src/components/layouts/ToolbarLayout";
-// Redux
-import { useAppSelector, useAppDispatch } from "src/store/hooks";
-// Hooks
-import { addAlert } from "src/store/Global/alerts-slice";
-import useUpdateRoute from "src/hooks/useUpdateRoute";
-import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 // Layouts
-import TitleLayout from "src/components/layouts/TitleLayout";
-import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
 import SecondaryButton from "src/components/layouts/SecondaryButton";
-import ToolbarLayout from "src/components/layouts/ToolbarLayout";
-import SearchInputLayout from "src/components/layouts/SearchInputLayout";
+import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
 // Tables
 import UsersTable from "../../components/tables/UsersTable";
-// Components
-import PaginationLayout from "src/components/layouts/PaginationLayout";
-import BulkSelectorPrep from "src/components/BulkSelectorPrep";
-import ContextualHelpPanel from "src/components/ContextualHelpPanel/ContextualHelpPanel";
 // Modals
 import DeleteUsers from "src/components/modals/UserModals/DeleteUsers";
 import AddUser from "src/components/modals/UserModals/AddUser";
 import ActivateStageUsers from "src/components/modals/UserModals/ActivateStageUsers";
 // Utils
 import { API_VERSION_BACKUP, isUserSelectable } from "src/utils/utils";
-// Errors
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 // RPC client
-import { GenericPayload, useSearchEntriesMutation } from "../../services/rpc";
+import { GenericPayload } from "../../services/rpc";
 import { useGettingStageUserQuery } from "../../services/rpcUsers";
-import useApiError from "src/hooks/useApiError";
-import GlobalErrors from "src/components/errors/GlobalErrors";
-import ModalErrors from "src/components/errors/ModalErrors";
+// Generic main page
+import {
+  useMainPageState,
+  useDataResponseEffect,
+  GenericMainPage,
+} from "src/components/GenericMainPage";
 
 const StageUsers = () => {
-  const dispatch = useAppDispatch();
+  const state = useMainPageState<User>({
+    pathname: "stage-users",
+    searchEntryType: "stage",
+    nameAttr: "uid",
+    getKeyValue: (user) => user.uid[0],
+    isSelectable: isUserSelectable,
+  });
 
-  // Update current route data to Redux and highlight the current page in the Nav bar
-  const { browserTitle } = useUpdateRoute({ pathname: "stage-users" });
-
-  // Set the page title to be shown in the browser tab
-  React.useEffect(() => {
-    document.title = browserTitle;
-  }, [browserTitle]);
-
-  // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
-    useListPageSearchParams();
-
-  // Retrieve API version from environment data
-  const apiVersion = useAppSelector(
-    (state) => state.global.environment.api_version
-  ) as string;
-
-  // Active users list
-  const [stageUsersList, setStageUsersList] = useState<User[]>([]);
-
-  // Handle API calls errors
-  const globalErrors = useApiError([]);
-  const modalErrors = useApiError([]);
-
-  // Main states - what user can define / what we could use in page URL
-  const [totalCount, setUsersTotalCount] = useState<number>(0);
-  const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
-
-  // Page indexes
-  const firstUserIdx = (page - 1) * perPage;
-  const lastUserIdx = page * perPage;
-
-  // Derived states - what we get from API
   const userDataResponse = useGettingStageUserQuery({
-    searchValue: searchValue,
+    searchValue: state.searchValue,
     sizeLimit: 0,
-    apiVersion: apiVersion || API_VERSION_BACKUP,
-    startIdx: firstUserIdx,
-    stopIdx: lastUserIdx,
+    apiVersion: state.apiVersion || API_VERSION_BACKUP,
+    startIdx: state.firstIdx,
+    stopIdx: state.lastIdx,
   } as GenericPayload);
 
-  const {
-    data: batchResponse,
-    isLoading: isBatchLoading,
-    error: batchError,
-  } = userDataResponse;
-
-  // Handle data when the API call is finished
-  useEffect(() => {
-    if (userDataResponse.isFetching) {
-      setShowTableRows(false);
-      // Reset selected users on refresh
-      setUsersTotalCount(0);
-      globalErrors.clear();
-      return;
-    }
-
-    // API response: Success
-    if (
-      userDataResponse.isSuccess &&
-      userDataResponse.data &&
-      batchResponse !== undefined
-    ) {
-      const usersListResult = batchResponse.result.results;
-      const usersListSize = batchResponse.result.count;
-      const totalCount = batchResponse.result.totalCount;
-      const usersList: User[] = [];
-
-      for (let i = 0; i < usersListSize; i++) {
-        usersList.push(usersListResult[i].result);
-      }
-
-      setUsersTotalCount(totalCount);
-      // Update the list of users
-      setStageUsersList(usersList);
-      // Show table elements
-      setShowTableRows(true);
-    }
-
-    // API response: Error
-    if (
-      !userDataResponse.isLoading &&
-      userDataResponse.isError &&
-      userDataResponse.error !== undefined
-    ) {
-      // This normally happens when the user is not authorized to view the data
-      // So instead of adding an error, refresh page
-      window.location.reload();
-    }
-  }, [userDataResponse]);
-
-  // Refresh button handling
-  const refreshUsersData = () => {
-    // Hide table
-    setShowTableRows(false);
-
-    // Reset selected users on refresh
-    setUsersTotalCount(0);
-    clearSelectedUsers();
-
-    userDataResponse.refetch();
-  };
+  useDataResponseEffect(userDataResponse, state);
 
   // Always refetch data when the component is loaded.
   // This ensures the data is always up-to-date.
@@ -161,171 +51,13 @@ const StageUsers = () => {
     userDataResponse.refetch();
   }, []);
 
-  // 'Delete' button state
-  const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
-    useState<boolean>(true);
+  const refreshData = () => state.refreshData(() => userDataResponse.refetch());
 
-  const updateIsDeleteButtonDisabled = (value: boolean) => {
-    setIsDeleteButtonDisabled(value);
-  };
-
-  // If some entries have been deleted, restore the selectedUsers list
-  const [isDeletion, setIsDeletion] = useState(false);
-
-  const updateIsDeletion = (value: boolean) => {
-    setIsDeletion(value);
-  };
-
-  // Elements selected (per page)
-  //  - This will help to calculate the remaining elements on a specific page (bulk selector)
-  const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
-
-  const updateSelectedPerPage = (selected: number) => {
-    setSelectedPerPage(selected);
-  };
-
-  // Pagination
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
-  };
-
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
-  };
-
-  // Users displayed on the first page
-  const updateShownUsersList = (newShownUsersList: User[]) => {
-    setStageUsersList(newShownUsersList);
-  };
-
-  // Filter (Input search)
-  const updateSearchValue = (value: string) => {
-    setSearchValue(value);
-  };
-
-  // Issue search with filter
-  const [retrieveUser] = useSearchEntriesMutation({});
-
-  // Issue a search using a specific search value
-  const submitSearchValue = () => {
-    setShowTableRows(false);
-    setUsersTotalCount(0);
-    setSearchIsDisabled(true);
-
-    retrieveUser({
-      searchValue: searchValue,
-      sizeLimit: 0,
-      apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: firstUserIdx,
-      stopIdx: lastUserIdx,
-      entryType: "stage",
-    } as GenericPayload).then((result) => {
-      // Manage new response here
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for stage users",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success
-          const usersListResult = result.data?.result.results || [];
-          const usersListSize = result.data?.result.count || 0;
-          const totalCount = result.data?.result.totalCount || 0;
-          const usersList: User[] = [];
-
-          for (let i = 0; i < usersListSize; i++) {
-            usersList.push(usersListResult[i].result);
-          }
-
-          setStageUsersList(usersList);
-          setUsersTotalCount(totalCount);
-          // Show table elements
-          setShowTableRows(true);
-        }
-        setSearchIsDisabled(false);
-      }
-    });
-  };
-
-  // Show table rows
-  const [showTableRows, setShowTableRows] = useState(!isBatchLoading);
-
-  // Show table rows only when data is fully retrieved
-  useEffect(() => {
-    if (showTableRows !== !isBatchLoading) {
-      setShowTableRows(!isBatchLoading);
-    }
-  }, [isBatchLoading]);
-
-  const [selectedUsers, setSelectedUsers] = useState<User[]>([]);
-
-  const clearSelectedUsers = () => {
-    const emptyList: User[] = [];
-    setSelectedUsers(emptyList);
-  };
-
-  const updateSelectedUsers = (users: User[], isSelected: boolean) => {
-    let newSelectedUsers: User[] = [];
-    if (isSelected) {
-      newSelectedUsers = JSON.parse(JSON.stringify(selectedUsers));
-      for (let i = 0; i < users.length; i++) {
-        if (
-          selectedUsers.find(
-            (selectedUser) => selectedUser.uid[0] === users[i].uid[0]
-          )
-        ) {
-          // Already in the list
-          continue;
-        }
-        // Add user to list
-        newSelectedUsers.push(users[i]);
-      }
-    } else {
-      // Remove user
-      for (let i = 0; i < selectedUsers.length; i++) {
-        let found = false;
-        for (let ii = 0; ii < users.length; ii++) {
-          if (selectedUsers[i].uid[0] === users[ii].uid[0]) {
-            found = true;
-            break;
-          }
-        }
-        if (!found) {
-          // Keep this valid selected entry
-          newSelectedUsers.push(selectedUsers[i]);
-        }
-      }
-    }
-    setSelectedUsers(newSelectedUsers);
-    setIsDeleteButtonDisabled(newSelectedUsers.length === 0);
-  };
-
-  // - Helper method to set the selected users from the table
-  const setUserSelected = (user: User, isSelecting = true) => {
-    if (isUserSelectable(user)) {
-      updateSelectedUsers([user], isSelecting);
-    }
-  };
-
-  // Modals functionality
+  // Page-specific states
   const [showAddModal, setShowAddModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showActivateModal, setShowActivateModal] = useState(false);
+
   const onAddClickHandler = () => {
     setShowAddModal(true);
   };
@@ -348,158 +80,35 @@ const StageUsers = () => {
     setShowActivateModal(!showActivateModal);
   };
 
-  // Table-related shared functionality
-  // - Selectable checkboxes on table
-  const selectableUsersTable = stageUsersList.filter(isUserSelectable); // elements per Table
-
-  // Data wrappers
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList: updateShownUsersList,
-    totalCount,
-  };
-
-  // - 'BulkSelectorPrep'
-  const usersBulkSelectorData = {
-    selected: selectedUsers,
-    updateSelected: updateSelectedUsers,
-    selectableTable: selectableUsersTable,
-    nameAttr: "uid",
-  };
-
-  const buttonsData = {
-    updateIsDeleteButtonDisabled,
-  };
-
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage,
-  };
-
-  // 'DeleteUsers'
-  const deleteUsersButtonsData = {
-    updateIsDeleteButtonDisabled,
-    updateIsDeletion,
-  };
-
+  // Data wrappers for child components
   const selectedUsersData = {
-    selectedUsers,
-    clearSelectedUsers,
+    selectedUsers: state.selectedElements,
+    clearSelectedUsers: state.clearSelectedElements,
   };
 
-  // 'UsersTable'
   const usersTableData = {
     isUserSelectable,
-    selectedUsers,
-    selectableUsersTable,
-    setUserSelected,
-    clearSelectedUsers,
+    selectedUsers: state.selectedElements,
+    selectableUsersTable: state.selectableElements,
+    setUserSelected: state.setElementSelected,
+    clearSelectedUsers: state.clearSelectedElements,
   };
 
   const usersTableButtonsData = {
-    updateIsDeleteButtonDisabled,
-    isDeletion,
-    updateIsDeletion,
+    updateIsDeleteButtonDisabled: state.updateIsDeleteButtonDisabled,
+    isDeletion: state.isDeletion,
+    updateIsDeletion: state.updateIsDeletion,
   };
 
-  // 'SearchInputLayout'
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
-  };
-
-  // Contextual links panel
-  const [isContextualPanelExpanded, setIsContextualPanelExpanded] =
-    React.useState(false);
-
-  const onOpenContextualPanel = () => {
-    setIsContextualPanelExpanded(!isContextualPanelExpanded);
-  };
-
-  const onCloseContextualPanel = () => {
-    setIsContextualPanelExpanded(false);
-  };
-
-  // List of Toolbar items
-  const toolbarItems: ToolbarItem[] = [
+  // Extra toolbar items
+  const extraToolbarItems: ToolbarItem[] = [
     {
-      key: 0,
-      element: (
-        <BulkSelectorPrep
-          list={stageUsersList}
-          shownElementsList={stageUsersList}
-          elementData={usersBulkSelectorData}
-          buttonsData={buttonsData}
-          selectedPerPageData={selectedPerPageData}
-        />
-      ),
-    },
-    {
-      key: 1,
-      element: (
-        <SearchInputLayout
-          dataCy="search"
-          name="search"
-          ariaLabel="Search user"
-          placeholder="Search"
-          searchValueData={searchValueData}
-          isDisabled={searchDisabled}
-        />
-      ),
-      toolbarItemVariant: ToolbarItemVariant.label,
-      toolbarItemGap: { default: "gapMd" },
-    },
-    {
-      key: 2,
-      toolbarItemVariant: ToolbarItemVariant.separator,
-    },
-    {
-      key: 3,
+      key: "activate",
       element: (
         <SecondaryButton
-          onClickHandler={refreshUsersData}
-          isDisabled={!showTableRows}
-          dataCy="stage-users-button-refresh"
-        >
-          Refresh
-        </SecondaryButton>
-      ),
-    },
-    {
-      key: 4,
-      element: (
-        <SecondaryButton
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
-          onClickHandler={onDeleteHandler}
-          dataCy="stage-users-button-delete"
-        >
-          Delete
-        </SecondaryButton>
-      ),
-    },
-    {
-      key: 5,
-      element: (
-        <SecondaryButton
-          onClickHandler={onAddClickHandler}
-          isDisabled={!showTableRows}
-          dataCy="stage-users-button-add"
-        >
-          Add
-        </SecondaryButton>
-      ),
-    },
-    {
-      key: 6,
-      element: (
-        <SecondaryButton
-          isDisabled={!showTableRows || selectedUsers.length === 0}
+          isDisabled={
+            !state.showTableRows || state.selectedElements.length === 0
+          }
           onClickHandler={onActivateHandler}
           dataCy="stage-users-button-activate"
         >
@@ -508,24 +117,24 @@ const StageUsers = () => {
       ),
     },
     {
-      key: 7,
+      key: "separator",
       toolbarItemVariant: ToolbarItemVariant.separator,
     },
     {
-      key: 8,
+      key: "help",
       element: (
         <HelpTextWithIconLayout
           textContent="Help"
-          onClick={onOpenContextualPanel}
+          onClick={state.toggleContextualPanel}
         />
       ),
     },
     {
-      key: 9,
+      key: "pagination-top",
       element: (
         <PaginationLayout
-          list={stageUsersList}
-          paginationData={paginationData}
+          list={state.elementsList}
+          paginationData={state.paginationData}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -534,88 +143,52 @@ const StageUsers = () => {
     },
   ];
 
-  // Render 'Stage users'
   return (
-    <ContextualHelpPanel
-      fromPage="stage-users"
-      isExpanded={isContextualPanelExpanded}
-      onClose={onCloseContextualPanel}
+    <GenericMainPage
+      state={state}
+      pageTitle="Stage users"
+      batchError={userDataResponse.error}
+      onRefresh={refreshData}
+      onAddClick={onAddClickHandler}
+      onDeleteClick={onDeleteHandler}
+      extraToolbarItems={extraToolbarItems}
+      contextualPanelPage="stage-users"
+      renderTable={(s) => (
+        <UsersTable
+          shownElementsList={s.elementsList}
+          from="stage-users"
+          showTableRows={s.showTableRows}
+          usersData={usersTableData}
+          buttonsData={usersTableButtonsData}
+          paginationData={s.selectedPerPageData}
+          searchValue={s.searchValue}
+        />
+      )}
     >
-      <div>
-        <PageSection hasBodyWrapper={false}>
-          <TitleLayout
-            id="stage users title"
-            headingLevel="h1"
-            text="Stage users"
-          />
-        </PageSection>
-        <PageSection hasBodyWrapper={false} isFilled={false}>
-          <Flex direction={{ default: "column" }}>
-            <FlexItem>
-              <ToolbarLayout toolbarItems={toolbarItems} />
-            </FlexItem>
-            <FlexItem style={{ flex: "0 0 auto" }}>
-              <OuterScrollContainer>
-                <InnerScrollContainer
-                  style={{ height: "60vh", overflow: "auto" }}
-                >
-                  {batchError !== undefined && batchError ? (
-                    <GlobalErrors errors={globalErrors.getAll()} />
-                  ) : (
-                    <UsersTable
-                      shownElementsList={stageUsersList}
-                      from="stage-users"
-                      showTableRows={showTableRows}
-                      usersData={usersTableData}
-                      buttonsData={usersTableButtonsData}
-                      paginationData={selectedPerPageData}
-                      searchValue={searchValue}
-                    />
-                  )}
-                </InnerScrollContainer>
-              </OuterScrollContainer>
-            </FlexItem>
-            <FlexItem
-              style={{ flex: "0 0 auto", position: "sticky", bottom: 0 }}
-            >
-              <PaginationLayout
-                list={stageUsersList}
-                paginationData={paginationData}
-                variant={PaginationVariant.bottom}
-                widgetId="pagination-options-menu-bottom"
-              />
-            </FlexItem>
-          </Flex>
-        </PageSection>
-        <ModalErrors
-          errors={modalErrors.getAll()}
-          dataCy="stage-users-modal-error"
-        />
-        <AddUser
-          show={showAddModal}
-          from="stage-users"
-          setShowTableRows={setShowTableRows}
-          handleModalToggle={onAddModalToggle}
-          onOpenAddModal={onAddClickHandler}
-          onCloseAddModal={onCloseAddModal}
-          onRefresh={refreshUsersData}
-        />
-        <DeleteUsers
-          show={showDeleteModal}
-          from="stage-users"
-          handleModalToggle={onDeleteModalToggle}
-          selectedUsersData={selectedUsersData}
-          buttonsData={deleteUsersButtonsData}
-          onRefresh={refreshUsersData}
-        />
-        <ActivateStageUsers
-          show={showActivateModal}
-          handleModalToggle={onActivateModalToggle}
-          selectedUsers={selectedUsers}
-          onSuccess={refreshUsersData}
-        />
-      </div>
-    </ContextualHelpPanel>
+      <AddUser
+        show={showAddModal}
+        from="stage-users"
+        setShowTableRows={state.setShowTableRows}
+        handleModalToggle={onAddModalToggle}
+        onOpenAddModal={onAddClickHandler}
+        onCloseAddModal={onCloseAddModal}
+        onRefresh={refreshData}
+      />
+      <DeleteUsers
+        show={showDeleteModal}
+        from="stage-users"
+        handleModalToggle={onDeleteModalToggle}
+        selectedUsersData={selectedUsersData}
+        buttonsData={state.deleteButtonsData}
+        onRefresh={refreshData}
+      />
+      <ActivateStageUsers
+        show={showActivateModal}
+        handleModalToggle={onActivateModalToggle}
+        selectedUsers={state.selectedElements}
+        onSuccess={refreshData}
+      />
+    </GenericMainPage>
   );
 };
 


### PR DESCRIPTION
## Summary by Sourcery

Extract common list-page behavior into a reusable GenericMainPage component and migrate ActiveUsers, StageUsers, PreservedUsers, and Hosts pages to use it.

Enhancements:
- Introduce a GenericMainPage component and useMainPageState hook to centralize shared main-page layout, pagination, search, selection, and error-handling logic.
- Refactor ActiveUsers, StageUsers, PreservedUsers, and Hosts screens to delegate common behavior to GenericMainPage while keeping page-specific table and modal logic.
- Extend ToolbarLayout item typing to support string keys for more flexible toolbar composition.