### PR TITLE
fix certutil hint and CSR placeholder in IssueNewCertificate

### DIFF
--- a/src/components/modals/CertificateModals/IssueNewCertificate.tsx
+++ b/src/components/modals/CertificateModals/IssueNewCertificate.tsx
@@ -58,7 +58,6 @@ const IssueNewCertificate = (props: PropsToIssueNewCertificate) => {
   const ipaServerConfiguration = useAppSelector(
     (state) => state.global.ipaServerConfiguration
   );
-  const ipaMasterServer = ipaServerConfiguration.ipa_master_server as string;
   const ipaCertificateSubjectBase =
     ipaServerConfiguration.ipacertificatesubjectbase as string;
 
@@ -316,7 +315,7 @@ const IssueNewCertificate = (props: PropsToIssueNewCertificate) => {
             <i>CN=&lt;common name&gt;,O=&lt;realm&gt;</i>, for example: <br />
             <code>
               # certutil -R -d ~/certdb/ -a -g 4096 -s &apos;CN=
-              {ipaMasterServer},{ipaCertificateSubjectBase}
+              {props.id},{ipaCertificateSubjectBase}
               &apos;
             </code>
           </ListItem>
@@ -347,7 +346,7 @@ const IssueNewCertificate = (props: PropsToIssueNewCertificate) => {
           onChange={(_event, value) => setCertificate(value)}
           style={{ height: "250px" }}
           className="pf-u-mb-lg"
-          placeholder="Paste certificate text here"
+          placeholder="Paste certificate request here"
           autoFocus
         />
       ),


### PR DESCRIPTION
Replace ipaMasterServer with props.id in the certutil hint so the displayed CN matches the actual user, host, or service. Also update the textarea placeholder from "Paste certificate text here" to "Paste certificate request here" since the field expects a CSR, not a certificate. Remove the now-unused ipaMasterServer variable.

Fixes: https://github.com/freeipa/freeipa-webui/issues/1018

<img width="1066" height="963" alt="Screenshot From 2026-04-15 13-27-18" src="https://github.com/user-attachments/assets/ce692a43-2b7d-4ca0-b683-6adc141d0652" />

## Summary by Sourcery

Update IssueNewCertificate modal to show accurate certutil CN hint and correct CSR textarea placeholder.

Bug Fixes:
- Ensure the certutil command hint uses the actual entity ID instead of the IPA master server so the suggested CN matches the certificate subject.

Enhancements:
- Clarify the certificate request textarea placeholder to indicate it expects a certificate request (CSR) rather than a certificate.