### PR TITLE
[Integration tests] Certificate Identity mapping rules

### DIFF
--- a/cypress/e2e/certificate_mapping/cert_id_mapping_rules.feature
+++ b/cypress/e2e/certificate_mapping/cert_id_mapping_rules.feature
@@ -1,0 +1,178 @@
+Feature: Certificate identity mapping rules manipulation
+    Create, delete, and validate certificate identity mapping rules
+
+    @test
+    Scenario: Add a new certificate identity mapping rule with mandatory fields
+        Given I am logged in as admin
+        And I am on "cert-id-mapping-rules" page
+
+        When I click on the "certificate-mapping-button-add" button
+        Then I should see "add-rule-modal" modal
+
+        When I type in the "modal-textbox-rule-name" textbox text "test_rule_mandatory"
+        Then I should see "test_rule_mandatory" in the "modal-textbox-rule-name" textbox
+
+        When I click on the "modal-button-add" button
+        Then I should not see "add-rule-modal" modal
+        And I should see "add-certmap-success" alert
+
+        When I search for "test_rule_mandatory" in the data table
+        Then I should see "test_rule_mandatory" entry in the data table
+
+    @cleanup
+    Scenario: Delete cert mapping rule "test_rule_mandatory"
+        Given I delete certmaprule "test_rule_mandatory"
+
+    @test
+    Scenario: Add a new certificate identity mapping rule with all fields
+        Given I am logged in as admin
+        And I am on "cert-id-mapping-rules" page
+
+        When I click on the "certificate-mapping-button-add" button
+        Then I should see "add-rule-modal" modal
+
+        When I type in the "modal-textbox-rule-name" textbox text "test_rule_all"
+        Then I should see "test_rule_all" in the "modal-textbox-rule-name" textbox
+
+        When I type in the "modal-textbox-mapping-rule" textbox text "(ipacertsubject=.*,O=EXAMPLE.ORG)"
+        Then I should see "(ipacertsubject=.*,O=EXAMPLE.ORG)" in the "modal-textbox-mapping-rule" textbox
+
+        When I type in the "modal-textbox-matching-rule" textbox text "<ISSUER>CN=CA,O=EXAMPLE.ORG"
+        Then I should see "<ISSUER>CN=CA,O=EXAMPLE.ORG" in the "modal-textbox-matching-rule" textbox
+
+        When I add "ipa.test" to "modal-domain-name" textbox list
+        Then I should see "ipa.test" in the "modal-domain-name" textbox list
+
+        When I type in the "modal-number-selector-priority-input" textbox text "5"
+        Then I should see "5" in the "modal-number-selector-priority-input" textbox
+
+        When I type in the "modal-textbox-description" textbox text "Test rule with all fields"
+        Then I should see "Test rule with all fields" in the "modal-textbox-description" textbox
+
+        When I click on the "modal-button-add" button
+        Then I should not see "add-rule-modal" modal
+        And I should see "add-certmap-success" alert
+
+        When I search for "test_rule_all" in the data table
+        Then I should see "test_rule_all" entry in the data table
+
+    @cleanup
+    Scenario: Delete cert mapping rule "test_rule_all"
+        Given I delete certmaprule "test_rule_all"
+
+    @seed
+    Scenario: Create cert mapping rule for deletion test
+        Given certmaprule "test_rule_delete" exists
+
+    @test
+    Scenario: Delete a certificate identity mapping rule via toolbar
+        Given I am logged in as admin
+        And I am on "cert-id-mapping-rules" page
+
+        When I select entry "test_rule_delete" in the data table
+        Then I should see "test_rule_delete" entry selected in the data table
+
+        When I click on the "certificate-mapping-button-delete" button
+        Then I should see "delete-multiple-rules-modal" modal
+
+        When I click on the "modal-button-delete" button
+        Then I should not see "delete-multiple-rules-modal" modal
+        And I should see "remove-certrules-success" alert
+
+        When I search for "test_rule_delete" in the data table
+        Then I should not see "test_rule_delete" entry in the data table
+
+    @test
+    Scenario: Cancel creation of a certificate identity mapping rule
+        Given I am logged in as admin
+        And I am on "cert-id-mapping-rules" page
+
+        When I click on the "certificate-mapping-button-add" button
+        Then I should see "add-rule-modal" modal
+
+        When I type in the "modal-textbox-rule-name" textbox text "test_rule_cancel"
+        Then I should see "test_rule_cancel" in the "modal-textbox-rule-name" textbox
+
+        When I click on the "modal-button-cancel" button
+        Then I should not see "add-rule-modal" modal
+
+        When I search for "test_rule_cancel" in the data table
+        Then I should not see "test_rule_cancel" entry in the data table
+
+    @seed
+    Scenario: Create cert mapping rule for duplicate test
+        Given certmaprule "test_rule_duplicate" exists
+
+    @test
+    Scenario: Add an invalid certificate identity mapping rule
+        Given I am logged in as admin
+        And I am on "cert-id-mapping-rules" page
+
+        When I click on the "certificate-mapping-button-add" button
+        Then I should see "add-rule-modal" modal
+        And I should see the "modal-button-add" button is disabled
+
+        When I type in the "modal-textbox-rule-name" textbox text "test_rule_duplicate"
+        Then I should see "test_rule_duplicate" in the "modal-textbox-rule-name" textbox
+
+        When I click on the "modal-button-add" button
+        Then I should see "add-cermap-error" alert
+
+        When I click on the "modal-button-cancel" button
+        Then I should not see "add-rule-modal" modal
+
+    @cleanup
+    Scenario: Delete cert mapping rule "test_rule_duplicate"
+        Given I delete certmaprule "test_rule_duplicate"
+
+    @seed
+    Scenario: Create cert mapping rule with status 'Enabled'
+        Given certmaprule "test_rule_status_enabled" exists
+
+    @test
+    Scenario: Disable a certificate identity mapping rule
+        Given I am logged in as admin
+        And I am on "cert-id-mapping-rules" page
+
+        When I select entry "test_rule_status_enabled" in the data table
+        Then I should see "test_rule_status_enabled" entry selected in the data table
+
+        When I click on the "certificate-mapping-button-disable" button
+        Then I should see "enable-disable-multiple-rules-modal" modal
+
+        When I click on the "modal-button-ok" button
+        Then I should not see "enable-disable-multiple-rules-modal" modal
+        And I should see "success" alert
+
+        When I search for "test_rule_status_enabled" in the data table
+        Then I should see element "test_rule_status_enabled" with status label "ipaenabledflag" in the list disabled
+
+    @cleanup
+    Scenario: Delete cert mapping rule "test_rule_status_enabled"
+        Given I delete certmaprule "test_rule_status_enabled"
+
+    @seed
+    Scenario: Create cert mapping rule with status 'Disabled'
+        Given certmaprule "test_rule_status_disabled" exists and is disabled
+
+    @test
+    Scenario: Enable a certificate identity mapping rule
+        Given I am logged in as admin
+        And I am on "cert-id-mapping-rules" page
+
+        When I select entry "test_rule_status_disabled" in the data table
+        Then I should see "test_rule_status_disabled" entry selected in the data table
+
+        When I click on the "certificate-mapping-button-enable" button
+        Then I should see "enable-disable-multiple-rules-modal" modal
+
+        When I click on the "modal-button-ok" button
+        Then I should not see "enable-disable-multiple-rules-modal" modal
+        And I should see "success" alert
+
+        When I search for "test_rule_status_disabled" in the data table
+        Then I should see element "test_rule_status_disabled" with status label "ipaenabledflag" in the list enabled
+
+    @cleanup
+    Scenario: Delete cert mapping rule "test_rule_status_disabled"
+        Given I delete certmaprule "test_rule_status_disabled"

--- a/cypress/e2e/certificate_mapping/cert_id_mapping_rules.ts
+++ b/cypress/e2e/certificate_mapping/cert_id_mapping_rules.ts
@@ -1,0 +1,27 @@
+import { Given } from "@badeball/cypress-cucumber-preprocessor";
+
+Given("certmaprule {string} exists", (ruleName: string) => {
+  cy.ipa({
+    command: "certmaprule-add",
+    name: ruleName,
+  });
+});
+
+Given("certmaprule {string} exists and is disabled", (ruleName: string) => {
+  cy.ipa({
+    command: "certmaprule-add",
+    name: ruleName,
+  }).then(() => {
+    cy.ipa({
+      command: "certmaprule-disable",
+      name: ruleName,
+    });
+  });
+});
+
+Given("I delete certmaprule {string}", (ruleName: string) => {
+  cy.ipa({
+    command: "certmaprule-del",
+    name: ruleName,
+  });
+});

--- a/cypress/e2e/common/data_tables.ts
+++ b/cypress/e2e/common/data_tables.ts
@@ -45,6 +45,21 @@ export const validateEntry = (name: string) => {
   entryExists(name);
 };
 
+// 'MainTable' component uses 'data-label' attribute to set the status label
+// Also contains an icon followed by a space and the status text
+// So it must be handled differently than other attributes
+export const isElementDisabled = (elementName: string, label: string) => {
+  cy.get(
+    "tr[id='" + elementName + "'] td[data-label='" + label + "']"
+  ).contains("Disabled");
+};
+
+export const isElementEnabled = (elementName: string, label: string) => {
+  cy.get(
+    "tr[id='" + elementName + "'] td[data-label='" + label + "']"
+  ).contains("Enabled");
+};
+
 When("I search for {string} in the data table", (name: string) => {
   searchForEntry(name);
 });
@@ -131,3 +146,17 @@ Then(
 Then("I should see no table with ID {string}", (tableId: string) => {
   cy.get("table#" + tableId).should("not.exist");
 });
+
+Then(
+  "I should see element {string} with status label {string} in the list disabled",
+  (elementName: string, statusLabel: string) => {
+    isElementDisabled(elementName, statusLabel);
+  }
+);
+
+Then(
+  "I should see element {string} with status label {string} in the list enabled",
+  (elementName: string, statusLabel: string) => {
+    isElementEnabled(elementName, statusLabel);
+  }
+);

--- a/src/components/Form/TextInputList.tsx
+++ b/src/components/Form/TextInputList.tsx
@@ -40,7 +40,7 @@ const TextInputList = (props: TextInputListProps) => {
   };
 
   return (
-    <>
+    <div data-cy={props.dataCy}>
       <Flex direction={{ default: "column" }} name={props.name}>
         {props.list.map((item, idx) => (
           <Flex
@@ -53,7 +53,7 @@ const TextInputList = (props: TextInputListProps) => {
               flex={{ default: "flex_1" }}
             >
               <TextInput
-                data-cy={props.dataCy + "-" + item}
+                data-cy={props.dataCy + "-textbox-" + idx}
                 id={props.name + "-" + idx}
                 value={item}
                 type="text"
@@ -64,7 +64,7 @@ const TextInputList = (props: TextInputListProps) => {
             </FlexItem>
             <FlexItem key={props.name + "-" + idx + "-delete-button"}>
               <Button
-                data-cy={props.dataCy + "-" + item + "-delete-button"}
+                data-cy={props.dataCy + "-button-delete-" + idx}
                 variant="danger"
                 name={"remove-" + props.name + "-" + idx}
                 onClick={() => onRemoveHandler(idx)}
@@ -76,7 +76,7 @@ const TextInputList = (props: TextInputListProps) => {
         ))}
       </Flex>
       <Button
-        data-cy={props.dataCy + "-add-button"}
+        data-cy={props.dataCy + "-button-add"}
         variant="secondary"
         className="pf-v6-u-mt-sm"
         name={"add-" + props.name}
@@ -84,7 +84,7 @@ const TextInputList = (props: TextInputListProps) => {
       >
         Add
       </Button>
-    </>
+    </div>
   );
 };
 

--- a/src/pages/CertificateMapping/CertificateMapping.tsx
+++ b/src/pages/CertificateMapping/CertificateMapping.tsx
@@ -282,7 +282,7 @@ const CertificateMappingPage = () => {
           const elementsList: CertificateMapping[] = [];
 
           for (let i = 0; i < listSize; i++) {
-            elementsList.push(listResult[i].result);
+            elementsList.push(apiToCertificateMapping(listResult[i].result));
           }
 
           setTotalCount(totalCount);


### PR DESCRIPTION
Tests must cover all the functionality
available in main page (i,e: adding, removing,
enabling, and disabling rules).

## Summary by Sourcery

Add end-to-end coverage for managing certificate identity mapping rules and fix the mapping of API results to UI models on the certificate mapping page.

New Features:
- Introduce Cypress feature scenarios for creating, deleting, enabling, disabling, and validating certificate identity mapping rules via the UI.
- Add reusable Cypress step definitions for asserting enabled/disabled status in data tables and interacting with text input list components.

Bug Fixes:
- Correct certificate mapping list population by converting API results to internal CertificateMapping models before storing them in state.

Tests:
- Add comprehensive Cypress scenarios for certificate identity mapping rules covering mandatory/all fields creation, cancellation, invalid/duplicate handling, deletion, and enable/disable flows.
- Extend common Cypress test utilities with helpers and step definitions for status checks in main tables and text input list manipulation.