### PR TITLE
[Integration tests] Unify enable/disable test functions

### DIFF
--- a/cypress/e2e/dns/dnszones.ts
+++ b/cypress/e2e/dns/dnszones.ts
@@ -2,6 +2,8 @@ import { Given, Then, When } from "@badeball/cypress-cucumber-preprocessor";
 import {
   entryExists,
   entryDoesNotExist,
+  isElementDisabled,
+  isElementEnabled,
   searchForEntry,
   selectEntry,
 } from "../common/data_tables";
@@ -78,16 +80,14 @@ const createReversedDnsZoneWithSkipOverlapCheck = (ip: string) => {
   cy.dataCy("add-dns-zone-modal").should("not.exist");
 };
 
+const DNS_ZONE_STATUS_LABEL = "idnszoneactive";
+
 const isDisabled = (name: string) => {
-  cy.get("tr[id='" + name + "'] td[data-label=idnszoneactive]").contains(
-    "Disabled"
-  );
+  isElementDisabled(name, DNS_ZONE_STATUS_LABEL);
 };
 
 const isEnabled = (name: string) => {
-  cy.get("tr[id='" + name + "'] td[data-label=idnszoneactive]").contains(
-    "Enabled"
-  );
+  isElementEnabled(name, DNS_ZONE_STATUS_LABEL);
 };
 
 const disableDnsZone = (zoneName: string) => {

--- a/cypress/e2e/sudo_rules/sudo_rules.ts
+++ b/cypress/e2e/sudo_rules/sudo_rules.ts
@@ -1,10 +1,12 @@
 import { Given } from "@badeball/cypress-cucumber-preprocessor";
 import { loginAsAdmin, logout } from "../common/authentication";
-import { selectEntry } from "../common/data_tables";
+import { isElementDisabled, selectEntry } from "../common/data_tables";
 import { navigateTo } from "../common/navigation";
 
+const SUDO_RULE_STATUS_LABEL = "Status";
+
 const isDisabled = (name: string) => {
-  cy.get("tr[id='" + name + "'] td[data-label=Status]").contains("Disabled");
+  isElementDisabled(name, SUDO_RULE_STATUS_LABEL);
 };
 
 Given("I disable sudo rule {string}", (ruleName: string) => {

--- a/cypress/e2e/users/users.ts
+++ b/cypress/e2e/users/users.ts
@@ -3,6 +3,8 @@ import { createUser, validateUser } from "../common/user_management";
 import { loginAsAdmin, logout } from "../common/authentication";
 import {
   entryExists,
+  isElementDisabled,
+  isElementEnabled,
   isSelected,
   searchForEntry,
   selectEntry,
@@ -26,12 +28,14 @@ const disableUser = (login: string) => {
   isDisabled(login);
 };
 
+const USER_STATUS_LABEL = "Status";
+
 const isDisabled = (name: string) => {
-  cy.get("tr[id='" + name + "'] td[data-label=Status]").contains("Disabled");
+  isElementDisabled(name, USER_STATUS_LABEL);
 };
 
 const isEnabled = (name: string) => {
-  cy.get("tr[id='" + name + "'] td[data-label=Status]").contains("Enabled");
+  isElementEnabled(name, USER_STATUS_LABEL);
 };
 
 Then(


### PR DESCRIPTION
The `dnszones.ts`, `users.ts` and
`cert_id_mapping_rules.ts` files
are using different functions to check
if a given element is enabled/disabled.
That duplicated code must be unified.

Fixes: https://github.com/freeipa/freeipa-webui/issues/1086

## Summary by Sourcery

Unify status checking in integration tests to use shared helpers for determining whether DNS zones and users are enabled or disabled.

Enhancements:
- Refactor DNS zone and user integration tests to use common helper functions for enabled/disabled status checks.

Tests:
- Standardize status label usage in DNS zone and user Cypress tests to reduce duplication and improve maintainability.