### PR TITLE
Fix blank Owner dropdown in "Add Subordinate ID" form

### DIFF
--- a/src/components/layouts/SimpleSelector.tsx
+++ b/src/components/layouts/SimpleSelector.tsx
@@ -20,6 +20,7 @@ interface PropsToSimpleSelector {
   options: SelectOptionProps[];
   onSelectedChange: (selected: string) => void;
   ariaLabel?: string;
+  noOptionsMessage?: string;
 }
 
 const SimpleSelector = (props: PropsToSimpleSelector) => {
@@ -67,17 +68,27 @@ const SimpleSelector = (props: PropsToSimpleSelector) => {
       isScrollable
     >
       <SelectList id={props.id + "-selector-list"}>
-        {props.options.map((option, idx) => (
+        {props.options.length === 0 ? (
           <SelectOption
-            data-cy={props.dataCy + "-select-" + option.key}
-            id={option.key + "-" + idx}
-            key={option.key + "-" + idx}
-            tabIndex={idx}
-            value={option.value}
+            data-cy={props.dataCy + "-select-no-options"}
+            isDisabled
+            value="no-options"
           >
-            {option.value}
+            {props.noOptionsMessage || "No options available"}
           </SelectOption>
-        ))}
+        ) : (
+          props.options.map((option, idx) => (
+            <SelectOption
+              data-cy={props.dataCy + "-select-" + option.key}
+              id={option.key + "-" + idx}
+              key={option.key + "-" + idx}
+              tabIndex={idx}
+              value={option.value}
+            >
+              {option.value}
+            </SelectOption>
+          ))
+        )}
       </SelectList>
     </Select>
   );

--- a/src/components/modals/SubIdsModals/AddModal.tsx
+++ b/src/components/modals/SubIdsModals/AddModal.tsx
@@ -176,6 +176,7 @@ const AddModal = (props: PropsToAddModal) => {
           }))}
           selected={selectedItem}
           onSelectedChange={(selected: string) => setSelectedItem(selected)}
+          noOptionsMessage="No owner available"
         />
       ),
       fieldRequired: true,


### PR DESCRIPTION
When all users already have a subordinate ID assigned, the Owner
dropdown rendered an empty SelectList, resulting in a broken UI.

Add empty-state handling to SimpleSelector with a configurable
noOptionsMessage prop that displays a disabled placeholder option
when no options are available. The SubId AddModal passes
"No owner available" for the Owner field.

Fixes: #981 

<img width="2550" height="1394" alt="Screenshot From 2026-04-13 11-26-42" src="https://github.com/user-attachments/assets/607d7e17-a3a2-42d4-ae6a-32b1f00a8990" />

## Summary by Sourcery

Handle empty owner selection state in the Subordinate ID add flow and hide password-related settings for staged users.

New Features:
- Add configurable empty-state messaging to SimpleSelector when no options are available.

Bug Fixes:
- Prevent the Owner dropdown in the Subordinate ID Add modal from rendering blank when no eligible owners exist by showing a disabled placeholder option.

Enhancements:
- Hide password policy and Kerberos ticket sections and their navigation links in user settings when viewing staged users.