### PR TITLE
[OTP tokens] Main page

### DIFF
--- a/src/components/modals/UserModals/AddOtpToken.tsx
+++ b/src/components/modals/UserModals/AddOtpToken.tsx
@@ -28,17 +28,40 @@ import { NO_SELECTION_OPTION } from "src/utils/constUtils";
 // RTK
 import { ErrorResult } from "src/services/rpc";
 import {
+  AddOtpTokenPayload,
   useAddOtpTokenMutation,
   useGetActiveUsersQuery,
 } from "src/services/rpcUsers";
 // Utils
 import { API_VERSION_BACKUP, toGeneralizedTime } from "src/utils/utils";
+import {
+  AlgorithmType,
+  OtpTokenDigits,
+  OtpTokenTypeValue,
+} from "src/utils/datatypes/globalDataTypes";
+
+interface OtpTokenValues {
+  tokenType: OtpTokenTypeValue;
+  tokenAlgorithm: AlgorithmType;
+  tokenDigits: OtpTokenDigits;
+  uniqueId: string;
+  description: string;
+  selectedOwner: string;
+  validityStart: Date | null;
+  validityEnd: Date | null;
+  model: string;
+  vendor: string;
+  serial: string;
+  key: string;
+  clockInterval: string;
+}
 
 interface PropsToAddOtpToken {
   uid: string | undefined;
   isOpen: boolean;
   setIsOpen: (isOpen: boolean) => void;
   onClose: () => void;
+  onRefresh?: () => void;
 }
 
 const AddOtpToken = (props: PropsToAddOtpToken) => {
@@ -56,24 +79,22 @@ const AddOtpToken = (props: PropsToAddOtpToken) => {
   React.useEffect(() => {
     if (!isActiveUsersListLoading) {
       if (activeUsersListData !== undefined) {
-        activeUsersListData.forEach((user) => {
-          activeUsersUids.push(user.uid[0]);
-        });
+        setOwnersToSelect([
+          NO_SELECTION_OPTION,
+          ...new Set(activeUsersListData.map((user) => user.uid[0])),
+        ]);
       }
-      // Add empty option at the beginning of the list
-      activeUsersUids.unshift(NO_SELECTION_OPTION);
-      setOwnersToSelect(activeUsersUids);
     }
   }, [isActiveUsersListLoading]);
 
   // Track initial values to detect changes
-  const initialValues = {
+  const initialValues: OtpTokenValues = {
     tokenType: "totp",
     tokenAlgorithm: "sha1",
     tokenDigits: "6",
     uniqueId: "",
     description: "",
-    selectedOwner: props.uid,
+    selectedOwner: props.uid ?? "",
     validityStart: null,
     validityEnd: null,
     model: "",
@@ -83,7 +104,9 @@ const AddOtpToken = (props: PropsToAddOtpToken) => {
     clockInterval: "",
   };
 
-  const [tokenType, setTokenType] = React.useState(initialValues.tokenType);
+  const [tokenType, setTokenType] = React.useState<OtpTokenTypeValue>(
+    initialValues.tokenType
+  );
   const [tokenAlgorithm, setTokenAlgorithm] = React.useState(
     initialValues.tokenAlgorithm
   );
@@ -91,19 +114,19 @@ const AddOtpToken = (props: PropsToAddOtpToken) => {
     initialValues.tokenDigits
   );
 
-  const onTokenTypeChange = (checked: boolean, value: string) => {
+  const onTokenTypeChange = (checked: boolean, value: OtpTokenTypeValue) => {
     if (checked) {
       setTokenType(value);
     }
   };
 
-  const onTokenAlgorithmChange = (checked: boolean, value: string) => {
+  const onTokenAlgorithmChange = (checked: boolean, value: AlgorithmType) => {
     if (checked) {
       setTokenAlgorithm(value);
     }
   };
 
-  const onTokenDigitsChange = (checked: boolean, value: string) => {
+  const onTokenDigitsChange = (checked: boolean, value: OtpTokenDigits) => {
     if (checked) {
       setTokenDigits(value);
     }
@@ -513,7 +536,11 @@ const AddOtpToken = (props: PropsToAddOtpToken) => {
     // Get updated values as params
     const params = getModifiedValues();
     // Payload
-    const payload = [[uniqueId], params];
+    const payload: AddOtpTokenPayload = {
+      ipatokenuniqueid: uniqueId,
+      type: tokenType,
+      ...params,
+    };
 
     addOtpToken(payload).then((response) => {
       if ("data" in response) {
@@ -603,6 +630,7 @@ const AddOtpToken = (props: PropsToAddOtpToken) => {
         isOpen={isQrModalOpen}
         onClose={onQrModalClose}
         QrUri={uri}
+        onRefresh={props.onRefresh}
       />
     </>
   );

--- a/src/components/modals/UserModals/QrCodeModal.tsx
+++ b/src/components/modals/UserModals/QrCodeModal.tsx
@@ -12,6 +12,7 @@ interface PropsToQrCodeModal {
   isOpen: boolean;
   onClose: () => void;
   QrUri: string;
+  onRefresh?: () => void;
 }
 
 /*
@@ -76,13 +77,21 @@ const QrCodeModal = (props: PropsToQrCodeModal) => {
     },
   ];
 
+  const onOkHandler = () => {
+    props.onClose();
+    if (props.onRefresh) {
+      props.onRefresh();
+    }
+  };
+
   // Actions
   const actions = [
     <Button
       data-cy="modal-button-ok"
+      aria-label="OK button to close the modal"
       key="ok"
       variant="link"
-      onClick={props.onClose}
+      onClick={onOkHandler}
     >
       Ok
     </Button>,
@@ -98,7 +107,7 @@ const QrCodeModal = (props: PropsToQrCodeModal) => {
       formId="configure-your-token-form"
       fields={fields}
       show={props.isOpen}
-      onClose={props.onClose}
+      onClose={onOkHandler}
       actions={actions}
     />
   );

--- a/src/components/tables/MainTable.tsx
+++ b/src/components/tables/MainTable.tsx
@@ -56,6 +56,7 @@ interface PropsToTable<T> {
   buttonsData?: ButtonsData;
   paginationData?: PaginationData;
   statusElementName?: string; // This will be used to determine the status and style the table rows (grey if disabled)
+  invertStatusValue?: boolean; // Sometimes the status is assumed "enabled" (i.e. `ipaenabledflag`) and others is "disabled" (i.e. `ipatokendisabled`)
 }
 
 const MainTable = <T,>(props: PropsToTable<T>) => {
@@ -130,6 +131,14 @@ const MainTable = <T,>(props: PropsToTable<T>) => {
     }
   };
 
+  // Helper function: Check if the status value is inverted
+  const invertStatusValue = (value: string) => {
+    if (props.invertStatusValue) {
+      return value === "true" ? "false" : "true";
+    }
+    return value;
+  };
+
   // Reset 'selectedElements array if a delete operation has been done
   React.useEffect(() => {
     if (props.buttonsData?.isDeletion) {
@@ -156,8 +165,11 @@ const MainTable = <T,>(props: PropsToTable<T>) => {
 
       if (updateIsDisableButtonDisabled && updateIsEnableButtonDisabled) {
         if (equalStatus) {
-          const ipaenabledflag: string =
-            selectedElements[0][props.statusElementName];
+          let ipaenabledflag: string =
+            selectedElements[0][props.statusElementName].toString();
+
+          ipaenabledflag = invertStatusValue(ipaenabledflag);
+
           if (ipaenabledflag === "true") {
             // Enabled
             updateIsDisableButtonDisabled(false);
@@ -264,7 +276,10 @@ const MainTable = <T,>(props: PropsToTable<T>) => {
   // Helper function to process boolean elements and return a string
   // (used for displaying statuses values in the table)
   const processBoolean = (value: boolean | string) => {
-    if (value === "false" || value === false) {
+    let valueString = value.toString();
+    valueString = invertStatusValue(valueString);
+
+    if (valueString === "false") {
       return (
         <>
           <MinusIcon key="minus-icon" /> {" Disabled"}

--- a/src/components/tables/MainTable.tsx
+++ b/src/components/tables/MainTable.tsx
@@ -132,9 +132,9 @@ const MainTable = <T,>(props: PropsToTable<T>) => {
   };
 
   // Helper function: Check if the status value is inverted
-  const invertStatusValue = (value: string) => {
+  const invertStatusValue = (value: boolean) => {
     if (props.invertStatusValue) {
-      return value === "true" ? "false" : "true";
+      return !value;
     }
     return value;
   };
@@ -165,17 +165,14 @@ const MainTable = <T,>(props: PropsToTable<T>) => {
 
       if (updateIsDisableButtonDisabled && updateIsEnableButtonDisabled) {
         if (equalStatus) {
-          let ipaenabledflag: string =
-            selectedElements[0][props.statusElementName].toString();
+          const isEnabled = invertStatusValue(
+            selectedElements[0][props.statusElementName].toString() === "true"
+          );
 
-          ipaenabledflag = invertStatusValue(ipaenabledflag);
-
-          if (ipaenabledflag === "true") {
-            // Enabled
+          if (isEnabled) {
             updateIsDisableButtonDisabled(false);
             updateIsEnableButtonDisabled(true);
-          } else if (ipaenabledflag === "false") {
-            // Disabled
+          } else {
             updateIsDisableButtonDisabled(true);
             updateIsEnableButtonDisabled(false);
           }
@@ -262,24 +259,22 @@ const MainTable = <T,>(props: PropsToTable<T>) => {
     </Tr>
   );
 
-  type Status = "true" | "false";
-
   // Helper method: Set styles depending on the status
-  const setStyleOnStatus = (status: Status) => {
-    if (status === "false") {
-      return { color: "grey" };
-    } else if (status === "true") {
-      return { color: "black" };
+  const setStyleOnStatus = (keyName: string, status: boolean | string) => {
+    if (keyName === props.statusElementName) {
+      const isEnabled = invertStatusValue(status.toString() === "true");
+
+      return { color: isEnabled ? "black" : "grey" };
     }
+    return { color: "black" };
   };
 
   // Helper function to process boolean elements and return a string
   // (used for displaying statuses values in the table)
   const processBoolean = (value: boolean | string) => {
-    let valueString = value.toString();
-    valueString = invertStatusValue(valueString);
+    const isEnabled = invertStatusValue(value.toString() === "true");
 
-    if (valueString === "false") {
+    if (!isEnabled) {
       return (
         <>
           <MinusIcon key="minus-icon" /> {" Disabled"}
@@ -338,7 +333,7 @@ const MainTable = <T,>(props: PropsToTable<T>) => {
               dataLabel={columnNames[keyName]}
               key={keyName + "-" + idx + "-" + elementName}
               id={idx.toString()}
-              style={setStyleOnStatus(element[keyName])}
+              style={setStyleOnStatus(keyName, element[keyName])}
               aria-label={keyName}
               data-label={keyName}
               data-cy={`table-row-${elementName}-${keyName}`}

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -75,6 +75,7 @@ import Trusts from "src/pages/Trusts/Trusts";
 import TrustsTabs from "src/pages/Trusts/TrustsTabs";
 import IdRangesTabs from "src/pages/IdRanges/IdRangesTabs";
 import GlobalTrustConfig from "src/pages/Trusts/GlobalTrustConfig";
+import OtpTokens from "src/pages/OtpTokens/OtpTokens";
 
 // Renders routes (React)
 export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
@@ -450,6 +451,9 @@ export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
               </Route>
               <Route path="kerberos-ticket-policy">
                 <Route path="" element={<KrbTicketPolicy />} />
+              </Route>
+              <Route path="otp-tokens">
+                <Route path="" element={<OtpTokens />} />
               </Route>
               <Route path="identity-provider-references">
                 <Route path="" element={<IdpReferences />} />

--- a/src/navigation/NavRoutes.ts
+++ b/src/navigation/NavRoutes.ts
@@ -50,6 +50,7 @@ const PasswordPoliciesGroupRef = "password-policies";
 // - Kerberos ticket policy
 const KerberosTicketPolicyGroupRef = "kerberos-ticket-policy";
 // AUTHENTICATION
+const OtpTokensGroupRef = "otp-tokens";
 const IdentityProviderReferencesGroupRef = "identity-provider-references";
 const CertificateMappingGroupRef = "cert-id-mapping-rules";
 const CertificateMappingConfigGroupRef = "cert-id-mapping-global-config";
@@ -311,6 +312,13 @@ export const getNavigationRoutes = (
       title: `${BASE_TITLE} - Authentication`,
       path: "",
       items: [
+        {
+          label: "OTP tokens",
+          group: OtpTokensGroupRef,
+          title: `${BASE_TITLE} - OTP tokens`,
+          path: "otp-tokens",
+          items: [],
+        },
         {
           label: "Identity Provider references",
           group: IdentityProviderReferencesGroupRef,

--- a/src/pages/OtpTokens/DeleteOtpTokensModal.tsx
+++ b/src/pages/OtpTokens/DeleteOtpTokensModal.tsx
@@ -1,0 +1,222 @@
+import React from "react";
+// PatternFly
+import {
+  Button,
+  Content,
+  ContentVariants,
+  Spinner,
+} from "@patternfly/react-core";
+// Redux
+import { useAppDispatch } from "src/store/hooks";
+// Hooks
+import { addAlert } from "src/store/Global/alerts-slice";
+// RPC
+import { useDeleteOtpTokensMutation } from "src/services/rpcOtpTokens";
+// Data types
+import { OtpToken, ErrorData } from "src/utils/datatypes/globalDataTypes";
+import { BatchRPCResponse } from "src/services/rpc";
+import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
+// Components
+import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
+import DeletedElementsTable from "src/components/tables/DeletedElementsTable";
+import { SerializedError } from "@reduxjs/toolkit";
+import ErrorModal from "src/components/modals/ErrorModal";
+
+interface DeleteOtpTokensModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  elementsToDelete: OtpToken[];
+  clearSelectedElements: () => void;
+  columnNames: string[]; // E.g. ["OTP Token Name", "OTP Token Type"]
+  keyNames: string[]; // E.g. for otp_token.name, otp_token.type --> ["name", "type"]
+  onRefresh: () => void;
+  updateIsDeleteButtonDisabled: (value: boolean) => void;
+  updateIsDeletion: (value: boolean) => void;
+}
+
+const DeleteOtpTokensModal = (props: DeleteOtpTokensModalProps) => {
+  const dispatch = useAppDispatch();
+
+  // RPC calls
+  const [deleteOtpTokens] = useDeleteOtpTokensMutation();
+
+  // States
+  const [spinning, setBtnSpinning] = React.useState<boolean>(false);
+
+  // Handle API error data
+  const [isModalErrorOpen, setIsModalErrorOpen] = React.useState(false);
+  const [errorTitle, setErrorTitle] = React.useState("");
+  const [errorMessage, setErrorMessage] = React.useState("");
+
+  const closeAndCleanErrorParameters = () => {
+    setIsModalErrorOpen(false);
+    setErrorTitle("");
+    setErrorMessage("");
+  };
+
+  const errorModalActions = [
+    <Button
+      data-cy="modal-button-ok"
+      key="cancel"
+      variant="link"
+      onClick={closeAndCleanErrorParameters}
+    >
+      OK
+    </Button>,
+  ];
+
+  const handleAPIError = (error: FetchBaseQueryError | SerializedError) => {
+    if ("code" in error) {
+      setErrorTitle("IPA error " + error.code + ": " + error.name);
+      if (error.message !== undefined) {
+        setErrorMessage(error.message);
+      }
+    } else if ("data" in error) {
+      const errorData = error.data as ErrorData;
+      const errorCode = errorData.code;
+      const errorName = errorData.name;
+      const errorMessage = errorData.error;
+
+      setErrorTitle("IPA error " + errorCode + ": " + errorName);
+      setErrorMessage(errorMessage);
+    }
+    setIsModalErrorOpen(true);
+  };
+
+  const onDelete = () => {
+    setBtnSpinning(true);
+
+    const elementsToDelete = props.elementsToDelete.map((element) =>
+      element.ipatokenuniqueid?.toString()
+    );
+
+    deleteOtpTokens(elementsToDelete)
+      .then((response) => {
+        if ("data" in response) {
+          const data = response.data as BatchRPCResponse;
+          const result = data.result;
+
+          if (result) {
+            if ("error" in result.results[0] && result.results[0].error) {
+              const errorData = {
+                code: result.results[0].error_code,
+                name: result.results[0].error_name,
+                error: result.results[0].error,
+              } as ErrorData;
+
+              const error = {
+                status: "CUSTOM_ERROR",
+                data: errorData,
+              } as FetchBaseQueryError;
+
+              // Handle error
+              handleAPIError(error);
+            } else {
+              props.clearSelectedElements();
+              props.updateIsDeleteButtonDisabled(true);
+              props.updateIsDeletion(true);
+
+              dispatch(
+                addAlert({
+                  name: "remove-otp-tokens-success",
+                  title: "OTP tokens removed",
+                  variant: "success",
+                })
+              );
+            }
+          }
+        }
+      })
+      .finally(() => {
+        setBtnSpinning(false);
+        props.onClose();
+        props.onRefresh();
+      });
+  };
+
+  // List of fields
+  const fields = [
+    {
+      id: "question-text",
+      pfComponent: (
+        <Content component={ContentVariants.p}>
+          Are you sure you want to delete the selected entries?
+        </Content>
+      ),
+    },
+    {
+      id: "deleted-elements-table",
+      pfComponent: (
+        <DeletedElementsTable
+          mode="passing_full_data"
+          elementsToDelete={props.elementsToDelete}
+          columnNames={props.columnNames}
+          columnIds={props.keyNames}
+          elementType="OTP token" // the final 's' is handled by the component
+          idAttr={"ipatokenuniqueid"}
+        />
+      ),
+    },
+  ];
+
+  // Set the Modal and Action buttons for 'Delete' option
+  const modalActionsDelete: JSX.Element[] = [
+    <Button
+      data-cy="modal-button-ok"
+      key="delete-otp-tokens"
+      variant="danger"
+      onClick={onDelete}
+      form="delete-otp-tokens-modal"
+      spinnerAriaValueText="Deleting"
+      spinnerAriaLabel="Deleting"
+      isLoading={spinning}
+      isDisabled={spinning}
+    >
+      {spinning ? (
+        <>
+          <Spinner size="sm" />
+          {"Deleting"}
+        </>
+      ) : (
+        "Delete"
+      )}
+    </Button>,
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-delete-otp-tokens"
+      variant="link"
+      onClick={props.onClose}
+    >
+      Cancel
+    </Button>,
+  ];
+
+  return (
+    <>
+      <ModalWithFormLayout
+        dataCy="delete-otp-tokens-modal"
+        variantType="medium"
+        modalPosition="top"
+        offPosition="76px"
+        title="Remove OTP tokens"
+        formId="delete-otp-tokens-modal"
+        fields={fields}
+        show={props.isOpen}
+        onClose={props.onClose}
+        actions={modalActionsDelete}
+      />
+      {isModalErrorOpen && (
+        <ErrorModal
+          dataCy="delete-otp-tokens-modal-error"
+          title={errorTitle}
+          isOpen={isModalErrorOpen}
+          onClose={closeAndCleanErrorParameters}
+          actions={errorModalActions}
+          errorMessage={errorMessage}
+        />
+      )}
+    </>
+  );
+};
+
+export default DeleteOtpTokensModal;

--- a/src/pages/OtpTokens/EnableDisableOtpTokensModal.tsx
+++ b/src/pages/OtpTokens/EnableDisableOtpTokensModal.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+// PatternFly
+import { Button } from "@patternfly/react-core";
+// Redux
+import { useAppDispatch } from "src/store/hooks";
+// Hooks
+import { addAlert } from "src/store/Global/alerts-slice";
+// RPC
+import {
+  OtpTokensModifyPayload,
+  useModifyOtpTokensMutation,
+} from "src/services/rpcOtpTokens";
+// Components
+import ConfirmationModal from "src/components/modals/ConfirmationModal";
+// Utils
+import capitalizeFirstLetter from "src/utils/utils";
+// Data types
+import { OtpToken } from "src/utils/datatypes/globalDataTypes";
+
+interface EnableDisableOtpTokensModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  elementsList: string[];
+  setElementsList: (elementsList: OtpToken[]) => void;
+  operation: "enable" | "disable";
+  setShowTableRows: (value: boolean) => void;
+  onRefresh: () => void;
+}
+
+const EnableDisableOtpTokensModal = (
+  props: EnableDisableOtpTokensModalProps
+) => {
+  const dispatch = useAppDispatch();
+
+  // RPC calls
+  const [modifyOtpTokens] = useModifyOtpTokensMutation();
+  // Enable/Disable operation
+  const onEnableDisable = () => {
+    // const operation = props.operation === "enable" ? enableOtpTokens : disableOtpTokens;
+    const payload: OtpTokensModifyPayload[] = props.elementsList.map(
+      (element) => ({
+        ipatokenuniqueid: element,
+        ipatokendisabled: props.operation !== "enable",
+      })
+    );
+    modifyOtpTokens(payload).then((response) => {
+      if ("data" in response) {
+        const { data } = response;
+        if (data?.error) {
+          dispatch(
+            addAlert({ name: "error", title: data.error, variant: "danger" })
+          );
+        }
+        if (data?.result) {
+          dispatch(
+            addAlert({
+              name: "success",
+              title: "OTP tokens status changed",
+              variant: "success",
+            })
+          );
+          // Clear selected elements
+          props.setElementsList([]);
+          // Refresh data
+          props.onRefresh();
+          onClose();
+        }
+      }
+    });
+  };
+
+  const onClose = () => {
+    props.setElementsList([]);
+    props.onClose();
+  };
+
+  const onCloseWithoutClearingElements = () => {
+    props.onClose();
+  };
+
+  const modalActions: JSX.Element[] = [
+    <Button
+      data-cy="modal-button-ok"
+      key={props.operation + "-otp-tokens"}
+      variant="primary"
+      onClick={onEnableDisable}
+    >
+      OK
+    </Button>,
+    <Button
+      data-cy="modal-button-cancel"
+      key={"cancel-" + props.operation + "-otp-tokens"}
+      variant="secondary"
+      onClick={onCloseWithoutClearingElements}
+    >
+      Cancel
+    </Button>,
+  ];
+
+  return (
+    <ConfirmationModal
+      dataCy="enable-disable-otp-tokens-modal"
+      title={capitalizeFirstLetter(props.operation) + " confirmation"}
+      isOpen={props.isOpen}
+      onClose={onClose}
+      actions={modalActions}
+      messageText={`Are you sure you want to ${props.operation} the following OTP tokens?`}
+      messageObj={props.elementsList.join(", ")}
+    />
+  );
+};
+
+export default EnableDisableOtpTokensModal;

--- a/src/pages/OtpTokens/OtpTokens.tsx
+++ b/src/pages/OtpTokens/OtpTokens.tsx
@@ -1,0 +1,497 @@
+import React from "react";
+// PatternFly
+import {
+  Flex,
+  FlexItem,
+  PageSection,
+  PaginationVariant,
+  ToolbarItemVariant,
+} from "@patternfly/react-core";
+import {
+  InnerScrollContainer,
+  OuterScrollContainer,
+} from "@patternfly/react-table";
+// Data types
+import { OtpToken } from "src/utils/datatypes/globalDataTypes";
+// Hooks
+import { addAlert } from "src/store/Global/alerts-slice";
+import useUpdateRoute from "src/hooks/useUpdateRoute";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
+import useApiError from "src/hooks/useApiError";
+// Redux
+import { useAppDispatch, useAppSelector } from "src/store/hooks";
+// RPC
+import {
+  useGetOtpTokensFullDataQuery,
+  useSearchOtpTokensEntriesMutation,
+} from "src/services/rpcOtpTokens";
+// Utils
+import { isOtpTokenSelectable } from "src/utils/utils";
+import { apiToOtpToken } from "src/utils/otpTokensUtils";
+// Components
+import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
+import { SerializedError } from "@reduxjs/toolkit";
+import ToolbarLayout, {
+  ToolbarItem,
+} from "src/components/layouts/ToolbarLayout";
+import SearchInputLayout from "src/components/layouts/SearchInputLayout";
+import SecondaryButton from "src/components/layouts/SecondaryButton";
+import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
+import TitleLayout from "src/components/layouts/TitleLayout";
+import GlobalErrors from "src/components/errors/GlobalErrors";
+import MainTable from "src/components/tables/MainTable";
+import BulkSelectorPrep from "src/components/BulkSelectorPrep";
+
+const OtpTokens = () => {
+  const dispatch = useAppDispatch();
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  const { browserTitle } = useUpdateRoute({
+    pathname: "otp-tokens",
+  });
+
+  // Set the page title to be shown in the browser tab
+  React.useEffect(() => {
+    document.title = browserTitle;
+  }, [browserTitle]);
+
+  // Retrieve API version from environment data
+  const apiVersion = useAppSelector(
+    (state) => state.global.environment.api_version
+  ) as string;
+
+  // URL parameters: page number, page size, search value
+  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+    useListPageSearchParams();
+
+  // Handle API calls errors
+  const globalErrors = useApiError([]);
+
+  // Page indexes
+  const firstUserIdx = (page - 1) * perPage;
+  const lastUserIdx = page * perPage;
+
+  // States
+  const [otpTokens, setOtpTokens] = React.useState<OtpToken[]>([]);
+  const [isSearchDisabled, setIsSearchDisabled] =
+    React.useState<boolean>(false);
+  const [totalCount, setTotalCount] = React.useState<number>(0);
+
+  // API calls
+  const otpTokensResponse = useGetOtpTokensFullDataQuery({
+    searchValue,
+    apiVersion,
+    sizelimit: 100,
+    startIdx: firstUserIdx,
+    stopIdx: lastUserIdx,
+  });
+
+  const { data, isLoading, error } = otpTokensResponse;
+
+  // Handle data when the API call is finished
+  React.useEffect(() => {
+    if (otpTokensResponse.isFetching) {
+      setShowTableRows(false);
+      // Reset selected elements on refresh
+      setTotalCount(0);
+      globalErrors.clear();
+      return;
+    }
+
+    // API response: Error
+    if (otpTokensResponse.isError) {
+      globalErrors.addError(
+        error,
+        "Error when fetching OTP tokens",
+        "otp-tokens-fetch-error"
+      );
+      return;
+    }
+
+    // API response: Success
+    if (
+      otpTokensResponse.isSuccess &&
+      otpTokensResponse.data &&
+      data !== undefined
+    ) {
+      const listResult = data.result.results;
+      const listSize = data.result.count;
+      const elementsList: OtpToken[] = [];
+
+      for (let i = 0; i < listSize; i++) {
+        elementsList.push(apiToOtpToken(listResult[i].result));
+      }
+
+      setOtpTokens(elementsList);
+      setTotalCount(otpTokensResponse.data.result.totalCount);
+      // Show table elements
+      setShowTableRows(true);
+    }
+  }, [otpTokensResponse]);
+
+  // Selected elements
+  const [selectedElements, setSelectedElements] = React.useState<OtpToken[]>(
+    []
+  );
+  const [selectedPerPage, setSelectedPerPage] = React.useState<number>(0);
+
+  // Refresh button handling
+  const refreshData = () => {
+    // Hide table
+    setShowTableRows(false);
+
+    // Reset selected elements on refresh
+    setTotalCount(0);
+
+    otpTokensResponse.refetch().then(() => {
+      setShowTableRows(true);
+    });
+  };
+
+  // 'Delete' button state
+  const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
+    React.useState<boolean>(true);
+
+  const [isDeletion, setIsDeletion] = React.useState<boolean>(false);
+
+  // 'Enable' button state
+  const [isEnableButtonDisabled, setIsEnableButtonDisabled] =
+    React.useState<boolean>(true);
+
+  // 'Disable' button state
+  const [isDisableButtonDisabled, setIsDisableButtonDisabled] =
+    React.useState<boolean>(true);
+
+  // Table-related shared functionality
+  // - Selectable checkboxes on table
+  const selectableOtpTokensTable = otpTokens.filter(isOtpTokenSelectable);
+
+  // - Manage the selected elements in the table (add/remove)
+  const updateSelectedOtpTokens = (
+    otpTokens: OtpToken[],
+    isSelected: boolean
+  ) => {
+    let newSelectedOtpTokens: OtpToken[] = [];
+    if (isSelected) {
+      newSelectedOtpTokens = JSON.parse(JSON.stringify(selectedElements));
+      for (let i = 0; i < otpTokens.length; i++) {
+        if (
+          selectedElements.find(
+            (selectedOtpToken) =>
+              selectedOtpToken.ipatokenuniqueid ===
+              otpTokens[i].ipatokenuniqueid
+          )
+        ) {
+          continue;
+        }
+        newSelectedOtpTokens.push(otpTokens[i]);
+      }
+    } else {
+      // Remove element
+      for (let i = 0; i < selectedElements.length; i++) {
+        let found = false;
+        for (let ii = 0; ii < otpTokens.length; ii++) {
+          if (
+            selectedElements[i].ipatokenuniqueid ===
+            otpTokens[ii].ipatokenuniqueid
+          ) {
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          // Keep this valid selected entry
+          newSelectedOtpTokens.push(selectedElements[i]);
+        }
+      }
+    }
+    setSelectedElements(newSelectedOtpTokens);
+    setIsDeleteButtonDisabled(newSelectedOtpTokens.length === 0);
+  };
+
+  // - Helper method to set the selected entries from the table
+  const setOtpTokensSelected = (otpToken: OtpToken, isSelecting = true) => {
+    if (isOtpTokenSelectable(otpToken)) {
+      updateSelectedOtpTokens([otpToken], isSelecting);
+    }
+  };
+
+  // Show table rows
+  const [showTableRows, setShowTableRows] = React.useState<boolean>(!isLoading);
+
+  // Show table rows only when data is fully retrieved
+  React.useEffect(() => {
+    setShowTableRows(!isLoading);
+  }, [isLoading]);
+
+  // Search API call
+  const [searchEntry] = useSearchOtpTokensEntriesMutation();
+
+  const submitSearchValue = () => {
+    setPage(1);
+    setSearchValue(searchValue);
+    setIsSearchDisabled(true);
+    searchEntry({
+      searchValue: searchValue,
+      apiVersion,
+      sizelimit: 100,
+      startIdx: 0,
+      stopIdx: 100, // Search will consider a max. of elements
+    }).then((result) => {
+      if ("data" in result) {
+        const searchError = result.data?.error as
+          | FetchBaseQueryError
+          | SerializedError;
+
+        if (searchError) {
+          // Error
+          let error: string | undefined = "";
+          if ("error" in searchError) {
+            error = searchError.error;
+          } else if ("message" in searchError) {
+            error = searchError.message;
+          }
+          dispatch(
+            addAlert({
+              name: "submit-search-value-error",
+              title: error || "Error when searching for OTP tokens",
+              variant: "danger",
+            })
+          );
+        } else {
+          // Success
+          const otpTokens = result.data?.result || [];
+          setTotalCount(result.data?.totalCount || otpTokens.length);
+          setOtpTokens(otpTokens);
+          setShowTableRows(true);
+        }
+        setIsSearchDisabled(false);
+      }
+    });
+  };
+
+  // Data wrappers
+  // TODO: Better separation of concerts
+  // - 'PaginationLayout'
+  const paginationData = {
+    page,
+    perPage,
+    updatePage: setPage,
+    updatePerPage: setPerPage,
+    updateSelectedPerPage: setSelectedPerPage,
+    updateShownElementsList: setOtpTokens,
+    totalCount,
+  };
+
+  // - 'SearchInputLayout'
+  const searchValueData = {
+    searchValue,
+    updateSearchValue: setSearchValue,
+    submitSearchValue,
+  };
+
+  // - 'BulkSelectorrep'
+  const bulkSelectorData = {
+    selected: selectedElements,
+    updateSelected: updateSelectedOtpTokens,
+    selectableTable: selectableOtpTokensTable,
+    nameAttr: "ipatokenuniqueid",
+  };
+
+  const selectedPerPageData = {
+    selectedPerPage,
+    updateSelectedPerPage: setSelectedPerPage,
+  };
+
+  // List of Toolbar items
+  const toolbarItems: ToolbarItem[] = [
+    {
+      key: 0,
+      element: (
+        <BulkSelectorPrep
+          list={otpTokens}
+          shownElementsList={otpTokens}
+          elementData={bulkSelectorData}
+          buttonsData={{
+            updateIsDeleteButtonDisabled: setIsDeleteButtonDisabled,
+          }}
+          selectedPerPageData={selectedPerPageData}
+        />
+      ),
+    },
+    {
+      key: 1,
+      element: (
+        <SearchInputLayout
+          dataCy="search"
+          name="search"
+          ariaLabel="Search OTP tokens"
+          placeholder="Search"
+          searchValueData={searchValueData}
+          isDisabled={isSearchDisabled}
+        />
+      ),
+      toolbarItemVariant: ToolbarItemVariant.label,
+      toolbarItemGap: { default: "gapMd" },
+    },
+    {
+      key: 2,
+      toolbarItemVariant: ToolbarItemVariant.separator,
+    },
+    {
+      key: 3,
+      element: (
+        <SecondaryButton
+          dataCy="otp-tokens-button-refresh"
+          onClickHandler={refreshData}
+          isDisabled={!showTableRows}
+        >
+          Refresh
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 4,
+      element: (
+        <SecondaryButton
+          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          dataCy="otp-tokens-button-delete"
+        >
+          Delete
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 5,
+      element: (
+        <SecondaryButton
+          isDisabled={!showTableRows}
+          dataCy="otp-tokens-button-add"
+        >
+          Add
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 6,
+      element: (
+        <SecondaryButton
+          isDisabled={isEnableButtonDisabled || !showTableRows}
+          dataCy="otp-tokens-button-enable"
+        >
+          Enable
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 7,
+      element: (
+        <SecondaryButton
+          isDisabled={isDisableButtonDisabled || !showTableRows}
+          dataCy="otp-tokens-button-disable"
+        >
+          Disable
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 8,
+      element: <HelpTextWithIconLayout textContent="Help" />,
+    },
+    {
+      key: 9,
+      element: (
+        <PaginationLayout
+          list={otpTokens}
+          paginationData={paginationData}
+          widgetId="pagination-options-menu-top"
+          isCompact={true}
+        />
+      ),
+      toolbarItemAlignment: { default: "alignEnd" },
+    },
+  ];
+
+  return (
+    <div>
+      <PageSection hasBodyWrapper={false}>
+        <TitleLayout id="otp-tokens page" headingLevel="h1" text="OTP tokens" />
+      </PageSection>
+      <PageSection hasBodyWrapper={false} isFilled={false}>
+        <Flex direction={{ default: "column" }}>
+          <FlexItem>
+            <ToolbarLayout toolbarItems={toolbarItems} />
+          </FlexItem>
+          <FlexItem style={{ flex: "0 0 auto" }}>
+            <OuterScrollContainer>
+              <InnerScrollContainer
+                style={{ height: "55vh", overflow: "auto" }}
+              >
+                {error !== undefined && error ? (
+                  <GlobalErrors errors={globalErrors.getAll()} />
+                ) : (
+                  <MainTable
+                    tableTitle="OTP tokens table"
+                    shownElementsList={otpTokens}
+                    pk="ipatokenuniqueid"
+                    keyNames={[
+                      "ipatokenuniqueid",
+                      "ipatokenowner",
+                      "ipatokendisabled",
+                      "description",
+                    ]}
+                    columnNames={[
+                      "Token unique ID",
+                      "Owner",
+                      "Status",
+                      "Description",
+                    ]}
+                    hasCheckboxes={true}
+                    pathname="otp-tokens"
+                    showTableRows={showTableRows}
+                    showLink={false}
+                    elementsData={{
+                      isElementSelectable: isOtpTokenSelectable,
+                      selectedElements,
+                      selectableElementsTable: selectableOtpTokensTable,
+                      setElementsSelected: setOtpTokensSelected,
+                      clearSelectedElements: () => setSelectedElements([]),
+                    }}
+                    buttonsData={{
+                      updateIsDeleteButtonDisabled: (value) =>
+                        setIsDeleteButtonDisabled(value),
+                      isDeletion,
+                      updateIsDeletion: (value) => setIsDeletion(value),
+                      updateIsEnableButtonDisabled: (value) =>
+                        setIsEnableButtonDisabled(value),
+                      updateIsDisableButtonDisabled: (value) =>
+                        setIsDisableButtonDisabled(value),
+                      isDisableEnableOp: true,
+                    }}
+                    paginationData={{
+                      selectedPerPage,
+                      updateSelectedPerPage: setSelectedPerPage,
+                    }}
+                    statusElementName="ipatokendisabled"
+                    invertStatusValue={true}
+                  />
+                )}
+              </InnerScrollContainer>
+            </OuterScrollContainer>
+          </FlexItem>
+          <FlexItem style={{ flex: "0 0 auto", position: "sticky", bottom: 0 }}>
+            <PaginationLayout
+              list={otpTokens}
+              paginationData={paginationData}
+              variant={PaginationVariant.bottom}
+              widgetId="pagination-options-menu-bottom"
+            />
+          </FlexItem>
+        </Flex>
+      </PageSection>
+    </div>
+  );
+};
+
+export default OtpTokens;

--- a/src/pages/OtpTokens/OtpTokens.tsx
+++ b/src/pages/OtpTokens/OtpTokens.tsx
@@ -44,6 +44,7 @@ import MainTable from "src/components/tables/MainTable";
 import BulkSelectorPrep from "src/components/BulkSelectorPrep";
 import AddOtpToken from "src/components/modals/UserModals/AddOtpToken";
 import DeleteOtpTokensModal from "./DeleteOtpTokensModal";
+import EnableDisableOtpTokensModal from "./EnableDisableOtpTokensModal";
 
 const OtpTokens = () => {
   const dispatch = useAppDispatch();
@@ -309,6 +310,21 @@ const OtpTokens = () => {
   // Modals functionality
   const [showAddModal, setShowAddModal] = React.useState<boolean>(false);
   const [showDeleteModal, setShowDeleteModal] = React.useState<boolean>(false);
+  const [showEnableDisableModal, setShowEnableDisableModal] =
+    React.useState<boolean>(false);
+  const [operation, setOperation] = React.useState<"enable" | "disable">(
+    "disable"
+  );
+
+  const onEnableOperation = () => {
+    setOperation("enable");
+    setShowEnableDisableModal(true);
+  };
+
+  const onDisableOperation = () => {
+    setOperation("disable");
+    setShowEnableDisableModal(true);
+  };
 
   // List of Toolbar items
   const toolbarItems: ToolbarItem[] = [
@@ -387,6 +403,7 @@ const OtpTokens = () => {
         <SecondaryButton
           isDisabled={isEnableButtonDisabled || !showTableRows}
           dataCy="otp-tokens-button-enable"
+          onClickHandler={onEnableOperation}
         >
           Enable
         </SecondaryButton>
@@ -398,6 +415,7 @@ const OtpTokens = () => {
         <SecondaryButton
           isDisabled={isDisableButtonDisabled || !showTableRows}
           dataCy="otp-tokens-button-disable"
+          onClickHandler={onDisableOperation}
         >
           Disable
         </SecondaryButton>
@@ -515,6 +533,17 @@ const OtpTokens = () => {
         onRefresh={refreshData}
         updateIsDeleteButtonDisabled={setIsDeleteButtonDisabled}
         updateIsDeletion={setIsDeletion}
+      />
+      <EnableDisableOtpTokensModal
+        isOpen={showEnableDisableModal}
+        onClose={() => setShowEnableDisableModal(false)}
+        elementsList={selectedElements.map(
+          (element) => element.ipatokenuniqueid
+        )}
+        setElementsList={setSelectedElements}
+        operation={operation}
+        setShowTableRows={setShowTableRows}
+        onRefresh={refreshData}
       />
     </div>
   );

--- a/src/pages/OtpTokens/OtpTokens.tsx
+++ b/src/pages/OtpTokens/OtpTokens.tsx
@@ -43,6 +43,7 @@ import GlobalErrors from "src/components/errors/GlobalErrors";
 import MainTable from "src/components/tables/MainTable";
 import BulkSelectorPrep from "src/components/BulkSelectorPrep";
 import AddOtpToken from "src/components/modals/UserModals/AddOtpToken";
+import DeleteOtpTokensModal from "./DeleteOtpTokensModal";
 
 const OtpTokens = () => {
   const dispatch = useAppDispatch();
@@ -307,6 +308,7 @@ const OtpTokens = () => {
 
   // Modals functionality
   const [showAddModal, setShowAddModal] = React.useState<boolean>(false);
+  const [showDeleteModal, setShowDeleteModal] = React.useState<boolean>(false);
 
   // List of Toolbar items
   const toolbarItems: ToolbarItem[] = [
@@ -361,6 +363,7 @@ const OtpTokens = () => {
         <SecondaryButton
           isDisabled={isDeleteButtonDisabled || !showTableRows}
           dataCy="otp-tokens-button-delete"
+          onClickHandler={() => setShowDeleteModal(true)}
         >
           Delete
         </SecondaryButton>
@@ -501,6 +504,17 @@ const OtpTokens = () => {
         setIsOpen={setShowAddModal}
         onClose={() => setShowAddModal(false)}
         onRefresh={refreshData}
+      />
+      <DeleteOtpTokensModal
+        isOpen={showDeleteModal}
+        onClose={() => setShowDeleteModal(false)}
+        elementsToDelete={selectedElements}
+        clearSelectedElements={() => setSelectedElements([])}
+        columnNames={["Unique ID", "Owner", "Description"]}
+        keyNames={["ipatokenuniqueid", "ipatokenowner", "description"]}
+        onRefresh={refreshData}
+        updateIsDeleteButtonDisabled={setIsDeleteButtonDisabled}
+        updateIsDeletion={setIsDeletion}
       />
     </div>
   );

--- a/src/pages/OtpTokens/OtpTokens.tsx
+++ b/src/pages/OtpTokens/OtpTokens.tsx
@@ -42,6 +42,7 @@ import TitleLayout from "src/components/layouts/TitleLayout";
 import GlobalErrors from "src/components/errors/GlobalErrors";
 import MainTable from "src/components/tables/MainTable";
 import BulkSelectorPrep from "src/components/BulkSelectorPrep";
+import AddOtpToken from "src/components/modals/UserModals/AddOtpToken";
 
 const OtpTokens = () => {
   const dispatch = useAppDispatch();
@@ -304,6 +305,9 @@ const OtpTokens = () => {
     updateSelectedPerPage: setSelectedPerPage,
   };
 
+  // Modals functionality
+  const [showAddModal, setShowAddModal] = React.useState<boolean>(false);
+
   // List of Toolbar items
   const toolbarItems: ToolbarItem[] = [
     {
@@ -368,6 +372,7 @@ const OtpTokens = () => {
         <SecondaryButton
           isDisabled={!showTableRows}
           dataCy="otp-tokens-button-add"
+          onClickHandler={() => setShowAddModal(true)}
         >
           Add
         </SecondaryButton>
@@ -490,6 +495,13 @@ const OtpTokens = () => {
           </FlexItem>
         </Flex>
       </PageSection>
+      <AddOtpToken
+        uid={undefined}
+        isOpen={showAddModal}
+        setIsOpen={setShowAddModal}
+        onClose={() => setShowAddModal(false)}
+        onRefresh={refreshData}
+      />
     </div>
   );
 };

--- a/src/services/rpcOtpTokens.ts
+++ b/src/services/rpcOtpTokens.ts
@@ -10,6 +10,7 @@ import {
 import { apiToOtpToken } from "../utils/otpTokensUtils";
 // Data types
 import { OtpToken, OtpTokenType } from "../utils/datatypes/globalDataTypes";
+import { API_VERSION_BACKUP } from "src/utils/utils";
 
 /**
  * Otp tokens-related endpoints:   useGetOtpTokensFullDataQuery,
@@ -227,6 +228,23 @@ const extendedApi = api.injectEndpoints({
         };
       },
     }),
+    /**
+     * Delete OTP tokens
+     * @param {string[]} - OTP token IDs
+     * @returns {Promise<BatchRPCResponse>} - Promise with the response data
+     */
+    deleteOtpTokens: build.mutation<BatchRPCResponse, string[]>({
+      query: (payload) => {
+        const commands: Command[] = [];
+        payload.forEach((otpTokenId) => {
+          commands.push({
+            method: "otptoken_del",
+            params: [[otpTokenId], {}],
+          });
+        });
+        return getBatchCommand(commands, API_VERSION_BACKUP);
+      },
+    }),
   }),
   overrideExisting: false,
 });
@@ -234,4 +252,5 @@ const extendedApi = api.injectEndpoints({
 export const {
   useGetOtpTokensFullDataQuery,
   useSearchOtpTokensEntriesMutation,
+  useDeleteOtpTokensMutation,
 } = extendedApi;

--- a/src/services/rpcOtpTokens.ts
+++ b/src/services/rpcOtpTokens.ts
@@ -38,6 +38,18 @@ interface OtpTokensBatchResponse {
   totalCount: number;
 }
 
+export interface OtpTokensModifyPayload {
+  ipatokenuniqueid: string;
+  ipatokenowner?: string;
+  description?: string;
+  ipatokennotbefore?: Date | string;
+  ipatokennotafter?: Date | string;
+  ipatokenvendor?: string;
+  ipatokenmodel?: string;
+  ipatokenserial?: string;
+  ipatokendisabled?: boolean;
+}
+
 const extendedApi = api.injectEndpoints({
   endpoints: (build) => ({
     /**
@@ -245,6 +257,51 @@ const extendedApi = api.injectEndpoints({
         return getBatchCommand(commands, API_VERSION_BACKUP);
       },
     }),
+    /**
+     * Modify OTP tokens
+     * @param {OtpTokensModifyPayload[]} - Payload containing the OTP token IDs and the modifications
+     * @returns {Promise<BatchRPCResponse>} - Promise with the response data
+     */
+    modifyOtpTokens: build.mutation<BatchRPCResponse, OtpTokensModifyPayload[]>(
+      {
+        query: (payload) => {
+          const commands: Command[] = [];
+
+          payload.forEach((otpToken) => {
+            const params: Record<string, unknown> = {
+              version: API_VERSION_BACKUP,
+            };
+
+            const optionalKeys: Array<
+              keyof Omit<OtpTokensModifyPayload, "ipatokenuniqueid">
+            > = [
+              "ipatokenowner",
+              "description",
+              "ipatokennotbefore",
+              "ipatokennotafter",
+              "ipatokenvendor",
+              "ipatokenmodel",
+              "ipatokenserial",
+              "ipatokendisabled",
+            ];
+
+            optionalKeys.forEach((key) => {
+              const value = otpToken[key];
+              if (value !== undefined) {
+                params[key] = value;
+              }
+            });
+
+            commands.push({
+              method: "otptoken_mod",
+              params: [[otpToken.ipatokenuniqueid], params],
+            });
+          });
+
+          return getBatchCommand(commands, API_VERSION_BACKUP);
+        },
+      }
+    ),
   }),
   overrideExisting: false,
 });
@@ -253,4 +310,5 @@ export const {
   useGetOtpTokensFullDataQuery,
   useSearchOtpTokensEntriesMutation,
   useDeleteOtpTokensMutation,
+  useModifyOtpTokensMutation,
 } = extendedApi;

--- a/src/services/rpcOtpTokens.ts
+++ b/src/services/rpcOtpTokens.ts
@@ -1,0 +1,237 @@
+import {
+  api,
+  Command,
+  getBatchCommand,
+  BatchRPCResponse,
+  FindRPCResponse,
+  getCommand,
+} from "./rpc";
+// utils
+import { apiToOtpToken } from "../utils/otpTokensUtils";
+// Data types
+import { OtpToken, OtpTokenType } from "../utils/datatypes/globalDataTypes";
+
+/**
+ * Otp tokens-related endpoints:   useGetOtpTokensFullDataQuery,
+ *   searchOtpTokensEntries
+ *
+ * API commands:
+ * - otptoken_find: https://freeipa.readthedocs.io/en/latest/api/otptoken_find.html
+ * - otptoken_show: https://freeipa.readthedocs.io/en/latest/api/otptoken_show.html
+ */
+
+interface OtpTokensFullDataPayload {
+  searchValue: string;
+  apiVersion: string;
+  sizelimit: number;
+  startIdx: number;
+  stopIdx: number;
+}
+
+interface OtpTokensBatchResponse {
+  error: string;
+  id: string;
+  principal: string;
+  version: string;
+  result: OtpToken[];
+  totalCount: number;
+}
+
+const extendedApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    /**
+     * Find OTP tokens full data
+     * @param {OtpTokensFullDataPayload} payload - The payload containing search parameters
+     * @returns {BatchRPCResponse} - List of OTP tokens full data
+     *
+     */
+    getOtpTokensFullData: build.query<
+      BatchRPCResponse,
+      OtpTokensFullDataPayload
+    >({
+      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
+        const { searchValue, apiVersion, sizelimit, startIdx, stopIdx } =
+          payloadData;
+
+        if (apiVersion === undefined) {
+          return {
+            error: {
+              status: "CUSTOM_ERROR",
+              data: "",
+              error: "API version not available",
+            },
+          };
+        }
+
+        // FETCH OTP TOKENS DATA VIA "otptoken_find" COMMAND
+        // Prepare search parameters
+        const otpTokensIdsParams = {
+          pkey_only: true,
+          sizelimit: sizelimit,
+          version: apiVersion,
+        };
+
+        // Prepare payload
+        const payloadDataOtpTokens: Command = {
+          method: "otptoken_find",
+          params: [[searchValue], otpTokensIdsParams],
+        };
+
+        // Make call using 'fetchWithBQ'
+        const getResultOtpTokens = await fetchWithBQ(
+          getCommand(payloadDataOtpTokens)
+        );
+
+        // Return possible errors
+        if (getResultOtpTokens.error) {
+          return { error: getResultOtpTokens.error };
+        }
+
+        // If no error: cast and assign 'ids'
+        const responseDataOtpTokens =
+          getResultOtpTokens.data as FindRPCResponse;
+
+        const otpTokensIds: string[] = [];
+        const otpTokensItemsCount = responseDataOtpTokens.result.result
+          .length as number;
+
+        for (let i = startIdx; i < otpTokensItemsCount && i < stopIdx; i++) {
+          const otpTokenId = responseDataOtpTokens.result.result[
+            i
+          ] as OtpTokenType;
+          const { ipatokenuniqueid } = otpTokenId;
+          otpTokensIds.push(ipatokenuniqueid[0] as string);
+        }
+
+        // FETCH OTP TOKENS DATA VIA "otptoken_show" COMMAND
+        const commands: Command[] = [];
+        otpTokensIds.map((otpTokenId) => {
+          commands.push({
+            method: "otptoken_show",
+            params: [[otpTokenId], {}],
+          });
+        });
+
+        const batchShow = await fetchWithBQ(
+          getBatchCommand(commands, apiVersion)
+        );
+        if (batchShow.error) {
+          return { error: batchShow.error };
+        }
+        const response = batchShow.data as BatchRPCResponse;
+        if (response) {
+          response.result.totalCount = otpTokensItemsCount;
+        }
+        return { data: response };
+      },
+    }),
+    /**
+     * Search for a specific OTP token
+     * @param {OtpTokensFullDataPayload} payload - The payload containing search parameters
+     * @returns {OtpTokensBatchResponse} - List of OTP tokens full data
+     *
+     */
+    searchOtpTokensEntries: build.mutation<
+      OtpTokensBatchResponse,
+      OtpTokensFullDataPayload
+    >({
+      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
+        const { searchValue, apiVersion, sizelimit, startIdx, stopIdx } =
+          payloadData;
+        if (apiVersion === undefined) {
+          return {
+            error: {
+              status: "CUSTOM_ERROR",
+              data: "",
+              error: "API version not available",
+            },
+          };
+        }
+
+        // FETCH OTP TOKENS DATA VIA "otptoken_find" COMMAND
+        // Prepare search parameters
+        const otpTokensIdsParams = {
+          pkey_only: true,
+          sizelimit: sizelimit,
+          version: apiVersion,
+        };
+        // Prepare payload
+        const payloadDataOtpTokens: Command = {
+          method: "otptoken_find",
+          params: [[searchValue], otpTokensIdsParams],
+        };
+
+        // Make call using 'fetchWithBQ'
+        const getResultOtpTokens = await fetchWithBQ(
+          getCommand(payloadDataOtpTokens)
+        );
+        // Return possible errors
+        if (getResultOtpTokens.error) {
+          return { error: getResultOtpTokens.error };
+        }
+        // If no error: cast and assign 'ids'
+        const responseDataOtpTokens =
+          getResultOtpTokens.data as FindRPCResponse;
+        const otpTokensIds: string[] = [];
+        const otpTokensItemsCount = responseDataOtpTokens.result.result
+          .length as number;
+
+        for (let i = startIdx; i < otpTokensItemsCount && i < stopIdx; i++) {
+          const otpTokenId = responseDataOtpTokens.result.result[
+            i
+          ] as OtpTokenType;
+          const { ipatokenuniqueid } = otpTokenId;
+          otpTokensIds.push(ipatokenuniqueid[0] as string);
+        }
+
+        // FETCH OTP TOKENS DATA VIA "otptoken_show" COMMAND
+        const commands: Command[] = [];
+        otpTokensIds.map((otpTokenId) => {
+          commands.push({
+            method: "otptoken_show",
+            params: [[otpTokenId], {}],
+          });
+        });
+
+        const batchShow = await fetchWithBQ(
+          getBatchCommand(commands, apiVersion)
+        );
+        if (batchShow.error) {
+          return { error: batchShow.error };
+        }
+        const response = batchShow.data as BatchRPCResponse;
+        if (response) {
+          response.result.totalCount = otpTokensItemsCount;
+        }
+
+        // Handle the '__base64__' fields
+        const otpTokens: OtpToken[] = [];
+        const count = response.result.totalCount;
+        for (let i = 0; i < count; i++) {
+          const otpToken = response.result.results[i].result as Record<
+            string,
+            unknown
+          >;
+          // Convert API object to OtpToken type
+          const convertedOtpToken: OtpToken = apiToOtpToken(otpToken);
+          otpTokens.push(convertedOtpToken);
+        }
+
+        // Return results
+        return {
+          data: {
+            ...response,
+            result: otpTokens,
+            totalCount: otpTokensItemsCount,
+          },
+        };
+      },
+    }),
+  }),
+  overrideExisting: false,
+});
+
+export const {
+  useGetOtpTokensFullDataQuery,
+  useSearchOtpTokensEntriesMutation,
+} = extendedApi;

--- a/src/services/rpcUsers.ts
+++ b/src/services/rpcUsers.ts
@@ -19,6 +19,7 @@ import {
   User,
   RadiusServer,
   IDPServer,
+  AlgorithmType,
 } from "../utils/datatypes/globalDataTypes";
 
 /**
@@ -96,6 +97,24 @@ export interface AddUserPayload {
   noprivate?: boolean;
   gidnumber?: string;
   userpassword?: string;
+}
+
+export interface AddOtpTokenPayload {
+  ipatokenuniqueid: string;
+  type: "totp" | "hotp";
+  description?: string;
+  ipatokenowner?: string;
+  ipatokennotbefore?: string;
+  ipatokennotafter?: string;
+  ipatokenvendor?: string;
+  ipatokenmodel?: string;
+  ipatokenserial?: string;
+  ipatokenotpkey?: string;
+  ipatokenotpalgorithm?: AlgorithmType;
+  ipatokenotpdigits?: 6 | 8;
+  ipatokentotpclockoffset?: number;
+  ipatokentotptimestep?: number | string;
+  version?: string;
 }
 
 const extendedApi = api.injectEndpoints({
@@ -441,13 +460,39 @@ const extendedApi = api.injectEndpoints({
       },
       invalidatesTags: ["FullUser"],
     }),
-    addOtpToken: build.mutation<FindRPCResponse, any[]>({
+    addOtpToken: build.mutation<FindRPCResponse, AddOtpTokenPayload>({
       query: (payload) => {
-        const params = [payload[0], payload[1]];
+        const params: Record<string, unknown> = {
+          version: payload.version || API_VERSION_BACKUP,
+        };
+
+        const optionalKeys: Array<
+          keyof Omit<AddOtpTokenPayload, "ipatokenuniqueid" | "apiVersion">
+        > = [
+          "type",
+          "description",
+          "ipatokenowner",
+          "ipatokennotbefore",
+          "ipatokennotafter",
+          "ipatokenvendor",
+          "ipatokenmodel",
+          "ipatokenserial",
+          "ipatokenotpkey",
+          "ipatokenotpalgorithm",
+          "ipatokenotpdigits",
+          "ipatokentotptimestep",
+        ];
+
+        optionalKeys.forEach((key) => {
+          const value = payload[key];
+          if (value !== undefined && value !== "") {
+            params[key] = value;
+          }
+        });
 
         return getCommand({
           method: "otptoken_add",
-          params: params,
+          params: [[payload.ipatokenuniqueid], params],
         });
       },
     }),

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -651,6 +651,12 @@ export interface SubId {
   dn: string;
 }
 
+export interface OtpTokenType {
+  ipatokenuniqueid: string;
+  type: string;
+  dn: string;
+}
+
 export type IDNSForwardPolicy = "only" | "first" | "none";
 
 export interface DNSZone {
@@ -1132,6 +1138,31 @@ export interface TrustDomain {
 }
 
 export type RangeType = "detect" | "ad-domain" | "ad-domain-posix";
+
+export type AlgorithmType = "sha1" | "sha256" | "sha384" | "sha512";
+export type OtpTokenTypeValue = "totp" | "hotp";
+export type OtpTokenDigits = "6" | "8";
+
+export interface OtpToken {
+  ipatokenuniqueid: string;
+  type: OtpTokenTypeValue;
+  description: string;
+  ipatokenowner: string;
+  managedby_user: string;
+  ipatokendisabled: boolean;
+  ipatokennotbefore: Date | string; // datetime
+  ipatokennotafter: Date | string; // datetime
+  ipatokenvendor: string;
+  ipatokenmodel: string;
+  ipatokenserial: string;
+  ipatokenotpkey: string; // bytes
+  ipatokenotpalgorithm: AlgorithmType; // Default: 'sha1'
+  ipatokenotpdigits: OtpTokenDigits; // Default: 6
+  ipatokentotpclockoffset: number; // Default: 0 | Minimum value: -2147483648 | Maximum value: 2147483647
+  ipatokentotptimestep: number; // Default: 30 | Minimum value: 5 | Maximum value: 2147483647
+  ipatokenhotpcounter: number; // Default: 0 | Minimum value: 0 | Maximum value: 2147483647
+  uri: string;
+}
 
 export type ErrorValidationData = {
   isError: boolean;

--- a/src/utils/otpTokensUtils.tsx
+++ b/src/utils/otpTokensUtils.tsx
@@ -1,0 +1,78 @@
+import { OtpToken } from "./datatypes/globalDataTypes";
+import { convertApiObj } from "./ipaObjectUtils";
+
+export const asRecord = (
+  element: Partial<OtpToken>,
+  onElementChange: (element: Partial<OtpToken>) => void
+) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ipaObject = element as Record<string, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function recordOnChange(ipaObject: Record<string, any>) {
+    onElementChange(ipaObject as OtpToken);
+  }
+  return { ipaObject, recordOnChange };
+};
+
+const simpleValues = new Set([
+  "ipatokenuniqueid",
+  "type",
+  "description",
+  "ipatokenowner",
+  "managedby_user",
+  "ipatokendisabled",
+  "ipatokenvendor",
+  "ipatokenmodel",
+  "ipatokenserial",
+  "ipatokenotpkey",
+  "ipatokenotpalgorithm",
+  "ipatokenotpdigits",
+  "ipatokentotpclockoffset",
+  "ipatokentotptimestep",
+  "ipatokenhotpcounter",
+  "uri",
+]);
+const dateValues = new Set(["ipatokennotbefore", "ipatokennotafter"]);
+const complexValues = new Map([["ipatokenotpkey", "__base64__"]]);
+
+export function apiToOtpToken(apiRecord: Record<string, unknown>): OtpToken {
+  const converted = convertApiObj(
+    apiRecord,
+    simpleValues,
+    dateValues,
+    complexValues
+  ) as Partial<OtpToken>;
+  return partialOtpTokenToOtpToken(converted);
+}
+
+export function partialOtpTokenToOtpToken(
+  partialOtpToken: Partial<OtpToken>
+): OtpToken {
+  return {
+    ...createEmptyOtpToken(),
+    ...partialOtpToken,
+  };
+}
+
+export function createEmptyOtpToken(): OtpToken {
+  return {
+    ipatokenuniqueid: "",
+    type: "totp",
+    description: "",
+    ipatokenowner: "",
+    managedby_user: "",
+    ipatokendisabled: false,
+    ipatokennotbefore: "",
+    ipatokennotafter: "",
+    ipatokenvendor: "",
+    ipatokenmodel: "",
+    ipatokenserial: "",
+    ipatokenotpkey: "",
+    ipatokenotpalgorithm: "sha1",
+    ipatokenotpdigits: "6",
+    ipatokentotpclockoffset: 0,
+    ipatokentotptimestep: 30,
+    ipatokenhotpcounter: 0,
+    uri: "",
+  };
+}

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -28,6 +28,7 @@ import {
   DNSForwardZone,
   Trust,
   TrustDomain,
+  OtpToken,
 } from "./datatypes/globalDataTypes";
 // Errors
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
@@ -230,6 +231,8 @@ export const isTrustSelectable = (trust: Trust) => trust.cn !== "";
 export const isTrustDomainSelectable = (trustDomain: TrustDomain) =>
   trustDomain.cn !== "";
 
+export const isOtpTokenSelectable = (otpToken: OtpToken) =>
+  otpToken.ipatokenuniqueid !== "";
 /**
  * Write JSX error messages into 'apiErrorsJsx' array
  * @param {FetchBaseQueryError | SerializedError} errorFromApiCall -  Error from the API call


### PR DESCRIPTION
The 'OTP token' main page must show the available elements in the table, as well as managing those via the action buttons (i.e. add, delete, enable, and disable).

## Summary by Sourcery

Add a new OTP tokens management page with full CRUD-like operations and integrate it into navigation and RPC APIs.

New Features:
- Introduce an OTP tokens listing page with search, pagination, bulk selection, and status display.
- Add modals to create OTP tokens and to delete or enable/disable multiple tokens.
- Expose new RPC endpoints for fetching, searching, modifying, and deleting OTP tokens, including type-safe payloads for token creation.

Enhancements:
- Extend the generic MainTable component to support inverted boolean status semantics for styling and button state handling.
- Update existing Add OTP Token and QR code modals to use stronger typings, new payload shape, and to refresh the token list after successful operations.