### PR TITLE
fix jump-to-section navigation on automember settings page

### DIFF
--- a/src/pages/AutoMemUserRules/AutoMemSettings.tsx
+++ b/src/pages/AutoMemUserRules/AutoMemSettings.tsx
@@ -223,16 +223,16 @@ const AutoMemSettings = (props: PropsToSettings) => {
           <JumpLinks
             isVertical
             label="Jump to section"
-            scrollableSelector="#settings-page"
+            scrollableSelector="#automember-settings-page"
             expandable={{ default: "expandable", md: "nonExpandable" }}
           >
             <JumpLinksItem key={0} href="#rule-general">
               General
             </JumpLinksItem>
-            <JumpLinksItem key={1} href="#inclusive">
+            <JumpLinksItem key={1} href="#rule-inclusive">
               Inclusive
             </JumpLinksItem>
-            <JumpLinksItem key={2} href="#exclusive">
+            <JumpLinksItem key={2} href="#rule-exclusive">
               Exclusive
             </JumpLinksItem>
           </JumpLinks>


### PR DESCRIPTION
The JumpLinks sidebar on the automember rule settings page failed to scroll to sections or highlight the active link. Two problems caused this: the scrollableSelector pointed at "#settings-page", which does not exist on this page (the TabLayout uses id="automember-settings-page"), and the Inclusive/Exclusive JumpLinksItem href values ("#inclusive", "#exclusive") did not match their corresponding TitleLayout ids ("rule-inclusive", "rule-exclusive").

Align scrollableSelector with the actual TabLayout id and correct the two mismatched href fragments so PatternFly's scroll-spy and anchor navigation work as expected.

Fixes: https://github.com/freeipa/freeipa-webui/issues/953

## Summary by Sourcery

Bug Fixes:
- Correct the scrollable container selector and section anchor hrefs for the automember settings JumpLinks sidebar so scroll-spy and section navigation work properly.