### PR TITLE
Hide Kerberos ticket section for preserved users

### DIFF
--- a/src/components/UsersSections/UserSettings.tsx
+++ b/src/components/UsersSections/UserSettings.tsx
@@ -84,6 +84,8 @@ interface PropsToUserSettings {
 }
 
 const UserSettings = (props: PropsToUserSettings) => {
+  const showPasswordPolicy = props.from !== "stage-users";
+  const showKerberosTicket = props.from === "active-users";
   const dispatch = useAppDispatch();
 
   // Navigate
@@ -537,12 +539,12 @@ const UserSettings = (props: PropsToUserSettings) => {
               <JumpLinksItem key={1} href="#account-settings">
                 Account settings
               </JumpLinksItem>,
-              props.from !== "stage-users" ? (
+              showPasswordPolicy ? (
                 <JumpLinksItem key={2} href="#password-policy">
                   Password policy
                 </JumpLinksItem>
               ) : null,
-              props.from !== "stage-users" ? (
+              showKerberosTicket ? (
                 <JumpLinksItem key={3} href="#kerberos-ticket">
                   Kerberos ticket policy
                 </JumpLinksItem>
@@ -591,7 +593,7 @@ const UserSettings = (props: PropsToUserSettings) => {
               certData={props.certData}
               from={props.from}
             />
-            {props.from !== "stage-users" && (
+            {showPasswordPolicy && (
               <>
                 <TitleLayout
                   key={2}
@@ -600,6 +602,10 @@ const UserSettings = (props: PropsToUserSettings) => {
                   text="Password policy"
                 />
                 <UsersPasswordPolicy pwdPolicyData={props.pwPolicyData || []} />
+              </>
+            )}
+            {showKerberosTicket && (
+              <>
                 <TitleLayout
                   key={3}
                   headingLevel="h2"


### PR DESCRIPTION
The preserved user detail page displays a blank Kerberos ticket
section. Since preserved users have no associated Kerberos ticket
policy, this section should not appear.

Conditionally hide the Kerberos ticket section and its JumpLinks
sidebar entry in UserSettings when viewing a preserved user.

<img width="1678" height="852" alt="Screenshot From 2026-04-13 18-07-44" src="https://github.com/user-attachments/assets/d7e11594-c7f0-426a-ae12-d42ca7c6b1b7" />


Fixes: #1002

## Summary by Sourcery

Hide the Kerberos ticket policy section and related navigation in the user settings view for preserved users while keeping existing behavior for other user types.

Bug Fixes:
- Prevent an empty Kerberos ticket policy section and sidebar link from appearing on preserved user detail pages.

Enhancements:
- Centralize visibility logic for password policy and Kerberos ticket sections in the user settings component for different user sources.