### PR TITLE
improve Add Host modal validation and field labeling

### DIFF
--- a/src/components/modals/HostModals/AddHost.tsx
+++ b/src/components/modals/HostModals/AddHost.tsx
@@ -56,7 +56,7 @@ const AddHost = (props: PropsToAddHost) => {
   // The domain name should require at least two labels,
   // but IPA accepts names like 'a.b'.
   const validHostNameRegex =
-    /^([^-][a-zA-Z0-9-]*[^-]?)([.][^-][a-zA-Z0-9-]*[^-]?)+[.]?$/;
+    /^([a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]?)(\.([a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]?))+\.?$/;
 
   // Buttons are disabled until the user fills the required fields
   const [buttonDisabled, setButtonDisabled] = useState(true);
@@ -84,7 +84,7 @@ const AddHost = (props: PropsToAddHost) => {
   const fields = [
     {
       id: "modal-form-host-name",
-      name: "Host name",
+      name: "Host FQDN",
       pfComponent: (
         <>
           <InputWithValidation
@@ -94,11 +94,19 @@ const AddHost = (props: PropsToAddHost) => {
             value={hostName}
             onChange={setHostName}
             isRequired
+            placeholder="e.g. host.example.com"
             rules={[
               {
-                id: "valid-chars",
-                message: "Allowed characters are a-z, A-Z, 0-9, and -",
+                id: "valid-fqdn",
+                message:
+                  "Must be a fully qualified domain name with at least two labels separated by a dot",
                 validate: (value: string) => validHostNameRegex.test(value),
+              },
+              {
+                id: "valid-chars",
+                message:
+                  "Allowed characters: a-z, A-Z, 0-9, hyphen (-), and dot (.) as label separator",
+                validate: (value: string) => /^[a-zA-Z0-9.-]+$/.test(value),
               },
             ]}
           />


### PR DESCRIPTION
Rename "Host name" field label to "Host FQDN" in src/components/modals/HostModals/AddHost.tsx
Add placeholder "e.g. host.example.com" to the FQDN input field
Split the single validation rule into two: a FQDN structure check ("Must be a
fully qualified domain name with at least two labels separated by a dot") and
a character-set check ("Allowed characters: a-z, A-Z, 0-9, hyphen (-), and
dot (.) as label separator")
Fix validHostNameRegex to use [a-zA-Z0-9] instead of [^-] for label
boundary characters, preventing overly permissive matches

<img width="734" height="527" alt="Screenshot From 2026-04-23 19-40-10" src="https://github.com/user-attachments/assets/0f56318e-2b0d-4d1d-ad9a-93e8d1050903" />
<img width="734" height="527" alt="Screenshot From 2026-04-23 19-40-17" src="https://github.com/user-attachments/assets/f193b4d6-f3c4-42ec-8d63-ff7d1c01cea6" />

Fixes: #950