### PR TITLE
[Integration tests] ID Ranges

### DIFF
--- a/cypress/e2e/dns/dnsrecords.ts
+++ b/cypress/e2e/dns/dnsrecords.ts
@@ -72,10 +72,10 @@ const addDnsRecordTypeA6 = (recordData: string) => {
 
 const addDnsRecordTypeAFSDB = (subtype: string, hostname: string) => {
   clearAndAddAdjustedNumberValue(
-    "modal-number-input-afsdb-part-subtype",
+    "modal-number-input-afsdb-part-subtype-input",
     subtype
   );
-  cy.dataCy("modal-number-input-afsdb-part-subtype").should(
+  cy.dataCy("modal-number-input-afsdb-part-subtype-input").should(
     "have.value",
     subtype
   );
@@ -111,23 +111,29 @@ const addDnsRecordTypeDS = (
   digestType: string,
   digest: string
 ) => {
-  clearAndAddAdjustedNumberValue("modal-number-input-ds-part-key-tag", keyTag);
-  cy.dataCy("modal-number-input-ds-part-key-tag").should("have.value", keyTag);
+  clearAndAddAdjustedNumberValue(
+    "modal-number-input-ds-part-key-tag-input",
+    keyTag
+  );
+  cy.dataCy("modal-number-input-ds-part-key-tag-input").should(
+    "have.value",
+    keyTag
+  );
 
   clearAndAddAdjustedNumberValue(
-    "modal-number-input-ds-part-algorithm",
+    "modal-number-input-ds-part-algorithm-input",
     algorithm
   );
-  cy.dataCy("modal-number-input-ds-part-algorithm").should(
+  cy.dataCy("modal-number-input-ds-part-algorithm-input").should(
     "have.value",
     algorithm
   );
 
   clearAndAddAdjustedNumberValue(
-    "modal-number-input-ds-part-digest-type",
+    "modal-number-input-ds-part-digest-type-input",
     digestType
   );
-  cy.dataCy("modal-number-input-ds-part-digest-type").should(
+  cy.dataCy("modal-number-input-ds-part-digest-type-input").should(
     "have.value",
     digestType
   );
@@ -144,25 +150,31 @@ const addDnsRecordTypeDLV = (
   digestType: string,
   digest: string
 ) => {
-  clearAndAddAdjustedNumberValue("modal-number-input-dlv-part-key-tag", keyTag);
-  cy.dataCy("modal-number-input-dlv-part-key-tag").should("have.value", keyTag);
+  clearAndAddAdjustedNumberValue(
+    "modal-number-input-dlv-part-key-tag-input",
+    keyTag
+  );
+  cy.dataCy("modal-number-input-dlv-part-key-tag-input").should(
+    "have.value",
+    keyTag
+  );
 
   clearAndAddAdjustedNumberValue(
-    "modal-number-input-dlv-part-algorithm",
+    "modal-number-input-dlv-part-algorithm-input",
     algorithm
   );
-  cy.dataCy("modal-number-input-dlv-part-algorithm").should(
+  cy.dataCy("modal-number-input-dlv-part-algorithm-input").should(
     "have.value",
     algorithm
   );
 
   clearAndAddAdjustedNumberValue(
-    "modal-number-input-dlv-part-digest-type",
+    "modal-number-input-dlv-part-digest-type-input",
     digestType
   );
-  cy.dataCy("modal-number-input-dlv-part-algorithm").should(
+  cy.dataCy("modal-number-input-dlv-part-digest-type-input").should(
     "have.value",
-    algorithm
+    digestType
   );
 
   clearAndAddAdjustedNumberValue("modal-textarea-dlv-part-digest", digest);
@@ -173,10 +185,10 @@ const addDnsRecordTypeDLV = (
 
 const addDnsRecordTypeKX = (preference: string, exchanger: string) => {
   clearAndAddAdjustedNumberValue(
-    "modal-number-input-kx-part-preference",
+    "modal-number-input-kx-part-preference-input",
     preference
   );
-  cy.dataCy("modal-number-input-kx-part-preference").should(
+  cy.dataCy("modal-number-input-kx-part-preference-input").should(
     "have.value",
     preference
   );
@@ -203,28 +215,64 @@ const addDnsRecordTypeLOC = (
   horizontalPrecision: string,
   verticalPrecision: string
 ) => {
-  clearAndAddAdjustedNumberValue("modal-number-input-loc-part-lat-deg", latDeg);
-  cy.dataCy("modal-number-input-loc-part-lat-deg").should("have.value", latDeg);
+  clearAndAddAdjustedNumberValue(
+    "modal-number-input-loc-part-lat-deg-input",
+    latDeg
+  );
+  cy.dataCy("modal-number-input-loc-part-lat-deg-input").should(
+    "have.value",
+    latDeg
+  );
 
-  clearAndAddAdjustedNumberValue("modal-number-input-loc-part-lat-min", latMin);
-  cy.dataCy("modal-number-input-loc-part-lat-min").should("have.value", latMin);
+  clearAndAddAdjustedNumberValue(
+    "modal-number-input-loc-part-lat-min-input",
+    latMin
+  );
+  cy.dataCy("modal-number-input-loc-part-lat-min-input").should(
+    "have.value",
+    latMin
+  );
 
-  clearAndAddAdjustedNumberValue("modal-number-input-loc-part-lat-sec", latSec);
-  cy.dataCy("modal-number-input-loc-part-lat-sec").should("have.value", latSec);
+  clearAndAddAdjustedNumberValue(
+    "modal-number-input-loc-part-lat-sec-input",
+    latSec
+  );
+  cy.dataCy("modal-number-input-loc-part-lat-sec-input").should(
+    "have.value",
+    latSec
+  );
 
   cy.dataCy("modal-radio-loc-part-lat-dir-radio-" + latDir).click();
   cy.dataCy("modal-radio-loc-part-lat-dir-radio-" + latDir).should(
     "be.checked"
   );
 
-  clearAndAddAdjustedNumberValue("modal-number-input-loc-part-lon-deg", lonDeg);
-  cy.dataCy("modal-number-input-loc-part-lon-deg").should("have.value", lonDeg);
+  clearAndAddAdjustedNumberValue(
+    "modal-number-input-loc-part-lon-deg-input",
+    lonDeg
+  );
+  cy.dataCy("modal-number-input-loc-part-lon-deg-input").should(
+    "have.value",
+    lonDeg
+  );
 
-  clearAndAddAdjustedNumberValue("modal-number-input-loc-part-lon-min", lonMin);
-  cy.dataCy("modal-number-input-loc-part-lon-min").should("have.value", lonMin);
+  clearAndAddAdjustedNumberValue(
+    "modal-number-input-loc-part-lon-min-input",
+    lonMin
+  );
+  cy.dataCy("modal-number-input-loc-part-lon-min-input").should(
+    "have.value",
+    lonMin
+  );
 
-  clearAndAddAdjustedNumberValue("modal-number-input-loc-part-lon-sec", lonSec);
-  cy.dataCy("modal-number-input-loc-part-lon-sec").should("have.value", lonSec);
+  clearAndAddAdjustedNumberValue(
+    "modal-number-input-loc-part-lon-sec-input",
+    lonSec
+  );
+  cy.dataCy("modal-number-input-loc-part-lon-sec-input").should(
+    "have.value",
+    lonSec
+  );
 
   cy.dataCy("modal-radio-loc-part-lon-dir-radio-" + lonDir).click();
   cy.dataCy("modal-radio-loc-part-lon-dir-radio-" + lonDir).should(
@@ -232,31 +280,37 @@ const addDnsRecordTypeLOC = (
   );
 
   clearAndAddAdjustedNumberValue(
-    "modal-number-input-loc-part-altitude",
+    "modal-number-input-loc-part-altitude-input",
     altitude
   );
-  cy.dataCy("modal-number-input-loc-part-altitude").should(
+  cy.dataCy("modal-number-input-loc-part-altitude-input").should(
     "have.value",
     altitude
   );
 
-  clearAndAddAdjustedNumberValue("modal-number-input-loc-part-size", size);
-  cy.dataCy("modal-number-input-loc-part-size").should("have.value", size);
+  clearAndAddAdjustedNumberValue(
+    "modal-number-input-loc-part-size-input",
+    size
+  );
+  cy.dataCy("modal-number-input-loc-part-size-input").should(
+    "have.value",
+    size
+  );
 
   clearAndAddAdjustedNumberValue(
-    "modal-number-input-loc-part-h-precision",
+    "modal-number-input-loc-part-h-precision-input",
     horizontalPrecision
   );
-  cy.dataCy("modal-number-input-loc-part-h-precision").should(
+  cy.dataCy("modal-number-input-loc-part-h-precision-input").should(
     "have.value",
     horizontalPrecision
   );
 
   clearAndAddAdjustedNumberValue(
-    "modal-number-input-loc-part-v-precision",
+    "modal-number-input-loc-part-v-precision-input",
     verticalPrecision
   );
-  cy.dataCy("modal-number-input-loc-part-v-precision").should(
+  cy.dataCy("modal-number-input-loc-part-v-precision-input").should(
     "have.value",
     verticalPrecision
   );
@@ -266,7 +320,7 @@ const addDnsRecordTypeLOC = (
 
 const addDnsRecordTypeMX = (preference: string, exchanger: string) => {
   clearAndAddAdjustedNumberValue(
-    "modal-number-input-mx-part-preference",
+    "modal-number-input-mx-part-preference-input",
     preference
   );
   cy.dataCy("modal-text-input-mx-part-exchanger").type(exchanger);
@@ -286,14 +340,20 @@ const addDnsRecordTypeNAPTR = (
   regexp: string,
   replacement: string
 ) => {
-  clearAndAddAdjustedNumberValue("modal-number-input-naptr-part-order", order);
-  cy.dataCy("modal-number-input-naptr-part-order").should("have.value", order);
+  clearAndAddAdjustedNumberValue(
+    "modal-number-input-naptr-part-order-input",
+    order
+  );
+  cy.dataCy("modal-number-input-naptr-part-order-input").should(
+    "have.value",
+    order
+  );
 
   clearAndAddAdjustedNumberValue(
-    "modal-number-input-naptr-part-preference",
+    "modal-number-input-naptr-part-preference-input",
     preference
   );
-  cy.dataCy("modal-number-input-naptr-part-preference").should(
+  cy.dataCy("modal-number-input-naptr-part-preference-input").should(
     "have.value",
     preference
   );
@@ -357,19 +417,31 @@ const addDnsRecordTypeSRV = (
   target: string
 ) => {
   clearAndAddAdjustedNumberValue(
-    "modal-number-input-srv-part-priority",
+    "modal-number-input-srv-part-priority-input",
     priority
   );
-  cy.dataCy("modal-number-input-srv-part-priority").should(
+  cy.dataCy("modal-number-input-srv-part-priority-input").should(
     "have.value",
     priority
   );
 
-  clearAndAddAdjustedNumberValue("modal-number-input-srv-part-weight", weight);
-  cy.dataCy("modal-number-input-srv-part-weight").should("have.value", weight);
+  clearAndAddAdjustedNumberValue(
+    "modal-number-input-srv-part-weight-input",
+    weight
+  );
+  cy.dataCy("modal-number-input-srv-part-weight-input").should(
+    "have.value",
+    weight
+  );
 
-  clearAndAddAdjustedNumberValue("modal-number-input-srv-part-port", port);
-  cy.dataCy("modal-number-input-srv-part-port").should("have.value", port);
+  clearAndAddAdjustedNumberValue(
+    "modal-number-input-srv-part-port-input",
+    port
+  );
+  cy.dataCy("modal-number-input-srv-part-port-input").should(
+    "have.value",
+    port
+  );
 
   clearAndAddAdjustedNumberValue("modal-text-input-srv-part-target", target);
   cy.dataCy("modal-text-input-srv-part-target").should("have.value", target);
@@ -383,19 +455,19 @@ const addDnsRecordTypeSSHFP = (
   fingerprint: string
 ) => {
   clearAndAddAdjustedNumberValue(
-    "modal-number-input-sshfp-part-algorithm",
+    "modal-number-input-sshfp-part-algorithm-input",
     algorithm
   );
-  cy.dataCy("modal-number-input-sshfp-part-algorithm").should(
+  cy.dataCy("modal-number-input-sshfp-part-algorithm-input").should(
     "have.value",
     algorithm
   );
 
   clearAndAddAdjustedNumberValue(
-    "modal-number-input-sshfp-part-fp-type",
+    "modal-number-input-sshfp-part-fp-type-input",
     fpType
   );
-  cy.dataCy("modal-number-input-sshfp-part-fp-type").should(
+  cy.dataCy("modal-number-input-sshfp-part-fp-type-input").should(
     "have.value",
     fpType
   );
@@ -418,28 +490,28 @@ const addDnsRecordTypeTLSA = (
   certAssociationData: string
 ) => {
   clearAndAddAdjustedNumberValue(
-    "modal-number-input-tlsa-part-cert-usage",
+    "modal-number-input-tlsa-part-cert-usage-input",
     certUsage
   );
-  cy.dataCy("modal-number-input-tlsa-part-cert-usage").should(
+  cy.dataCy("modal-number-input-tlsa-part-cert-usage-input").should(
     "have.value",
     certUsage
   );
 
   clearAndAddAdjustedNumberValue(
-    "modal-number-input-tlsa-part-selector",
+    "modal-number-input-tlsa-part-selector-input",
     selector
   );
-  cy.dataCy("modal-number-input-tlsa-part-selector").should(
+  cy.dataCy("modal-number-input-tlsa-part-selector-input").should(
     "have.value",
     selector
   );
 
   clearAndAddAdjustedNumberValue(
-    "modal-number-input-tlsa-part-matching-type",
+    "modal-number-input-tlsa-part-matching-type-input",
     matchingType
   );
-  cy.dataCy("modal-number-input-tlsa-part-matching-type").should(
+  cy.dataCy("modal-number-input-tlsa-part-matching-type-input").should(
     "have.value",
     matchingType
   );
@@ -472,16 +544,22 @@ const addDnsRecordTypeURI = (
   target: string
 ) => {
   clearAndAddAdjustedNumberValue(
-    "modal-number-input-uri-part-priority",
+    "modal-number-input-uri-part-priority-input",
     priority
   );
-  cy.dataCy("modal-number-input-uri-part-priority").should(
+  cy.dataCy("modal-number-input-uri-part-priority-input").should(
     "have.value",
     priority
   );
 
-  clearAndAddAdjustedNumberValue("modal-number-input-uri-part-weight", weight);
-  cy.dataCy("modal-number-input-uri-part-weight").should("have.value", weight);
+  clearAndAddAdjustedNumberValue(
+    "modal-number-input-uri-part-weight-input",
+    weight
+  );
+  cy.dataCy("modal-number-input-uri-part-weight-input").should(
+    "have.value",
+    weight
+  );
 
   clearAndAddAdjustedNumberValue("modal-text-input-uri-part-target", target);
   cy.dataCy("modal-text-input-uri-part-target").should("have.value", target);

--- a/cypress/e2e/id_ranges/id_ranges.feature
+++ b/cypress/e2e/id_ranges/id_ranges.feature
@@ -1,0 +1,320 @@
+Feature: ID Range manipulation
+    Create, and delete ID ranges
+
+    @test
+    Scenario: Add a new ID range (local domain)
+        Given I am logged in as admin
+        And I am on "id-ranges" page
+
+        When I click on the "id-ranges-button-add" button
+        Then I should see "add-id-range-modal" modal
+
+        When I type in the "modal-textbox-range-name" textbox text "IDM.EXAMPLE.COM_new_range"
+        Then I should see "IDM.EXAMPLE.COM_new_range" in the "modal-textbox-range-name" textbox
+
+        When I type in the "modal-textbox-base-id-input" textbox text "5000"
+        Then I should see "5000" in the "modal-textbox-base-id-input" textbox
+
+        When I type in the "modal-textbox-range-size-input" textbox text "1000"
+        Then I should see "1000" in the "modal-textbox-range-size-input" textbox
+
+        When I type in the "modal-textbox-primary-rid-base-input" textbox text "30000"
+        Then I should see "30000" in the "modal-textbox-primary-rid-base-input" textbox
+
+        When I type in the "modal-textbox-secondary-rid-base-input" textbox text "1300000"
+        Then I should see "1300000" in the "modal-textbox-secondary-rid-base-input" textbox
+
+        When I click on the "modal-button-add" button
+        Then I should not see "add-id-range-modal" modal
+        And I should see "add-idrange-success" alert
+
+        When I search for "IDM.EXAMPLE.COM_new_range" in the data table
+        Then I should see "IDM.EXAMPLE.COM_new_range" entry in the data table
+
+    @cleanup
+    Scenario: Delete a ID range
+        Given I delete id range "IDM.EXAMPLE.COM_new_range"
+
+    @test
+    Scenario: Add a new ID range with special characters in the name
+        Given I am logged in as admin
+        And I am on "id-ranges" page
+
+        When I click on the "id-ranges-button-add" button
+        Then I should see "add-id-range-modal" modal
+
+        When I type in the "modal-textbox-range-name" textbox text "itest-range-!@#$%^&*"
+        Then I should see "itest-range-!@#$%^&*" in the "modal-textbox-range-name" textbox
+
+        When I type in the "modal-textbox-base-id-input" textbox text "5000"
+        Then I should see "5000" in the "modal-textbox-base-id-input" textbox
+
+        When I type in the "modal-textbox-range-size-input" textbox text "1000"
+        Then I should see "1000" in the "modal-textbox-range-size-input" textbox
+
+        When I type in the "modal-textbox-primary-rid-base-input" textbox text "30000"
+        Then I should see "30000" in the "modal-textbox-primary-rid-base-input" textbox
+
+        When I type in the "modal-textbox-secondary-rid-base-input" textbox text "1300000"
+        Then I should see "1300000" in the "modal-textbox-secondary-rid-base-input" textbox
+
+        When I click on the "modal-button-add" button
+        Then I should not see "add-id-range-modal" modal
+        And I should see "add-idrange-success" alert
+
+        When I search for "itest-range-!@#$%^&*" in the data table
+        Then I should see "itest-range-!@#$%^&*" entry in the data table
+
+    @cleanup
+    Scenario: Delete a ID range with special characters in the name
+        Given I delete id range "itest-range-!@#$%^&*"
+
+    @seed
+    Scenario: Create a ID range
+        Given id range "IDM.EXAMPLE.COM_exists" exists with base ID "5000", range size "1000", primary RID base "30000", and secondary RID base "1300000"
+
+    @test
+    Scenario: Add a new ID range with existing name
+        Given I am logged in as admin
+        And I am on "id-ranges" page
+
+        When I click on the "id-ranges-button-add" button
+        Then I should see "add-id-range-modal" modal
+
+        When I type in the "modal-textbox-range-name" textbox text "IDM.EXAMPLE.COM_exists"
+        Then I should see "IDM.EXAMPLE.COM_exists" in the "modal-textbox-range-name" textbox
+
+        When I type in the "modal-textbox-base-id-input" textbox text "5000"
+        Then I should see "5000" in the "modal-textbox-base-id-input" textbox
+
+        When I type in the "modal-textbox-range-size-input" textbox text "1000"
+        Then I should see "1000" in the "modal-textbox-range-size-input" textbox
+
+        When I type in the "modal-textbox-primary-rid-base-input" textbox text "30000"
+        Then I should see "30000" in the "modal-textbox-primary-rid-base-input" textbox
+
+        When I type in the "modal-textbox-secondary-rid-base-input" textbox text "1300000"
+        Then I should see "1300000" in the "modal-textbox-secondary-rid-base-input" textbox
+
+        When I click on the "modal-button-add" button
+        Then I should see "add-id-range-modal" modal
+        And I should see "add-idrange-error" alert
+
+        When I click on the "modal-button-cancel" button
+        Then I should not see "add-id-range-modal" modal
+
+    @cleanup
+    Scenario: Delete a ID range with existing name
+        Given I delete id range "IDM.EXAMPLE.COM_exists"
+
+    @seed
+    Scenario: Create a ID range
+        Given id range "IDM.EXAMPLE.COM_new_range" exists with base ID "5000", range size "1000", primary RID base "30000", and secondary RID base "1300000"
+
+    @test
+    Scenario: Delete a ID range
+        Given I am logged in as admin
+        And I am on "id-ranges" page
+
+        When I search for "IDM.EXAMPLE.COM_new_range" in the data table
+        Then I should see "IDM.EXAMPLE.COM_new_range" entry in the data table
+
+        When I select entry "IDM.EXAMPLE.COM_new_range" in the data table
+        Then I should see "IDM.EXAMPLE.COM_new_range" entry selected in the data table
+
+        When I click on the "id-ranges-button-delete" button
+        Then I should see "delete-idranges-modal" modal
+
+        When I click on the "modal-button-delete" button
+        Then I should not see "delete-idranges-modal" modal
+        And I should see "remove-idranges-success" alert
+
+        When I search for "IDM.EXAMPLE.COM_new_range" in the data table
+        Then I should not see "IDM.EXAMPLE.COM_new_range" entry in the data table
+
+    @test
+    Scenario: Cancel creation of a ID range
+        Given I am logged in as admin
+        And I am on "id-ranges" page
+
+        When I click on the "id-ranges-button-add" button
+        Then I should see "add-id-range-modal" modal
+
+        When I type in the "modal-textbox-range-name" textbox text "cancel_id_range"
+        Then I should see "cancel_id_range" in the "modal-textbox-range-name" textbox
+
+        When I click on the "modal-button-cancel" button
+        Then I should not see "add-id-range-modal" modal
+
+        When I search for "cancel_id_range" in the data table
+        Then I should not see "cancel_id_range" entry in the data table
+
+    @test
+    Scenario: Add a new ID range (AD trust) that fails due to missing trust
+        Given I am logged in as admin
+        And I am on "id-ranges" page
+
+        When I click on the "id-ranges-button-add" button
+        Then I should see "add-id-range-modal" modal
+
+        When I type in the "modal-textbox-range-name" textbox text "fail_id_range"
+        Then I should see "fail_id_range" in the "modal-textbox-range-name" textbox
+
+        When I click on the "ad-domain-radio" radio button
+        Then I should see the "ad-domain-radio" radio button is selected
+
+        When I type in the "modal-textbox-base-id-input" textbox text "5000"
+        Then I should see "5000" in the "modal-textbox-base-id-input" textbox
+
+        When I type in the "modal-textbox-range-size-input" textbox text "1000"
+        Then I should see "1000" in the "modal-textbox-range-size-input" textbox
+
+        When I type in the "modal-textbox-primary-rid-base-input" textbox text "30000"
+        Then I should see "30000" in the "modal-textbox-primary-rid-base-input" textbox
+
+        When I type in the "modal-textbox-trusted-domain" textbox text "ad.ipa.test"
+        Then I should see "ad.ipa.test" in the "modal-textbox-trusted-domain" textbox
+
+        When I click on the "modal-button-add" button
+        Then I should see "add-id-range-modal" modal
+        And I should see "add-idrange-error" alert
+
+        When I click on the "modal-button-cancel" button
+        Then I should not see "add-id-range-modal" modal
+
+    @seed
+    Scenario: Create a ID range
+        Given id range "IDM.EXAMPLE.COM_exists_base_id" exists with base ID "5000", range size "1000", primary RID base "30000", and secondary RID base "1300000"
+
+    @test
+    Scenario: Add a new ID range (AD trust with POSIX attributes) that fails due to missing trust and existing base ID
+        Given I am logged in as admin
+        And I am on "id-ranges" page
+
+        When I click on the "id-ranges-button-add" button
+        Then I should see "add-id-range-modal" modal
+
+        When I type in the "modal-textbox-range-name" textbox text "IDM.EXAMPLE.COM_exists_base_id"
+        Then I should see "IDM.EXAMPLE.COM_exists_base_id" in the "modal-textbox-range-name" textbox
+
+        When I click on the "range-type-radio" radio button
+        Then I should see the "range-type-radio" radio button is selected
+
+        When I type in the "modal-textbox-base-id-input" textbox text "5000"
+        Then I should see "5000" in the "modal-textbox-base-id-input" textbox
+
+        When I type in the "modal-textbox-range-size-input" textbox text "1000"
+        Then I should see "1000" in the "modal-textbox-range-size-input" textbox
+
+        When I type in the "modal-textbox-trusted-domain" textbox text "ad.ipa.test"
+        Then I should see "ad.ipa.test" in the "modal-textbox-trusted-domain" textbox
+
+        When I click on the "modal-button-add" button
+        Then I should see "add-id-range-modal" modal
+        And I should see "add-idrange-error" alert
+
+        When I click on the "modal-button-cancel" button
+        Then I should not see "add-id-range-modal" modal
+
+    @cleanup
+    Scenario: Delete a ID range with existing base ID
+        Given I delete id range "IDM.EXAMPLE.COM_exists_base_id"
+
+    @seed
+    Scenario: Create a ID range
+        Given id range "IDM.EXAMPLE.COM_exists_secondary_rid_base" exists with base ID "5000", range size "1000", primary RID base "30000", and secondary RID base "1300000"
+
+    @test
+    Scenario: Add a new ID range with existing secondary RID base
+        Given I am logged in as admin
+        And I am on "id-ranges" page
+
+        When I click on the "id-ranges-button-add" button
+        Then I should see "add-id-range-modal" modal
+
+        When I type in the "modal-textbox-range-name" textbox text "IDM.EXAMPLE.COM_exists_secondary_rid_base"
+        Then I should see "IDM.EXAMPLE.COM_exists_secondary_rid_base" in the "modal-textbox-range-name" textbox
+
+        When I type in the "modal-textbox-base-id-input" textbox text "5000"
+        Then I should see "5000" in the "modal-textbox-base-id-input" textbox
+
+        When I type in the "modal-textbox-range-size-input" textbox text "1000"
+        Then I should see "1000" in the "modal-textbox-range-size-input" textbox
+
+        When I type in the "modal-textbox-primary-rid-base-input" textbox text "30000"
+        Then I should see "30000" in the "modal-textbox-primary-rid-base-input" textbox
+
+        When I type in the "modal-textbox-secondary-rid-base-input" textbox text "1300000"
+        Then I should see "1300000" in the "modal-textbox-secondary-rid-base-input" textbox
+
+        When I click on the "modal-button-add" button
+        Then I should see "add-id-range-modal" modal
+        And I should see "add-idrange-error" alert
+
+        When I click on the "modal-button-cancel" button
+        Then I should not see "add-id-range-modal" modal
+
+    @cleanup
+    Scenario: Delete a ID range with existing secondary RID base
+        Given I delete id range "IDM.EXAMPLE.COM_exists_secondary_rid_base"
+
+    @seed
+    Scenario: Create a ID range
+        Given id range "IDM.EXAMPLE.COM_exists_overlapping_rid_bases" exists with base ID "5000", range size "1000", primary RID base "30000", and secondary RID base "1300000"
+
+    @test
+    Scenario: Add a new ID range with overlapping primary and secondary RID bases
+        Given I am logged in as admin
+        And I am on "id-ranges" page
+
+        When I click on the "id-ranges-button-add" button
+        Then I should see "add-id-range-modal" modal
+
+        When I type in the "modal-textbox-range-name" textbox text "IDM.EXAMPLE.COM_exists_overlapping_rid_bases"
+        Then I should see "IDM.EXAMPLE.COM_exists_overlapping_rid_bases" in the "modal-textbox-range-name" textbox
+
+        When I type in the "modal-textbox-base-id-input" textbox text "5000"
+        Then I should see "5000" in the "modal-textbox-base-id-input" textbox
+
+        When I type in the "modal-textbox-range-size-input" textbox text "1000"
+        Then I should see "1000" in the "modal-textbox-range-size-input" textbox
+
+        When I type in the "modal-textbox-primary-rid-base-input" textbox text "30000"
+        Then I should see "30000" in the "modal-textbox-primary-rid-base-input" textbox
+
+        When I type in the "modal-textbox-secondary-rid-base-input" textbox text "1300000"
+        Then I should see "1300000" in the "modal-textbox-secondary-rid-base-input" textbox
+
+        When I click on the "modal-button-add" button
+        Then I should see "add-id-range-modal" modal
+        And I should see "add-idrange-error" alert
+
+        When I click on the "modal-button-cancel" button
+        Then I should not see "add-id-range-modal" modal
+
+    @cleanup
+    Scenario: Delete a ID range with overlapping primary and secondary RID bases
+        Given I delete id range "IDM.EXAMPLE.COM_exists_overlapping_rid_bases"
+
+    @test
+    Scenario: Add a new ID range without any of the required fields (e.g. secondary RID base)
+        Given I am logged in as admin
+        And I am on "id-ranges" page
+
+        When I click on the "id-ranges-button-add" button
+        Then I should see "add-id-range-modal" modal
+
+        When I type in the "modal-textbox-range-name" textbox text "fail_id_range_no_fields"
+        Then I should see "fail_id_range_no_fields" in the "modal-textbox-range-name" textbox
+
+        When I type in the "modal-textbox-base-id-input" textbox text "5000"
+        Then I should see "5000" in the "modal-textbox-base-id-input" textbox
+
+        When I type in the "modal-textbox-range-size-input" textbox text "1000"
+        Then I should see "1000" in the "modal-textbox-range-size-input" textbox
+
+        When I type in the "modal-textbox-primary-rid-base-input" textbox text "30000"
+        Then I should see "30000" in the "modal-textbox-primary-rid-base-input" textbox
+
+        When I should see the "modal-button-add" button is disabled
+        Then I click on the "modal-button-cancel" button

--- a/cypress/e2e/id_ranges/id_ranges.ts
+++ b/cypress/e2e/id_ranges/id_ranges.ts
@@ -1,0 +1,25 @@
+import { Given } from "@badeball/cypress-cucumber-preprocessor";
+
+Given(
+  "id range {string} exists with base ID {string}, range size {string}, primary RID base {string}, and secondary RID base {string}",
+  (
+    idRange: string,
+    baseID: string,
+    rangeSize: string,
+    primaryRIDBase: string,
+    secondaryRIDBase: string
+  ) => {
+    cy.ipa({
+      command: "idrange-add",
+      name: idRange,
+      specificOptions: `--base-id=${baseID} --range-size=${rangeSize} --rid-base=${primaryRIDBase} --secondary-rid-base=${secondaryRIDBase}`,
+    });
+  }
+);
+
+Given("I delete id range {string}", (idRange: string) => {
+  cy.ipa({
+    command: "idrange-del",
+    name: idRange,
+  });
+});

--- a/src/components/Form/NumberInput.tsx
+++ b/src/components/Form/NumberInput.tsx
@@ -80,7 +80,7 @@ const NumberSelector = (props: NumberSelectorProps) => {
       isDisabled={props.isDisabled || false}
       widthChars={props.numCharsShown || 1}
       className={props.className || ""}
-      inputProps={{ id: props.id, "data-cy": props.dataCy }}
+      inputProps={{ id: props.id, "data-cy": props.dataCy + "-input" }}
     />
   );
 };

--- a/src/components/modals/IdRanges/AddIdRangeModal.tsx
+++ b/src/components/modals/IdRanges/AddIdRangeModal.tsx
@@ -25,6 +25,8 @@ import {
 import { SerializedError } from "@reduxjs/toolkit";
 import InputRequiredText from "src/components/layouts/InputRequiredText";
 import NumberSelector from "src/components/Form/NumberInput";
+// Utils
+import { NO_SELECTION_OPTION } from "src/utils/constUtils";
 
 interface PropsToAddModal {
   isOpen: boolean;
@@ -36,6 +38,7 @@ interface PropsToAddModal {
 type RangeType = "ipa-local" | "ipa-ad-trust" | "ipa-ad-trust-posix";
 
 const autoPrivateGroupsOptions = [
+  { value: "", label: NO_SELECTION_OPTION },
   { value: "true", label: "true" },
   { value: "false", label: "false" },
   { value: "hybrid", label: "hybrid" },
@@ -63,8 +66,7 @@ const AddIdRangeModal = (props: PropsToAddModal) => {
   >("");
   const [ipanttrusteddomainname, setIpanttrusteddomainname] =
     React.useState("");
-  const [ipaautoprivategroups, setIpaautoprivategroups] =
-    React.useState("true");
+  const [ipaautoprivategroups, setIpaautoprivategroups] = React.useState("");
 
   const [isAutoPrivOpen, setIsAutoPrivOpen] = React.useState(false);
 
@@ -93,7 +95,7 @@ const AddIdRangeModal = (props: PropsToAddModal) => {
     setIpabaserid("");
     setIpasecondarybaserid("");
     setIpanttrusteddomainname("");
-    setIpaautoprivategroups("true");
+    setIpaautoprivategroups("");
   };
 
   // Derived validation state
@@ -138,8 +140,8 @@ const AddIdRangeModal = (props: PropsToAddModal) => {
       iparangetype: rangeType,
     };
 
-    // 'ipaautoprivategroups' only included when it is false. Otherwise, addition will fail.
-    if (ipaautoprivategroups === "false") {
+    // 'ipaautoprivategroups' only included when it is specified.
+    if (ipaautoprivategroups !== NO_SELECTION_OPTION) {
       newIdRangePayload.ipaautoprivategroups = ipaautoprivategroups;
     }
 

--- a/src/components/modals/IdRanges/AddIdRangeModal.tsx
+++ b/src/components/modals/IdRanges/AddIdRangeModal.tsx
@@ -135,9 +135,13 @@ const AddIdRangeModal = (props: PropsToAddModal) => {
           : undefined,
       ipabaserid: ipabaseridStr,
       ipasecondarybaserid: ipasecondarybaseridStr,
-      ipaautoprivategroups,
       iparangetype: rangeType,
     };
+
+    // 'ipaautoprivategroups' only included when it is false. Otherwise, addition will fail.
+    if (ipaautoprivategroups === "false") {
+      newIdRangePayload.ipaautoprivategroups = ipaautoprivategroups;
+    }
 
     addIdRange(newIdRangePayload)
       .then((result) => {


### PR DESCRIPTION
The tests must cover main page's operations.

However, due to a limitation affecting the current environment, there is no way to create new ID ranges from type `AD domain` and `AD domain with POSIX attributes`, as it requires an existing AD server to be used. We might want to expand these tests in the future.

## Summary by Sourcery

Add end-to-end coverage for ID range creation and deletion and adjust related UI behavior for ID range creation and test selectors.

New Features:
- Introduce Cypress feature scenarios for creating, deleting, and canceling ID range operations on the ID ranges page.

Bug Fixes:
- Ensure ID range creation only sends the 'ipaautoprivategroups' field when it is explicitly set to false to avoid backend failures.

Enhancements:
- Adjust numeric input data-cy attributes to target the underlying input element more precisely for automated tests.

Tests:
- Add Cypress BDD feature and step definitions for ID range creation, deletion, and cancelation flows on the main page.