### PR TITLE
add entity-specific search bar placeholders across all pages

### DIFF
--- a/src/components/ManagedBy/ManagedByHosts.tsx
+++ b/src/components/ManagedBy/ManagedByHosts.tsx
@@ -304,6 +304,8 @@ const ManagedByHosts = (props: ManagedByHostsProps) => {
         searchText={searchValue}
         onSearchTextChange={setSearchValue}
         onSearch={() => {}}
+        searchPlaceholder="Search hosts"
+        searchAriaLabel="Search hosts"
         refreshButtonEnabled={isRefreshButtonEnabled}
         onRefreshButtonClick={props.onRefreshData}
         deleteButtonEnabled={isDeleteEnabled}

--- a/src/components/MemberManagers/ManagersUserGroups.tsx
+++ b/src/components/MemberManagers/ManagersUserGroups.tsx
@@ -285,6 +285,8 @@ const ManagersUserGroups = (props: PropsToManagersUsergroups) => {
         searchText={searchValue}
         onSearchTextChange={setSearchValue}
         onSearch={() => {}}
+        searchPlaceholder="Search user groups"
+        searchAriaLabel="Search user groups"
         refreshButtonEnabled={isRefreshButtonEnabled}
         onRefreshButtonClick={props.onRefreshData}
         deleteButtonEnabled={userGroupsSelected.length > 0}

--- a/src/components/MemberManagers/ManagersUsers.tsx
+++ b/src/components/MemberManagers/ManagersUsers.tsx
@@ -281,6 +281,8 @@ const ManagersUsers = (props: PropsToManagersUsers) => {
         searchText={searchValue}
         onSearchTextChange={setSearchValue}
         onSearch={() => {}}
+        searchPlaceholder="Search users"
+        searchAriaLabel="Search users"
         refreshButtonEnabled={isRefreshButtonEnabled}
         onRefreshButtonClick={props.onRefreshData}
         deleteButtonEnabled={usersSelected.length > 0}

--- a/src/components/MemberOf/MemberOfHbacRules.tsx
+++ b/src/components/MemberOf/MemberOfHbacRules.tsx
@@ -310,6 +310,8 @@ const MemberOfHbacRules = (props: MemberOfHbacRulesProps) => {
         searchText={searchValue}
         onSearchTextChange={setSearchValue}
         onSearch={() => {}}
+        searchPlaceholder="Search HBAC rules"
+        searchAriaLabel="Search HBAC rules"
         refreshButtonEnabled={isRefreshButtonEnabled}
         onRefreshButtonClick={props.onRefreshData}
         deleteButtonEnabled={

--- a/src/components/MemberOf/MemberOfHbacServiceGroups.tsx
+++ b/src/components/MemberOf/MemberOfHbacServiceGroups.tsx
@@ -258,6 +258,8 @@ const MemberOfHbacServices = (props: MemberOfHbacServicesProps) => {
         searchText={searchValue}
         onSearchTextChange={setSearchValue}
         onSearch={() => {}}
+        searchPlaceholder="Search HBAC service groups"
+        searchAriaLabel="Search HBAC service groups"
         refreshButtonEnabled={isRefreshButtonEnabled}
         onRefreshButtonClick={props.onRefreshData}
         deleteButtonEnabled={hbacGroupsSelected.length > 0}

--- a/src/components/MemberOf/MemberOfHostGroups.tsx
+++ b/src/components/MemberOf/MemberOfHostGroups.tsx
@@ -296,6 +296,8 @@ const MemberOfHostGroups = (props: MemberOfHostGroupsProps) => {
         searchText={searchValue}
         onSearchTextChange={setSearchValue}
         onSearch={() => {}}
+        searchPlaceholder="Search host groups"
+        searchAriaLabel="Search host groups"
         refreshButtonEnabled={isRefreshButtonEnabled}
         onRefreshButtonClick={props.onRefreshData}
         deleteButtonEnabled={

--- a/src/components/MemberOf/MemberOfNetgroups.tsx
+++ b/src/components/MemberOf/MemberOfNetgroups.tsx
@@ -315,6 +315,8 @@ const memberOfNetgroups = (props: MemberOfNetgroupsProps) => {
           searchText={searchValue}
           onSearchTextChange={setSearchValue}
           onSearch={() => {}}
+          searchPlaceholder="Search netgroups"
+          searchAriaLabel="Search netgroups"
           refreshButtonEnabled={isRefreshButtonEnabled}
           onRefreshButtonClick={props.onRefreshData}
           deleteButtonEnabled={
@@ -340,6 +342,8 @@ const memberOfNetgroups = (props: MemberOfNetgroupsProps) => {
           searchText={searchValue}
           onSearchTextChange={setSearchValue}
           onSearch={() => {}}
+          searchPlaceholder="Search netgroups"
+          searchAriaLabel="Search netgroups"
           refreshButtonEnabled={isRefreshButtonEnabled}
           onRefreshButtonClick={props.onRefreshData}
           deleteButtonEnabled={

--- a/src/components/MemberOf/MemberOfRoles.tsx
+++ b/src/components/MemberOf/MemberOfRoles.tsx
@@ -295,6 +295,8 @@ const MemberOfRoles = (props: MemberOfRolesProps) => {
           searchText={searchValue}
           onSearchTextChange={setSearchValue}
           onSearch={() => {}}
+          searchPlaceholder="Search roles"
+          searchAriaLabel="Search roles"
           refreshButtonEnabled={isRefreshButtonEnabled}
           onRefreshButtonClick={props.onRefreshData}
           deleteButtonEnabled={
@@ -317,6 +319,8 @@ const MemberOfRoles = (props: MemberOfRolesProps) => {
           searchText={searchValue}
           onSearchTextChange={setSearchValue}
           onSearch={() => {}}
+          searchPlaceholder="Search roles"
+          searchAriaLabel="Search roles"
           refreshButtonEnabled={isRefreshButtonEnabled}
           onRefreshButtonClick={props.onRefreshData}
           deleteButtonEnabled={

--- a/src/components/MemberOf/MemberOfSudoCmdGroups.tsx
+++ b/src/components/MemberOf/MemberOfSudoCmdGroups.tsx
@@ -254,6 +254,8 @@ const MemberOfSudoCmdGroups = (props: MemberOfSudoCmdGroupsProps) => {
         searchText={searchValue}
         onSearchTextChange={setSearchValue}
         onSearch={() => {}}
+        searchPlaceholder="Search sudo command groups"
+        searchAriaLabel="Search sudo command groups"
         refreshButtonEnabled={isRefreshButtonEnabled}
         onRefreshButtonClick={props.onRefreshData}
         deleteButtonEnabled={sudoGroupsSelected.length > 0}

--- a/src/components/MemberOf/MemberOfSudoRules.tsx
+++ b/src/components/MemberOf/MemberOfSudoRules.tsx
@@ -302,6 +302,8 @@ const MemberOfSudoRules = (props: MemberOfSudoRulesProps) => {
         searchText={searchValue}
         onSearchTextChange={setSearchValue}
         onSearch={() => {}}
+        searchPlaceholder="Search sudo rules"
+        searchAriaLabel="Search sudo rules"
         refreshButtonEnabled={isRefreshButtonEnabled}
         onRefreshButtonClick={props.onRefreshData}
         deleteButtonEnabled={

--- a/src/components/MemberOf/MemberOfToolbar.tsx
+++ b/src/components/MemberOf/MemberOfToolbar.tsx
@@ -23,6 +23,8 @@ interface MemberOfToolbarProps {
   searchText: string;
   onSearchTextChange: (value: string) => void;
   onSearch: () => void;
+  searchPlaceholder: string;
+  searchAriaLabel: string;
 
   // buttons
   refreshButtonEnabled: boolean;
@@ -65,8 +67,8 @@ const MemberOfToolbar = (props: MemberOfToolbarProps) => {
           <SearchInputLayout
             dataCy="search"
             name="search"
-            ariaLabel="Search user"
-            placeholder="Search"
+            ariaLabel={props.searchAriaLabel}
+            placeholder={props.searchPlaceholder}
             searchValueData={{
               searchValue: props.searchText,
               updateSearchValue: props.onSearchTextChange,

--- a/src/components/MemberOf/MemberOfUserGroups.tsx
+++ b/src/components/MemberOf/MemberOfUserGroups.tsx
@@ -288,6 +288,8 @@ const MemberOfUserGroups = (props: MemberOfUserGroupsProps) => {
           searchText={searchValue}
           onSearchTextChange={setSearchValue}
           onSearch={() => {}}
+          searchPlaceholder="Search user groups"
+          searchAriaLabel="Search user groups"
           refreshButtonEnabled={isRefreshButtonEnabled}
           onRefreshButtonClick={props.onRefreshUserData}
           deleteButtonEnabled={

--- a/src/components/Members/MembersExternal.tsx
+++ b/src/components/Members/MembersExternal.tsx
@@ -229,6 +229,8 @@ const MembersExternal = (props: PropsToMembersExternal) => {
         searchText={searchValue}
         onSearchTextChange={setSearchValue}
         onSearch={() => {}}
+        searchPlaceholder="Search external members"
+        searchAriaLabel="Search external members"
         refreshButtonEnabled={isRefreshButtonEnabled}
         onRefreshButtonClick={props.onRefreshData}
         deleteButtonEnabled={isDeleteEnabled}

--- a/src/components/Members/MembersHbacServices.tsx
+++ b/src/components/Members/MembersHbacServices.tsx
@@ -261,6 +261,8 @@ const MembersHBACServices = (props: PropsToMembersHBACServices) => {
         searchText={searchValue}
         onSearchTextChange={setSearchValue}
         onSearch={() => {}}
+        searchPlaceholder="Search HBAC services"
+        searchAriaLabel="Search HBAC services"
         refreshButtonEnabled={isRefreshButtonEnabled}
         onRefreshButtonClick={props.onRefreshData}
         deleteButtonEnabled={membersSelected.length > 0}

--- a/src/components/Members/MembersHostGroups.tsx
+++ b/src/components/Members/MembersHostGroups.tsx
@@ -335,6 +335,8 @@ const MembersHostGroups = (props: PropsToMembersHostGroups) => {
           searchText={searchValue}
           onSearchTextChange={setSearchValue}
           onSearch={() => {}}
+          searchPlaceholder="Search host groups"
+          searchAriaLabel="Search host groups"
           refreshButtonEnabled={isRefreshButtonEnabled}
           onRefreshButtonClick={props.onRefreshData}
           deleteButtonEnabled={
@@ -357,6 +359,8 @@ const MembersHostGroups = (props: PropsToMembersHostGroups) => {
           searchText={searchValue}
           onSearchTextChange={setSearchValue}
           onSearch={() => {}}
+          searchPlaceholder="Search host groups"
+          searchAriaLabel="Search host groups"
           refreshButtonEnabled={isRefreshButtonEnabled}
           onRefreshButtonClick={props.onRefreshData}
           deleteButtonEnabled={

--- a/src/components/Members/MembersHosts.tsx
+++ b/src/components/Members/MembersHosts.tsx
@@ -321,6 +321,8 @@ const MembersHosts = (props: PropsToMembersHosts) => {
           searchText={searchValue}
           onSearchTextChange={setSearchValue}
           onSearch={() => {}}
+          searchPlaceholder="Search hosts"
+          searchAriaLabel="Search hosts"
           refreshButtonEnabled={isRefreshButtonEnabled}
           onRefreshButtonClick={props.onRefreshData}
           deleteButtonEnabled={
@@ -343,6 +345,8 @@ const MembersHosts = (props: PropsToMembersHosts) => {
           searchText={searchValue}
           onSearchTextChange={setSearchValue}
           onSearch={() => {}}
+          searchPlaceholder="Search hosts"
+          searchAriaLabel="Search hosts"
           refreshButtonEnabled={isRefreshButtonEnabled}
           onRefreshButtonClick={props.onRefreshData}
           deleteButtonEnabled={

--- a/src/components/Members/MembersNetgroups.tsx
+++ b/src/components/Members/MembersNetgroups.tsx
@@ -294,6 +294,8 @@ const MembersNetgroups = (props: PropsToMembersNetgroups) => {
         searchText={searchValue}
         onSearchTextChange={setSearchValue}
         onSearch={() => {}}
+        searchPlaceholder="Search netgroups"
+        searchAriaLabel="Search netgroups"
         refreshButtonEnabled={isRefreshButtonEnabled}
         onRefreshButtonClick={props.onRefreshData}
         deleteButtonEnabled={

--- a/src/components/Members/MembersServices.tsx
+++ b/src/components/Members/MembersServices.tsx
@@ -297,6 +297,8 @@ const MembersServices = (props: PropsToMembersServices) => {
           searchText={searchValue}
           onSearchTextChange={setSearchValue}
           onSearch={() => {}}
+          searchPlaceholder="Search services"
+          searchAriaLabel="Search services"
           refreshButtonEnabled={isRefreshButtonEnabled}
           onRefreshButtonClick={props.onRefreshData}
           deleteButtonEnabled={isDeleteEnabled}
@@ -315,6 +317,8 @@ const MembersServices = (props: PropsToMembersServices) => {
           searchText={searchValue}
           onSearchTextChange={setSearchValue}
           onSearch={() => {}}
+          searchPlaceholder="Search services"
+          searchAriaLabel="Search services"
           refreshButtonEnabled={isRefreshButtonEnabled}
           onRefreshButtonClick={props.onRefreshData}
           deleteButtonEnabled={

--- a/src/components/Members/MembersSudoCommands.tsx
+++ b/src/components/Members/MembersSudoCommands.tsx
@@ -239,6 +239,8 @@ const MembersSudoCommands = (props: PropsToMembersSudoGroups) => {
         searchText={searchValue}
         onSearchTextChange={setSearchValue}
         onSearch={() => {}}
+        searchPlaceholder="Search sudo commands"
+        searchAriaLabel="Search sudo commands"
         refreshButtonEnabled={isRefreshButtonEnabled}
         onRefreshButtonClick={props.onRefreshData}
         deleteButtonEnabled={membersSelected.length > 0}

--- a/src/components/Members/MembersUserGroups.tsx
+++ b/src/components/Members/MembersUserGroups.tsx
@@ -332,6 +332,8 @@ const MembersUserGroups = (props: PropsToMembersUsergroups) => {
           searchText={searchValue}
           onSearchTextChange={setSearchValue}
           onSearch={() => {}}
+          searchPlaceholder="Search user groups"
+          searchAriaLabel="Search user groups"
           refreshButtonEnabled={isRefreshButtonEnabled}
           onRefreshButtonClick={props.onRefreshData}
           deleteButtonEnabled={
@@ -354,6 +356,8 @@ const MembersUserGroups = (props: PropsToMembersUsergroups) => {
           searchText={searchValue}
           onSearchTextChange={setSearchValue}
           onSearch={() => {}}
+          searchPlaceholder="Search user groups"
+          searchAriaLabel="Search user groups"
           refreshButtonEnabled={isRefreshButtonEnabled}
           onRefreshButtonClick={props.onRefreshData}
           deleteButtonEnabled={

--- a/src/components/Members/MembersUsers.tsx
+++ b/src/components/Members/MembersUsers.tsx
@@ -325,6 +325,8 @@ const MembersUsers = (props: PropsToMembersUsers) => {
           searchText={searchValue}
           onSearchTextChange={setSearchValue}
           onSearch={() => {}}
+          searchPlaceholder="Search users"
+          searchAriaLabel="Search users"
           refreshButtonEnabled={isRefreshButtonEnabled}
           onRefreshButtonClick={props.onRefreshData}
           deleteButtonEnabled={
@@ -347,6 +349,8 @@ const MembersUsers = (props: PropsToMembersUsers) => {
           searchText={searchValue}
           onSearchTextChange={setSearchValue}
           onSearch={() => {}}
+          searchPlaceholder="Search users"
+          searchAriaLabel="Search users"
           refreshButtonEnabled={isRefreshButtonEnabled}
           onRefreshButtonClick={props.onRefreshData}
           deleteButtonEnabled={

--- a/src/pages/ActiveUsers/ActiveUsers.tsx
+++ b/src/pages/ActiveUsers/ActiveUsers.tsx
@@ -636,8 +636,8 @@ const ActiveUsers = () => {
         <SearchInputLayout
           dataCy="search"
           name="search"
-          ariaLabel="Search user"
-          placeholder="Search"
+          ariaLabel="Search users"
+          placeholder="Search users"
           searchValueData={searchValueData}
           isDisabled={searchDisabled}
         />

--- a/src/pages/AutoMemHostRules/AutoMemHostRules.tsx
+++ b/src/pages/AutoMemHostRules/AutoMemHostRules.tsx
@@ -520,8 +520,8 @@ const AutoMemHostRules = () => {
         <SearchInputLayout
           dataCy="search"
           name="search"
-          ariaLabel="Search rules"
-          placeholder="Search"
+          ariaLabel="Search host rules"
+          placeholder="Search host rules"
           searchValueData={searchValueData}
           isDisabled={searchDisabled}
         />

--- a/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
+++ b/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
@@ -518,8 +518,8 @@ const AutoMemUserRules = () => {
         <SearchInputLayout
           dataCy={"search"}
           name="search"
-          ariaLabel="Search rules"
-          placeholder="Search"
+          ariaLabel="Search user rules"
+          placeholder="Search user rules"
           searchValueData={searchValueData}
           isDisabled={searchDisabled}
         />

--- a/src/pages/CertificateMapping/CertificateMapping.tsx
+++ b/src/pages/CertificateMapping/CertificateMapping.tsx
@@ -370,7 +370,7 @@ const CertificateMappingPage = () => {
           dataCy="search"
           name="search"
           ariaLabel="Search certificate mapping rules"
-          placeholder="Search"
+          placeholder="Search certificate mapping rules"
           searchValueData={searchValueData}
           isDisabled={isSearchDisabled}
         />

--- a/src/pages/DNSZones/DnsForwardZones.tsx
+++ b/src/pages/DNSZones/DnsForwardZones.tsx
@@ -301,8 +301,8 @@ const DnsForwardZones = () => {
       element: (
         <SearchInputLayout
           name="search"
-          ariaLabel="Search dns zones"
-          placeholder="Search"
+          ariaLabel="Search DNS forward zones"
+          placeholder="Search DNS forward zones"
           searchValueData={searchValueData}
           isDisabled={isSearchDisabled}
           dataCy={"search"}

--- a/src/pages/DNSZones/DnsResourceRecords.tsx
+++ b/src/pages/DNSZones/DnsResourceRecords.tsx
@@ -320,7 +320,7 @@ const DnsResourceRecords = (props: DnsResourceRecordsProps) => {
         <SearchInputLayout
           name="search"
           ariaLabel="Search DNS records"
-          placeholder="Search"
+          placeholder="Search DNS records"
           searchValueData={searchValueData}
           isDisabled={isSearchDisabled}
           dataCy="search"

--- a/src/pages/DNSZones/DnsServers.tsx
+++ b/src/pages/DNSZones/DnsServers.tsx
@@ -206,8 +206,8 @@ const DnsServers = () => {
         <SearchInputLayout
           dataCy="search"
           name="search"
-          ariaLabel="Search dns servers"
-          placeholder="Search"
+          ariaLabel="Search DNS servers"
+          placeholder="Search DNS servers"
           searchValueData={searchValueData}
           isDisabled={isSearchDisabled}
         />

--- a/src/pages/DNSZones/DnsZones.tsx
+++ b/src/pages/DNSZones/DnsZones.tsx
@@ -339,8 +339,8 @@ const DnsZones = () => {
         <SearchInputLayout
           dataCy="search"
           name="search"
-          ariaLabel="Search dns zones"
-          placeholder="Search"
+          ariaLabel="Search DNS zones"
+          placeholder="Search DNS zones"
           searchValueData={searchValueData}
           isDisabled={isSearchDisabled}
         />

--- a/src/pages/HBACRules/HBACRules.tsx
+++ b/src/pages/HBACRules/HBACRules.tsx
@@ -480,8 +480,8 @@ const HBACRules = () => {
         <SearchInputLayout
           dataCy="search"
           name="search"
-          ariaLabel="Search user"
-          placeholder="Search"
+          ariaLabel="Search HBAC rules"
+          placeholder="Search HBAC rules"
           searchValueData={searchValueData}
           isDisabled={searchDisabled}
         />

--- a/src/pages/HBACServiceGroups/HBACServiceGroups.tsx
+++ b/src/pages/HBACServiceGroups/HBACServiceGroups.tsx
@@ -433,8 +433,8 @@ const HBACServiceGroups = () => {
         <SearchInputLayout
           dataCy="search"
           name="search"
-          ariaLabel="Search services"
-          placeholder="Search"
+          ariaLabel="Search HBAC service groups"
+          placeholder="Search HBAC service groups"
           searchValueData={searchValueData}
           isDisabled={searchDisabled}
         />

--- a/src/pages/HBACServices/HBACServices.tsx
+++ b/src/pages/HBACServices/HBACServices.tsx
@@ -429,8 +429,8 @@ const HBACServices = () => {
         <SearchInputLayout
           dataCy="search"
           name="search"
-          ariaLabel="Search services"
-          placeholder="Search"
+          ariaLabel="Search HBAC services"
+          placeholder="Search HBAC services"
           searchValueData={searchValueData}
           isDisabled={searchDisabled}
         />

--- a/src/pages/HostGroups/HostGroups.tsx
+++ b/src/pages/HostGroups/HostGroups.tsx
@@ -427,7 +427,7 @@ const HostGroups = () => {
           dataCy="search"
           name="search"
           ariaLabel="Search host groups"
-          placeholder="Search"
+          placeholder="Search host groups"
           searchValueData={searchValueData}
           isDisabled={searchDisabled}
         />

--- a/src/pages/Hosts/Hosts.tsx
+++ b/src/pages/Hosts/Hosts.tsx
@@ -566,7 +566,7 @@ const Hosts = () => {
           dataCy="search"
           name="search"
           ariaLabel="Search hosts"
-          placeholder="Search"
+          placeholder="Search hosts"
           searchValueData={searchValueData}
           isDisabled={searchDisabled}
         />

--- a/src/pages/IDViews/IDViews.tsx
+++ b/src/pages/IDViews/IDViews.tsx
@@ -560,7 +560,7 @@ const IDViews = () => {
           dataCy="search"
           name="search"
           ariaLabel="Search ID views"
-          placeholder="Search"
+          placeholder="Search ID views"
           searchValueData={searchValueData}
           isDisabled={searchDisabled}
         />

--- a/src/pages/IDViews/IDViewsOverrideGroups.tsx
+++ b/src/pages/IDViews/IDViewsOverrideGroups.tsx
@@ -331,7 +331,7 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
           dataCy="search"
           name="search"
           ariaLabel="Search groups"
-          placeholder="Search"
+          placeholder="Search groups"
           searchValueData={searchValueData}
           isDisabled={searchDisabled}
         />

--- a/src/pages/IDViews/IDViewsOverrideUsers.tsx
+++ b/src/pages/IDViews/IDViewsOverrideUsers.tsx
@@ -305,7 +305,7 @@ const IDViewsOverrideUsers = (props: PropsToOverrides) => {
           dataCy="search"
           name="search"
           ariaLabel="Search users"
-          placeholder="Search"
+          placeholder="Search users"
           searchValueData={searchValueData}
           isDisabled={searchDisabled}
         />

--- a/src/pages/IdPReferences/IdpReferences.tsx
+++ b/src/pages/IdPReferences/IdpReferences.tsx
@@ -350,8 +350,8 @@ const IdpReferences = () => {
         <SearchInputLayout
           dataCy="search"
           name="search"
-          ariaLabel="Search subIds"
-          placeholder="Search"
+          ariaLabel="Search IdP references"
+          placeholder="Search IdP references"
           searchValueData={searchValueData}
           isDisabled={isSearchDisabled}
         />

--- a/src/pages/IdRanges/IdRanges.tsx
+++ b/src/pages/IdRanges/IdRanges.tsx
@@ -290,7 +290,7 @@ const IdRanges = () => {
           dataCy="search"
           name="search"
           ariaLabel="Search ID ranges"
-          placeholder="Search"
+          placeholder="Search ID ranges"
           searchValueData={searchValueData}
           isDisabled={isSearchDisabled}
         />

--- a/src/pages/Netgroups/Netgroups.tsx
+++ b/src/pages/Netgroups/Netgroups.tsx
@@ -417,7 +417,7 @@ const Netgroups = () => {
           dataCy="search"
           name="search"
           ariaLabel="Search netgroups"
-          placeholder="Search"
+          placeholder="Search netgroups"
           searchValueData={searchValueData}
           isDisabled={searchDisabled}
         />

--- a/src/pages/PasswordPolicies/PasswordPolicies.tsx
+++ b/src/pages/PasswordPolicies/PasswordPolicies.tsx
@@ -385,8 +385,8 @@ const PasswordPolicies = () => {
         <SearchInputLayout
           dataCy="search"
           name="search"
-          ariaLabel="Search subIds"
-          placeholder="Search"
+          ariaLabel="Search password policies"
+          placeholder="Search password policies"
           searchValueData={searchValueData}
           isDisabled={searchIsDisabled}
         />

--- a/src/pages/PreservedUsers/PreservedUsers.tsx
+++ b/src/pages/PreservedUsers/PreservedUsers.tsx
@@ -442,8 +442,8 @@ const PreservedUsers = () => {
         <SearchInputLayout
           dataCy="search"
           name="search"
-          ariaLabel="Search user"
-          placeholder="Search"
+          ariaLabel="Search preserved users"
+          placeholder="Search preserved users"
           searchValueData={searchValueData}
           isDisabled={searchDisabled}
         />

--- a/src/pages/Services/Services.tsx
+++ b/src/pages/Services/Services.tsx
@@ -468,7 +468,7 @@ const Services = () => {
           dataCy="search"
           name="search"
           ariaLabel="Search services"
-          placeholder="Search"
+          placeholder="Search services"
           searchValueData={searchValueData}
           isDisabled={searchDisabled}
         />

--- a/src/pages/StageUsers/StageUsers.tsx
+++ b/src/pages/StageUsers/StageUsers.tsx
@@ -446,8 +446,8 @@ const StageUsers = () => {
         <SearchInputLayout
           dataCy="search"
           name="search"
-          ariaLabel="Search user"
-          placeholder="Search"
+          ariaLabel="Search stage users"
+          placeholder="Search stage users"
           searchValueData={searchValueData}
           isDisabled={searchDisabled}
         />

--- a/src/pages/SubordinateIDs/SubordinateIDs.tsx
+++ b/src/pages/SubordinateIDs/SubordinateIDs.tsx
@@ -272,8 +272,8 @@ const SubordinateIDs = () => {
         <SearchInputLayout
           dataCy="search"
           name="search"
-          ariaLabel="Search subIds"
-          placeholder="Search"
+          ariaLabel="Search subordinate IDs"
+          placeholder="Search subordinate IDs"
           searchValueData={searchValueData}
           isDisabled={searchDisabled}
         />

--- a/src/pages/SudoCmdGroups/SudoCmdGroups.tsx
+++ b/src/pages/SudoCmdGroups/SudoCmdGroups.tsx
@@ -422,8 +422,8 @@ const SudoCmds = () => {
         <SearchInputLayout
           dataCy="search"
           name="search"
-          ariaLabel="Search command groups"
-          placeholder="Search"
+          ariaLabel="Search sudo command groups"
+          placeholder="Search sudo command groups"
           searchValueData={searchValueData}
           isDisabled={searchDisabled}
         />

--- a/src/pages/SudoCmds/SudoCmds.tsx
+++ b/src/pages/SudoCmds/SudoCmds.tsx
@@ -423,8 +423,8 @@ const SudoCmds = () => {
         <SearchInputLayout
           dataCy="search"
           name="search"
-          ariaLabel="Search commands"
-          placeholder="Search"
+          ariaLabel="Search sudo commands"
+          placeholder="Search sudo commands"
           searchValueData={searchValueData}
           isDisabled={searchDisabled}
         />

--- a/src/pages/SudoRules/SudoRules.tsx
+++ b/src/pages/SudoRules/SudoRules.tsx
@@ -480,8 +480,8 @@ const SudoRules = () => {
         <SearchInputLayout
           dataCy="search"
           name="search"
-          ariaLabel="Search rules"
-          placeholder="Search"
+          ariaLabel="Search sudo rules"
+          placeholder="Search sudo rules"
           searchValueData={searchValueData}
           isDisabled={searchDisabled}
         />

--- a/src/pages/Trusts/TrustedDomains.tsx
+++ b/src/pages/Trusts/TrustedDomains.tsx
@@ -375,7 +375,7 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
           dataCy="search"
           name="search"
           ariaLabel="Search trusted domains"
-          placeholder="Search"
+          placeholder="Search trusted domains"
           searchValueData={searchValueData}
           isDisabled={isSearchDisabled}
         />

--- a/src/pages/Trusts/Trusts.tsx
+++ b/src/pages/Trusts/Trusts.tsx
@@ -313,7 +313,7 @@ const Trusts = () => {
           dataCy="search"
           name="search"
           ariaLabel="Search trusts"
-          placeholder="Search"
+          placeholder="Search trusts"
           searchValueData={searchValueData}
           isDisabled={isSearchDisabled}
         />

--- a/src/pages/UserGroups/UserGroups.tsx
+++ b/src/pages/UserGroups/UserGroups.tsx
@@ -420,7 +420,7 @@ const UserGroups = () => {
           dataCy="search"
           name="search"
           ariaLabel="Search user groups"
-          placeholder="Search"
+          placeholder="Search user groups"
           searchValueData={searchValueData}
           isDisabled={searchDisabled}
         />


### PR DESCRIPTION
The search bar on every list page displayed a generic "Search" placeholder, giving users no indication of what entity type the field filters. This made the UI less discoverable, especially on pages like Network Services or IPA Server tabs where the purpose of the input was ambiguous.

Every SearchInputLayout call site in src/pages/ now uses an entity-specific placeholder such as "Search users", "Search HBAC rules", or "Search DNS zones". Several copy-paste bugs in ariaLabel values were fixed in the same pass — notably HBACRules carried "Search user", PasswordPolicies and IdpReferences carried "Search subIds", and DnsForwardZones carried "Search dns zones" instead of the correct entity label.

The shared MemberOfToolbar component was parameterized with two new optional props, searchPlaceholder and searchAriaLabel, which default to "Search" for backward compatibility. All twenty consumer files across Members, MemberOf, MemberManagers, and ManagedBy now pass entity-specific values so that member relationship tabs also show contextual placeholders.

Fixes: https://github.com/freeipa/freeipa-webui/issues/1021

## Summary by Sourcery

Use contextual, entity-specific search text across list and membership views to improve discoverability and accessibility of search inputs.

New Features:
- Allow MemberOfToolbar to accept customizable search placeholder and aria-label text via optional props with sensible defaults.

Bug Fixes:
- Correct mismatched and misleading search aria-labels on several pages, such as HBAC rules, password policies, IdP references, and DNS forward zones.

Enhancements:
- Apply entity-specific search placeholders and aria-labels to search fields across user, group, host, DNS, sudo, HBAC, IdP, and related membership pages for a more descriptive UI.