### PR TITLE
I18n

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -30,6 +30,9 @@
     "src/utils/*.ts",
     "src/utils/*.tsx",
     "src/utils/**/*.ts",
-    "src/utils/**/*.tsx"
+    "src/utils/**/*.tsx",
+    "src/hooks/useTranslation.ts",
+    "src/services/rpci18n.ts",
+    "src/services/rpc.ts"
   ]
 }

--- a/src/hooks/useTranslation.ts
+++ b/src/hooks/useTranslation.ts
@@ -1,0 +1,64 @@
+import { useState } from "react";
+import { useGetInternalizationQuery } from "src/services/rpci18n";
+import invariant from "tiny-invariant";
+import {
+  Translations,
+  TranslationKey,
+  TranslationReplaces,
+} from "../utils/datatypes/Internalization";
+
+// Source - https://stackoverflow.com/a/37510735
+// Posted by Pranav C Balan, modified by community. See post 'Timeline' for change history
+// Retrieved 2026-03-09, License - CC BY-SA 3.0
+const getNestedProperty = (
+  i18n: Translations,
+  key: TranslationKey
+): string | undefined => {
+  // We know that the server response must be a string,
+  // otherwise something is wrong with the server
+  return key.split(".").reduce((o, k) => o && o[k], i18n) as unknown as
+    | string
+    | undefined;
+};
+
+export const useTranslation = () => {
+  const [language, setLanguage] = useState(navigator.language);
+  const { data, isLoading } = useGetInternalizationQuery({ language });
+
+  if (isLoading) {
+    return { t: () => "", language: "", setLanguage: () => {} };
+  }
+
+  invariant(data !== undefined, "Data is not defined");
+  invariant(data.result !== null, "Error obtaining response");
+
+  const t = <K extends TranslationKey>(
+    key: K,
+    ...args: TranslationReplaces<K> extends undefined
+      ? []
+      : [TranslationReplaces<K>]
+  ): string => {
+    let str = getNestedProperty(data.result, key);
+
+    if (str === undefined) {
+      console.warn(`Key ${key} doesn't exist in i18n`);
+      return key;
+    }
+
+    const replaces = args[0];
+
+    if (!replaces) {
+      return str;
+    }
+
+    for (const [k, v] of Object.entries(replaces)) {
+      invariant(str.includes(`\${${k}}`), `Key ${k} not in ${str}!`);
+
+      str = str.replace(new RegExp(`\\\${${k}}`, "g"), String(v));
+    }
+
+    return str;
+  };
+
+  return { t, language, setLanguage };
+};

--- a/src/services/rpc.ts
+++ b/src/services/rpc.ts
@@ -66,6 +66,22 @@ export interface KwError {
   };
 }
 
+export type ErrorRPCResponse = {
+  result: null;
+  error: ErrorResult;
+  id: null;
+  principal: string;
+  version: string;
+};
+
+export type ValidResponse<T> = {
+  result: T;
+  error: null;
+  id: null;
+  principal: string;
+  version: string;
+};
+
 // 'FindRPCResponse' type
 //   - Has 'result' > 'result' structure
 export interface FindRPCResponse {

--- a/src/services/rpci18n.ts
+++ b/src/services/rpci18n.ts
@@ -1,0 +1,31 @@
+import { InternalizationResponse } from "src/utils/datatypes/Internalization";
+import { api } from "./rpc";
+import { API_VERSION_BACKUP } from "src/utils/utils";
+
+type InternalizationPayload = {
+  language: string;
+};
+
+const extendedApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    getInternalization: build.query<
+      InternalizationResponse,
+      InternalizationPayload
+    >({
+      query: ({ language }) => ({
+        url: "/ipa/i18n_messages",
+        method: "POST",
+        headers: {
+          "Accept-Language": language,
+        },
+        body: {
+          method: "i18n_messages",
+          params: [[], { version: API_VERSION_BACKUP }],
+        },
+      }),
+    }),
+  }),
+  overrideExisting: false,
+});
+
+export const { useGetInternalizationQuery } = extendedApi;

--- a/src/utils/datatypes/Internalization.ts
+++ b/src/utils/datatypes/Internalization.ts
@@ -1,0 +1,35 @@
+import { ErrorRPCResponse, ValidResponse } from "src/services/rpc";
+
+export type InternalizationResponse =
+  | ErrorRPCResponse
+  | ValidResponse<Translations>;
+
+export type Translations = {
+  [K in TranslationKey]: string;
+};
+
+export type TranslationKey = keyof typeof TRANSLATIONS;
+
+export type TranslationReplaces<K extends TranslationKey> =
+  (typeof TRANSLATIONS)[K] extends readonly []
+    ? undefined
+    : {
+        [P in (typeof TRANSLATIONS)[K][number]]: string;
+      };
+
+export const TRANSLATIONS = {
+  "texts.ajax.401.message": [],
+  "texts.actions.apply": [],
+  "texts.actions.automember_rebuild": [],
+  "texts.actions.automember_rebuild_confirm": [],
+  "texts.actions.automember_rebuild_success": [],
+  "texts.actions.confirm": [],
+  "texts.actions.delete_confirm": ["object"],
+  "texts.actions.disable_confirm": ["object"],
+  "texts.actions.enable_confirm": ["object"],
+  "texts.actions.title": [],
+  "texts.association.paging": ["start", "end", "total"],
+  // Example errors:
+  "texts.association.removed": ["error"],
+  "texts.association.error-key": ["start", "end", "total"],
+} as const;


### PR DESCRIPTION
Wondering if I'm missing something here.

We'll simply be using `useInternalization()`, returns a function for querying the strings, current language and also setting language. As to why we'd wanna change the language, well, I just find it intuitive that one has to go to browser settings, it may or may not be used, but I did saw a few requests for that and reports as a bug, so we can implement our own UI for changing language. 

I think it's safe to crash if we can't obtain any internalization. The contents of the strings should be obtained manually, they also use `${variable}` that should be replaced with the `replaces` Record. Should we improve on the typing there? I think we could make a PoC with full types, that is, the `${variables}` will be mandatory and required by TypeScript's type system.

There will be a lot work on top of this, this is just something I quickly drafted and would like to know an opinion.

(ignore temp example, it's just an ugly showcase)

## Summary by Sourcery

Introduce a typed internationalization system and wire it into the app using a translation hook backed by an RPC endpoint.

New Features:
- Add a useTranslation hook that fetches language-specific messages and provides a type-safe translation function with variable substitution.
- Define Internalization typings and metadata to constrain valid translation keys and required replacement variables.
- Expose an RPC endpoint wrapper for fetching i18n messages based on the selected language.

Enhancements:
- Extend generic RPC response types to standardize success and error shapes used by new i18n calls.
- Integrate the translation hook into top-level layout and app components as an initial usage example.