### PR TITLE
Integration tests for dns_forward_zones

### DIFF
--- a/cypress/e2e/common/modal.ts
+++ b/cypress/e2e/common/modal.ts
@@ -5,5 +5,5 @@ Then("I should see {string} modal", (modalName: string) => {
 });
 
 Then("I should not see {string} modal", (modalName: string) => {
-  cy.dataCy(modalName).should("not.exist");
+  cy.get(`[data-cy='${modalName}']`, { timeout: 30000 }).should("not.exist");
 });

--- a/cypress/e2e/common/ui/element.ts
+++ b/cypress/e2e/common/ui/element.ts
@@ -1,0 +1,5 @@
+import { Then } from "@badeball/cypress-cucumber-preprocessor";
+
+Then("I should not see {string} element", (element: string) => {
+  cy.dataCy(element).should("not.exist");
+});

--- a/cypress/e2e/dns/dns_forward_zones/dns_forward_zones.feature
+++ b/cypress/e2e/dns/dns_forward_zones/dns_forward_zones.feature
@@ -1,0 +1,273 @@
+Feature: DNS Forward Zones
+    Create, delete, enable and disable DNS forward zones
+
+    @test
+    Scenario: Create a new DNS forward zone (8.8.8.8)
+        Given I am logged in as admin
+        And I am on "dns-forward-zones" page
+
+        When I click on the "dns-forward-zones-add" button
+        Then I should see "add-dns-forward-zone-modal" modal
+
+        When I type in the "modal-textbox-dns-zone-name" textbox text "my-dnsforwardzone"
+        Then I should see "my-dnsforwardzone" in the "modal-textbox-dns-zone-name" textbox
+        Then I should see the "modal-button-add" button is disabled
+
+        When I click on the "modal-textbox-forwarders-add-button" button
+        Then I should see the "modal-textbox-forwarders-0" textbox is empty
+
+        When I type in the "modal-textbox-forwarders-0" textbox text "8.8.8.8"
+        Then I should see "8.8.8.8" in the "modal-textbox-forwarders-0" textbox
+        Then I should see the "modal-button-add" button is enabled
+
+        When I click on the "modal-button-add" button
+        Then I should not see "add-dns-forward-zone-modal" modal
+        And I should see "add-dnsforwardzones-success" alert
+
+        When I search for "my-dnsforwardzone." in the data table
+        Then I should see "my-dnsforwardzone." entry in the data table with attribute "idnsforwarders" set to "8.8.8.8"
+        And I should see "my-dnsforwardzone." entry in the data table with attribute "idnsforwardpolicy" set to "first"
+
+    @cleanup
+    Scenario: Delete DNS forward zone
+        Given I delete DNS forward zone "my-dnsforwardzone"
+
+    @test
+    Scenario: Create a new DNS forward zone (192.168.23.24)
+        Given I am logged in as admin
+        And I am on "dns-forward-zones" page
+
+        When I click on the "dns-forward-zones-add" button
+        Then I should see "add-dns-forward-zone-modal" modal
+
+        When I type in the "modal-textbox-dns-zone-name" textbox text "my-dnsforwardzone"
+        Then I should see "my-dnsforwardzone" in the "modal-textbox-dns-zone-name" textbox
+        Then I should see the "modal-button-add" button is disabled
+
+        When I click on the "modal-textbox-forwarders-add-button" button
+        Then I should see the "modal-textbox-forwarders-0" textbox is empty
+
+        When I type in the "modal-textbox-forwarders-0" textbox text "192.168.23.24"
+        Then I should see "192.168.23.24" in the "modal-textbox-forwarders-0" textbox
+        Then I should see the "modal-button-add" button is enabled
+
+        When I click on the "modal-button-add" button
+        Then I should not see "add-dns-forward-zone-modal" modal
+        And I should see "add-dnsforwardzones-success" alert
+
+        When I search for "my-dnsforwardzone." in the data table
+        Then I should see "my-dnsforwardzone." entry in the data table with attribute "idnsforwarders" set to "192.168.23.24"
+        And I should see "my-dnsforwardzone." entry in the data table with attribute "idnsforwardpolicy" set to "first"
+
+    @cleanup
+    Scenario: Delete DNS forward zone
+        Given I delete DNS forward zone "my-dnsforwardzone"
+
+    @test
+    Scenario: Create a new DNS forward zone forward only
+        Given I am logged in as admin
+        And I am on "dns-forward-zones" page
+
+        When I click on the "dns-forward-zones-add" button
+        Then I should see "add-dns-forward-zone-modal" modal
+
+        When I type in the "modal-textbox-dns-zone-name" textbox text "my-dnsforwardzone"
+        Then I should see "my-dnsforwardzone" in the "modal-textbox-dns-zone-name" textbox
+        Then I should see the "modal-button-add" button is disabled
+
+        When I click on the "modal-textbox-forwarders-add-button" button
+        Then I should see the "modal-textbox-forwarders-0" textbox is empty
+
+        When I type in the "modal-textbox-forwarders-0" textbox text "8.8.8.8"
+        Then I should see "8.8.8.8" in the "modal-textbox-forwarders-0" textbox
+        Then I should see the "modal-button-add" button is enabled
+
+        When I click on the "modal-radio-forward-policy-only" radio button
+        Then I should see the "modal-radio-forward-policy-only" radio button is selected
+
+        When I click on the "modal-button-add" button
+        Then I should not see "add-dns-forward-zone-modal" modal
+        And I should see "add-dnsforwardzones-success" alert
+
+        When I search for "my-dnsforwardzone." in the data table
+        Then I should see "my-dnsforwardzone." entry in the data table with attribute "idnsforwarders" set to "8.8.8.8"
+        And I should see "my-dnsforwardzone." entry in the data table with attribute "idnsforwardpolicy" set to "only"
+
+    @cleanup
+    Scenario: Delete DNS forward zone
+        Given I delete DNS forward zone "my-dnsforwardzone"
+
+    @test
+    Scenario: Create a new DNS forward zone forwarding disabled
+        Given I am logged in as admin
+        And I am on "dns-forward-zones" page
+
+        When I click on the "dns-forward-zones-add" button
+        Then I should see "add-dns-forward-zone-modal" modal
+
+        When I type in the "modal-textbox-dns-zone-name" textbox text "my-dnsforwardzone"
+        Then I should see "my-dnsforwardzone" in the "modal-textbox-dns-zone-name" textbox
+        Then I should see the "modal-button-add" button is disabled
+
+        When I click on the "modal-textbox-forwarders-add-button" button
+        Then I should see the "modal-textbox-forwarders-0" textbox is empty
+
+        When I type in the "modal-textbox-forwarders-0" textbox text "8.8.8.8"
+        Then I should see "8.8.8.8" in the "modal-textbox-forwarders-0" textbox
+        Then I should see the "modal-button-add" button is enabled
+
+        When I click on the "modal-radio-forward-policy-none" radio button
+        Then I should see the "modal-radio-forward-policy-none" radio button is selected
+
+        When I click on the "modal-button-add" button
+        Then I should not see "add-dns-forward-zone-modal" modal
+        And I should see "add-dnsforwardzones-success" alert
+
+        When I search for "my-dnsforwardzone." in the data table
+        Then I should see "my-dnsforwardzone." entry in the data table with attribute "idnsforwarders" set to "8.8.8.8"
+        And I should see "my-dnsforwardzone." entry in the data table with attribute "idnsforwardpolicy" set to "none"
+
+    @cleanup
+    Scenario: Delete DNS forward zone
+        Given I delete DNS forward zone "my-dnsforwardzone"
+
+    @test
+    Scenario: Create a new DNS forward zone with skip overlap check
+        Given I am logged in as admin
+        And I am on "dns-forward-zones" page
+
+        When I click on the "dns-forward-zones-add" button
+        Then I should see "add-dns-forward-zone-modal" modal
+
+        When I type in the "modal-textbox-dns-zone-name" textbox text "my-dnsforwardzone"
+        Then I should see "my-dnsforwardzone" in the "modal-textbox-dns-zone-name" textbox
+        Then I should see the "modal-button-add" button is disabled
+
+        When I click on the "modal-textbox-forwarders-add-button" button
+        Then I should see the "modal-textbox-forwarders-0" textbox is empty
+
+        When I type in the "modal-textbox-forwarders-0" textbox text "8.8.8.8"
+        Then I should see "8.8.8.8" in the "modal-textbox-forwarders-0" textbox
+        Then I should see the "modal-button-add" button is enabled
+
+        When I click on the "modal-checkbox-skip-overlap-check" checkbox
+        Then I should see the "modal-checkbox-skip-overlap-check" checkbox is checked
+
+        When I click on the "modal-button-add" button
+        Then I should not see "add-dns-forward-zone-modal" modal
+        And I should see "add-dnsforwardzones-success" alert
+
+        When I search for "my-dnsforwardzone." in the data table
+        Then I should see "my-dnsforwardzone." entry in the data table with attribute "idnsforwarders" set to "8.8.8.8"
+
+    @cleanup
+    Scenario: Delete DNS forward zone
+        Given I delete DNS forward zone "my-dnsforwardzone"
+
+    @test
+    Scenario: Create a new reverse DNS forward zone (explicit IP network)
+        Given I am logged in as admin
+        And I am on "dns-forward-zones" page
+
+        When I click on the "dns-forward-zones-add" button
+        Then I should see "add-dns-forward-zone-modal" modal
+
+        When I click on the "modal-radio-reverse-zone-ip" radio button
+        Then I should see the "modal-radio-reverse-zone-ip" radio button is selected
+
+        When I type in the "modal-textbox-reverse-zone-ip" textbox text "192.168.0.0/23"
+        Then I should see "192.168.0.0/23" in the "modal-textbox-reverse-zone-ip" textbox
+        Then I should see the "modal-button-add" button is disabled
+
+        When I click on the "modal-textbox-forwarders-add-button" button
+        Then I should see the "modal-textbox-forwarders-0" textbox is empty
+
+        When I type in the "modal-textbox-forwarders-0" textbox text "8.8.8.8"
+        Then I should see "8.8.8.8" in the "modal-textbox-forwarders-0" textbox
+        Then I should see the "modal-button-add" button is enabled
+
+        When I click on the "modal-button-add" button
+        Then I should not see "add-dns-forward-zone-modal" modal
+        And I should see "add-dnsforwardzones-success" alert
+
+        When I search for "168.192.in-addr.arpa." in the data table
+        Then I should see "168.192.in-addr.arpa." entry in the data table with attribute "idnsforwarders" set to "8.8.8.8"
+
+    @cleanup
+    Scenario: Delete DNS forward zone
+        Given I delete DNS forward zone "168.192.in-addr.arpa"
+
+    @seed
+    Scenario: Create a DNS forward zone
+        Given DNS forward zone "my-dnsforwardzone" exists with forwarder "8.8.8.8"
+
+    @test
+    Scenario: Delete DNS forward zone
+        Given I am logged in as admin
+        And I am on "dns-forward-zones" page
+
+        When I select entry "my-dnsforwardzone." in the data table
+        Then I should see "my-dnsforwardzone." entry selected in the data table
+
+        When I click on the "dns-forward-zones-button-delete" button
+        Then I should see "dns-forward-zones-delete-modal" modal
+
+        When I click on the "modal-button-delete" button
+        Then I should not see "dns-forward-zones-delete-modal" modal
+        And I should see "remove-dnsforwardzones-success" alert
+
+        When I search for "my-dnsforwardzone." in the data table
+        Then I should not see "my-dnsforwardzone." entry in the data table
+
+    @seed
+    Scenario: Create a DNS forward zone
+        Given DNS forward zone "my-dnsforwardzone" exists with forwarder "8.8.8.8"
+
+    @test
+    Scenario: Disable DNS forward zone
+        Given I am logged in as admin
+        And I am on "dns-forward-zones" page
+
+        When I select entry "my-dnsforwardzone." in the data table
+        Then I should see "my-dnsforwardzone." entry selected in the data table
+
+        When I click on the "dns-forward-zones-disable" button
+        Then I should see "dns-forward-zones-enable-disable-modal" modal
+
+        When I click on the "modal-button-disable" button
+        Then I should not see "dns-forward-zones-enable-disable-modal" modal
+        And I should see "disable-dnsforwardzones-success" alert
+
+        When I search for "my-dnsforwardzone." in the data table
+        Then I should see element "my-dnsforwardzone." with status label "idnszoneactive" in the list disabled
+
+    @cleanup
+    Scenario: Delete DNS forward zone
+        Given I delete DNS forward zone "my-dnsforwardzone"
+
+    @seed
+    Scenario: Create a disabled DNS forward zone
+        Given DNS forward zone "my-dnsforwardzone" exists with forwarder "8.8.8.8"
+        And DNS forward zone "my-dnsforwardzone" is disabled
+
+    @test
+    Scenario: Enable DNS forward zone
+        Given I am logged in as admin
+        And I am on "dns-forward-zones" page
+
+        When I select entry "my-dnsforwardzone." in the data table
+        Then I should see "my-dnsforwardzone." entry selected in the data table
+
+        When I click on the "dns-forward-zones-enable" button
+        Then I should see "dns-forward-zones-enable-disable-modal" modal
+
+        When I click on the "modal-button-enable" button
+        Then I should not see "dns-forward-zones-enable-disable-modal" modal
+        And I should see "enable-dnsforwardzones-success" alert
+
+        When I search for "my-dnsforwardzone." in the data table
+        Then I should see element "my-dnsforwardzone." with status label "idnszoneactive" in the list enabled
+
+    @cleanup
+    Scenario: Delete DNS forward zone
+        Given I delete DNS forward zone "my-dnsforwardzone"

--- a/cypress/e2e/dns/dns_forward_zones/dns_forward_zones.ts
+++ b/cypress/e2e/dns/dns_forward_zones/dns_forward_zones.ts
@@ -1,0 +1,33 @@
+import { Given } from "@badeball/cypress-cucumber-preprocessor";
+
+Given("I delete DNS forward zone {string}", (zoneName: string) => {
+  cy.ipa({
+    command: "dnsforwardzone-del",
+    name: zoneName,
+  });
+});
+
+Given(
+  "DNS forward zone {string} exists with forwarder {string}",
+  (zoneName: string, forwarder: string) => {
+    cy.ipa({
+      command: "dnsforwardzone-add",
+      name: zoneName,
+      specificOptions: `--forwarder ${forwarder}`,
+    });
+  }
+);
+
+Given("DNS forward zone {string} is disabled", (zoneName: string) => {
+  cy.ipa({
+    command: "dnsforwardzone-disable",
+    name: zoneName,
+  });
+});
+
+Given("DNS forward zone {string} is enabled", (zoneName: string) => {
+  cy.ipa({
+    command: "dnsforwardzone-enable",
+    name: zoneName,
+  });
+});

--- a/cypress/e2e/dns/dns_forward_zones/dns_forward_zones_settings.feature
+++ b/cypress/e2e/dns/dns_forward_zones/dns_forward_zones_settings.feature
@@ -1,0 +1,124 @@
+Feature: DNS Forward Zones Settings
+    Configure DNS forward zones settings
+
+    @seed
+    Scenario: Create a new DNS forward zone
+        Given DNS forward zone "my-dnsforwardzone" exists with forwarder "8.8.8.8"
+
+    @test
+    Scenario: Change forwarder
+        Given I am logged in as admin
+        And I am on "dns-forward-zones/my-dnsforwardzone." page
+
+        When I type in the "dns-forward-zones-tab-settings-textbox-idnsforwarders-0" textbox text "8.8.4.4"
+        Then I should see "8.8.4.4" in the "dns-forward-zones-tab-settings-textbox-idnsforwarders-0" textbox
+
+        When I click on the "dns-forward-zones-tab-settings-button-save" button
+        Then I should see "8.8.4.4" in the "dns-forward-zones-tab-settings-textbox-idnsforwarders-0" textbox
+        Then I should see "success" alert
+
+    @cleanup
+    Scenario: Delete DNS forward zone
+        Given I delete DNS forward zone "my-dnsforwardzone"
+
+    @seed
+    Scenario: Create a new DNS forward zone
+        Given DNS forward zone "my-dnsforwardzone" exists with forwarder "8.8.8.8"
+
+    @test
+    Scenario: Change forwarder port
+        Given I am logged in as admin
+        And I am on "dns-forward-zones/my-dnsforwardzone." page
+
+        When I type in the "dns-forward-zones-tab-settings-textbox-idnsforwarders-0-port" textbox text "53"
+        Then I should see "53" in the "dns-forward-zones-tab-settings-textbox-idnsforwarders-0-port" textbox
+
+        When I click on the "dns-forward-zones-tab-settings-button-save" button
+        Then I should see "8.8.8.8" in the "dns-forward-zones-tab-settings-textbox-idnsforwarders-0" textbox
+        Then I should see "53" in the "dns-forward-zones-tab-settings-textbox-idnsforwarders-0-port" textbox
+        Then I should see "success" alert
+
+    @cleanup
+    Scenario: Delete DNS forward zone
+        Given I delete DNS forward zone "my-dnsforwardzone"
+
+    @seed
+    Scenario: Create a new DNS forward zone
+        Given DNS forward zone "my-dnsforwardzone" exists with forwarder "8.8.8.8"
+
+    @test
+    Scenario: Add another forwarder
+        Given I am logged in as admin
+        And I am on "dns-forward-zones/my-dnsforwardzone." page
+
+        When I click on the "dns-forward-zones-tab-settings-textbox-idnsforwarders-add-button" button
+        Then I should see the "dns-forward-zones-tab-settings-textbox-idnsforwarders-1" textbox is empty
+
+        When I type in the "dns-forward-zones-tab-settings-textbox-idnsforwarders-1" textbox text "8.8.4.4"
+        Then I should see "8.8.4.4" in the "dns-forward-zones-tab-settings-textbox-idnsforwarders-1" textbox
+
+        When I click on the "dns-forward-zones-tab-settings-button-save" button
+        Then I should see "8.8.8.8" in the "dns-forward-zones-tab-settings-textbox-idnsforwarders-0" textbox
+        Then I should see "8.8.4.4" in the "dns-forward-zones-tab-settings-textbox-idnsforwarders-1" textbox
+        Then I should see "success" alert
+
+    @cleanup
+    Scenario: Delete DNS forward zone
+        Given I delete DNS forward zone "my-dnsforwardzone"
+
+    @seed
+    Scenario: Create a new DNS forward zone
+        Given DNS forward zone "my-dnsforwardzone" exists with forwarder "8.8.8.8"
+
+    @test
+    Scenario: No forwarders fails
+        Given I am logged in as admin
+        And I am on "dns-forward-zones/my-dnsforwardzone." page
+
+        When I click on the "dns-forward-zones-tab-settings-textbox-idnsforwarders-0-delete-button" button
+        Then I should not see "dns-forward-zones-tab-settings-textbox-idnsforwarders-0" element
+
+        When I click on the "dns-forward-zones-tab-settings-button-save" button
+        Then I should see "error" alert
+
+    @cleanup
+    Scenario: Delete DNS forward zone
+        Given I delete DNS forward zone "my-dnsforwardzone"
+
+    @seed
+    Scenario: Create a new DNS forward zone
+        Given DNS forward zone "my-dnsforwardzone" exists with forwarder "8.8.8.8"
+
+    @test
+    Scenario: Change Forward policy to "Forward only"
+        Given I am logged in as admin
+        And I am on "dns-forward-zones/my-dnsforwardzone." page
+
+        When I click on the "dns-forward-zones-tab-settings-radio-forward-only" radio button
+        Then I should see the "dns-forward-zones-tab-settings-radio-forward-only" radio button is selected
+
+        When I click on the "dns-forward-zones-tab-settings-button-save" button
+        Then I should see "success" alert
+
+    @cleanup
+    Scenario: Delete DNS forward zone
+        Given I delete DNS forward zone "my-dnsforwardzone"
+
+    @seed
+    Scenario: Create a new DNS forward zone
+        Given DNS forward zone "my-dnsforwardzone" exists with forwarder "8.8.8.8"
+
+    @test
+    Scenario: Change Forward policy to "Forwarding disabled"
+        Given I am logged in as admin
+        And I am on "dns-forward-zones/my-dnsforwardzone." page
+
+        When I click on the "dns-forward-zones-tab-settings-radio-forwarding-disabled" radio button
+        Then I should see the "dns-forward-zones-tab-settings-radio-forwarding-disabled" radio button is selected
+
+        When I click on the "dns-forward-zones-tab-settings-button-save" button
+        Then I should see "success" alert
+
+    @cleanup
+    Scenario: Delete DNS forward zone
+        Given I delete DNS forward zone "my-dnsforwardzone"

--- a/cypress/e2e/dns/dns_global_configuration.feature
+++ b/cypress/e2e/dns/dns_global_configuration.feature
@@ -33,8 +33,8 @@ Feature: DNS Global Configuration
         Given I am logged in as admin
         And I am on "dns-global-config" page
 
-        When I click on the "dns-zone-tab-settings-radio-forward-only" radio button
-        Then I should see the "dns-zone-tab-settings-radio-forward-only" radio button is selected
+        When I click on the "dns-global-config-radio-forward-only" radio button
+        Then I should see the "dns-global-config-radio-forward-only" radio button is selected
 
         When I click on the "dns-global-config-button-save" button
         Then I should see "success" alert
@@ -50,8 +50,8 @@ Feature: DNS Global Configuration
         When I remove all elements from the "dns-global-config-textbox-forwarders" textbox list
         Then I should see the "dns-global-config-textbox-forwarders" textbox list is empty
 
-        When I click on the "dns-zone-tab-settings-radio-forwarding-disabled" radio button
-        Then I should see the "dns-zone-tab-settings-radio-forwarding-disabled" radio button is selected
+        When I click on the "dns-global-config-radio-forwarding-disabled" radio button
+        Then I should see the "dns-global-config-radio-forwarding-disabled" radio button is selected
 
         When I click on the "dns-global-config-button-save" button
         Then I should see "success" alert

--- a/cypress/e2e/dns/dns_servers_settings.feature
+++ b/cypress/e2e/dns/dns_servers_settings.feature
@@ -42,11 +42,11 @@ Feature: DNS Servers
         Given I am logged in as admin
         And I am on "dns-servers/webui.ipa.test" page
 
-        When I click on the "dns-zone-tab-settings-radio-forward-first" radio button
-        Then I should see the "dns-zone-tab-settings-radio-forward-first" radio button is selected
+        When I click on the "dns-servers-tab-settings-radio-forward-first" radio button
+        Then I should see the "dns-servers-tab-settings-radio-forward-first" radio button is selected
 
         When I click on the "dns-servers-tab-settings-button-save" button
-        Then I should see the "dns-zone-tab-settings-radio-forward-first" radio button is selected
+        Then I should see the "dns-servers-tab-settings-radio-forward-first" radio button is selected
         And I should see "success" alert
 
     @cleanup

--- a/cypress/e2e/dns/dnszones_settings.feature
+++ b/cypress/e2e/dns/dnszones_settings.feature
@@ -158,12 +158,12 @@ Feature: DNS Zones Settings
         When I add zone forwarder "8.8.8.8"
         Then I should see "8.8.8.8" in the "dns-zones-tab-settings-textbox-idnsforwarders" textbox list
 
-        When I click on the "dns-zone-tab-settings-radio-forward-only" radio button
-        Then I should see the "dns-zone-tab-settings-radio-forward-only" radio button is selected
+        When I click on the "dns-zones-tab-settings-radio-forward-only" radio button
+        Then I should see the "dns-zones-tab-settings-radio-forward-only" radio button is selected
 
         When I click on the "dns-zones-tab-settings-button-save" button
         Then I should see "8.8.8.8" in the "dns-zones-tab-settings-textbox-idnsforwarders" textbox list
-        Then I should see the "dns-zone-tab-settings-radio-forward-only" radio button is selected
+        Then I should see the "dns-zones-tab-settings-radio-forward-only" radio button is selected
         Then I should see "success" alert
 
     @cleanup

--- a/src/components/Form/IPAddressWithPortInputList.tsx
+++ b/src/components/Form/IPAddressWithPortInputList.tsx
@@ -70,7 +70,7 @@ const IPAddressWithPortInputList = (props: IPAddressWithPortInputListProps) => {
                 flex={{ default: "flex_1" }}
               >
                 <TextInput
-                  data-cy={props.dataCy + "-" + item + "-port"}
+                  data-cy={props.dataCy + "-" + idx + "-port"}
                   id={props.name + "-" + idx + "-port"}
                   name={props.name + "-" + idx + "-port"}
                   value={item.port ?? ""}
@@ -97,7 +97,7 @@ const IPAddressWithPortInputList = (props: IPAddressWithPortInputListProps) => {
               key={props.name + "-" + idx + "-delete-button"}
             >
               <Button
-                data-cy={props.dataCy + "-" + item + "-delete-button"}
+                data-cy={props.dataCy + "-" + idx + "-delete-button"}
                 variant="secondary"
                 name={"remove-" + props.name + "-" + idx}
                 onClick={() =>

--- a/src/components/Form/IpaForwardPolicy.tsx
+++ b/src/components/Form/IpaForwardPolicy.tsx
@@ -8,7 +8,11 @@ import {
   updateIpaObject,
 } from "src/utils/ipaObjectUtils";
 
-const IpaForwardPolicy = (props: IPAParamDefinition) => {
+interface IpaForwardPolicyProps extends IPAParamDefinition {
+  dataCy: string;
+}
+
+const IpaForwardPolicy = (props: IpaForwardPolicyProps) => {
   const { readOnly, value } = getParamProperties(props);
 
   // States
@@ -30,7 +34,7 @@ const IpaForwardPolicy = (props: IPAParamDefinition) => {
     <Flex>
       <FlexItem>
         <Radio
-          data-cy="dns-zone-tab-settings-radio-forward-first"
+          data-cy={props.dataCy + "-radio-forward-first"}
           id={"forward-first"}
           key={"forward-first"}
           name={props.name}
@@ -43,7 +47,7 @@ const IpaForwardPolicy = (props: IPAParamDefinition) => {
       </FlexItem>
       <FlexItem>
         <Radio
-          data-cy="dns-zone-tab-settings-radio-forward-only"
+          data-cy={props.dataCy + "-radio-forward-only"}
           id={"forward-only"}
           key={"forward-only"}
           name={props.name}
@@ -56,7 +60,7 @@ const IpaForwardPolicy = (props: IPAParamDefinition) => {
       </FlexItem>
       <FlexItem>
         <Radio
-          data-cy="dns-zone-tab-settings-radio-forwarding-disabled"
+          data-cy={props.dataCy + "-radio-forwarding-disabled"}
           id={"forwarding-disabled"}
           key={"forwarding-disabled"}
           name={props.name}

--- a/src/components/modals/DnsZones/AddDnsForwardZoneModal.tsx
+++ b/src/components/modals/DnsZones/AddDnsForwardZoneModal.tsx
@@ -86,7 +86,7 @@ const AddDnsForwardZoneModalInner = (props: PropsToAddModal) => {
           if (error) {
             dispatch(
               addAlert({
-                name: "add-dnszone-error",
+                name: "add-dnsforwardzones-error",
                 title: error.message,
                 variant: "danger",
               })
@@ -96,8 +96,8 @@ const AddDnsForwardZoneModalInner = (props: PropsToAddModal) => {
           if (data) {
             dispatch(
               addAlert({
-                name: "add-dnszone-success",
-                title: "DNS Zone successfully added",
+                name: "add-dnsforwardzones-success",
+                title: "DNS forward zone successfully added",
                 variant: "success",
               })
             );
@@ -262,7 +262,8 @@ const AddDnsForwardZoneModalInner = (props: PropsToAddModal) => {
         (isReverseZoneIpRadioChecked && reverseZoneIP === "")
       }
       form="add-dns-forward-zone-modal-form"
-      onClick={() => {
+      onClick={(e) => {
+        e.preventDefault();
         setIsAddButtonSpinning(true);
         onAddDnsForwardZone();
       }}

--- a/src/components/modals/DnsZones/DeleteDnsForwardZonesModal.tsx
+++ b/src/components/modals/DnsZones/DeleteDnsForwardZonesModal.tsx
@@ -175,10 +175,13 @@ const DeleteDnsForwardZonesModal = (props: DeleteDnsForwardZonesModalProps) => {
 
   const modalActions: JSX.Element[] = [
     <Button
-      data-cy="modal-button-ok"
+      data-cy="modal-button-delete"
       key="delete-dnsforwardzones"
       variant="danger"
-      onClick={onDelete}
+      onClick={(e) => {
+        e.preventDefault();
+        onDelete();
+      }}
       form="delete-dnsforwardzones-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"

--- a/src/components/modals/DnsZones/EnableDisableDnsForwardZonesModal.tsx
+++ b/src/components/modals/DnsZones/EnableDisableDnsForwardZonesModal.tsx
@@ -50,7 +50,7 @@ const EnableDisableDnsForwardZonesModal = (
         if (data?.result) {
           dispatch(
             addAlert({
-              name: "success",
+              name: props.operation + "-dnsforwardzones-success",
               title: "DNS forward zone status changed",
               variant: "success",
             })
@@ -79,10 +79,13 @@ const EnableDisableDnsForwardZonesModal = (
 
   const modalActions: JSX.Element[] = [
     <Button
-      data-cy="modal-button-ok"
+      data-cy={"modal-button-" + props.operation}
       key={props.operation + "-dnsforwardzones"}
       variant="primary"
-      onClick={onEnableDisable}
+      onClick={(e) => {
+        e.preventDefault();
+        onEnableDisable();
+      }}
     >
       OK
     </Button>,

--- a/src/pages/DNSZones/DnsForwardZones.tsx
+++ b/src/pages/DNSZones/DnsForwardZones.tsx
@@ -332,7 +332,7 @@ const DnsForwardZones = () => {
       element: (
         <SecondaryButton
           isDisabled={isDeleteButtonDisabled || !showTableRows}
-          dataCy={"dns-forward-zones-delete"}
+          dataCy={"dns-forward-zones-button-delete"}
           onClickHandler={() => setShowDeleteForwardZonesModal(true)}
         >
           Delete

--- a/src/pages/DNSZones/DnsForwardZonesSettings.tsx
+++ b/src/pages/DNSZones/DnsForwardZonesSettings.tsx
@@ -194,7 +194,7 @@ const DnsForwardZonesSettings = (props: DnsForwardZonesSettingsProps) => {
               >
                 <FormGroup label="Zone name" role="idnsname">
                   <IpaTextInput
-                    dataCy="dns-zones-tab-settings-textbox-idnsname"
+                    dataCy="dns-forward-zones-tab-settings-textbox-idnsname"
                     name={"idnsname"}
                     ariaLabel={"Zone name text input"}
                     ipaObject={ipaObject}
@@ -205,7 +205,7 @@ const DnsForwardZonesSettings = (props: DnsForwardZonesSettingsProps) => {
                 </FormGroup>
                 <FormGroup label="Forwarders" role="idnsforwarders">
                   <IPAddressWithPortInputList
-                    dataCy="modal-textbox-forwarders"
+                    dataCy="dns-forward-zones-tab-settings-textbox-idnsforwarders"
                     name="idnsforwarders"
                     ariaLabel="Forwarders text input"
                     list={ipaObject.idnsforwarders}
@@ -216,6 +216,7 @@ const DnsForwardZonesSettings = (props: DnsForwardZonesSettingsProps) => {
                 </FormGroup>
                 <FormGroup label="Forward policy" role="idnsforwardpolicy">
                   <IpaForwardPolicy
+                    dataCy="dns-forward-zones-tab-settings"
                     name={"idnsforwardpolicy"}
                     ariaLabel={"Forward policy radio group"}
                     ipaObject={ipaObject}

--- a/src/pages/DNSZones/DnsGlobalConfig.tsx
+++ b/src/pages/DNSZones/DnsGlobalConfig.tsx
@@ -298,6 +298,7 @@ const DnsGlobalConfig = () => {
                   </FormGroup>
                   <FormGroup label="Forward policy" role="idnsforwardpolicy">
                     <IpaForwardPolicy
+                      dataCy="dns-global-config"
                       name={"idnsforwardpolicy"}
                       ariaLabel={"Forward policy radio group"}
                       ipaObject={ipaObject}

--- a/src/pages/DNSZones/DnsServersSettings.tsx
+++ b/src/pages/DNSZones/DnsServersSettings.tsx
@@ -239,6 +239,7 @@ const DnsServersSettings = (props: DnsServersSettingsProps) => {
                 </FormGroup>
                 <FormGroup label="Forward policy" role="idnsforwardpolicy">
                   <IpaForwardPolicy
+                    dataCy="dns-servers-tab-settings"
                     name={"idnsforwardpolicy"}
                     ariaLabel={"Forward policy radio group"}
                     ipaObject={ipaObject}

--- a/src/pages/DNSZones/DnsZonesSettings.tsx
+++ b/src/pages/DNSZones/DnsZonesSettings.tsx
@@ -550,6 +550,7 @@ const DnsZonesSettings = (props: DnsZonesSettingsProps) => {
                   </FormGroup>
                   <FormGroup label="Forward policy" role="idnsforwardpolicy">
                     <IpaForwardPolicy
+                      dataCy="dns-zones-tab-settings"
                       name={"idnsforwardpolicy"}
                       ariaLabel={"Forward policy radio group"}
                       ipaObject={ipaObject}


### PR DESCRIPTION
Contains also plenty of changes to make more sensible testing names.
Few changes to dnszones, and other tests, to make the components
reusable with different selector or to make them more consistent.
Fixes few form issues in the dns-forward-zones.

## Summary by Sourcery

Add comprehensive end-to-end coverage and supporting UI/test-id adjustments for DNS forward zones management and settings.

New Features:
- Add Cypress feature scenarios covering creation, deletion, enabling, disabling, and configuration of DNS forward zones, including reverse zones and overlap checks.
- Introduce dedicated settings scenarios for DNS forward zones to validate forwarders, ports, and forward policy changes.

Bug Fixes:
- Prevent form submission default behavior in DNS forward zone add, enable/disable, and delete modals to avoid unintended side effects.
- Correct alert identifiers and messages for DNS forward zone add, delete, enable, and disable operations for accurate user feedback.

Enhancements:
- Make IpaForwardPolicy reusable by parameterizing its data-cy prefix and align forward zone and regular zone settings test IDs.
- Standardize data-cy attributes across DNS forward zone list actions, settings inputs, and modal controls to support more robust UI automation.
- Adjust IPAddressWithPortInputList data-cy generation to be index-based instead of value-based for stable selector naming.