### PR TITLE
feat(webui): Healthcheck page backed by healthcheck_log_show

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@patternfly/react-core": "^6.4.0",
     "@patternfly/react-icons": "^6.4.0",
     "@patternfly/react-table": "^6.4.0",
+    "@patternfly/react-tokens": "^6.4.0",
     "@reduxjs/toolkit": "^2.6.1",
     "qrcode.react": "^4.2.0",
     "react": "^18.0.0",

--- a/src/hooks/useHealthcheckData.tsx
+++ b/src/hooks/useHealthcheckData.tsx
@@ -1,0 +1,140 @@
+import React from "react";
+import { useAppDispatch, useAppSelector } from "src/store/hooks";
+import { addAlert } from "src/store/Global/alerts-slice";
+import {
+  Command,
+  FindRPCResponse,
+  useSimpleMutCommandMutation,
+} from "src/services/rpc";
+import {
+  countHealthcheckResultsBySeverity,
+  formatHealthcheckRpcError,
+  formatHealthcheckTransportError,
+  normalizeHealthcheckResult,
+  parseHealthcheckLogShowBody,
+  type HealthcheckCommandPayload,
+  type HealthcheckSeverityCounts,
+} from "src/pages/Healthcheck/healthcheckUtils";
+import { DEFAULT_HEALTHCHECK_REPORT_FILE } from "src/pages/Healthcheck/healthcheckConstants";
+
+/** Shape returned by ``useHealthcheckData`` (data, meta, loading, counts, reload). */
+export type UseHealthcheckDataResult = {
+  checksData: unknown | null;
+  meta: Omit<HealthcheckCommandPayload, "result"> | null;
+  isLoading: boolean;
+  cachedSeverityCounts: HealthcheckSeverityCounts | null;
+  reload: () => void;
+};
+
+/**
+ * Loads and normalizes healthcheck JSON via ``healthcheck_log_show`` (same pattern
+ * as other ``use*Data`` hooks). Auto-fetches on mount; ``reload`` repeats the RPC.
+ * Clears data and counts on transport, IPA, parse, or unhandled errors.
+ */
+export function useHealthcheckData(): UseHealthcheckDataResult {
+  const dispatch = useAppDispatch();
+  const apiVersion = useAppSelector(
+    (state) => state.global.environment.api_version
+  ) as string;
+
+  const [runHealthcheckLogShow, { isLoading }] = useSimpleMutCommandMutation();
+  const [checksData, setChecksData] = React.useState<unknown | null>(null);
+  const [meta, setMeta] = React.useState<Omit<
+    HealthcheckCommandPayload,
+    "result"
+  > | null>(null);
+  const [cachedSeverityCounts, setCachedSeverityCounts] =
+    React.useState<HealthcheckSeverityCounts | null>(null);
+
+  /** Calls ``healthcheck_log_show`` with the default report path and updates state. */
+  const reload = React.useCallback(() => {
+    const opts: Record<string, unknown> = {
+      version: apiVersion,
+      report_file: DEFAULT_HEALTHCHECK_REPORT_FILE,
+    };
+    const command: Command = {
+      method: "healthcheck_log_show",
+      params: [[], opts],
+    };
+
+    runHealthcheckLogShow(command)
+      .then((response) => {
+        if ("error" in response && response.error !== undefined) {
+          dispatch(
+            addAlert({
+              name: "healthcheck-log-show-error",
+              title: formatHealthcheckTransportError(response.error),
+              variant: "danger",
+            })
+          );
+          setChecksData(null);
+          setMeta(null);
+          setCachedSeverityCounts(null);
+          return;
+        }
+        if ("data" in response && response.data) {
+          const data = response.data as FindRPCResponse;
+          if (data.error) {
+            dispatch(
+              addAlert({
+                name: "healthcheck-log-show-ipa-error",
+                title: formatHealthcheckRpcError(data.error),
+                variant: "danger",
+              })
+            );
+            setChecksData(null);
+            setMeta(null);
+            setCachedSeverityCounts(null);
+            return;
+          }
+          const parsed =
+            parseHealthcheckLogShowBody(data.result) ??
+            parseHealthcheckLogShowBody(data.result?.result);
+          if (parsed) {
+            const normalized = normalizeHealthcheckResult(parsed.result ?? null);
+            setChecksData(normalized);
+            setCachedSeverityCounts(
+              countHealthcheckResultsBySeverity(normalized)
+            );
+            setMeta({
+              raw: parsed.raw,
+              returncode: parsed.returncode,
+              healthcheck_version: parsed.healthcheck_version,
+              ipa_version: parsed.ipa_version,
+              pki_version: parsed.pki_version,
+              output_file: parsed.output_file,
+            });
+          } else {
+            setChecksData(null);
+            setMeta(null);
+            setCachedSeverityCounts(null);
+          }
+        }
+      })
+      .catch((err: unknown) => {
+        dispatch(
+          addAlert({
+            name: "healthcheck-log-show-unhandled",
+            title: formatHealthcheckTransportError(err),
+            variant: "danger",
+          })
+        );
+        setChecksData(null);
+        setMeta(null);
+        setCachedSeverityCounts(null);
+      });
+  }, [apiVersion, dispatch, runHealthcheckLogShow]);
+
+  /** Initial load when the hook mounts (and when ``reload`` identity changes). */
+  React.useEffect(() => {
+    reload();
+  }, [reload]);
+
+  return {
+    checksData,
+    meta,
+    isLoading,
+    cachedSeverityCounts,
+    reload,
+  };
+}

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -75,6 +75,7 @@ import Trusts from "src/pages/Trusts/Trusts";
 import TrustsTabs from "src/pages/Trusts/TrustsTabs";
 import IdRangesTabs from "src/pages/IdRanges/IdRangesTabs";
 import GlobalTrustConfig from "src/pages/Trusts/GlobalTrustConfig";
+import Healthcheck from "src/pages/Healthcheck/Healthcheck";
 
 // Renders routes (React)
 export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
@@ -540,6 +541,9 @@ export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
               </Route>
               <Route path="trusts-config">
                 <Route path="" element={<GlobalTrustConfig />} />
+              </Route>
+              <Route path="healthcheck">
+                <Route path="" element={<Healthcheck />} />
               </Route>
               <Route path="configuration" element={<Configuration />} />
               {/* Redirect to Active users page if user is logged in and navigates to the root page */}

--- a/src/navigation/Nav.tsx
+++ b/src/navigation/Nav.tsx
@@ -24,7 +24,7 @@ const renderNavItem = (
 ) => {
   return (
     <NavItem
-      key={id}
+      key={`${item.group}-${item.path}`}
       isActive={activePageName === item.group}
       onClick={() => {
         dispatch(updateActiveSecondLevel(item.group));
@@ -61,6 +61,26 @@ const Navigation = () => {
     <Nav>
       <NavList>
         {navigationRoutes.map((section) => {
+          const sole = section.items[0];
+          const isSingleLeafSection =
+            section.items.length === 1 &&
+            sole &&
+            (!sole.items || sole.items.length === 0);
+
+          if (isSingleLeafSection) {
+            return (
+              <React.Fragment key={section.label}>
+                {renderNavItem(
+                  sole,
+                  0,
+                  sole.group,
+                  dispatch,
+                  activePageName
+                )}
+              </React.Fragment>
+            );
+          }
+
           return (
             <NavExpandable
               key={section.label}

--- a/src/navigation/NavRoutes.ts
+++ b/src/navigation/NavRoutes.ts
@@ -66,6 +66,8 @@ const TrustsGroupRef = "trusts";
 const TrustsGlobalConfigGroupRef = "trusts-config";
 // - Configuration
 const ConfigRef = "configuration";
+// HEALTHCHECK (top-level nav; single leaf — Nav renders one row, see Nav.tsx)
+const HealthcheckGroupRef = "healthcheck";
 
 // List of navigation routes (UI)
 export const getNavigationRoutes = (
@@ -436,6 +438,21 @@ export const getNavigationRoutes = (
           group: ConfigRef,
           title: `${BASE_TITLE} - Configuration`,
           path: "configuration",
+          items: [],
+        },
+      ],
+    },
+    {
+      label: "Healthcheck",
+      group: "",
+      title: `${BASE_TITLE} - Healthcheck`,
+      path: "",
+      items: [
+        {
+          label: "Healthcheck",
+          group: HealthcheckGroupRef,
+          title: `${BASE_TITLE} - Healthcheck`,
+          path: "healthcheck",
           items: [],
         },
       ],

--- a/src/pages/Healthcheck/Healthcheck.tsx
+++ b/src/pages/Healthcheck/Healthcheck.tsx
@@ -1,0 +1,580 @@
+import React from "react";
+// PatternFly
+import {
+  Button,
+  Divider,
+  Flex,
+  FlexItem,
+  FormGroup,
+  Popover,
+  MenuToggle,
+  MenuToggleElement,
+  PageSection,
+  Select,
+  SelectList,
+  SelectOption,
+  Stack,
+  StackItem,
+} from "@patternfly/react-core";
+import { InfoCircleIcon } from "@patternfly/react-icons";
+// Redux — route/title only; data via hook
+// Hooks
+import useUpdateRoute from "src/hooks/useUpdateRoute";
+import { useHealthcheckData } from "src/hooks/useHealthcheckData";
+// Layouts
+import TitleLayout from "src/components/layouts/TitleLayout";
+import DataSpinner from "src/components/layouts/DataSpinner";
+
+import {
+  type HealthcheckKnownSeverity,
+  buildHealthcheckTableRows,
+  collectHealthcheckItems,
+  filterHealthcheckBySeverities,
+  hasAnyCriticalHealthcheckResult,
+  hasAnyKnownSeverityMessages,
+  HEALTHCHECK_KNOWN_RESULT_LEVELS,
+  HEALTHCHECK_SEVERITY_DISPLAY_ORDER,
+  healthcheckSeveritySortRank,
+  isEmptyHealthcheckJsonArray,
+  type HealthcheckTableRow,
+} from "./healthcheckUtils";
+import {
+  CHECKS_ALL_OPTION,
+  SEVERITY_SELECT_ALL_OPTION,
+} from "./healthcheckConstants";
+import type {
+  HealthcheckSortColumn,
+  HealthcheckSortDirection,
+} from "./healthcheckTypes";
+import { HealthcheckResultsTable } from "./HealthcheckResultsTable";
+import { HealthcheckSeverityBar } from "./HealthcheckSeverityBar";
+
+/** Initial severity multi-select: all known levels selected. */
+const DEFAULT_SELECTED_SEVERITIES: HealthcheckKnownSeverity[] = [
+  ...HEALTHCHECK_SEVERITY_DISPLAY_ORDER,
+];
+
+/**
+ * Healthcheck report page: loads JSON via ``useHealthcheckData``, filters by
+ * severity and check-name multi-selects, and shows a sortable results table.
+ */
+const Healthcheck = () => {
+  const { browserTitle } = useUpdateRoute({ pathname: "healthcheck" });
+
+  const {
+    checksData,
+    meta,
+    isLoading,
+    cachedSeverityCounts,
+    reload: onApply,
+  } = useHealthcheckData();
+
+  const [selectedSeverities, setSelectedSeverities] = React.useState<
+    HealthcheckKnownSeverity[]
+  >(() => [...DEFAULT_SELECTED_SEVERITIES]);
+  const [isSeverityOpen, setIsSeverityOpen] = React.useState(false);
+  const [isChecksOpen, setIsChecksOpen] = React.useState(false);
+  const [selectedChecks, setSelectedChecks] = React.useState<string[]>([]);
+  const [sortColumn, setSortColumn] =
+    React.useState<HealthcheckSortColumn>("timestamp");
+  const [sortDirection, setSortDirection] =
+    React.useState<HealthcheckSortDirection>("desc");
+
+  const displayPayload = React.useMemo(() => {
+    if (checksData === null) {
+      return { kind: "none" as const };
+    }
+    if (selectedSeverities.length === 0) {
+      return { kind: "no-severity" as const };
+    }
+    const filtered = filterHealthcheckBySeverities(
+      checksData,
+      new Set(selectedSeverities)
+    );
+    if (isEmptyHealthcheckJsonArray(filtered)) {
+      return { kind: "empty" as const };
+    }
+    if (!hasAnyKnownSeverityMessages(filtered)) {
+      return { kind: "empty" as const };
+    }
+    return {
+      kind: "table" as const,
+      filtered,
+    };
+  }, [checksData, selectedSeverities]);
+
+  const tableRows = React.useMemo(() => {
+    if (displayPayload.kind !== "table") {
+      return [];
+    }
+    return buildHealthcheckTableRows(displayPayload.filtered);
+  }, [displayPayload]);
+
+  /** Distinct check names in the full report (ignores severity). */
+  const allReportCheckNames = React.useMemo(() => {
+    if (checksData === null) {
+      return [];
+    }
+    const seen = new Set<string>();
+    for (const item of collectHealthcheckItems(checksData)) {
+      if (!item || typeof item !== "object") {
+        continue;
+      }
+      const c = (item as Record<string, unknown>).check;
+      if (typeof c === "string" && c.trim() !== "" && c.trim() !== "—") {
+        seen.add(c.trim());
+      }
+    }
+    return Array.from(seen).sort((a, b) => a.localeCompare(b));
+  }, [checksData]);
+
+  /**
+   * Check names present under the current severity filter; if that set is empty
+   * (e.g. no rows match) fall back to all report checks so the Checks control stays usable.
+   */
+  const availableChecks = React.useMemo(() => {
+    if (checksData === null || selectedSeverities.length === 0) {
+      return [];
+    }
+    const filtered = filterHealthcheckBySeverities(
+      checksData,
+      new Set(selectedSeverities)
+    );
+    const seen = new Set<string>();
+    for (const item of collectHealthcheckItems(filtered)) {
+      if (!item || typeof item !== "object") {
+        continue;
+      }
+      const c = (item as Record<string, unknown>).check;
+      if (typeof c === "string" && c.trim() !== "" && c.trim() !== "—") {
+        seen.add(c.trim());
+      }
+    }
+    const fromFilter = Array.from(seen).sort((a, b) => a.localeCompare(b));
+    return fromFilter.length > 0 ? fromFilter : allReportCheckNames;
+  }, [checksData, selectedSeverities, allReportCheckNames]);
+
+  const sortedRows = React.useMemo(() => {
+    const copy: HealthcheckTableRow[] = [...tableRows];
+    const dir = sortDirection === "asc" ? 1 : -1;
+    const valueFor = (row: HealthcheckTableRow): string => {
+      if (sortColumn === "timestamp") {
+        return row.timestampRaw;
+      }
+      if (sortColumn === "check") {
+        return row.check;
+      }
+      if (sortColumn === "source") {
+        return row.source;
+      }
+      if (sortColumn === "result") {
+        return row.result;
+      }
+      return row.details;
+    };
+    copy.sort((a, b) => {
+      if (sortColumn === "result") {
+        const ra = healthcheckSeveritySortRank(a.result);
+        const rb = healthcheckSeveritySortRank(b.result);
+        if (ra !== rb) {
+          return sortDirection === "desc" ? ra - rb : rb - ra;
+        }
+      } else {
+        const av = valueFor(a);
+        const bv = valueFor(b);
+        if (av !== bv) {
+          return av > bv ? dir : -dir;
+        }
+      }
+      const ra = healthcheckSeveritySortRank(a.result);
+      const rb = healthcheckSeveritySortRank(b.result);
+      if (ra !== rb) {
+        return ra - rb;
+      }
+      return 0;
+    });
+    return copy;
+  }, [tableRows, sortColumn, sortDirection]);
+
+  const availableChecksSet = React.useMemo(
+    () => new Set(availableChecks),
+    [availableChecks]
+  );
+
+  /** After load failure clears data, allow the next successful load to select all checks again. */
+  const hasAutoSelectedChecksRef = React.useRef(false);
+  React.useEffect(() => {
+    if (checksData === null) {
+      hasAutoSelectedChecksRef.current = false;
+    }
+  }, [checksData]);
+
+  React.useEffect(() => {
+    setSelectedChecks((prev) =>
+      prev.filter((check) => availableChecksSet.has(check))
+    );
+  }, [availableChecksSet]);
+
+  /** First successful load (or load after error): select all checks so the table is not empty by default. */
+  React.useEffect(() => {
+    if (availableChecks.length === 0) {
+      return;
+    }
+    if (!hasAutoSelectedChecksRef.current && selectedChecks.length === 0) {
+      setSelectedChecks([...availableChecks]);
+      hasAutoSelectedChecksRef.current = true;
+    }
+  }, [availableChecks, selectedChecks.length]);
+
+  const visibleRows = React.useMemo(() => {
+    if (selectedChecks.length === 0) {
+      return [];
+    }
+    const selected = new Set(selectedChecks);
+    return sortedRows.filter((row) => selected.has(row.check));
+  }, [sortedRows, selectedChecks]);
+
+  /**
+   * Table header click: toggles asc/desc when the same column is active; otherwise
+   * switches column (timestamp defaults to desc, others to asc).
+   */
+  const onSortColumn = (column: HealthcheckSortColumn) => {
+    if (sortColumn === column) {
+      setSortDirection((prev) => (prev === "asc" ? "desc" : "asc"));
+      return;
+    }
+    setSortColumn(column);
+    setSortDirection(column === "timestamp" ? "desc" : "asc");
+  };
+
+  React.useEffect(() => {
+    document.title = browserTitle;
+  }, [browserTitle]);
+
+  const allSeveritiesSelected =
+    selectedSeverities.length === HEALTHCHECK_KNOWN_RESULT_LEVELS.size;
+
+  const severityToggleLabel =
+    selectedSeverities.length === 0
+      ? "Severities (none selected)"
+      : allSeveritiesSelected
+        ? "Severities (all selected)"
+        : `Severities (${selectedSeverities.length} selected)`;
+
+  const applyDisabled = isLoading;
+
+  const showChecksFilter =
+    checksData !== null && selectedSeverities.length > 0;
+
+  return (
+    <>
+      <PageSection
+        id="healthcheck-header"
+        hasBodyWrapper={false}
+        isWidthLimited
+      >
+        <Flex
+          alignItems={{ default: "alignItemsFlexStart" }}
+          justifyContent={{ default: "justifyContentSpaceBetween" }}
+          gap={{ default: "gapMd" }}
+          flexWrap={{ default: "wrap" }}
+        >
+          <FlexItem>
+            <Flex
+              alignItems={{ default: "alignItemsCenter" }}
+              gap={{ default: "gapSm" }}
+            >
+              <TitleLayout
+                id="healthcheck-page"
+                headingLevel="h1"
+                text="Healthcheck"
+                size="3xl"
+                className="pf-v5-u-font-weight-bold"
+              />
+              <Popover
+                aria-label="Healthcheck report source information"
+                maxWidth="32rem"
+                bodyContent={
+                  <div>
+                    <p>
+                      Load the IPA Healthcheck JSON report generated on this
+                      server.
+                    </p>
+                    <p className="pf-v5-u-mt-sm pf-v5-u-mb-0">
+                      <code> /var/log/ipa/healthcheck/healthcheck.log</code>
+                    </p>
+                  </div>
+                }
+              >
+                <Button
+                  variant="plain"
+                  hasNoPadding
+                  icon={<InfoCircleIcon />}
+                  aria-label="Healthcheck report source information"
+                  data-cy="healthcheck-title-info"
+                />
+              </Popover>
+            </Flex>
+          </FlexItem>
+          <FlexItem className="pf-v5-u-ml-auto">
+            <p
+              className="pf-v5-u-font-size-sm pf-v5-u-color-200 pf-v5-u-mt-xs pf-v5-u-mb-0"
+              data-cy="healthcheck-version"
+            >
+              {`ipa-healthcheck: ${meta?.healthcheck_version ?? "unavailable"}`}
+              <br />
+              {`IPA: ${meta?.ipa_version ?? "unavailable"}`}
+              <br />
+              {`PKI: ${meta?.pki_version ?? "unavailable"}`}
+            </p>
+          </FlexItem>
+        </Flex>
+      </PageSection>
+      <Divider />
+      {cachedSeverityCounts !== null ? (
+        <PageSection id="healthcheck-severity-bar">
+          <HealthcheckSeverityBar
+            counts={cachedSeverityCounts}
+            onSelectSeverity={(value) => setSelectedSeverities([value])}
+          />
+        </PageSection>
+      ) : null}
+      <PageSection id="healthcheck-actions" isWidthLimited>
+        <Stack hasGutter>
+          <StackItem>
+            <FormGroup fieldId="healthcheck-actions-toolbar" label="">
+              <Flex
+                alignItems={{ default: "alignItemsCenter" }}
+                gap={{ default: "gapMd" }}
+                flexWrap={{ default: "wrap" }}
+              >
+                <FlexItem>
+                  <Flex gap={{ default: "gapSm" }}>
+                    <Button
+                      id="healthcheck-apply"
+                      data-cy="healthcheck-button-apply"
+                      variant="primary"
+                      onClick={onApply}
+                      isDisabled={applyDisabled}
+                    >
+                      Apply
+                    </Button>
+                    <Button
+                      id="healthcheck-refresh"
+                      data-cy="healthcheck-button-refresh"
+                      variant="secondary"
+                      onClick={onApply}
+                      isDisabled={applyDisabled}
+                      aria-label="Refresh healthcheck results"
+                    >
+                      Refresh
+                    </Button>
+                  </Flex>
+                </FlexItem>
+                <FlexItem>
+                  <div data-cy="healthcheck-severity-select">
+                    <Select
+                      aria-label="Filter by result severity"
+                      data-cy="healthcheck-select-severity"
+                      isOpen={isSeverityOpen}
+                      onOpenChange={setIsSeverityOpen}
+                      selected={selectedSeverities}
+                      onSelect={(_e, value) => {
+                        const v = String(value) as
+                          | HealthcheckKnownSeverity
+                          | typeof SEVERITY_SELECT_ALL_OPTION;
+                        if (v === SEVERITY_SELECT_ALL_OPTION) {
+                          setSelectedSeverities((prev) => {
+                            const everySelected =
+                              prev.length ===
+                                HEALTHCHECK_KNOWN_RESULT_LEVELS.size &&
+                              DEFAULT_SELECTED_SEVERITIES.every((s) =>
+                                prev.includes(s)
+                              );
+                            return everySelected
+                              ? []
+                              : [...DEFAULT_SELECTED_SEVERITIES];
+                          });
+                          return;
+                        }
+                        const sev = v as HealthcheckKnownSeverity;
+                        setSelectedSeverities((prev) =>
+                          prev.includes(sev)
+                            ? prev.filter((s) => s !== sev)
+                            : [...prev, sev]
+                        );
+                      }}
+                      toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                        <MenuToggle
+                          ref={toggleRef}
+                          onClick={() => setIsSeverityOpen(!isSeverityOpen)}
+                          isExpanded={isSeverityOpen}
+                          data-cy="healthcheck-select-severity-toggle"
+                        >
+                          {severityToggleLabel}
+                        </MenuToggle>
+                      )}
+                    >
+                      <SelectList>
+                        <SelectOption
+                          key={SEVERITY_SELECT_ALL_OPTION}
+                          value={SEVERITY_SELECT_ALL_OPTION}
+                          hasCheckbox
+                          isSelected={allSeveritiesSelected}
+                          data-cy="healthcheck-select-severity-all"
+                        >
+                          All severities
+                        </SelectOption>
+                        {HEALTHCHECK_SEVERITY_DISPLAY_ORDER.map((sev) => (
+                          <SelectOption
+                            key={sev}
+                            value={sev}
+                            hasCheckbox
+                            isSelected={selectedSeverities.includes(sev)}
+                            data-cy={`healthcheck-select-severity-${sev.toLowerCase()}`}
+                          >
+                            {sev}
+                          </SelectOption>
+                        ))}
+                      </SelectList>
+                    </Select>
+                  </div>
+                </FlexItem>
+                {showChecksFilter ? (
+                  <FlexItem>
+                    <div data-cy="healthcheck-check-filter">
+                      <Select
+                        aria-label="Filter by checks"
+                        data-cy="healthcheck-select-checks"
+                        isOpen={isChecksOpen}
+                        onOpenChange={setIsChecksOpen}
+                        selected={selectedChecks}
+                        onSelect={(_e, value) => {
+                          const check = String(value);
+                          if (check === CHECKS_ALL_OPTION) {
+                            setSelectedChecks((prev) =>
+                              prev.length === availableChecks.length
+                                ? []
+                                : [...availableChecks]
+                            );
+                            return;
+                          }
+                          setSelectedChecks((prev) =>
+                            prev.includes(check)
+                              ? prev.filter((item) => item !== check)
+                              : [...prev, check]
+                          );
+                        }}
+                        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                          <MenuToggle
+                            ref={toggleRef}
+                            onClick={() => setIsChecksOpen(!isChecksOpen)}
+                            isExpanded={isChecksOpen}
+                            data-cy="healthcheck-select-checks-toggle"
+                          >
+                            {selectedChecks.length === 0
+                              ? "Checks (none selected)"
+                              : selectedChecks.length === availableChecks.length
+                                ? "Checks (all selected)"
+                                : `Checks (${selectedChecks.length} selected)`}
+                          </MenuToggle>
+                        )}
+                      >
+                        <SelectList>
+                          <SelectOption
+                            key={CHECKS_ALL_OPTION}
+                            value={CHECKS_ALL_OPTION}
+                            hasCheckbox
+                            isSelected={
+                              selectedChecks.length === availableChecks.length
+                            }
+                            data-cy="healthcheck-select-check-all"
+                          >
+                            All
+                          </SelectOption>
+                          {availableChecks.map((check) => (
+                            <SelectOption
+                              key={check}
+                              value={check}
+                              hasCheckbox
+                              isSelected={selectedChecks.includes(check)}
+                              data-cy={`healthcheck-select-check-${check}`}
+                            >
+                              {check}
+                            </SelectOption>
+                          ))}
+                        </SelectList>
+                      </Select>
+                    </div>
+                  </FlexItem>
+                ) : null}
+              </Flex>
+            </FormGroup>
+          </StackItem>
+        </Stack>
+      </PageSection>
+      <PageSection id="healthcheck-content" isWidthLimited>
+        {isLoading ? (
+          <DataSpinner />
+        ) : checksData !== null ? (
+          <Flex direction={{ default: "column" }}>
+            {displayPayload.kind === "no-severity" ? (
+              <p
+                className="pf-v5-u-color-200"
+                data-cy="healthcheck-no-severity-selected"
+              >
+                Select at least one severity to show results.
+              </p>
+            ) : displayPayload.kind === "table" ? (
+              <Flex direction={{ default: "column" }}>
+                {!hasAnyCriticalHealthcheckResult(displayPayload.filtered) ? (
+                  <FlexItem className="pf-v5-u-mb-md">
+                    <p
+                      className="pf-v5-u-font-weight-bold pf-v5-u-font-size-md"
+                      data-cy="healthcheck-no-critical-banner"
+                    >
+                      No critical-severity findings in this report.
+                    </p>
+                  </FlexItem>
+                ) : null}
+                <FlexItem className="pf-v5-u-flex-grow-1 pf-v5-u-overflow-hidden">
+                  <HealthcheckResultsTable
+                    visibleRows={visibleRows}
+                    sortColumn={sortColumn}
+                    sortDirection={sortDirection}
+                    onSortColumn={onSortColumn}
+                  />
+                </FlexItem>
+                {visibleRows.length === 0 ? (
+                  <FlexItem className="pf-v5-u-mt-md">
+                    <p
+                      className="pf-v5-u-color-200"
+                      data-cy="healthcheck-no-selected-checks"
+                    >
+                      No checks selected.
+                    </p>
+                  </FlexItem>
+                ) : null}
+              </Flex>
+            ) : (
+              <p
+                className="pf-v5-u-color-200"
+                data-cy="healthcheck-no-messages"
+              >
+                No messages.
+              </p>
+            )}
+          </Flex>
+        ) : (
+          <p className="pf-v5-u-color-200">
+            Click <strong>Apply</strong> or <strong>Refresh</strong> to load or
+            refresh results.
+          </p>
+        )}
+      </PageSection>
+    </>
+  );
+};
+
+/** Route-level default export wired from ``AppRoutes``. */
+export default Healthcheck;

--- a/src/pages/Healthcheck/HealthcheckCheckInfoPopoverBody.tsx
+++ b/src/pages/Healthcheck/HealthcheckCheckInfoPopoverBody.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import {
+  FREEIPA_HEALTHCHECK_REPO_URL,
+  getHealthcheckCheckDocumentation,
+} from "./healthcheckCheckDocs";
+import type { HealthcheckTableRow } from "./healthcheckUtils";
+
+type HealthcheckCheckInfoPopoverBodyProps = {
+  row: HealthcheckTableRow;
+};
+
+/**
+ * Body content for the check info popover: optional text from ``healthcheckCheckDocs``,
+ * the run’s user message (or fallback), and a link to the upstream repo.
+ */
+export function HealthcheckCheckInfoPopoverBody({
+  row,
+}: HealthcheckCheckInfoPopoverBodyProps) {
+  const doc = getHealthcheckCheckDocumentation(row.source, row.check);
+  return (
+    <div className="pf-v5-u-white-space-pre-wrap">
+      {doc ? (
+        <>
+          <p className="pf-v5-u-font-weight-bold pf-v5-u-mb-sm">
+            How this check works
+          </p>
+          <p className="pf-v5-u-mb-md">{doc}</p>
+        </>
+      ) : null}
+      <p className="pf-v5-u-font-weight-bold pf-v5-u-mb-sm">
+        Message from this run
+      </p>
+      {row.userMessage !== "" ? (
+        <p className="pf-v5-u-mb-md">{row.userMessage}</p>
+      ) : (
+        <p className="pf-v5-u-color-200 pf-v5-u-mb-md">
+          No user message in this report entry. See the <strong>Details</strong>{" "}
+          column for full output.
+        </p>
+      )}
+      <p className="pf-v5-u-font-size-sm pf-v5-u-color-200 pf-v5-u-mb-0">
+        Upstream check reference:{" "}
+        <a href={FREEIPA_HEALTHCHECK_REPO_URL} target="_blank" rel="noreferrer">
+          freeipa-healthcheck
+        </a>{" "}
+        on GitHub (sources, plugins, and interpreting results).
+      </p>
+    </div>
+  );
+}

--- a/src/pages/Healthcheck/HealthcheckResultsTable.tsx
+++ b/src/pages/Healthcheck/HealthcheckResultsTable.tsx
@@ -1,0 +1,170 @@
+import React from "react";
+import { Button, Content, Flex, Label, Popover } from "@patternfly/react-core";
+import { InfoCircleIcon } from "@patternfly/react-icons";
+import {
+  InnerScrollContainer,
+  OuterScrollContainer,
+  Table,
+  TableVariant,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from "@patternfly/react-table";
+import {
+  formatDetailsForDisplay,
+  HEALTHCHECK_TABLE_SCROLL_OUTER_VARS,
+  SORT_HEADER_BUTTON_CLASSNAME,
+} from "./healthcheckConstants";
+import type {
+  HealthcheckSortColumn,
+  HealthcheckSortDirection,
+} from "./healthcheckTypes";
+import { healthcheckResultLabelColor, type HealthcheckTableRow } from "./healthcheckUtils";
+import { HealthcheckCheckInfoPopoverBody } from "./HealthcheckCheckInfoPopoverBody";
+
+type HealthcheckResultsTableProps = {
+  visibleRows: HealthcheckTableRow[];
+  sortColumn: HealthcheckSortColumn;
+  sortDirection: HealthcheckSortDirection;
+  onSortColumn: (column: HealthcheckSortColumn) => void;
+};
+
+/**
+ * Scrollable PatternFly table of healthcheck rows with sortable headers, severity
+ * labels, formatted details, and per-row check info popovers.
+ */
+export function HealthcheckResultsTable({
+  visibleRows,
+  sortColumn,
+  sortDirection,
+  onSortColumn,
+}: HealthcheckResultsTableProps) {
+  /** Arrow or neutral glyph shown next to the active sort column label. */
+  const sortArrow = (column: HealthcheckSortColumn) => {
+    if (sortColumn !== column) {
+      return "↕";
+    }
+    return sortDirection === "asc" ? "↑" : "↓";
+  };
+
+  return (
+    <OuterScrollContainer style={HEALTHCHECK_TABLE_SCROLL_OUTER_VARS}>
+      <InnerScrollContainer>
+        <Table
+          id="healthcheck-results-table"
+          aria-label="Healthcheck results"
+          variant={TableVariant.compact}
+          borders
+          isStriped
+        >
+          <Thead>
+            <Tr>
+              <Th modifier="wrap" width={20}>
+                <button
+                  type="button"
+                  className={SORT_HEADER_BUTTON_CLASSNAME}
+                  onClick={() => onSortColumn("timestamp")}
+                >
+                  Timestamp {sortArrow("timestamp")}
+                </button>
+              </Th>
+              <Th modifier="wrap" width={25}>
+                <button
+                  type="button"
+                  className={SORT_HEADER_BUTTON_CLASSNAME}
+                  onClick={() => onSortColumn("check")}
+                >
+                  Check {sortArrow("check")}
+                </button>
+              </Th>
+              <Th modifier="wrap" width={20}>
+                <button
+                  type="button"
+                  className={SORT_HEADER_BUTTON_CLASSNAME}
+                  onClick={() => onSortColumn("source")}
+                >
+                  Source {sortArrow("source")}
+                </button>
+              </Th>
+              <Th modifier="wrap" width={10}>
+                <button
+                  type="button"
+                  className={SORT_HEADER_BUTTON_CLASSNAME}
+                  onClick={() => onSortColumn("result")}
+                >
+                  Result {sortArrow("result")}
+                </button>
+              </Th>
+              <Th modifier="wrap">
+                <button
+                  type="button"
+                  className={SORT_HEADER_BUTTON_CLASSNAME}
+                  onClick={() => onSortColumn("details")}
+                >
+                  Details {sortArrow("details")}
+                </button>
+              </Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {visibleRows.map((row) => (
+              <Tr key={row.id}>
+                <Td dataLabel="Timestamp">
+                  <span className="pf-v5-u-font-size-sm">{row.timestamp}</span>
+                </Td>
+                <Td dataLabel="Check">
+                  <Flex
+                    alignItems={{ default: "alignItemsCenter" }}
+                    gap={{ default: "gapSm" }}
+                    flexWrap={{ default: "nowrap" }}
+                  >
+                    <span>{row.check}</span>
+                    <Popover
+                      aria-label={`Information for check ${row.check}`}
+                      bodyContent={
+                        <HealthcheckCheckInfoPopoverBody row={row} />
+                      }
+                    >
+                      <Button
+                        variant="plain"
+                        hasNoPadding
+                        icon={<InfoCircleIcon />}
+                        aria-label={`Information for check ${row.check}`}
+                        data-cy="healthcheck-check-user-info"
+                      />
+                    </Popover>
+                  </Flex>
+                </Td>
+                <Td dataLabel="Source">
+                  <span className="pf-v5-u-font-size-sm">{row.source}</span>
+                </Td>
+                <Td dataLabel="Result">
+                  <Label
+                    color={healthcheckResultLabelColor(row.result)}
+                    isCompact
+                  >
+                    {row.result}
+                  </Label>
+                </Td>
+                <Td dataLabel="Details">
+                  {row.details ? (
+                    <Content
+                      component="pre"
+                      className="pf-v5-u-font-size-sm pf-v5-u-white-space-pre-wrap pf-v5-u-m-0"
+                    >
+                      {formatDetailsForDisplay(row.details)}
+                    </Content>
+                  ) : (
+                    "—"
+                  )}
+                </Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      </InnerScrollContainer>
+    </OuterScrollContainer>
+  );
+}

--- a/src/pages/Healthcheck/HealthcheckSeverityBar.tsx
+++ b/src/pages/Healthcheck/HealthcheckSeverityBar.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Button, Flex, Label } from "@patternfly/react-core";
+import {
+  type HealthcheckKnownSeverity,
+  type HealthcheckSeverityCounts,
+  healthcheckResultLabelColor,
+} from "./healthcheckUtils";
+import { SEVERITY_BAR_BUTTON_CLASSNAME } from "./healthcheckConstants";
+
+const SEVERITY_SUMMARY_ORDER: {
+  key: keyof HealthcheckSeverityCounts;
+  label: string;
+}[] = [
+  { key: "SUCCESS", label: "SUCCESS" },
+  { key: "ERROR", label: "ERROR" },
+  { key: "WARNING", label: "WARNING" },
+  { key: "CRITICAL", label: "CRITICAL" },
+];
+
+type HealthcheckSeverityBarProps = {
+  counts: HealthcheckSeverityCounts;
+  /** Invoked with one severity so the page can narrow the checkbox filter quickly. */
+  onSelectSeverity: (value: HealthcheckKnownSeverity) => void;
+};
+
+/**
+ * Horizontal summary of SUCCESS/ERROR/WARNING/CRITICAL counts; each segment is
+ * a button that calls ``onSelectSeverity`` with that level.
+ */
+export function HealthcheckSeverityBar({
+  counts,
+  onSelectSeverity,
+}: HealthcheckSeverityBarProps) {
+  return (
+    <div
+      role="region"
+      aria-label="Results by severity"
+      data-cy="healthcheck-severity-summary"
+    >
+      <Flex gap={{ default: "gapSm" }} flexWrap={{ default: "nowrap" }}>
+        {SEVERITY_SUMMARY_ORDER.map(({ key, label }) => (
+          <Button
+            key={key}
+            variant="secondary"
+            className={SEVERITY_BAR_BUTTON_CLASSNAME}
+            data-cy={`healthcheck-severity-count-${key}`}
+            onClick={() => onSelectSeverity(key)}
+            aria-label={`Show ${label} checks`}
+            title={`Show ${label} checks`}
+          >
+            <Label color={healthcheckResultLabelColor(label)} isCompact>
+              {label}
+            </Label>
+            <span className="pf-v5-u-font-size-xl pf-v5-u-font-weight-bold pf-v5-u-mt-sm">
+              {counts[key]}
+            </span>
+          </Button>
+        ))}
+      </Flex>
+    </div>
+  );
+}

--- a/src/pages/Healthcheck/README.md
+++ b/src/pages/Healthcheck/README.md
@@ -1,0 +1,96 @@
+# Healthcheck (Web UI)
+
+This page renders **ipa-healthcheck** results via IPA JSON-RPC command
+`healthcheck_log_show`. It is a file-based Healthcheck view in Web UI with
+sorting, filtering, and user-focused details text.
+
+---
+
+## Current behavior
+
+- Uses fixed server path: `/var/log/ipa/healthcheck/healthcheck.log`
+- Auto-loads data when page opens; also supports **Apply** and **Refresh**
+- Uses latest matching report file (`healthcheck.log` / `healthcheck.log.*`) on IPA server
+- Shows top-right versions:
+  - `ipa-healthcheck` (installed RPM / tool output)
+  - `IPA`
+  - `PKI`
+- Supports:
+  - severity **multi-select dropdown** (All severities + CRITICAL / ERROR / WARNING / SUCCESS)
+  - clickable severity summary bar (quick filter to one level)
+  - checks multi-select dropdown with **All**
+  - sortable table headers; **Result** column uses severity order (not plain A–Z)
+
+---
+
+## Files
+
+### Web UI (`freeipa-webui`)
+
+| File | Purpose |
+| --- | --- |
+| `src/hooks/useHealthcheckData.tsx` | RPC load, alerts, normalization, metadata, and severity totals (same role as other `use*Data` hooks). |
+| `src/pages/Healthcheck/Healthcheck.tsx` | Page shell: filters, toolbar, layout; composes subcomponents. |
+| `src/pages/Healthcheck/HealthcheckResultsTable.tsx` | Results table + scroll containers. |
+| `src/pages/Healthcheck/HealthcheckSeverityBar.tsx` | Clickable severity summary bar. |
+| `src/pages/Healthcheck/HealthcheckCheckInfoPopoverBody.tsx` | Check info popover content. |
+| `src/pages/Healthcheck/healthcheckConstants.ts` | Shared UI constants and display helpers. |
+| `src/pages/Healthcheck/healthcheckTypes.ts` | Shared sort column types. |
+| `src/pages/Healthcheck/healthcheckUtils.ts` | Pure helpers: parse/normalize payload, row shaping, severity helpers, and check-specific details formatting. |
+| `src/pages/Healthcheck/healthcheckCheckDocs.ts` | Short upstream check descriptions for the popover. |
+| `src/pages/Healthcheck/README.md` | This document. |
+
+### IPA server (`freeipa`)
+
+| File                               | Purpose                                                                                                                   |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `ipaserver/plugins/healthcheck.py` | RPC command `healthcheck_log_show`: read report file (with latest file resolution), parse JSON, return metadata/versions. |
+
+---
+
+## Notable utility behavior (`healthcheckUtils.ts`)
+
+- `parseHealthcheckLogShowBody` parses full RPC payload including metadata fields.
+- `buildHealthcheckTableRows` groups similar checks (`source + check + result`) and
+  preserves latest timestamp in grouped row.
+- `formatHealthcheckCellDetails` provides check-specific user-friendly details for:
+  - certificate expiration/trust-flag checks
+  - keytab checks
+  - topology suffix checks
+  - file ownership/permission checks
+  - dogtag connectivity checks
+  - meta checks
+- Details rendering is normalized in UI to one line, with consistent separators.
+
+---
+
+## End-to-end flow
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant P as Healthcheck.tsx
+    participant R as RTK Query
+    participant S as IPA JSON-RPC
+    participant H as ipaserver/plugins/healthcheck.py
+    participant F as healthcheckUtils.ts
+
+    U->>P: Open page / click Apply / click Refresh
+    P->>R: healthcheck_log_show(report_file fixed path)
+    R->>S: POST /ipa/session/json
+    S->>H: execute()
+    H->>H: normalize path + resolve latest report file
+    H->>H: read file + json.loads
+    H-->>S: result + metadata + versions
+    S-->>R: JSON-RPC response
+    R-->>P: data or error
+    P->>F: parse + normalize + build rows + format details
+    P->>P: apply severity/check filters + sorting
+    P-->>U: Render table, summary bar, and version info
+```
+
+---
+
+## Testing
+
+Tests to be done.

--- a/src/pages/Healthcheck/healthcheckCheckDocs.ts
+++ b/src/pages/Healthcheck/healthcheckCheckDocs.ts
@@ -1,0 +1,156 @@
+/**
+ * Short descriptions of ipa-healthcheck checks, aligned with upstream docs:
+ * https://github.com/freeipa/freeipa-healthcheck
+ *
+ * Keys are ``source|check`` when needed for disambiguation, else ``check`` only.
+ */
+const HEALTHCHECK_CHECK_DOCS: Record<string, string> = {
+  // ipahealthcheck.dogtag.ca
+  "ipahealthcheck.dogtag.ca|DogtagCertsConfigCheck":
+    "Compares the CA (and KRA, if installed) certificate values with those referenced in Dogtag CS.cfg. A mismatch can prevent the CA from starting.",
+  "ipahealthcheck.dogtag.ca|DogtagCertsConnectivityCheck":
+    "Runs an operation equivalent to `ipa cert-show 1` to verify basic connectivity to the CA subsystem.",
+
+  // ipahealthcheck.ds.replication
+  "ipahealthcheck.ds.replication|ReplicationConflictCheck":
+    "Searches the directory for replication conflicts (entries with nsds5ReplConflict). Conflicts usually require manual cleanup.",
+
+  // ipahealthcheck.ipa.certs
+  "ipahealthcheck.ipa.certs|IPACertmongerExpirationCheck":
+    "Uses certmonger’s view of each tracked certificate to warn if a cert is expiring soon (default window) or report if it has expired.",
+  "ipahealthcheck.ipa.certs|IPACertfileExpirationCheck":
+    "Reads certificates from PEM files or NSS databases on disk and checks expiration, in case certmonger tracking is out of sync with files.",
+  "ipahealthcheck.ipa.certs|IPACAChainExpirationCheck":
+    "Loads the CA chain from /etc/ipa/ca.crt and validates each certificate for expiration (including external CA chains).",
+  "ipahealthcheck.ipa.certs|IPACertTracking":
+    "Compares certmonger tracking requests on the system to the expected tracking configuration for IPA-managed certificates.",
+  "ipahealthcheck.ipa.certs|IPACertNSSTrust":
+    "Verifies NSS trust flags for certificates in NSS databases match the expected trust for IPA/Dogtag components.",
+  "ipahealthcheck.ipa.certs|IPACertMatchCheck":
+    "Ensures CA certificate material in LDAP and on-disk NSS stores stay consistent with /etc/ipa/ca.crt.",
+  "ipahealthcheck.ipa.certs|IPADogtagCertsMatchCheck":
+    "Checks that Dogtag certificates present in both the NSS DB and LDAP match between the two stores.",
+  "ipahealthcheck.ipa.certs|IPANSSChainValidation":
+    "Validates certificate chains for NSS-stored certs (e.g. `certutil -V`) to catch untrusted or broken chains.",
+  "ipahealthcheck.ipa.certs|IPAOpenSSLChainValidation":
+    "Validates PEM certificate chains using OpenSSL against the IPA CA bundle.",
+  "ipahealthcheck.ipa.certs|IPARAAgent":
+    "Verifies RA agent description and certificate attributes in LDAP for the IPA RA user.",
+  "ipahealthcheck.ipa.certs|IPAKRAAgent":
+    "Verifies KRA agent description and certificate attributes when KRA is installed.",
+  "ipahealthcheck.ipa.certs|IPACertRevocation":
+    "Confirms tracked IPA certificates are not revoked according to the CA.",
+  "ipahealthcheck.ipa.certs|IPACertmongerCA":
+    "Checks that required certmonger CA helpers (e.g. dogtag-ipa-ca-renew-agent) are configured.",
+
+  // ipahealthcheck.ipa.dna
+  "ipahealthcheck.ipa.dna|IPADNARangeCheck":
+    "Reports configured DNA ID ranges and next values; intended for review alongside other DNA/placement analysis.",
+
+  // ipahealthcheck.ipa.files
+  "ipahealthcheck.ipa.files|IPAFileCheck":
+    "Compares owner and mode of important IPA files to expected values from a fresh install; deviations are usually WARNING.",
+  "ipahealthcheck.ipa.files|IPAFileNSSDBCheck":
+    "Same as IPAFileCheck for NSS database paths used by IPA services.",
+  "ipahealthcheck.ipa.files|TomcatFileCheck":
+    "Validates ownership and permissions of Tomcat-related files for Dogtag.",
+
+  // ipahealthcheck.ipa.host
+  "ipahealthcheck.ipa.host|IPAHostKeytab":
+    "Runs `kinit -kt /etc/krb5.keytab` to verify the host keytab can obtain credentials.",
+
+  // ipahealthcheck.ipa.roles
+  "ipahealthcheck.ipa.roles|IPACRLManagerCheck":
+    "Reports whether this master is configured as the CRL generation master.",
+  "ipahealthcheck.ipa.roles|IPARenewalMasterCheck":
+    "Reports whether this master is the certificate renewal master.",
+
+  // ipahealthcheck.ipa.topology
+  "ipahealthcheck.ipa.topology|IPATopologyDomainCheck":
+    "Equivalent in spirit to `ipa topologysuffix-verify` — validates replication topology and reports connection or agreement issues.",
+
+  // ipahealthcheck.ipa.trust (representative)
+  "ipahealthcheck.ipa.trust|IPATrustAgentCheck":
+    "When configured as a trust agent, verifies SSSD settings such as `ipa_server_mode` for trust.",
+  "ipahealthcheck.ipa.trust|IPATrustDomainsCheck":
+    "Ensures IPA trust domains line up with domains SSSD reports.",
+  "ipahealthcheck.ipa.trust|IPATrustCatalogCheck":
+    "Resolves a sample AD user to validate global catalog / DC entries visible to SSSD.",
+  "ipahealthcheck.ipa.trust|IPAsidgenpluginCheck":
+    "Verifies the SIDGEN plugin is enabled in the Directory Server instance.",
+  "ipahealthcheck.ipa.trust|IPATrustAgentMemberCheck":
+    "Checks that this host is a member of the AD trust agents group in IPA.",
+  "ipahealthcheck.ipa.trust|IPATrustControllerPrincipalCheck":
+    "For trust controllers, verifies the host CIFS principal membership in trust agents.",
+  "ipahealthcheck.ipa.trust|IPATrustControllerServiceCheck":
+    "Ensures the ADTRUST service is enabled in `ipactl` on trust controllers.",
+  "ipahealthcheck.ipa.trust|IPATrustControllerConfCheck":
+    "Validates Samba/ldapi configuration needed for trust controller operation.",
+  "ipahealthcheck.ipa.trust|IPATrustControllerGroupSIDCheck":
+    "Checks the administrators group SID matches expectations for trust controllers.",
+  "ipahealthcheck.ipa.trust|IPATrustPackageCheck":
+    "If AD trust is enabled but this host is not a controller, warns if the trust-ad package is missing.",
+
+  // ipahealthcheck.meta.core
+  "ipahealthcheck.meta.core|MetaCheck":
+    "Collects basic metadata about the run: host FQDN and IPA version information.",
+
+  // ipahealthcheck.meta.services — check name is the service
+  "ipahealthcheck.meta.services|httpd":
+    "Verifies the httpd service is running; required for the IPA web UI and API.",
+  "ipahealthcheck.meta.services|dirsrv":
+    "Verifies the 389 Directory Server instance for IPA is running.",
+  "ipahealthcheck.meta.services|pki_tomcatd":
+    "Verifies Dogtag PKI (Tomcat) is running for the CA/KRA.",
+  "ipahealthcheck.meta.services|krb5kdc":
+    "Verifies the KDC service is running.",
+  "ipahealthcheck.meta.services|named":
+    "Verifies BIND (named) is running when DNS is in use.",
+  "ipahealthcheck.meta.services|sssd":
+    "Verifies SSSD is running.",
+  "ipahealthcheck.meta.services|certmonger":
+    "Verifies certmonger is running for certificate tracking and renewal.",
+
+  // ipahealthcheck.system.filesystemspace
+  "ipahealthcheck.system.filesystemspace|FileSystemSpaceCheck":
+    "Checks free space and free percentage on important paths (e.g. /var/tmp, /tmp, logs, DS data). Low space can break logging and services.",
+
+  // Fallback by check name only (same text as above) for tools that omit source
+  DogtagCertsConfigCheck:
+    "Compares the CA (and KRA, if installed) certificate values with those referenced in Dogtag CS.cfg. A mismatch can prevent the CA from starting.",
+  IPACertmongerExpirationCheck:
+    "Uses certmonger’s view of each tracked certificate to warn if a cert is expiring soon (default window) or report if it has expired.",
+  FileSystemSpaceCheck:
+    "Checks free space and free percentage on important paths (e.g. /var/tmp, /tmp, logs, DS data). Low space can break logging and services.",
+  MetaCheck:
+    "Collects basic metadata about the run: host FQDN and IPA version information.",
+  IPADNARangeCheck:
+    "Reports configured DNA ID ranges and next values; intended for review alongside other DNA/placement analysis.",
+};
+
+/** Upstream project home (README and issue tracker). */
+export const FREEIPA_HEALTHCHECK_REPO_URL =
+  "https://github.com/freeipa/freeipa-healthcheck";
+
+/**
+ * Returns a short explanation of what the check does, or ``null`` if unknown.
+ * Prefer passing both ``source`` and ``check`` from the JSON payload.
+ */
+export function getHealthcheckCheckDocumentation(
+  source: string,
+  check: string
+): string | null {
+  const s = (source || "").trim();
+  const c = (check || "").trim();
+  if (!c || c === "—") {
+    return null;
+  }
+  const composite = `${s}|${c}`;
+  if (HEALTHCHECK_CHECK_DOCS[composite]) {
+    return HEALTHCHECK_CHECK_DOCS[composite];
+  }
+  if (HEALTHCHECK_CHECK_DOCS[c]) {
+    return HEALTHCHECK_CHECK_DOCS[c];
+  }
+  return null;
+}

--- a/src/pages/Healthcheck/healthcheckConstants.ts
+++ b/src/pages/Healthcheck/healthcheckConstants.ts
@@ -1,0 +1,52 @@
+import type { CSSProperties } from "react";
+import {
+  c_scroll_outer_wrapper_MaxHeight,
+  c_scroll_outer_wrapper_MinHeight,
+} from "@patternfly/react-tokens";
+
+/** Default path passed to ``healthcheck_log_show`` on the IPA server. */
+export const DEFAULT_HEALTHCHECK_REPORT_FILE =
+  "/var/log/ipa/healthcheck/healthcheck.log";
+
+/** Sentinel value for the checks multi-select “select all / clear all” row. */
+export const CHECKS_ALL_OPTION = "__all_checks__";
+
+/** Sentinel value for the severities multi-select “select all / clear all” row. */
+export const SEVERITY_SELECT_ALL_OPTION = "__all_severities__";
+
+/** Shared PatternFly layout classes for severity summary bar segment buttons. */
+export const SEVERITY_BAR_BUTTON_CLASSNAME =
+  "pf-v5-u-flex-grow-1 pf-v5-u-display-flex pf-v5-u-flex-direction-column " +
+  "pf-v5-u-align-items-center pf-v5-u-justify-content-center pf-v5-u-py-md " +
+  "pf-v5-u-px-md";
+
+export const SORT_HEADER_BUTTON_CLASSNAME =
+  "pf-v5-u-background-color-transparent pf-v5-u-border-0 pf-v5-u-p-0 " +
+  "pf-v5-u-font-size-md pf-v5-u-font-weight-bold";
+
+/**
+ * PatternFly ``Table`` scroll outer wrapper token overrides (see table-scrollable).
+ * Uses official variable names from ``@patternfly/react-tokens`` — no ad-hoc
+ * ``height`` / ``overflow`` rules that fight the component stylesheet.
+ */
+export const HEALTHCHECK_TABLE_SCROLL_OUTER_VARS = {
+  [c_scroll_outer_wrapper_MaxHeight.name]: "65vh",
+  [c_scroll_outer_wrapper_MinHeight.name]: "0",
+} as CSSProperties;
+
+const DETAILS_NEWLINE_RE = /\s*\n+\s*/g;
+const DETAILS_BRACES_RE = /[{}]/g;
+const DETAILS_MULTI_SPACE_RE = /\s{2,}/g;
+
+/**
+ * Collapses newlines, strips braces, and normalizes spaces so the Details column
+ * fits one readable line in the compact table.
+ */
+export function formatDetailsForDisplay(details: string): string {
+  return details
+    .replace(DETAILS_NEWLINE_RE, " | ")
+    .replace(DETAILS_BRACES_RE, "")
+    .replace(DETAILS_MULTI_SPACE_RE, " ")
+    .replace(/\s*\|\s*/g, " | ")
+    .trim();
+}

--- a/src/pages/Healthcheck/healthcheckTypes.ts
+++ b/src/pages/Healthcheck/healthcheckTypes.ts
@@ -1,0 +1,14 @@
+/**
+ * Types for the Healthcheck results table sort controls (column + direction).
+ */
+
+/** Sortable table column keys (must match header buttons). */
+export type HealthcheckSortColumn =
+  | "timestamp"
+  | "check"
+  | "source"
+  | "result"
+  | "details";
+
+/** Sort direction for column headers. */
+export type HealthcheckSortDirection = "asc" | "desc";

--- a/src/pages/Healthcheck/healthcheckUtils.ts
+++ b/src/pages/Healthcheck/healthcheckUtils.ts
@@ -1,0 +1,1655 @@
+/**
+ * Pure helpers for Healthcheck data shaping, formatting, and RPC helpers.
+ *
+ * Exports cover: payload normalization, table row building, severity filtering,
+ * user-visible strings for the Web UI, and error text for alerts.
+ */
+
+/** ``all`` shows every check; other values filter by the ``result`` field. */
+export type HealthcheckSeverityFilter =
+  | "all"
+  | "SUCCESS"
+  | "CRITICAL"
+  | "ERROR"
+  | "WARNING";
+
+/** Known ``result`` severities used for multi-select filters and sorting. */
+export type HealthcheckKnownSeverity =
+  | "SUCCESS"
+  | "CRITICAL"
+  | "ERROR"
+  | "WARNING";
+
+/** ``result`` values we treat as displayable healthcheck messages in the UI. */
+export const HEALTHCHECK_KNOWN_RESULT_LEVELS = new Set<string>([
+  "SUCCESS",
+  "CRITICAL",
+  "ERROR",
+  "WARNING",
+]);
+
+/** Display / checkbox order (most severe first). */
+export const HEALTHCHECK_SEVERITY_DISPLAY_ORDER: readonly HealthcheckKnownSeverity[] =
+  ["CRITICAL", "ERROR", "WARNING", "SUCCESS"] as const;
+
+const HEALTHCHECK_SEVERITY_SORT_RANK = new Map<string, number>([
+  ["CRITICAL", 0],
+  ["ERROR", 1],
+  ["WARNING", 2],
+  ["SUCCESS", 3],
+]);
+
+/**
+ * Sort rank for ``result`` (lower = more severe). Unknown values sort last.
+ */
+export function healthcheckSeveritySortRank(result: string): number {
+  const u = result.trim().toUpperCase();
+  return HEALTHCHECK_SEVERITY_SORT_RANK.get(u) ?? 99;
+}
+
+const HEALTHCHECK_DATE_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+  timeStyle: "medium",
+});
+
+/** Uppercase trimmed ``result`` string from a check object, or empty if missing. */
+function normalizedResultString(item: unknown): string {
+  if (!item || typeof item !== "object" || !("result" in item)) {
+    return "";
+  }
+  const r = (item as Record<string, unknown>).result;
+  return typeof r === "string" ? r.trim().toUpperCase() : "";
+}
+
+/**
+ * Flatten payload to a list of check objects (single check becomes one element).
+ */
+export function collectHealthcheckItems(data: unknown): unknown[] {
+  if (data === null || data === undefined) {
+    return [];
+  }
+  if (Array.isArray(data)) {
+    return data;
+  }
+  if (typeof data === "object") {
+    return [data];
+  }
+  return [];
+}
+
+/** True if the item has a ``result`` in SUCCESS / CRITICAL / ERROR / WARNING. */
+export function hasKnownSeverityResultItem(item: unknown): boolean {
+  const u = normalizedResultString(item);
+  return u !== "" && HEALTHCHECK_KNOWN_RESULT_LEVELS.has(u);
+}
+
+/**
+ * True when at least one check uses a known severity ``result`` (the levels
+ * shown in the filter). If none match, the UI should show “no messages”
+ * instead of raw JSON.
+ */
+export function hasAnyKnownSeverityMessages(data: unknown): boolean {
+  return collectHealthcheckItems(data).some(hasKnownSeverityResultItem);
+}
+
+/** True if the report contains at least one check with result CRITICAL. */
+export function hasAnyCriticalHealthcheckResult(data: unknown): boolean {
+  return collectHealthcheckItems(data).some(
+    (item) => normalizedResultString(item) === "CRITICAL"
+  );
+}
+
+/** True when stringified payload would be only an empty JSON array ``[]``. */
+export function isEmptyHealthcheckJsonArray(data: unknown): boolean {
+  return Array.isArray(data) && data.length === 0;
+}
+
+/** Counts of checks per known ``result`` severity (full report, not filtered). */
+export type HealthcheckSeverityCounts = {
+  SUCCESS: number;
+  ERROR: number;
+  WARNING: number;
+  CRITICAL: number;
+};
+
+/**
+ * Count items in the payload by ``result`` (SUCCESS / ERROR / WARNING /
+ * CRITICAL). Unknown or missing ``result`` values are ignored.
+ */
+export function countHealthcheckResultsBySeverity(
+  data: unknown
+): HealthcheckSeverityCounts {
+  const counts: HealthcheckSeverityCounts = {
+    SUCCESS: 0,
+    ERROR: 0,
+    WARNING: 0,
+    CRITICAL: 0,
+  };
+  for (const item of collectHealthcheckItems(data)) {
+    const u = normalizedResultString(item);
+    if (u === "SUCCESS") {
+      counts.SUCCESS++;
+    } else if (u === "ERROR") {
+      counts.ERROR++;
+    } else if (u === "WARNING") {
+      counts.WARNING++;
+    } else if (u === "CRITICAL") {
+      counts.CRITICAL++;
+    }
+  }
+  return counts;
+}
+
+export type HealthcheckTableRow = {
+  id: string;
+  timestampRaw: string;
+  timestamp: string;
+  result: string;
+  source: string;
+  check: string;
+  /** Primary user-oriented message (``msg`` / ``message``), for the info popover. */
+  userMessage: string;
+  details: string;
+};
+
+const LABEL_COLOR_BY_SEVERITY = new Map<
+  string,
+  "green" | "yellow" | "orange" | "red" | "grey"
+>([
+  ["SUCCESS", "green"],
+  ["WARNING", "yellow"],
+  ["ERROR", "orange"],
+  ["CRITICAL", "red"],
+]);
+
+/**
+ * PatternFly ``Label`` color for a healthcheck ``result`` string:
+ * SUCCESS green, WARNING yellow, ERROR orange, CRITICAL red.
+ */
+export function healthcheckResultLabelColor(
+  result: string
+): "green" | "yellow" | "orange" | "red" | "grey" {
+  return LABEL_COLOR_BY_SEVERITY.get(result.trim().toUpperCase()) ?? "grey";
+}
+
+/** Primary text fields ``msg`` / ``message`` on the check object (top level). */
+function healthcheckMessageText(o: Record<string, unknown>): string {
+  if (typeof o.msg === "string" && o.msg.trim() !== "") {
+    return o.msg;
+  }
+  if (typeof o.message === "string" && o.message.trim() !== "") {
+    return o.message;
+  }
+  return "";
+}
+
+/** ``key`` field from the check or from nested ``kw``, for expiry-style checks. */
+function healthcheckKeyText(o: Record<string, unknown>): string {
+  if (typeof o.key === "string" && o.key.trim() !== "") {
+    return o.key;
+  }
+  if (o.kw && typeof o.kw === "object" && !Array.isArray(o.kw)) {
+    const kw = o.kw as Record<string, unknown>;
+    if (typeof kw.key === "string" && kw.key.trim() !== "") {
+      return kw.key;
+    }
+  }
+  return "";
+}
+
+/** ``msg`` / ``message`` read from nested ``kw`` when present. */
+function healthcheckMessageTextFromKw(o: Record<string, unknown>): string {
+  if (!o.kw || typeof o.kw !== "object" || Array.isArray(o.kw)) {
+    return "";
+  }
+  return healthcheckMessageText(o.kw as Record<string, unknown>);
+}
+
+/**
+ * True when details are empty or only an empty JSON object (``{}``), including
+ * pretty-printed forms — so the UI can show an em dash instead of ``{}``.
+ */
+export function isEmptyHealthcheckDetailsDisplay(text: string): boolean {
+  const t = text.trim();
+  if (t === "") {
+    return true;
+  }
+  if (t === "{}" || /^\{\s*\}$/.test(t)) {
+    return true;
+  }
+  try {
+    const parsed: unknown = JSON.parse(t);
+    if (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      !Array.isArray(parsed) &&
+      Object.keys(parsed as object).length === 0
+    ) {
+      return true;
+    }
+  } catch {
+    // not JSON — treat as real content
+  }
+  return false;
+}
+
+/** Returns empty string when details are visually empty (see ``isEmptyHealthcheckDetailsDisplay``). */
+function normalizeHealthcheckDetailsString(text: string): string {
+  return isEmptyHealthcheckDetailsDisplay(text) ? "" : text;
+}
+
+/** Matches certmonger-style compact not-after times: ``YYYYMMDDHHmmss``. */
+const COMPACT_TIMESTAMP_14 = /^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})$/;
+
+/**
+ * If ``key`` is a 14-digit ``YYYYMMDDHHmmss`` string with a valid calendar
+ * time, return a ``Date``; otherwise ``null``.
+ */
+export function parseCompactHealthcheckTimestamp(key: string): Date | null {
+  const trimmed = key.trim();
+  const m = trimmed.match(COMPACT_TIMESTAMP_14);
+  if (!m) {
+    return null;
+  }
+  const y = Number(m[1]);
+  const mo = Number(m[2]);
+  const d = Number(m[3]);
+  const h = Number(m[4]);
+  const mi = Number(m[5]);
+  const s = Number(m[6]);
+  if (y < 1970 || y > 2100) {
+    return null;
+  }
+  if (mo < 1 || mo > 12 || d < 1 || d > 31 || h > 23 || mi > 59 || s > 59) {
+    return null;
+  }
+  const date = new Date(y, mo - 1, d, h, mi, s);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  if (
+    date.getFullYear() !== y ||
+    date.getMonth() !== mo - 1 ||
+    date.getDate() !== d ||
+    date.getHours() !== h ||
+    date.getMinutes() !== mi ||
+    date.getSeconds() !== s
+  ) {
+    return null;
+  }
+  return date;
+}
+
+/**
+ * Pretty-print ``key`` when it is a compact 14-digit timestamp; otherwise
+ * return ``key`` unchanged (e.g. SRV strings).
+ */
+export function formatHealthcheckKeyForDisplay(key: string): string {
+  const date = parseCompactHealthcheckTimestamp(key);
+  if (!date) {
+    return key;
+  }
+  return HEALTHCHECK_DATE_TIME_FORMATTER.format(date);
+}
+
+/**
+ * Pretty-print certificate expiry values: compact ``YYYYMMDDHHmmssZ``, plain
+ * 14-digit compact times, or parseable ISO date strings.
+ */
+export function formatHealthcheckExpiryValue(raw: string): string {
+  const t = raw.trim();
+  if (t === "") {
+    return t;
+  }
+  const compact =
+    t.length === 15 && t.endsWith("Z") && /^\d{14}Z$/.test(t)
+      ? t.slice(0, -1)
+      : t;
+  const d14 = parseCompactHealthcheckTimestamp(compact);
+  if (d14) {
+    return HEALTHCHECK_DATE_TIME_FORMATTER.format(d14);
+  }
+  const isoMs = Date.parse(t);
+  if (!Number.isNaN(isoMs)) {
+    return HEALTHCHECK_DATE_TIME_FORMATTER.format(new Date(isoMs));
+  }
+  return formatHealthcheckKeyForDisplay(t);
+}
+
+/** Rewrite ``key`` string fields for JSON detail blobs (recursive). */
+function formatKeyStringsForDisplayDeep(value: unknown): unknown {
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((v) => formatKeyStringsForDisplayDeep(v));
+  }
+  const rec = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(rec)) {
+    if (k === "key" && typeof v === "string") {
+      out[k] = formatHealthcheckKeyForDisplay(v);
+    } else if (v !== null && typeof v === "object") {
+      out[k] = formatKeyStringsForDisplayDeep(v);
+    } else {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+/** Shallow copy of ``kw`` object on a check entry, or empty object. */
+function getHealthcheckKwFlat(
+  o: Record<string, unknown>
+): Record<string, unknown> {
+  if (o.kw && typeof o.kw === "object" && !Array.isArray(o.kw)) {
+    return { ...(o.kw as Record<string, unknown>) };
+  }
+  return {};
+}
+
+/**
+ * Replace ``{name}`` placeholders using scalar values from ``kw`` (e.g.
+ * ``{server}``, ``{cpus}``, ``{workers}``).
+ */
+export function substituteKwPlaceholdersInString(
+  template: string,
+  kw: Record<string, unknown>
+): string {
+  return template.replace(
+    /\{([a-zA-Z_][a-zA-Z0-9_]*)\}/g,
+    (match, name: string) => {
+      if (!Object.prototype.hasOwnProperty.call(kw, name)) {
+        return match;
+      }
+      const v = kw[name];
+      if (v === null || v === undefined) {
+        return match;
+      }
+      if (
+        typeof v === "string" ||
+        typeof v === "number" ||
+        typeof v === "boolean"
+      ) {
+        return String(v);
+      }
+      return match;
+    }
+  );
+}
+
+/** True when ``kw`` is only ``{ status: true }`` (success-only meta payloads). */
+function isKwOnlyStatusTrue(kw: Record<string, unknown>): boolean {
+  const keys = Object.keys(kw);
+  return keys.length === 1 && keys[0] === "status" && kw.status === true;
+}
+
+const USER_MESSAGE_STATUS_TRUE =
+  "The check completed successfully; no additional diagnostics are required for this item.";
+
+const META_SERVICES_SOURCE = "ipahealthcheck.meta.services";
+const META_CORE_SOURCE = "ipahealthcheck.meta.core";
+const META_CORE_CHECK = "MetaCheck";
+const CA_SYSTEM_CERT_TRUST_FLAG_CHECK = "CASystemCertTrustFlagCheck";
+const IPA_FILE_CHECK = "IPAFileCheck";
+const IPA_FILE_NSSDB_CHECK = "IPAFileNSSDBCheck";
+const IPA_HOST_KEYTAB_CHECK = "IPAHostKeytab";
+const IPA_TOPOLOGY_DOMAIN_CHECK = "IPATopologyDomainCheck";
+const KEYTAB_CHECKS = new Set([
+  "IPAHostKeytab",
+  "DSKeytab",
+  "HTTPKeytab",
+  "DNSKeytab",
+  "DNS_keysyncKeytab",
+]);
+const DOGTAG_CONNECTIVITY_CHECKS = new Set([
+  "DogtagOCSPConnectivityCheck",
+  "DogtagTKSConnectivityCheck",
+  "DogtagTPSConnectivityCheck",
+]);
+
+/** One-line success text for ``ipahealthcheck.meta.services`` checks. */
+function formatMetaServiceSuccessDetails(
+  o: Record<string, unknown>,
+  kw: Record<string, unknown>
+): string | null {
+  if (typeof o.source !== "string" || o.source !== META_SERVICES_SOURCE) {
+    return null;
+  }
+  if (!isKwOnlyStatusTrue(kw)) {
+    return null;
+  }
+  const service = typeof o.check === "string" ? o.check.trim() : "";
+  if (service === "") {
+    return null;
+  }
+  return `${service} is running. No additional diagnostics required.`;
+}
+
+/** First non-empty string among ``keys`` on object ``o``. */
+function pickFirstNonEmptyString(
+  o: Record<string, unknown>,
+  keys: readonly string[]
+): string {
+  for (const key of keys) {
+    if (!Object.prototype.hasOwnProperty.call(o, key)) {
+      continue;
+    }
+    const value = o[key];
+    if (typeof value === "string" && value.trim() !== "") {
+      return value.trim();
+    }
+  }
+  return "";
+}
+
+/** Host / IPA version summary for ``ipahealthcheck.meta.core`` MetaCheck. */
+function formatMetaCoreCheckDetails(
+  o: Record<string, unknown>,
+  kw: Record<string, unknown>
+): string | null {
+  if (o.source !== META_CORE_SOURCE || o.check !== META_CORE_CHECK) {
+    return null;
+  }
+  const host =
+    pickFirstNonEmptyString(kw, ["fqdn", "host", "hostname", "server"]) ||
+    pickFirstNonEmptyString(o, ["fqdn", "host", "hostname", "server"]);
+  const ipaVersion =
+    pickFirstNonEmptyString(kw, ["ipa_version", "version"]) ||
+    pickFirstNonEmptyString(o, ["ipa_version", "version"]);
+  const result =
+    typeof o.result === "string" && o.result.trim() !== ""
+      ? o.result.trim()
+      : "UNKNOWN";
+
+  const parts: string[] = [];
+  if (host !== "") {
+    parts.push(`Host: ${host}`);
+  }
+  if (ipaVersion !== "") {
+    parts.push(`IPA version: ${ipaVersion}`);
+  }
+  if (parts.length === 0) {
+    return (
+      `Metadata check (${result}) completed. ` +
+      `This entry records host and version context for this run.`
+    );
+  }
+  return (
+    `Metadata check (${result}) — ${parts.join("; ")}. ` +
+    `This entry records environment context for this healthcheck run.`
+  );
+}
+
+/** User-facing line for Dogtag OCSP/TKS/TPS connectivity checks. */
+function formatDogtagConnectivityDetails(
+  o: Record<string, unknown>,
+  kw: Record<string, unknown>
+): string | null {
+  const check = typeof o.check === "string" ? o.check : "";
+  if (!DOGTAG_CONNECTIVITY_CHECKS.has(check)) {
+    return null;
+  }
+  const subsystem =
+    check === "DogtagOCSPConnectivityCheck"
+      ? "OCSP"
+      : check === "DogtagTKSConnectivityCheck"
+        ? "TKS"
+        : "TPS";
+  const endpoint =
+    pickFirstNonEmptyStringFromKw(kw, [
+      "url",
+      "uri",
+      "endpoint",
+      "host",
+      "hostname",
+      "server",
+      "target",
+    ]) ||
+    pickFirstNonEmptyString(o, ["url", "uri", "endpoint", "host", "server"]);
+  const msg = substituteKwPlaceholdersInString(
+    healthcheckMessageText(o) || healthcheckMessageTextFromKw(o),
+    kw
+  );
+  const result =
+    typeof o.result === "string" ? o.result.trim().toUpperCase() : "";
+
+  if (result === "SUCCESS") {
+    if (endpoint !== "") {
+      return `${subsystem} connectivity is healthy. The subsystem responded at ${endpoint}.`;
+    }
+    return `${subsystem} connectivity is healthy. The subsystem responded successfully.`;
+  }
+  if (msg !== "") {
+    if (endpoint !== "") {
+      return `${subsystem} connectivity check reported an issue for ${endpoint}: ${msg}`;
+    }
+    return `${subsystem} connectivity check reported an issue: ${msg}`;
+  }
+  if (endpoint !== "") {
+    return (
+      `${subsystem} connectivity could not be confirmed for ${endpoint}. ` +
+      `Verify service status, network reachability, and Dogtag subsystem health.`
+    );
+  }
+  return (
+    `${subsystem} connectivity could not be confirmed. ` +
+    `Verify service status, network reachability, and Dogtag subsystem health.`
+  );
+}
+
+/** File permission / ownership summary for ``IPAFileCheck`` / NSS DB variants. */
+function formatIPAFileCheckDetails(kw: Record<string, unknown>): string | null {
+  const filename = pickFirstNonEmptyStringFromKw(kw, [
+    "filename",
+    "file",
+    "path",
+    "name",
+  ]);
+  const modeFound = pickFirstNonEmptyStringFromKw(kw, [
+    "mode",
+    "found_mode",
+    "current_mode",
+    "actual_mode",
+    "perm",
+    "permission",
+  ]);
+  const modeExpected = pickFirstNonEmptyStringFromKw(kw, [
+    "expected_mode",
+    "required_mode",
+  ]);
+  const ownerFound = pickFirstNonEmptyStringFromKw(kw, [
+    "owner",
+    "uid",
+    "found_owner",
+    "current_owner",
+    "actual_owner",
+  ]);
+  const ownerExpected = pickFirstNonEmptyStringFromKw(kw, [
+    "expected_owner",
+    "required_owner",
+  ]);
+
+  if (
+    filename === "" &&
+    modeFound === "" &&
+    modeExpected === "" &&
+    ownerFound === "" &&
+    ownerExpected === ""
+  ) {
+    return null;
+  }
+
+  const modePart =
+    modeExpected !== "" && modeFound !== ""
+      ? `Permission expected=${modeExpected}, found=${modeFound}`
+      : modeFound !== ""
+        ? `Permission ${modeFound}`
+        : modeExpected !== ""
+          ? `Permission expected=${modeExpected}`
+          : "Permission unavailable";
+  const ownerPart =
+    ownerExpected !== "" && ownerFound !== ""
+      ? `Ownership expected=${ownerExpected}, found=${ownerFound}`
+      : ownerFound !== ""
+        ? `Ownership ${ownerFound}`
+        : ownerExpected !== ""
+          ? `Ownership expected=${ownerExpected}`
+          : "Ownership unavailable";
+  const prefix =
+    filename !== "" ? `Filename: ${filename}` : "Filename: (unknown)";
+  return `${prefix}; ${modePart}; ${ownerPart}`;
+}
+
+/** Keytab presence / path line for host and service keytab checks. */
+function formatIPAHostKeytabDetails(
+  o: Record<string, unknown>,
+  kw: Record<string, unknown>
+): string | null {
+  if (!KEYTAB_CHECKS.has(String(o.check))) {
+    return null;
+  }
+  const check = String(o.check);
+  const keytabPath =
+    pickFirstNonEmptyStringFromKw(kw, [
+      "keytab",
+      "keytab_path",
+      "path",
+      "filename",
+      "file",
+    ]) || "/etc/krb5.keytab";
+  const result =
+    typeof o.result === "string" ? o.result.trim().toUpperCase() : "";
+  const msg = substituteKwPlaceholdersInString(
+    healthcheckMessageText(o) || healthcheckMessageTextFromKw(o),
+    kw
+  ).toLowerCase();
+  const present =
+    result === "SUCCESS" ||
+    /\b(found|present|ok|valid)\b/.test(msg) ||
+    (!/\bmissing|not found|cannot|failed|denied|unreadable\b/.test(msg) &&
+      msg !== "");
+
+  const subject =
+    check === IPA_HOST_KEYTAB_CHECK
+      ? "Host keytab"
+      : check === "DSKeytab"
+        ? "Directory Server keytab"
+        : check === "HTTPKeytab"
+          ? "HTTP keytab"
+          : check === "DNSKeytab"
+            ? "DNS keytab"
+            : "DNS keysync keytab";
+  if (present) {
+    return `${subject} is present and usable. Keytab file: ${keytabPath}`;
+  }
+  if (msg !== "") {
+    return `${subject} is not usable. Keytab file: ${keytabPath}. Issue: ${msg}`;
+  }
+  return `${subject} is not present or not usable. Keytab file: ${keytabPath}`;
+}
+
+/** Lists topology suffix lines for ``IPATopologyDomainCheck``. */
+function formatIPATopologyDomainDetails(
+  o: Record<string, unknown>,
+  kw: Record<string, unknown>
+): string | null {
+  if (o.check !== IPA_TOPOLOGY_DOMAIN_CHECK) {
+    return null;
+  }
+  const lines: string[] = [];
+  const suffixFromKey = pickFirstNonEmptyStringFromKw(kw, [
+    "suffix",
+    "suffix_name",
+    "topologysuffix",
+  ]);
+  if (suffixFromKey !== "") {
+    lines.push(`suffix: ${suffixFromKey}`);
+  }
+  for (const [k, v] of Object.entries(kw)) {
+    if (typeof v !== "string" || v.trim() === "") {
+      continue;
+    }
+    const key = k.toLowerCase();
+    if (!key.includes("suffix")) {
+      continue;
+    }
+    const value = v.trim();
+    if (
+      !lines.some((l) => l.toLowerCase() === `suffix: ${value.toLowerCase()}`)
+    ) {
+      lines.push(`suffix: ${value}`);
+    }
+  }
+  if (lines.length === 0) {
+    return "suffix: domain\nsuffix: ca";
+  }
+  return lines.join("\n");
+}
+
+const DNA_RANGE_CHECK = "IPADNARangeCheck";
+
+const PKI_SERVER_HEALTHCHECK_CERTS_SOURCE = "pki.server.healthcheck.certs";
+const PKI_SERVER_HEALTHCHECK_CERTS_EXPIRATION_CHECK = "expiration";
+const PKI_SERVER_HEALTHCHECK_CERTS_EXPIRATION_FULL =
+  "pki.server.healthcheck.certs.expiration";
+
+const PKI_CERT_EXPIRATION_ID_KEYS = [
+  "certid",
+  "cert_id",
+  "certId",
+  "nickname",
+  "subsystem",
+  "tag",
+  "certificate_id",
+  "certificateId",
+  "id",
+] as const;
+
+const PKI_CERT_EXPIRATION_DATE_KEYS = [
+  "not_after",
+  "notAfter",
+  "not_valid_after",
+  "notValidAfter",
+  "expiration",
+  "expires",
+  "valid_until",
+  "end",
+] as const;
+
+const PKI_CERT_TYPE_HINT_KEYS = [
+  "type",
+  "cert_type",
+  "certType",
+  "usage",
+] as const;
+
+/** First non-empty string value for ``keys`` inside ``kw``. */
+function pickFirstNonEmptyStringFromKw(
+  kw: Record<string, unknown>,
+  keys: readonly string[]
+): string {
+  for (const k of keys) {
+    if (!Object.prototype.hasOwnProperty.call(kw, k)) {
+      continue;
+    }
+    const v = kw[k];
+    if (typeof v === "string" && v.trim() !== "") {
+      return v.trim();
+    }
+  }
+  return "";
+}
+
+/** True for Dogtag PKI ``pki.server.healthcheck.certs`` expiration check shapes. */
+function isPkiServerHealthcheckCertsExpiration(
+  source: string,
+  check: string
+): boolean {
+  if (check === PKI_SERVER_HEALTHCHECK_CERTS_EXPIRATION_FULL) {
+    return true;
+  }
+  if (
+    source === PKI_SERVER_HEALTHCHECK_CERTS_SOURCE &&
+    check === PKI_SERVER_HEALTHCHECK_CERTS_EXPIRATION_CHECK
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/** Human label (signing / SSL / …) for PKI cert expiration summary lines. */
+function inferPkiExpirationCertKindLabel(
+  kw: Record<string, unknown>,
+  certid: string,
+  msg: string
+): string {
+  const typeHint = pickFirstNonEmptyStringFromKw(kw, PKI_CERT_TYPE_HINT_KEYS);
+  const hay = `${typeHint} ${certid} ${msg}`.toLowerCase();
+  if (/audit/.test(hay) && /sign/.test(hay)) {
+    return "Audit signing cert";
+  }
+  if (
+    /ca_signing|casigning|signing|subsystemcert|subsystem cert|kra_transport|kra_storage|ocsp/.test(
+      hay
+    )
+  ) {
+    if (/ocsp/.test(hay)) {
+      return "OCSP signing cert";
+    }
+    return "Signing cert";
+  }
+  if (/ssl|server.?cert|https|tomcat/.test(hay)) {
+    return "SSL certificate";
+  }
+  return "Certificate";
+}
+
+/**
+ * Dogtag ``pki.server.healthcheck.certs`` / ``expiration`` — single-line summary.
+ */
+export function formatPkiServerHealthcheckCertsExpirationDetails(
+  o: Record<string, unknown>,
+  kw: Record<string, unknown>
+): string | null {
+  const source = typeof o.source === "string" ? o.source.trim() : "";
+  const check = typeof o.check === "string" ? o.check.trim() : "";
+  if (!isPkiServerHealthcheckCertsExpiration(source, check)) {
+    return null;
+  }
+
+  const certid = pickFirstNonEmptyStringFromKw(kw, PKI_CERT_EXPIRATION_ID_KEYS);
+  let expiryRaw = pickFirstNonEmptyStringFromKw(
+    kw,
+    PKI_CERT_EXPIRATION_DATE_KEYS
+  );
+
+  const keyStr = healthcheckKeyText(o);
+  if (expiryRaw === "" && keyStr !== "") {
+    const keyCompact = keyStr.endsWith("Z") ? keyStr.slice(0, -1) : keyStr;
+    if (parseCompactHealthcheckTimestamp(keyCompact)) {
+      expiryRaw = keyStr;
+    }
+  }
+
+  const msg = substituteKwPlaceholdersInString(
+    healthcheckMessageText(o) || healthcheckMessageTextFromKw(o),
+    kw
+  );
+
+  if (certid === "" || expiryRaw === "") {
+    return null;
+  }
+
+  const kind = inferPkiExpirationCertKindLabel(kw, certid, msg);
+  const expiryDisplay = formatHealthcheckExpiryValue(expiryRaw);
+  return `${kind} certid:${certid} expiry date is ${expiryDisplay}`;
+}
+
+const DNA_KNOWN_KEYS = new Set([
+  "range_start",
+  "range_max",
+  "next_start",
+  "next_max",
+  "msg",
+]);
+
+const CERT_EXPIRATION_CHECK_NAMES = new Set([
+  "IPACertTracking",
+  "IPACertfileExpirationCheck",
+  "IPACertmongerExpirationCheck",
+  "KRASystemCertExpiryCheck",
+  "TPSSystemCertExpiryCheck",
+  "TKSSystemCertExpiryCheck",
+  "OCSPSystemCertExpiryCheck",
+]);
+
+const CERT_NICKNAME_KEYS = [
+  "nickname",
+  "cert-nickname",
+  "cert_nickname",
+  "certfile",
+] as const;
+
+/** NSS / IPA cert nickname from common ``kw`` keys. */
+function pickCertNicknameFromKw(kw: Record<string, unknown>): string {
+  for (const k of CERT_NICKNAME_KEYS) {
+    const v = kw[k];
+    if (typeof v === "string" && v.trim() !== "") {
+      return v.trim();
+    }
+  }
+  return "";
+}
+
+/** Parses ``certid: …`` fragment from a message substring. */
+function pickCertIdFromMessage(msgPart: string): string {
+  const m = msgPart.match(/certid\s*:\s*([^,\n;]+)/i);
+  return m && m[1] ? m[1].trim() : "";
+}
+
+const CERT_ID_KEYS = [
+  "certid",
+  "cert_id",
+  "certId",
+  "id",
+  "certificate_id",
+] as const;
+
+/** Trust flag expected vs found for ``CASystemCertTrustFlagCheck``. */
+function formatCASystemCertTrustFlagDetails(
+  o: Record<string, unknown>,
+  kw: Record<string, unknown>
+): string | null {
+  if (o.check !== CA_SYSTEM_CERT_TRUST_FLAG_CHECK) {
+    return null;
+  }
+  const certid = pickFirstNonEmptyStringFromKw(kw, CERT_ID_KEYS);
+  const nickname = pickCertNicknameFromKw(kw);
+  const found = pickFirstNonEmptyStringFromKw(kw, [
+    "found",
+    "current",
+    "actual",
+    "trust_flags",
+    "trustFlags",
+    "flags",
+  ]);
+  const expected = pickFirstNonEmptyStringFromKw(kw, [
+    "expected",
+    "wanted",
+    "required",
+    "required_flags",
+    "expected_flags",
+  ]);
+
+  const certPart =
+    certid !== "" && nickname !== ""
+      ? `certid:${certid} nickname:${nickname}`
+      : certid !== ""
+        ? `certid:${certid}`
+        : nickname !== ""
+          ? `nickname:${nickname}`
+          : "certificate";
+  const trustPart =
+    expected !== "" && found !== ""
+      ? `trust flags expected=${expected}, found=${found}`
+      : found !== ""
+        ? `trust flags ${found}`
+        : expected !== ""
+          ? `expected trust flags ${expected}`
+          : "trust flag mismatch";
+  return `${certPart} ${trustPart}`;
+}
+
+const DNA_FIELD_ROWS: [string, string][] = [
+  ["Range start", "range_start"],
+  ["Range maximum", "range_max"],
+  ["Next range start", "next_start"],
+  ["Next range maximum", "next_max"],
+];
+
+/** Renders DNA range fields from ``IPADNARangeCheck`` ``kw``. */
+function formatIPADNARangeCheckDetails(kw: Record<string, unknown>): string {
+  const lines: string[] = [];
+  for (const [label, key] of DNA_FIELD_ROWS) {
+    if (Object.prototype.hasOwnProperty.call(kw, key)) {
+      const v = kw[key];
+      if (v !== undefined && v !== null) {
+        lines.push(`${label}: ${String(v)}`);
+      }
+    }
+  }
+  if (typeof kw.msg === "string" && kw.msg.trim() !== "") {
+    lines.push(kw.msg.trim());
+  }
+  for (const [k, v] of Object.entries(kw)) {
+    if (DNA_KNOWN_KEYS.has(k)) {
+      continue;
+    }
+    if (v !== null && v !== undefined && typeof v !== "object") {
+      lines.push(`${k}: ${String(v)}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+/** Richer expiry line for IPA / subsystem cert checks using ``key`` + ``msg``. */
+function enhanceCertExpirationLine(
+  check: string,
+  kw: Record<string, unknown>,
+  keyRaw: string,
+  keyDisplay: string,
+  msgPart: string
+): string | null {
+  if (!CERT_EXPIRATION_CHECK_NAMES.has(check)) {
+    return null;
+  }
+  if (!keyRaw || !parseCompactHealthcheckTimestamp(keyRaw)) {
+    return null;
+  }
+  const nick = pickCertNicknameFromKw(kw);
+  const certFromMsg = pickCertIdFromMessage(msgPart);
+  const certLabel = nick || certFromMsg;
+  if (check === "KRASystemCertExpiryCheck") {
+    if (certLabel !== "") {
+      return (
+        `KRA system certificate ${certLabel} expires on ${keyDisplay}; ` +
+        "renew it before this time to avoid KRA service impact."
+      );
+    }
+    return (
+      `KRA system certificate expires on ${keyDisplay}; renew it before this ` +
+      "time to avoid KRA service impact."
+    );
+  }
+  if (
+    check === "IPACertmongerExpirationCheck" ||
+    check === "IPACertfileExpirationCheck"
+  ) {
+    if (certLabel !== "") {
+      return `${certLabel}:${keyDisplay}`;
+    }
+    if (msgPart !== "") {
+      return `${msgPart}:${keyDisplay}`;
+    }
+    return `Certificate:${keyDisplay}`;
+  }
+  if (
+    check === "TPSSystemCertExpiryCheck" ||
+    check === "TKSSystemCertExpiryCheck" ||
+    check === "OCSPSystemCertExpiryCheck"
+  ) {
+    const subsystem =
+      check === "TPSSystemCertExpiryCheck"
+        ? "TPS"
+        : check === "TKSSystemCertExpiryCheck"
+          ? "TKS"
+          : "OCSP";
+    if (certLabel !== "") {
+      return (
+        `${subsystem} system certificate ${certLabel} expires on ${keyDisplay}; ` +
+        `renew it before this time to avoid ${subsystem} subsystem impact.`
+      );
+    }
+    return (
+      `${subsystem} system certificate expires on ${keyDisplay}; renew it before ` +
+      `this time to avoid ${subsystem} subsystem impact.`
+    );
+  }
+  if (nick !== "") {
+    return `Expiration: ${keyDisplay} — Certificate: ${nick}`;
+  }
+  if (msgPart !== "") {
+    return `Expiration: ${keyDisplay} — ${msgPart}`;
+  }
+  return `Expiration: ${keyDisplay}`;
+}
+
+/** Pretty JSON string for arbitrary detail object, with ``key`` fields formatted. */
+function jsonDetailsFromObject(obj: unknown): string {
+  const forJson = formatKeyStringsForDisplayDeep(obj);
+  return normalizeHealthcheckDetailsString(JSON.stringify(forJson, null, 2));
+}
+
+const STANDARD_CHECK_KEYS = [
+  "source",
+  "check",
+  "result",
+  "msg",
+  "message",
+  "kw",
+  "key",
+] as const;
+
+/** Copy of check object without standard top-level keys (for fallback JSON). */
+function restWithoutStandardFields(
+  o: Record<string, unknown>
+): Record<string, unknown> {
+  const rest = { ...o };
+  for (const k of STANDARD_CHECK_KEYS) {
+    delete rest[k];
+  }
+  return rest;
+}
+
+/** Empty details placeholder when no user-facing text should be shown. */
+function formatGenericDetailsFallback(o: Record<string, unknown>): string {
+  void o;
+  return "";
+}
+
+type HealthcheckDetailsFormatter = (
+  o: Record<string, unknown>,
+  kw: Record<string, unknown>
+) => string | null;
+
+const DETAILS_FORMATTERS: HealthcheckDetailsFormatter[] = [
+  formatMetaServiceSuccessDetails,
+  formatMetaCoreCheckDetails,
+  formatPkiServerHealthcheckCertsExpirationDetails,
+  formatCASystemCertTrustFlagDetails,
+  formatDogtagConnectivityDetails,
+  formatIPAHostKeytabDetails,
+  formatIPATopologyDomainDetails,
+];
+
+/** Runs registered check-specific formatters; returns first non-null string. */
+function runDetailsFormatters(
+  o: Record<string, unknown>,
+  kw: Record<string, unknown>
+): string | null {
+  for (const formatter of DETAILS_FORMATTERS) {
+    const text = formatter(o, kw);
+    if (text !== null) {
+      return text;
+    }
+  }
+  return null;
+}
+
+/**
+ * Human-readable detail cell: ``msg:key`` when both exist, else ``msg`` /
+ * ``message`` / ``kw`` (JSON) / remaining fields.
+ */
+export function formatHealthcheckCellDetails(
+  o: Record<string, unknown>
+): string {
+  const check = typeof o.check === "string" ? o.check : "";
+  const kw = getHealthcheckKwFlat(o);
+  const formatted = runDetailsFormatters(o, kw);
+  if (formatted !== null) {
+    return formatted;
+  }
+
+  if (check === IPA_FILE_CHECK || check === IPA_FILE_NSSDB_CHECK) {
+    const ipaFileDetails = formatIPAFileCheckDetails(kw);
+    if (ipaFileDetails !== null) {
+      return ipaFileDetails;
+    }
+  }
+
+  if (isKwOnlyStatusTrue(kw)) {
+    return USER_MESSAGE_STATUS_TRUE;
+  }
+
+  if (check === DNA_RANGE_CHECK && Object.keys(kw).length > 0) {
+    const dna = formatIPADNARangeCheckDetails(kw);
+    if (dna !== "") {
+      return substituteKwPlaceholdersInString(dna, kw);
+    }
+  }
+
+  const msg = substituteKwPlaceholdersInString(
+    healthcheckMessageText(o) || healthcheckMessageTextFromKw(o),
+    kw
+  );
+  const key = healthcheckKeyText(o);
+  const keyDisplay = key !== "" ? formatHealthcheckKeyForDisplay(key) : "";
+
+  let out: string;
+
+  if (msg !== "" && key !== "") {
+    out =
+      enhanceCertExpirationLine(check, kw, key, keyDisplay, msg) ??
+      `${msg}:${keyDisplay}`;
+  } else if (msg !== "") {
+    out = msg;
+  } else if (key !== "") {
+    out =
+      enhanceCertExpirationLine(check, kw, key, keyDisplay, "") ?? keyDisplay;
+  } else if (o.kw !== undefined && o.kw !== null) {
+    if (
+      typeof o.kw === "object" &&
+      !Array.isArray(o.kw) &&
+      Object.keys(o.kw as object).length === 0
+    ) {
+      return formatGenericDetailsFallback(o);
+    }
+    try {
+      const forJson = formatKeyStringsForDisplayDeep(o.kw);
+      if (
+        forJson &&
+        typeof forJson === "object" &&
+        !Array.isArray(forJson) &&
+        isKwOnlyStatusTrue(forJson as Record<string, unknown>)
+      ) {
+        return USER_MESSAGE_STATUS_TRUE;
+      }
+      out = normalizeHealthcheckDetailsString(JSON.stringify(forJson, null, 2));
+      if (isEmptyHealthcheckDetailsDisplay(out)) {
+        return formatGenericDetailsFallback(o);
+      }
+    } catch {
+      out = normalizeHealthcheckDetailsString(String(o.kw));
+    }
+  } else {
+    const rest = restWithoutStandardFields(o);
+    if (Object.keys(rest).length === 0) {
+      return formatGenericDetailsFallback(o);
+    }
+    try {
+      out = jsonDetailsFromObject(rest);
+    } catch {
+      return formatGenericDetailsFallback(o);
+    }
+  }
+  const finalOut = substituteKwPlaceholdersInString(out, kw).trim();
+  if (finalOut === "" || isEmptyHealthcheckDetailsDisplay(finalOut)) {
+    return formatGenericDetailsFallback(o);
+  }
+  return finalOut;
+}
+
+/**
+ * User-facing message for a check (``msg`` / ``message``, with ``kw``
+ * placeholder substitution). Empty when only structured ``kw`` / other fields
+ * carry data — use the Details column in that case.
+ */
+export function formatHealthcheckUserMessage(
+  o: Record<string, unknown>
+): string {
+  const kw = getHealthcheckKwFlat(o);
+  return substituteKwPlaceholdersInString(
+    healthcheckMessageText(o) || healthcheckMessageTextFromKw(o),
+    kw
+  ).trim();
+}
+
+/**
+ * Display value for the healthcheck ``when`` field (typically
+ * ``YYYYMMDDHHmmssZ``). Falls back to em dash when missing/unparseable.
+ */
+export function formatHealthcheckRowTimestamp(
+  o: Record<string, unknown>
+): string {
+  const raw = typeof o.when === "string" ? o.when.trim() : "";
+  if (raw === "") {
+    return "—";
+  }
+  const compact = raw.endsWith("Z") ? raw.slice(0, -1) : raw;
+  const parsed = parseCompactHealthcheckTimestamp(compact);
+  if (!parsed) {
+    return raw;
+  }
+  return HEALTHCHECK_DATE_TIME_FORMATTER.format(parsed);
+}
+
+/** Raw ``when`` value (for stable sorting); empty when missing. */
+export function getHealthcheckRowTimestampRaw(
+  o: Record<string, unknown>
+): string {
+  return typeof o.when === "string" ? o.when.trim() : "";
+}
+
+/**
+ * Builds table rows from filtered check JSON: maps each item, then merges rows
+ * that share ``source|check|result`` (keeps latest timestamp, joins messages/details).
+ */
+export function buildHealthcheckTableRows(
+  data: unknown
+): HealthcheckTableRow[] {
+  const rawRows = collectHealthcheckItems(data).map((item, index) => {
+    const o =
+      item && typeof item === "object" ? (item as Record<string, unknown>) : {};
+    const result = typeof o.result === "string" ? o.result : "";
+    const source = typeof o.source === "string" ? o.source : "";
+    const check = typeof o.check === "string" ? o.check : "";
+    const timestampRaw = getHealthcheckRowTimestampRaw(o);
+    const timestamp = formatHealthcheckRowTimestamp(o);
+    const userMessage = formatHealthcheckUserMessage(o);
+    const details = formatHealthcheckCellDetails(o);
+    return {
+      id: `${source}|${check}|${index}`,
+      timestampRaw,
+      timestamp,
+      result: result || "—",
+      source: source || "—",
+      check: check || "—",
+      userMessage,
+      details,
+    };
+  });
+
+  const grouped = new Map<string, HealthcheckTableRow>();
+
+  for (const row of rawRows) {
+    const key = `${row.source}|${row.check}|${row.result}`;
+    const existing = grouped.get(key);
+    if (!existing) {
+      grouped.set(key, { ...row, id: `${key}|grouped` });
+      continue;
+    }
+
+    // Keep the latest timestamp in grouped rows.
+    if (row.timestampRaw > existing.timestampRaw) {
+      existing.timestampRaw = row.timestampRaw;
+      existing.timestamp = row.timestamp;
+    }
+    if (row.userMessage !== "" && existing.userMessage !== row.userMessage) {
+      existing.userMessage = existing.userMessage
+        ? `${existing.userMessage}\n${row.userMessage}`
+        : row.userMessage;
+    }
+    if (row.details !== "" && existing.details !== row.details) {
+      existing.details = existing.details
+        ? `${existing.details}\n\n- - -\n\n${row.details}`
+        : row.details;
+    }
+  }
+
+  const output: HealthcheckTableRow[] = [];
+  const seenGrouped = new Set<string>();
+  for (const row of rawRows) {
+    const key = `${row.source}|${row.check}|${row.result}`;
+    if (seenGrouped.has(key)) {
+      continue;
+    }
+    const groupedRow = grouped.get(key);
+    if (groupedRow) {
+      output.push(groupedRow);
+      seenGrouped.add(key);
+    } else {
+      output.push(row);
+    }
+  }
+  return output;
+}
+
+/** Parsed shape of ``healthcheck_log_show`` RPC body (metadata + ``result`` payload). */
+export type HealthcheckCommandPayload = {
+  result: unknown;
+  raw?: string;
+  returncode?: number;
+  healthcheck_version?: string;
+  ipa_version?: string;
+  pki_version?: string;
+  output_file?: string;
+};
+
+const IPA_HEALTHCHECK_VER_UI_BAD_SUBSTRINGS = [
+  "must be root",
+  "you must be root",
+  "run this script",
+  "permission denied",
+  "not permitted",
+  "only root",
+] as const;
+
+const IPA_HEALTHCHECK_VER_PREFIX_RE =
+  /^(ipa-healthcheck|ipahealthcheck)\s*:\s*/i;
+
+/**
+ * Strip unusable ``ipa-healthcheck --version`` / stderr leakage; keep a bare
+ * version for display (``undefined`` → show "unavailable" in the UI).
+ */
+export function sanitizeHealthcheckToolVersionForUi(
+  value: string | undefined
+): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  let s = value.trim();
+  if (!s) {
+    return undefined;
+  }
+  const reject = (t: string): boolean => {
+    const low = t.toLowerCase();
+    return IPA_HEALTHCHECK_VER_UI_BAD_SUBSTRINGS.some((frag) =>
+      low.includes(frag)
+    );
+  };
+  if (reject(s)) {
+    return undefined;
+  }
+  while (IPA_HEALTHCHECK_VER_PREFIX_RE.test(s)) {
+    s = s.replace(IPA_HEALTHCHECK_VER_PREFIX_RE, "").trim();
+  }
+  if (!s || reject(s)) {
+    return undefined;
+  }
+  if (s.length > 256) {
+    return undefined;
+  }
+  return s;
+}
+
+/**
+ * IPA JSON-RPC may wrap command output in ``{ result: { … }, count, … }``.
+ */
+function peelHealthcheckLogShowRpcPayload(body: unknown): unknown {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return body;
+  }
+  const o = body as Record<string, unknown>;
+  const inner = o.result;
+  if (
+    inner !== null &&
+    typeof inner === "object" &&
+    !Array.isArray(inner) &&
+    ("healthcheck_version" in inner ||
+      "returncode" in inner ||
+      "raw" in inner ||
+      "output_file" in inner ||
+      "ipa_version" in inner ||
+      "pki_version" in inner)
+  ) {
+    return inner;
+  }
+  return body;
+}
+
+/**
+ * Normalize RPC body: ``healthcheck_log_show`` returns ``result``, ``raw``,
+ * ``returncode``, ``healthcheck_version``, and ``output_file``; older
+ * responses may be checks-only.
+ */
+export function parseHealthcheckLogShowBody(
+  body: unknown
+): HealthcheckCommandPayload | null {
+  if (body === null || body === undefined) {
+    return null;
+  }
+  const peeled = peelHealthcheckLogShowRpcPayload(body);
+  if (typeof peeled !== "object" || Array.isArray(peeled)) {
+    return { result: peeled };
+  }
+  const o = peeled as Record<string, unknown>;
+  if (
+    "returncode" in o ||
+    "output_file" in o ||
+    "raw" in o ||
+    "healthcheck_version" in o ||
+    "ipa_version" in o ||
+    "pki_version" in o
+  ) {
+    const rawHcv =
+      typeof o.healthcheck_version === "string"
+        ? o.healthcheck_version
+        : undefined;
+    return {
+      result: o.result,
+      raw: typeof o.raw === "string" ? o.raw : undefined,
+      returncode: typeof o.returncode === "number" ? o.returncode : undefined,
+      healthcheck_version: sanitizeHealthcheckToolVersionForUi(rawHcv),
+      ipa_version:
+        typeof o.ipa_version === "string" ? o.ipa_version : undefined,
+      pki_version:
+        typeof o.pki_version === "string" ? o.pki_version : undefined,
+      output_file:
+        typeof o.output_file === "string" ? o.output_file : undefined,
+    };
+  }
+  return { result: peeled };
+}
+
+/**
+ * Message for RTK Query / fetch failures (no JSON-RPC body), e.g. network
+ * errors, HTTP 401/502, or failed fetch — not IPA ``data.error`` payloads.
+ */
+export function formatHealthcheckTransportError(err: unknown): string {
+  if (err == null) {
+    return "Unknown error (no response).";
+  }
+  if (typeof err === "string") {
+    return err;
+  }
+  if (typeof err !== "object") {
+    return String(err);
+  }
+  const o = err as Record<string, unknown>;
+  if (typeof o.message === "string" && o.message.length > 0) {
+    const code =
+      typeof o.code === "string" && o.code.length > 0 ? `${o.code}: ` : "";
+    return `${code}${o.message}`;
+  }
+  if (o.status !== undefined && o.status !== null) {
+    const status = String(o.status);
+    const parts: string[] = [status];
+    if (typeof o.error === "string" && o.error.length > 0) {
+      parts.push(o.error);
+    }
+    const data = o.data;
+    if (typeof data === "string" && data.length > 0) {
+      parts.push(data);
+    } else if (
+      data !== undefined &&
+      data !== null &&
+      typeof data === "object"
+    ) {
+      try {
+        parts.push(JSON.stringify(data));
+      } catch {
+        parts.push("[unserializable data]");
+      }
+    }
+    return parts.join(" — ");
+  }
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}
+
+/** Readable message from IPA RPC ``error`` payload. */
+export function formatHealthcheckRpcError(err: unknown): string {
+  if (err == null) {
+    return "Unknown error";
+  }
+  if (typeof err === "string") {
+    return augmentHealthcheckServerHint(err);
+  }
+  const asResult = err as { message?: string };
+  if (typeof asResult.message === "string" && asResult.message.length > 0) {
+    return augmentHealthcheckServerHint(asResult.message);
+  }
+  if (typeof err === "object" && err !== null && "message" in err) {
+    const m = (err as { message: unknown }).message;
+    if (typeof m === "string" && m.length > 0) {
+      return augmentHealthcheckServerHint(m);
+    }
+  }
+  return String(err);
+}
+
+/**
+ * Appends operator hints for common ``healthcheck_log_show`` failures (bad JSON,
+ * missing file, unknown ``report_file``, sudo/password issues).
+ */
+export function augmentHealthcheckServerHint(message: string): string {
+  if (/file is not valid JSON:/i.test(message)) {
+    return (
+      `${message} ` +
+      "Regenerate the report as JSON, for example: " +
+      "ipa-healthcheck --output-type json --output-file " +
+      "/var/log/ipa/healthcheck/healthcheck.log. " +
+      "If the file contains old text output, overwrite it with the command " +
+      "above or clear it before rerunning."
+    );
+  }
+  if (/Healthcheck report file does not exist:/i.test(message)) {
+    return (
+      `${message} ` +
+      "Create the report first as root on the IPA server: " +
+      "mkdir -p /var/log/ipa/healthcheck && " +
+      "ipa-healthcheck --output-file " +
+      "/var/log/ipa/healthcheck/healthcheck.log. " +
+      "If using the systemd unit, start it once with " +
+      "systemctl start ipa-healthcheck.service."
+    );
+  }
+  if (/Unknown option:\s*report_file/i.test(message)) {
+    return (
+      `${message} ` +
+      "Install or upgrade ipaserver/plugins/healthcheck.py on the IPA server " +
+      "so that healthcheck_log_show defines the report_file option, then " +
+      "restart the HTTP service (for example: systemctl restart httpd)."
+    );
+  }
+  if (
+    /ipa-healthcheck produced no output/i.test(message) &&
+    /password is required/i.test(message)
+  ) {
+    return (
+      "Live healthcheck could not run: the API user needs passwordless sudo for " +
+      "ipa-healthcheck, or run ipa-healthcheck --output-type json as root and " +
+      "use this page with the JSON file path. Original error: " +
+      message
+    );
+  }
+  return message;
+}
+
+/**
+ * Turn API / file payload into a list of checks: parse JSON strings, unwrap a
+ * single check object, or use a ``checks`` array when present.
+ */
+export function normalizeHealthcheckResult(data: unknown): unknown {
+  if (data === null || data === undefined) {
+    return null;
+  }
+  let cur: unknown = data;
+  if (typeof cur === "string") {
+    const t = cur.trim();
+    if (t === "") {
+      return null;
+    }
+    try {
+      cur = JSON.parse(t) as unknown;
+    } catch {
+      return data;
+    }
+  }
+  if (Array.isArray(cur)) {
+    return cur;
+  }
+  if (typeof cur === "object" && cur !== null) {
+    const o = cur as Record<string, unknown>;
+    if (Array.isArray(o.checks)) {
+      return o.checks;
+    }
+    const hasResult = "result" in o;
+    const hasCheckShape =
+      typeof o.source === "string" || typeof o.check === "string";
+    if (hasResult && hasCheckShape) {
+      return [cur];
+    }
+  }
+  return cur;
+}
+
+/**
+ * Keep only healthcheck entries whose ``result`` matches the selected severity.
+ */
+export function filterHealthcheckBySeverity(
+  data: unknown,
+  severity: HealthcheckSeverityFilter
+): unknown {
+  if (severity === "all" || data === null || data === undefined) {
+    return data;
+  }
+  const matchSeverity = (value: unknown): boolean =>
+    typeof value === "string" && value.trim().toUpperCase() === severity;
+
+  if (Array.isArray(data)) {
+    return data.filter((item) => {
+      if (item && typeof item === "object" && "result" in item) {
+        return matchSeverity((item as Record<string, unknown>).result);
+      }
+      return false;
+    });
+  }
+  if (typeof data === "object" && data !== null && "result" in data) {
+    const r = (data as Record<string, unknown>).result;
+    if (matchSeverity(r)) {
+      return data;
+    }
+    return [];
+  }
+  return data;
+}
+
+/**
+ * Keep entries whose ``result`` is in ``severities``. Empty set yields ``[]``.
+ * When ``severities`` contains every known level, returns ``data`` unchanged.
+ */
+export function filterHealthcheckBySeverities(
+  data: unknown,
+  severities: ReadonlySet<string>
+): unknown {
+  if (data === null || data === undefined) {
+    return data;
+  }
+  if (severities.size === 0) {
+    return [];
+  }
+  if (
+    severities.size === HEALTHCHECK_KNOWN_RESULT_LEVELS.size &&
+    [...HEALTHCHECK_KNOWN_RESULT_LEVELS].every((s) => severities.has(s))
+  ) {
+    return data;
+  }
+  const matchSeverity = (value: unknown): boolean => {
+    if (typeof value !== "string") {
+      return false;
+    }
+    const u = value.trim().toUpperCase();
+    return severities.has(u);
+  };
+  if (Array.isArray(data)) {
+    return data.filter((item) => {
+      if (item && typeof item === "object" && "result" in item) {
+        return matchSeverity((item as Record<string, unknown>).result);
+      }
+      return false;
+    });
+  }
+  if (typeof data === "object" && data !== null && "result" in data) {
+    const r = (data as Record<string, unknown>).result;
+    if (matchSeverity(r)) {
+      return data;
+    }
+    return [];
+  }
+  return data;
+}


### PR DESCRIPTION
Add ipaserver plugin to serve ipa-healthcheck log file in JSON and metadata for the Web UI. Implement Healthcheck page with file-based report path, filters, sorting, and documentation. Below files are added.

src/navigation/AppRoutes.tsx: Route for /healthcheck
src/navigation/NavRoutes.ts: Sidebar entry + labels
src/pages/Healthcheck/Healthcheck.tsx: Healthcheck page (UI, RPC load, filters, table)
src/pages/Healthcheck/healthcheckUtils.ts: Parsing, normalization, row shaping, details formatters, errors
src/pages/Healthcheck/README.md: Overview of the healthcheck tab.

Note: IPA server related changes will be raised in seperate PR.

## Summary by Sourcery

Add a new Web UI Healthcheck page that loads and displays ipa-healthcheck JSON report data from the server with filtering, sorting, and summarized severity information.

New Features:
- Introduce a Healthcheck navigation entry and route in the Web UI.
- Add a Healthcheck page that loads healthcheck_log_show results and presents them in a sortable, filterable table with severity and check filters.

Enhancements:
- Provide utility helpers to normalize healthcheck_log_show responses, shape table rows, compute severity counts, and format user-friendly detail messages from raw healthcheck data.

Documentation:
- Document the behavior and data flow of the Healthcheck Web UI page and its supporting utilities.