### PR TITLE
 add variant='secondary' and standard tab props

### DIFF
--- a/src/pages/DNSZones/DnsServersTabs.tsx
+++ b/src/pages/DNSZones/DnsServersTabs.tsx
@@ -85,7 +85,15 @@ const DnsServersTabs = ({ section }: { section: string }) => {
         />
       </PageSection>
       <PageSection hasBodyWrapper={false} isFilled={false}>
-        <Tabs activeKey={section} onSelect={handleTabClick}>
+        <Tabs
+          activeKey={section}
+          onSelect={handleTabClick}
+          variant="secondary"
+          isBox
+          className="pf-v6-u-ml-lg"
+          mountOnEnter
+          unmountOnExit
+        >
           <Tab
             eventKey="settings"
             title={<TabTitleText>Settings</TabTitleText>}


### PR DESCRIPTION
The DnsServersTabs component was missing the variant="secondary", isBox, className, mountOnEnter, and unmountOnExit props on its Tabs component, making it visually inconsistent with every other *Tabs page in the project.

Add the same props that all sibling tab components already use: variant="secondary" for the underline tab style, isBox for the box border, pf-v6-u-ml-lg for left margin, and mountOnEnter/unmountOnExit for lazy rendering.

Fixes: https://github.com/freeipa/freeipa-webui/issues/914

## Summary by Sourcery

Align the DnsServersTabs component’s Tabs configuration with other tab pages for consistent styling and lazy rendering behavior.

Enhancements:
- Add secondary variant, boxed styling, and margin class to the DnsServersTabs Tabs component to match existing tab layouts.
- Enable mountOnEnter and unmountOnExit on DnsServersTabs to lazily render tab content and unmount inactive tabs.