### PR TITLE
Remove Password policy and Kerberos ticket sections for staged users

### DIFF
--- a/src/components/UsersSections/UserSettings.tsx
+++ b/src/components/UsersSections/UserSettings.tsx
@@ -530,30 +530,36 @@ const UserSettings = (props: PropsToUserSettings) => {
             scrollableSelector="#settings-page"
             expandable={{ default: "expandable", md: "nonExpandable" }}
           >
-            <JumpLinksItem key={0} href="#identity-settings">
-              Identity settings
-            </JumpLinksItem>
-            <JumpLinksItem key={1} href="#account-settings">
-              Account settings
-            </JumpLinksItem>
-            <JumpLinksItem key={2} href="#password-policy">
-              Password policy
-            </JumpLinksItem>
-            <JumpLinksItem key={3} href="#kerberos-ticket">
-              Kerberos ticket policy
-            </JumpLinksItem>
-            <JumpLinksItem key={4} href="#contact-settings">
-              Contact settings
-            </JumpLinksItem>
-            <JumpLinksItem key={5} href="#mailing-address">
-              Mailing address
-            </JumpLinksItem>
-            <JumpLinksItem key={6} href="#employee-information">
-              Employee information
-            </JumpLinksItem>
-            <JumpLinksItem key={7} href="#smb-services">
-              User attributes for SMB services
-            </JumpLinksItem>
+            {[
+              <JumpLinksItem key={0} href="#identity-settings">
+                Identity settings
+              </JumpLinksItem>,
+              <JumpLinksItem key={1} href="#account-settings">
+                Account settings
+              </JumpLinksItem>,
+              props.from !== "stage-users" ? (
+                <JumpLinksItem key={2} href="#password-policy">
+                  Password policy
+                </JumpLinksItem>
+              ) : null,
+              props.from !== "stage-users" ? (
+                <JumpLinksItem key={3} href="#kerberos-ticket">
+                  Kerberos ticket policy
+                </JumpLinksItem>
+              ) : null,
+              <JumpLinksItem key={4} href="#contact-settings">
+                Contact settings
+              </JumpLinksItem>,
+              <JumpLinksItem key={5} href="#mailing-address">
+                Mailing address
+              </JumpLinksItem>,
+              <JumpLinksItem key={6} href="#employee-information">
+                Employee information
+              </JumpLinksItem>,
+              <JumpLinksItem key={7} href="#smb-services">
+                User attributes for SMB services
+              </JumpLinksItem>,
+            ].filter(Boolean)}
           </JumpLinks>
         </SidebarPanel>
         <SidebarContent className="pf-v6-u-mr-xl">
@@ -585,20 +591,26 @@ const UserSettings = (props: PropsToUserSettings) => {
               certData={props.certData}
               from={props.from}
             />
-            <TitleLayout
-              key={2}
-              headingLevel="h2"
-              id="password-policy"
-              text="Password policy"
-            />
-            <UsersPasswordPolicy pwdPolicyData={props.pwPolicyData || []} />
-            <TitleLayout
-              key={3}
-              headingLevel="h2"
-              id="kerberos-ticket"
-              text="Kerberos ticket"
-            />
-            <UsersKerberosTicket krbPolicyData={props.krbPolicyData || []} />
+            {props.from !== "stage-users" && (
+              <>
+                <TitleLayout
+                  key={2}
+                  headingLevel="h2"
+                  id="password-policy"
+                  text="Password policy"
+                />
+                <UsersPasswordPolicy pwdPolicyData={props.pwPolicyData || []} />
+                <TitleLayout
+                  key={3}
+                  headingLevel="h2"
+                  id="kerberos-ticket"
+                  text="Kerberos ticket"
+                />
+                <UsersKerberosTicket
+                  krbPolicyData={props.krbPolicyData || []}
+                />
+              </>
+            )}
             <TitleLayout
               key={4}
               headingLevel="h2"


### PR DESCRIPTION
The staged user detail page displays Password policy and Kerberos ticket sections. These sections are meaningless for staged users since they have no associated password or Kerberos ticket policies.

Conditionally hide both sections and their corresponding JumpLinks sidebar entries when props.from is "stage-users" in UserSettings. The JumpLinks items use an array with `.filter(Boolean)` instead of inline `{condition && element}` because PatternFly's JumpLinks component does not handle null children, its internal getScrollItems function accesses
child.type without a null guard, causing a crash.

Fixes : #1001 

<img width="1916" height="1023" alt="Screenshot From 2026-04-10 16-41-49" src="https://github.com/user-attachments/assets/ed495aee-e5e0-4a33-91dc-dd67dbfe3b28" />

## Summary by Sourcery

Hide password and Kerberos policy sections for staged users in the user settings view.

Bug Fixes:
- Prevent crashes in the JumpLinks sidebar by building its items array and filtering out null entries instead of rendering conditional children directly.

Enhancements:
- Hide password policy and Kerberos ticket sections and their JumpLinks entries when viewing staged users in the user settings page.