### PR TITLE
Fix audit vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8584,9 +8584,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -10421,20 +10421,20 @@
       }
     },
     "node_modules/rollup-plugin-license": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-license/-/rollup-plugin-license-3.6.0.tgz",
-      "integrity": "sha512-1ieLxTCaigI5xokIfszVDRoy6c/Wmlot1fDEnea7Q/WXSR8AqOjYljHDLObAx7nFxHC2mbxT3QnTSPhaic2IYw==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-license/-/rollup-plugin-license-3.7.0.tgz",
+      "integrity": "sha512-RvvOIF+GH3fBR3wffgc/vmjQn6qOn72WjppWVDp/v+CLpT0BbcRBdSkPeeIOL6U5XccdYgSIMjUyXgxlKEEFcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "commenting": "~1.1.0",
+        "commenting": "^1.1.0",
         "fdir": "^6.4.3",
-        "lodash": "~4.17.21",
-        "magic-string": "~0.30.0",
-        "moment": "~2.30.1",
-        "package-name-regex": "~2.0.6",
-        "spdx-expression-validate": "~2.0.0",
-        "spdx-satisfies": "~5.0.1"
+        "lodash": "^4.17.21",
+        "magic-string": "^0.30.0",
+        "moment": "^2.30.1",
+        "package-name-regex": "^2.0.6",
+        "spdx-expression-validate": "^2.0.0",
+        "spdx-satisfies": "^5.0.1"
       },
       "engines": {
         "node": ">=14.0.0"


### PR DESCRIPTION
The following packages need to be
updated to a safer version:
- `lodash`
- `rollup-plugin-license`

## Summary by Sourcery

Bug Fixes:
- Resolve security vulnerabilities in npm dependencies by refreshing the package-lock.json.