### PR TITLE
Normalize settings toolbar buttons to PatternFly pattern

### DIFF
--- a/src/components/UsersSections/UserSettings.tsx
+++ b/src/components/UsersSections/UserSettings.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 // PatternFly
 import {
+  Button,
   JumpLinks,
   JumpLinksItem,
   Flex,
@@ -21,7 +22,6 @@ import {
 // Layouts
 import TitleLayout from "src/components/layouts/TitleLayout";
 import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
-import SecondaryButton from "src/components/layouts/SecondaryButton";
 import KebabLayout from "src/components/layouts/KebabLayout";
 import TabLayout from "src/components/layouts/TabLayout";
 // Field sections
@@ -462,36 +462,39 @@ const UserSettings = (props: PropsToUserSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton
-          dataCy="user-tab-settings-button-refresh"
-          onClickHandler={props.onRefresh}
+        <Button
+          data-cy="user-tab-settings-button-refresh"
+          variant="secondary"
+          onClick={props.onRefresh}
         >
           Refresh
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 1,
       element: (
-        <SecondaryButton
-          dataCy="user-tab-settings-button-revert"
+        <Button
+          data-cy="user-tab-settings-button-revert"
+          variant="secondary"
           isDisabled={!props.isModified}
-          onClickHandler={onRevert}
+          onClick={onRevert}
         >
           Revert
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 2,
       element: (
-        <SecondaryButton
-          dataCy="user-tab-settings-button-save"
+        <Button
+          data-cy="user-tab-settings-button-save"
+          variant="primary"
           isDisabled={!props.isModified}
-          onClickHandler={onSave}
+          onClick={onSave}
         >
           Save
-        </SecondaryButton>
+        </Button>
       ),
     },
     {

--- a/src/pages/AutoMemUserRules/AutoMemSettings.tsx
+++ b/src/pages/AutoMemUserRules/AutoMemSettings.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 // PatternFly
 import {
+  Button,
   Flex,
   Form,
   FormGroup,
@@ -14,7 +15,6 @@ import {
 import IpaTextArea from "src/components/Form/IpaTextArea";
 // Layouts
 import TitleLayout from "src/components/layouts/TitleLayout";
-import SecondaryButton from "src/components/layouts/SecondaryButton";
 import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
 import TabLayout from "src/components/layouts/TabLayout";
 // Utils
@@ -112,7 +112,8 @@ const AutoMemSettings = (props: PropsToSettings) => {
   }, [props.automemberRule]);
 
   // 'Save' handler method
-  const onSave = () => {
+  const onSave = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     const modifiedValues = props.modifiedValues();
     const payload = {
       automemberId: props.automemberRule.cn?.toString(),
@@ -171,40 +172,43 @@ const AutoMemSettings = (props: PropsToSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton
-          dataCy="auto-member-tab-settings-button-refresh"
-          onClickHandler={props.onRefresh}
+        <Button
+          variant="secondary"
+          data-cy="auto-member-tab-settings-button-refresh"
+          onClick={props.onRefresh}
         >
           Refresh
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 1,
       element: (
-        <SecondaryButton
-          dataCy="auto-member-tab-settings-button-revert"
+        <Button
+          variant="secondary"
+          data-cy="auto-member-tab-settings-button-revert"
           isDisabled={!props.isModified}
-          onClickHandler={onRevert}
+          onClick={onRevert}
         >
           Revert
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 2,
       element: (
-        <SecondaryButton
-          dataCy="auto-member-tab-settings-button-save"
+        <Button
+          variant="primary"
+          data-cy="auto-member-tab-settings-button-save"
           isDisabled={!props.isModified || isSaving}
-          onClickHandler={onSave}
           isLoading={isSaving}
           spinnerAriaValueText="Saving"
-          spinnerAriaLabelledBy="Saving"
           spinnerAriaLabel="Saving"
+          type="submit"
+          form="auto-member-settings-form"
         >
           {isSaving ? "Saving" : "Save"}
-        </SecondaryButton>
+        </Button>
       ),
     },
   ];
@@ -245,7 +249,11 @@ const AutoMemSettings = (props: PropsToSettings) => {
               id="rule-general"
               text="General"
             />
-            <Form className="pf-v6-u-mt-sm pf-v6-u-mb-lg pf-v6-u-mr-md">
+            <Form
+              className="pf-v6-u-mt-sm pf-v6-u-mb-lg pf-v6-u-mr-md"
+              id="auto-member-settings-form"
+              onSubmit={onSave}
+            >
               <FormGroup label="Description" fieldId="description" role="group">
                 <IpaTextArea
                   dataCy="auto-member-tab-settings-textbox-description"

--- a/src/pages/CertificateMapping/CertificateMappingGlobalConfig.tsx
+++ b/src/pages/CertificateMapping/CertificateMappingGlobalConfig.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 // PatternFly
 import {
+  Button,
   Flex,
   FlexItem,
   Form,
@@ -28,7 +29,6 @@ import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
 import { NotFound } from "src/components/errors/PageErrors";
 import DataSpinner from "src/components/layouts/DataSpinner";
 import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
-import SecondaryButton from "src/components/layouts/SecondaryButton";
 import PageWithGrayBorderLayout from "src/components/layouts/PageWithGrayBorderLayout";
 import IpaCheckbox from "src/components/Form/IpaCheckbox";
 
@@ -72,7 +72,8 @@ const CertificateMappingGlobalConfig = () => {
   };
 
   // on Save handler method
-  const onSave = () => {
+  const onSave = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     setIsDataLoading(true);
     const modifiedValues = certMapConfigData.modifiedValues();
 
@@ -115,36 +116,40 @@ const CertificateMappingGlobalConfig = () => {
     {
       key: 0,
       element: (
-        <SecondaryButton
-          dataCy="certificate-mapping-global-config-button-refresh"
-          onClickHandler={certMapConfigData.refetch}
+        <Button
+          variant="secondary"
+          data-cy="certificate-mapping-global-config-button-refresh"
+          onClick={certMapConfigData.refetch}
         >
           Refresh
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 1,
       element: (
-        <SecondaryButton
-          dataCy="certificate-mapping-global-config-button-revert"
+        <Button
+          variant="secondary"
+          data-cy="certificate-mapping-global-config-button-revert"
           isDisabled={!certMapConfigData.modified || isDataLoading}
-          onClickHandler={onRevert}
+          onClick={onRevert}
         >
           Revert
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 2,
       element: (
-        <SecondaryButton
-          dataCy="certificate-mapping-global-config-button-save"
+        <Button
+          variant="primary"
+          data-cy="certificate-mapping-global-config-button-save"
           isDisabled={!certMapConfigData.modified || isDataLoading}
-          onClickHandler={onSave}
+          type="submit"
+          form="certificate-mapping-global-config-form"
         >
           Save
-        </SecondaryButton>
+        </Button>
       ),
     },
   ];
@@ -185,7 +190,11 @@ const CertificateMappingGlobalConfig = () => {
         <SidebarContent className="pf-v6-u-mr-xl">
           <Flex direction={{ default: "column", lg: "row" }}>
             <FlexItem flex={{ default: "flex_1" }}>
-              <Form className="pf-v6-u-mb-lg">
+              <Form
+                className="pf-v6-u-mb-lg"
+                id="certificate-mapping-global-config-form"
+                onSubmit={onSave}
+              >
                 <FormGroup fieldId="ipacertmappromptusername" role="group">
                   <IpaCheckbox
                     dataCy="certificate-mapping-global-config-checkbox-ipacertmappromptusername"

--- a/src/pages/CertificateMapping/CertificateMappingSettings.tsx
+++ b/src/pages/CertificateMapping/CertificateMappingSettings.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 // PatternFly
 import {
+  Button,
   DropdownItem,
   Flex,
   FlexItem,
@@ -32,7 +33,6 @@ import {
 // Components
 import IpaTextInput from "src/components/Form/IpaTextInput/IpaTextInput";
 import TabLayout from "src/components/layouts/TabLayout";
-import SecondaryButton from "src/components/layouts/SecondaryButton";
 import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
 import KebabLayout from "src/components/layouts/KebabLayout";
 import IpaTextArea from "src/components/Form/IpaTextArea";
@@ -119,7 +119,8 @@ const CertificateMappingSettings = (props: CertificateMappingSettingsProps) => {
   };
 
   // on Save handler method
-  const onSave = () => {
+  const onSave = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     setIsDataLoading(true);
     const modifiedValues = props.modifiedValues();
 
@@ -195,36 +196,40 @@ const CertificateMappingSettings = (props: CertificateMappingSettingsProps) => {
     {
       key: 0,
       element: (
-        <SecondaryButton
-          dataCy="certificate-mapping-tab-settings-button-refresh"
-          onClickHandler={props.onRefresh}
+        <Button
+          variant="secondary"
+          data-cy="certificate-mapping-tab-settings-button-refresh"
+          onClick={props.onRefresh}
         >
           Refresh
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 1,
       element: (
-        <SecondaryButton
-          dataCy="certificate-mapping-tab-settings-button-revert"
+        <Button
+          variant="secondary"
+          data-cy="certificate-mapping-tab-settings-button-revert"
           isDisabled={!props.isModified || isDataLoading}
-          onClickHandler={onRevert}
+          onClick={onRevert}
         >
           Revert
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 2,
       element: (
-        <SecondaryButton
-          dataCy="certificate-mapping-tab-settings-button-save"
+        <Button
+          variant="primary"
+          data-cy="certificate-mapping-tab-settings-button-save"
           isDisabled={!props.isModified || isDataLoading}
-          onClickHandler={onSave}
+          type="submit"
+          form="certificate-mapping-settings-form"
         >
           Save
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
@@ -276,7 +281,11 @@ const CertificateMappingSettings = (props: CertificateMappingSettingsProps) => {
           <SidebarContent className="pf-v6-u-mr-xl">
             <Flex direction={{ default: "column", lg: "row" }}>
               <FlexItem flex={{ default: "flex_1" }}>
-                <Form className="pf-v6-u-mb-lg">
+                <Form
+                  className="pf-v6-u-mb-lg"
+                  id="certificate-mapping-settings-form"
+                  onSubmit={onSave}
+                >
                   <FormGroup label="Rule name" role="group">
                     <IpaTextInput
                       dataCy="certificate-mapping-tab-settings-textbox-cn"

--- a/src/pages/Configuration/Configuration.tsx
+++ b/src/pages/Configuration/Configuration.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 // PatternFly
 import {
+  Button,
   Flex,
   FlexItem,
   JumpLinks,
@@ -14,7 +15,6 @@ import {
 import { useAppDispatch, useAppSelector } from "src/store/hooks";
 // Layouts
 import TitleLayout from "src/components/layouts/TitleLayout";
-import SecondaryButton from "src/components/layouts/SecondaryButton";
 import DataSpinner from "src/components/layouts/DataSpinner";
 // Components
 import ToolbarLayout from "src/components/layouts/ToolbarLayout";
@@ -206,40 +206,42 @@ const Configuration = () => {
     {
       key: 0,
       element: (
-        <SecondaryButton
-          dataCy="configuration-button-refresh"
-          onClickHandler={onRefresh}
+        <Button
+          data-cy="configuration-button-refresh"
+          variant="secondary"
+          onClick={onRefresh}
         >
           Refresh
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 1,
       element: (
-        <SecondaryButton
-          dataCy="configuration-button-revert"
+        <Button
+          data-cy="configuration-button-revert"
+          variant="secondary"
           isDisabled={!configData.modified}
-          onClickHandler={onRevert}
+          onClick={onRevert}
         >
           Revert
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 2,
       element: (
-        <SecondaryButton
-          dataCy="configuration-button-save"
+        <Button
+          data-cy="configuration-button-save"
+          variant="primary"
           isDisabled={!configData.modified || isSaving}
-          onClickHandler={onSave}
+          onClick={onSave}
           isLoading={isSaving}
           spinnerAriaValueText="Saving"
-          spinnerAriaLabelledBy="Saving"
           spinnerAriaLabel="Saving"
         >
           {isSaving ? "Saving" : "Save"}
-        </SecondaryButton>
+        </Button>
       ),
     },
   ];

--- a/src/pages/DNSZones/DnsGlobalConfig.tsx
+++ b/src/pages/DNSZones/DnsGlobalConfig.tsx
@@ -211,7 +211,6 @@ const DnsGlobalConfig = () => {
         <Button
           variant="primary"
           data-cy="dns-global-config-button-save"
-          onClick={onSave}
           isDisabled={!dnsConfigData.modified || isDataLoading}
           form="dns-global-config-form"
           type="submit"
@@ -272,7 +271,7 @@ const DnsGlobalConfig = () => {
           <SidebarContent className="pf-v6-u-mr-xl">
             <Flex>
               <FlexItem>
-                <Form id="dns-global-config-form">
+                <Form id="dns-global-config-form" onSubmit={onSave}>
                   <FormGroup label="Allow PTR sync" fieldId="idnsallowsyncptr">
                     <IpaCheckbox
                       ipaObject={ipaObject}

--- a/src/pages/DNSZones/DnsResourceRecordsSettings.tsx
+++ b/src/pages/DNSZones/DnsResourceRecordsSettings.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 // PatternFly
 import {
+  Button,
   Form,
   FormGroup,
   Sidebar,
@@ -25,7 +26,6 @@ import {
 // Utils
 import { dnsRecordAsRecord } from "src/utils/dnsRecordUtils";
 // Components
-import SecondaryButton from "src/components/layouts/SecondaryButton";
 import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
 import { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
 import TitleLayout from "src/components/layouts/TitleLayout";
@@ -89,7 +89,8 @@ const DnsResourceRecordsSettings = (props: DnsResourceRecordsSettingsProps) => {
   };
 
   // on save handler method
-  const onSave = () => {
+  const onSave = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     const modifiedValues = props.modifiedValues();
 
     const payload: ModDnsRecordPayload = {
@@ -130,36 +131,40 @@ const DnsResourceRecordsSettings = (props: DnsResourceRecordsSettingsProps) => {
     {
       key: 0,
       element: (
-        <SecondaryButton
-          dataCy="dns-zones-tab-settings-button-refresh"
-          onClickHandler={onRefresh}
+        <Button
+          variant="secondary"
+          data-cy="dns-zones-tab-settings-button-refresh"
+          onClick={onRefresh}
         >
           Refresh
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 1,
       element: (
-        <SecondaryButton
-          dataCy="dns-zones-tab-settings-button-revert"
+        <Button
+          variant="secondary"
+          data-cy="dns-zones-tab-settings-button-revert"
           isDisabled={!props.isModified || props.isDataLoading}
-          onClickHandler={onRevert}
+          onClick={onRevert}
         >
           Revert
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 2,
       element: (
-        <SecondaryButton
-          dataCy="dns-zones-tab-settings-button-save"
+        <Button
+          variant="primary"
+          data-cy="dns-zones-tab-settings-button-save"
           isDisabled={!props.isModified || props.isDataLoading}
-          onClickHandler={onSave}
+          type="submit"
+          form="dns-resource-records-settings-form"
         >
           Save
-        </SecondaryButton>
+        </Button>
       ),
     },
   ];
@@ -189,7 +194,12 @@ const DnsResourceRecordsSettings = (props: DnsResourceRecordsSettingsProps) => {
               headingLevel="h1"
               className="pf-v5-u-mb-lg"
             />
-            <Form className="pf-v5-u-mb-lg" isHorizontal>
+            <Form
+              className="pf-v5-u-mb-lg"
+              isHorizontal
+              id="dns-resource-records-settings-form"
+              onSubmit={onSave}
+            >
               <FormGroup label="Record name" role="idnsname">
                 <TextInput
                   data-cy="dns-zones-tab-settings-textbox-idnsname"

--- a/src/pages/DNSZones/DnsZonesSettings.tsx
+++ b/src/pages/DNSZones/DnsZonesSettings.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 // PatternFly
 import {
+  Button,
   DropdownItem,
   Flex,
   FlexItem,
@@ -34,7 +35,6 @@ import {
 // Components
 import IpaTextInput from "src/components/Form/IpaTextInput/IpaTextInput";
 import TabLayout from "src/components/layouts/TabLayout";
-import SecondaryButton from "src/components/layouts/SecondaryButton";
 import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
 import KebabLayout from "src/components/layouts/KebabLayout";
 import IpaTextArea from "src/components/Form/IpaTextArea";
@@ -156,7 +156,8 @@ const DnsZonesSettings = (props: DnsZonesSettingsProps) => {
   };
 
   // on Save handler method
-  const onSave = () => {
+  const onSave = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     setIsDataLoading(true);
     const modifiedValues = props.modifiedValues();
 
@@ -267,36 +268,40 @@ const DnsZonesSettings = (props: DnsZonesSettingsProps) => {
     {
       key: 0,
       element: (
-        <SecondaryButton
-          dataCy="dns-zones-tab-settings-button-refresh"
-          onClickHandler={props.onRefresh}
+        <Button
+          variant="secondary"
+          data-cy="dns-zones-tab-settings-button-refresh"
+          onClick={props.onRefresh}
         >
           Refresh
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 1,
       element: (
-        <SecondaryButton
-          dataCy="dns-zones-tab-settings-button-revert"
+        <Button
+          variant="secondary"
+          data-cy="dns-zones-tab-settings-button-revert"
           isDisabled={!props.isModified || isDataLoading}
-          onClickHandler={onRevert}
+          onClick={onRevert}
         >
           Revert
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 2,
       element: (
-        <SecondaryButton
-          dataCy="dns-zones-tab-settings-button-save"
+        <Button
+          variant="primary"
+          data-cy="dns-zones-tab-settings-button-save"
           isDisabled={!props.isModified || isDataLoading}
-          onClickHandler={onSave}
+          type="submit"
+          form="dns-zones-settings-form"
         >
           Save
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
@@ -342,7 +347,11 @@ const DnsZonesSettings = (props: DnsZonesSettingsProps) => {
           <SidebarContent className="pf-v6-u-mr-xl">
             <Flex direction={{ default: "column", lg: "row" }}>
               <FlexItem flex={{ default: "flex_1" }}>
-                <Form className="pf-v6-u-mb-lg">
+                <Form
+                  className="pf-v6-u-mb-lg"
+                  id="dns-zones-settings-form"
+                  onSubmit={onSave}
+                >
                   <FormGroup label="Zone name" role="idnsname">
                     <IpaTextInput
                       dataCy="dns-zones-tab-settings-textbox-idnsname"

--- a/src/pages/HBACRules/HBACRulesSettings.tsx
+++ b/src/pages/HBACRules/HBACRulesSettings.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 // PatternFly
 import {
+  Button,
   Flex,
   Form,
   FormGroup,
@@ -22,7 +23,6 @@ import IpaTextArea from "src/components/Form/IpaTextArea";
 import IpaCheckbox from "src/components/Form/IpaCheckbox";
 // Layouts
 import TitleLayout from "src/components/layouts/TitleLayout";
-import SecondaryButton from "src/components/layouts/SecondaryButton";
 import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
 import TabLayout from "src/components/layouts/TabLayout";
 // Utils
@@ -129,7 +129,8 @@ const HBACRulesSettings = (props: PropsToSettings) => {
   const [isSaving, setSaving] = useState(false);
 
   // 'Save' handler method
-  const onSave = () => {
+  const onSave = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     const modifiedValues = props.modifiedValues();
     const payload = {
       groupName: cn,
@@ -193,40 +194,43 @@ const HBACRulesSettings = (props: PropsToSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton
-          dataCy="hbac-rules-tab-settings-button-refresh"
-          onClickHandler={props.onRefresh}
+        <Button
+          variant="secondary"
+          data-cy="hbac-rules-tab-settings-button-refresh"
+          onClick={props.onRefresh}
         >
           Refresh
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 1,
       element: (
-        <SecondaryButton
-          dataCy="hbac-rules-tab-settings-button-revert"
+        <Button
+          variant="secondary"
+          data-cy="hbac-rules-tab-settings-button-revert"
           isDisabled={!props.isModified}
-          onClickHandler={onRevert}
+          onClick={onRevert}
         >
           Revert
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 2,
       element: (
-        <SecondaryButton
-          dataCy="hbac-rules-tab-settings-button-save"
+        <Button
+          variant="primary"
+          data-cy="hbac-rules-tab-settings-button-save"
           isDisabled={!props.isModified || isSaving}
-          onClickHandler={onSave}
+          type="submit"
+          form="hbac-rules-settings-form"
           isLoading={isSaving}
           spinnerAriaValueText="Saving"
-          spinnerAriaLabelledBy="Saving"
           spinnerAriaLabel="Saving"
         >
           {isSaving ? "Saving" : "Save"}
-        </SecondaryButton>
+        </Button>
       ),
     },
   ];
@@ -280,7 +284,11 @@ const HBACRulesSettings = (props: PropsToSettings) => {
               id="hbacrule-settings"
               text="HBAC rule settings"
             />
-            <Form className="pf-v6-u-mt-sm pf-v6-u-mb-lg pf-v6-u-mr-md">
+            <Form
+              className="pf-v6-u-mt-sm pf-v6-u-mb-lg pf-v6-u-mr-md"
+              id="hbac-rules-settings-form"
+              onSubmit={onSave}
+            >
               <FormGroup label="Description" fieldId="description">
                 <IpaTextArea
                   dataCy="hbac-rules-tab-settings-textbox-description"

--- a/src/pages/HBACServiceGroups/HBACServiceGroupsSettings.tsx
+++ b/src/pages/HBACServiceGroups/HBACServiceGroupsSettings.tsx
@@ -1,11 +1,10 @@
 import React, { useState } from "react";
 // PatternFly
-import { Flex, Form, FormGroup } from "@patternfly/react-core";
+import { Button, Flex, Form, FormGroup } from "@patternfly/react-core";
 // Forms
 import IpaTextArea from "src/components/Form/IpaTextArea";
 // Layouts
 import TitleLayout from "src/components/layouts/TitleLayout";
-import SecondaryButton from "src/components/layouts/SecondaryButton";
 import TabLayout from "src/components/layouts/TabLayout";
 // Utils
 import { asRecord } from "../../utils/hostUtils";
@@ -53,7 +52,8 @@ const HBACServiceGroupsSettings = (props: PropsToSettings) => {
   const [isSaving, setSaving] = useState(false);
 
   // 'Save' handler method
-  const onSave = () => {
+  const onSave = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     const modifiedValues = props.modifiedValues();
     modifiedValues.cn = props.svcGroup.cn;
     setSaving(true);
@@ -105,40 +105,43 @@ const HBACServiceGroupsSettings = (props: PropsToSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton
-          dataCy="hbac-service-groups-tab-settings-button-refresh"
-          onClickHandler={props.onRefresh}
+        <Button
+          variant="secondary"
+          data-cy="hbac-service-groups-tab-settings-button-refresh"
+          onClick={props.onRefresh}
         >
           Refresh
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 1,
       element: (
-        <SecondaryButton
-          dataCy="hbac-service-groups-tab-settings-button-revert"
+        <Button
+          variant="secondary"
+          data-cy="hbac-service-groups-tab-settings-button-revert"
           isDisabled={!props.isModified}
-          onClickHandler={onRevert}
+          onClick={onRevert}
         >
           Revert
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 2,
       element: (
-        <SecondaryButton
-          dataCy="hbac-service-groups-tab-settings-button-save"
+        <Button
+          variant="primary"
+          data-cy="hbac-service-groups-tab-settings-button-save"
           isDisabled={!props.isModified || isSaving}
-          onClickHandler={onSave}
+          type="submit"
+          form="hbac-service-groups-settings-form"
           isLoading={isSaving}
           spinnerAriaValueText="Saving"
-          spinnerAriaLabelledBy="Saving"
           spinnerAriaLabel="Saving"
         >
           {isSaving ? "Saving" : "Save"}
-        </SecondaryButton>
+        </Button>
       ),
     },
   ];
@@ -153,7 +156,11 @@ const HBACServiceGroupsSettings = (props: PropsToSettings) => {
           id="hbacservice-group-settings"
           text="HBAC service group settings"
         />
-        <Form className="pf-v6-u-mt-sm pf-v6-u-mb-lg pf-v6-u-mr-md">
+        <Form
+          className="pf-v6-u-mt-sm pf-v6-u-mb-lg pf-v6-u-mr-md"
+          id="hbac-service-groups-settings-form"
+          onSubmit={onSave}
+        >
           <FormGroup label="Description" fieldId="description">
             <IpaTextArea
               dataCy="hbac-service-groups-tab-settings-textbox-description"

--- a/src/pages/HBACServices/HBACServicesSettings.tsx
+++ b/src/pages/HBACServices/HBACServicesSettings.tsx
@@ -1,11 +1,10 @@
 import React, { useState } from "react";
 // PatternFly
-import { Flex, Form, FormGroup } from "@patternfly/react-core";
+import { Button, Flex, Form, FormGroup } from "@patternfly/react-core";
 // Forms
 import IpaTextArea from "src/components/Form/IpaTextArea";
 // Layouts
 import TitleLayout from "src/components/layouts/TitleLayout";
-import SecondaryButton from "src/components/layouts/SecondaryButton";
 import TabLayout from "src/components/layouts/TabLayout";
 // Utils
 import { asRecord } from "../../utils/hostUtils";
@@ -50,7 +49,8 @@ const HBACServicesSettings = (props: PropsToSettings) => {
   const [isSaving, setSaving] = useState(false);
 
   // 'Save' handler method
-  const onSave = () => {
+  const onSave = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     const modifiedValues = props.modifiedValues();
     modifiedValues.cn = props.service.cn;
     setSaving(true);
@@ -102,40 +102,43 @@ const HBACServicesSettings = (props: PropsToSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton
-          dataCy="hbac-services-tab-settings-button-refresh"
-          onClickHandler={props.onRefresh}
+        <Button
+          variant="secondary"
+          data-cy="hbac-services-tab-settings-button-refresh"
+          onClick={props.onRefresh}
         >
           Refresh
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 1,
       element: (
-        <SecondaryButton
-          dataCy="hbac-services-tab-settings-button-revert"
+        <Button
+          variant="secondary"
+          data-cy="hbac-services-tab-settings-button-revert"
           isDisabled={!props.isModified}
-          onClickHandler={onRevert}
+          onClick={onRevert}
         >
           Revert
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 2,
       element: (
-        <SecondaryButton
-          dataCy="hbac-services-tab-settings-button-save"
+        <Button
+          variant="primary"
+          data-cy="hbac-services-tab-settings-button-save"
           isDisabled={!props.isModified || isSaving}
-          onClickHandler={onSave}
+          type="submit"
+          form="hbac-services-settings-form"
           isLoading={isSaving}
           spinnerAriaValueText="Saving"
-          spinnerAriaLabelledBy="Saving"
           spinnerAriaLabel="Saving"
         >
           {isSaving ? "Saving" : "Save"}
-        </SecondaryButton>
+        </Button>
       ),
     },
   ];
@@ -150,7 +153,11 @@ const HBACServicesSettings = (props: PropsToSettings) => {
           id="hbacservice-settings"
           text="HBAC service settings"
         />
-        <Form className="pf-v6-u-mt-sm pf-v6-u-mb-lg pf-v6-u-mr-md">
+        <Form
+          className="pf-v6-u-mt-sm pf-v6-u-mb-lg pf-v6-u-mr-md"
+          id="hbac-services-settings-form"
+          onSubmit={onSave}
+        >
           <FormGroup label="Description" fieldId="description">
             <IpaTextArea
               dataCy="hbac-services-tab-settings-textbox-description"

--- a/src/pages/HostGroups/HostGroupsSettings.tsx
+++ b/src/pages/HostGroups/HostGroupsSettings.tsx
@@ -1,11 +1,10 @@
 import React, { useState } from "react";
 // PatternFly
-import { Flex, Form, FormGroup } from "@patternfly/react-core";
+import { Button, Flex, Form, FormGroup } from "@patternfly/react-core";
 // Forms
 import IpaTextArea from "../../components/Form/IpaTextArea";
 // Layouts
 import TitleLayout from "src/components/layouts/TitleLayout";
-import SecondaryButton from "src/components/layouts/SecondaryButton";
 import TabLayout from "src/components/layouts/TabLayout";
 // Utils
 import { asRecord } from "../../utils/hostUtils";
@@ -50,7 +49,8 @@ const HostGroupsSettings = (props: PropsToGroupsSettings) => {
   );
 
   // 'Save' handler method
-  const onSave = () => {
+  const onSave = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     const modifiedValues = props.modifiedValues();
     modifiedValues.cn = props.hostGroup.cn;
     setSaving(true);
@@ -101,40 +101,43 @@ const HostGroupsSettings = (props: PropsToGroupsSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton
-          dataCy="host-groups-tab-settings-button-refresh"
-          onClickHandler={props.onRefresh}
+        <Button
+          variant="secondary"
+          data-cy="host-groups-tab-settings-button-refresh"
+          onClick={props.onRefresh}
         >
           Refresh
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 1,
       element: (
-        <SecondaryButton
-          dataCy="host-groups-tab-settings-button-revert"
+        <Button
+          variant="secondary"
+          data-cy="host-groups-tab-settings-button-revert"
           isDisabled={!props.isModified}
-          onClickHandler={onRevert}
+          onClick={onRevert}
         >
           Revert
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 2,
       element: (
-        <SecondaryButton
-          dataCy="host-groups-tab-settings-button-save"
+        <Button
+          variant="primary"
+          data-cy="host-groups-tab-settings-button-save"
           isDisabled={!props.isModified || isSaving}
-          onClickHandler={onSave}
+          type="submit"
+          form="host-groups-settings-form"
           isLoading={isSaving}
           spinnerAriaValueText="Saving"
-          spinnerAriaLabelledBy="Saving"
           spinnerAriaLabel="Saving"
         >
           {isSaving ? "Saving" : "Save"}
-        </SecondaryButton>
+        </Button>
       ),
     },
   ];
@@ -152,6 +155,8 @@ const HostGroupsSettings = (props: PropsToGroupsSettings) => {
         <Form
           className="pf-v6-u-mt-sm pf-v6-u-mb-lg pf-v6-u-mr-md"
           isHorizontal
+          id="host-groups-settings-form"
+          onSubmit={onSave}
         >
           <FormGroup label="Description" fieldId="description">
             <IpaTextArea

--- a/src/pages/Hosts/HostsSettings.tsx
+++ b/src/pages/Hosts/HostsSettings.tsx
@@ -29,7 +29,6 @@ import ConfirmationModal from "src/components/modals/ConfirmationModal";
 // Layouts
 import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
 import TitleLayout from "src/components/layouts/TitleLayout";
-import SecondaryButton from "src/components/layouts/SecondaryButton";
 import KebabLayout from "src/components/layouts/KebabLayout";
 import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
 import TabLayout from "src/components/layouts/TabLayout";
@@ -360,40 +359,42 @@ const HostsSettings = (props: PropsToHostsSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton
-          dataCy="hosts-tab-settings-button-refresh"
-          onClickHandler={props.onRefresh}
+        <Button
+          data-cy="hosts-tab-settings-button-refresh"
+          variant="secondary"
+          onClick={props.onRefresh}
         >
           Refresh
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 1,
       element: (
-        <SecondaryButton
-          dataCy="hosts-tab-settings-button-revert"
+        <Button
+          data-cy="hosts-tab-settings-button-revert"
+          variant="secondary"
           isDisabled={!props.isModified}
-          onClickHandler={onRevert}
+          onClick={onRevert}
         >
           Revert
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 2,
       element: (
-        <SecondaryButton
-          dataCy="hosts-tab-settings-button-save"
+        <Button
+          data-cy="hosts-tab-settings-button-save"
+          variant="primary"
           isDisabled={!props.isModified || isSaving}
-          onClickHandler={onSave}
+          onClick={onSave}
           isLoading={isSaving}
           spinnerAriaValueText="Saving"
-          spinnerAriaLabelledBy="Saving"
           spinnerAriaLabel="Saving"
         >
           {isSaving ? "Saving" : "Save"}
-        </SecondaryButton>
+        </Button>
       ),
     },
     {

--- a/src/pages/IDViews/IDViewsSettings.tsx
+++ b/src/pages/IDViews/IDViewsSettings.tsx
@@ -1,12 +1,18 @@
 import React, { useState } from "react";
 // PatternFly
-import { Flex, Form, FormGroup, Icon, Tooltip } from "@patternfly/react-core";
+import {
+  Button,
+  Flex,
+  Form,
+  FormGroup,
+  Icon,
+  Tooltip,
+} from "@patternfly/react-core";
 // Forms
 import IpaTextArea from "../../components/Form/IpaTextArea";
 import IpaTextInput from "src/components/Form/IpaTextInput";
 // Layouts
 import TitleLayout from "src/components/layouts/TitleLayout";
-import SecondaryButton from "src/components/layouts/SecondaryButton";
 import TabLayout from "src/components/layouts/TabLayout";
 // Utils
 import { asRecord } from "../../utils/hostUtils";
@@ -55,7 +61,8 @@ const IDViewSettings = (props: PropsToIDViewSettings) => {
   );
 
   // 'Save' handler method
-  const onSave = () => {
+  const onSave = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     const modifiedValues = props.modifiedValues();
     modifiedValues.cn = props.idView.cn;
     setSaving(true);
@@ -106,40 +113,43 @@ const IDViewSettings = (props: PropsToIDViewSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton
-          dataCy="id-views-tab-settings-button-refresh"
-          onClickHandler={props.onRefresh}
+        <Button
+          variant="secondary"
+          data-cy="id-views-tab-settings-button-refresh"
+          onClick={props.onRefresh}
         >
           Refresh
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 1,
       element: (
-        <SecondaryButton
-          dataCy="id-views-tab-settings-button-revert"
+        <Button
+          variant="secondary"
+          data-cy="id-views-tab-settings-button-revert"
           isDisabled={!props.isModified}
-          onClickHandler={onRevert}
+          onClick={onRevert}
         >
           Revert
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 2,
       element: (
-        <SecondaryButton
-          dataCy="id-views-tab-settings-button-save"
+        <Button
+          variant="primary"
+          data-cy="id-views-tab-settings-button-save"
           isDisabled={!props.isModified || isSaving}
-          onClickHandler={onSave}
           isLoading={isSaving}
           spinnerAriaValueText="Saving"
-          spinnerAriaLabelledBy="Saving"
           spinnerAriaLabel="Saving"
+          type="submit"
+          form="id-views-settings-form"
         >
           {isSaving ? "Saving" : "Save"}
-        </SecondaryButton>
+        </Button>
       ),
     },
   ];
@@ -157,6 +167,8 @@ const IDViewSettings = (props: PropsToIDViewSettings) => {
         <Form
           className="pf-v6-u-mt-sm pf-v6-u-mb-lg pf-v6-u-mr-md"
           isHorizontal
+          id="id-views-settings-form"
+          onSubmit={onSave}
         >
           <FormGroup
             label="Domain resolution order"

--- a/src/pages/IdPReferences/IdpReferencesSettings.tsx
+++ b/src/pages/IdPReferences/IdpReferencesSettings.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 // PatternFly
 import {
+  Button,
   DropdownItem,
   Flex,
   FlexItem,
@@ -28,7 +29,6 @@ import { IdpModPayload, useIdpModMutation } from "src/services/rpcIdp";
 // Components
 import IpaTextInput from "src/components/Form/IpaTextInput/IpaTextInput";
 import TabLayout from "src/components/layouts/TabLayout";
-import SecondaryButton from "src/components/layouts/SecondaryButton";
 import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
 import IpaTextContent from "src/components/Form/IpaTextContent/IpaTextContent";
 import TitleLayout from "src/components/layouts/TitleLayout";
@@ -103,7 +103,8 @@ const IdpRefSettings = (props: PropsToIdpRefSettings) => {
   };
 
   // on Save handler method
-  const onSave = () => {
+  const onSave = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     setIsDataLoading(true);
     const modifiedValues = props.modifiedValues();
 
@@ -172,36 +173,40 @@ const IdpRefSettings = (props: PropsToIdpRefSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton
-          dataCy="idp-references-tab-settings-button-refresh"
-          onClickHandler={props.onRefresh}
+        <Button
+          variant="secondary"
+          data-cy="idp-references-tab-settings-button-refresh"
+          onClick={props.onRefresh}
         >
           Refresh
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 1,
       element: (
-        <SecondaryButton
-          dataCy="idp-references-tab-settings-button-revert"
+        <Button
+          variant="secondary"
+          data-cy="idp-references-tab-settings-button-revert"
           isDisabled={!props.isModified || isDataLoading}
-          onClickHandler={onRevert}
+          onClick={onRevert}
         >
           Revert
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 2,
       element: (
-        <SecondaryButton
-          dataCy="idp-references-tab-settings-button-save"
+        <Button
+          variant="primary"
+          data-cy="idp-references-tab-settings-button-save"
           isDisabled={!props.isModified || isDataLoading}
-          onClickHandler={onSave}
+          type="submit"
+          form="idp-references-settings-form"
         >
           Save
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
@@ -258,7 +263,11 @@ const IdpRefSettings = (props: PropsToIdpRefSettings) => {
             />
             <Flex direction={{ default: "column", lg: "row" }}>
               <FlexItem flex={{ default: "flex_1" }}>
-                <Form className="pf-v6-u-mb-lg">
+                <Form
+                  className="pf-v6-u-mb-lg"
+                  id="idp-references-settings-form"
+                  onSubmit={onSave}
+                >
                   <FormGroup
                     label="Identity Provider reference name"
                     role="group"

--- a/src/pages/IdRanges/IdRangesSettings.tsx
+++ b/src/pages/IdRanges/IdRangesSettings.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 // PatternFly
 import {
+  Button,
   Flex,
   FlexItem,
   Form,
@@ -18,7 +19,6 @@ import useUpdateRoute from "src/hooks/useUpdateRoute";
 import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
 // Components
 import TabLayout from "src/components/layouts/TabLayout";
-import SecondaryButton from "src/components/layouts/SecondaryButton";
 import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
 
 interface IdRangesSettingsProps {
@@ -49,12 +49,13 @@ const IdRangesSettings = (props: IdRangesSettingsProps) => {
     {
       key: 0,
       element: (
-        <SecondaryButton
-          dataCy="id-ranges-tab-settings-button-refresh"
-          onClickHandler={props.onRefresh}
+        <Button
+          variant="secondary"
+          data-cy="id-ranges-tab-settings-button-refresh"
+          onClick={props.onRefresh}
         >
           Refresh
-        </SecondaryButton>
+        </Button>
       ),
     },
   ];

--- a/src/pages/KrbTicketPolicy/KrbTicketPolicy.tsx
+++ b/src/pages/KrbTicketPolicy/KrbTicketPolicy.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 // PatternFly
 import {
+  Button,
   Flex,
   FlexItem,
   Form,
@@ -32,7 +33,6 @@ import DataSpinner from "src/components/layouts/DataSpinner";
 import TitleLayout from "src/components/layouts/TitleLayout";
 import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
 import { asRecord } from "src/utils/krbTicketUtils";
-import SecondaryButton from "src/components/layouts/SecondaryButton";
 import IpaTextInput from "src/components/Form/IpaTextInput";
 import PageWithGrayBorderLayout from "src/components/layouts/PageWithGrayBorderLayout";
 
@@ -96,7 +96,8 @@ const KrbTicketPolicy = () => {
   };
 
   // on Save handler method
-  const onSave = () => {
+  const onSave = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     setIsDataLoading(true);
     const modifiedValues = krbTicketPolicyData.modifiedValues();
 
@@ -152,36 +153,40 @@ const KrbTicketPolicy = () => {
     {
       key: 0,
       element: (
-        <SecondaryButton
-          dataCy="krb-ticket-policy-button-refresh"
-          onClickHandler={krbTicketPolicyData.refetch}
+        <Button
+          variant="secondary"
+          data-cy="krb-ticket-policy-button-refresh"
+          onClick={krbTicketPolicyData.refetch}
         >
           Refresh
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 1,
       element: (
-        <SecondaryButton
-          dataCy="krb-ticket-policy-button-revert"
+        <Button
+          variant="secondary"
+          data-cy="krb-ticket-policy-button-revert"
           isDisabled={!krbTicketPolicyData.modified || isDataLoading}
-          onClickHandler={onRevert}
+          onClick={onRevert}
         >
           Revert
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 2,
       element: (
-        <SecondaryButton
-          dataCy="krb-ticket-policy-button-save"
+        <Button
+          variant="primary"
+          data-cy="krb-ticket-policy-button-save"
           isDisabled={!krbTicketPolicyData.modified || isDataLoading}
-          onClickHandler={onSave}
+          type="submit"
+          form="krb-ticket-policy-form"
         >
           Save
-        </SecondaryButton>
+        </Button>
       ),
     },
   ];
@@ -240,7 +245,11 @@ const KrbTicketPolicy = () => {
             />
             <Flex direction={{ default: "column", lg: "row" }}>
               <FlexItem flex={{ default: "flex_1" }}>
-                <Form className="pf-v6-u-mb-lg">
+                <Form
+                  className="pf-v6-u-mb-lg"
+                  id="krb-ticket-policy-form"
+                  onSubmit={onSave}
+                >
                   <FormGroup
                     label="Max renew (seconds)"
                     fieldId="krbmaxrenewableage"

--- a/src/pages/Netgroups/NetgroupsSettings.tsx
+++ b/src/pages/Netgroups/NetgroupsSettings.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 // PatternFly
 import {
+  Button,
   Flex,
   Form,
   FormGroup,
@@ -15,7 +16,6 @@ import IpaTextInput from "src/components/Form/IpaTextInput";
 import IpaCheckbox from "src/components/Form/IpaCheckbox";
 // Layouts
 import TitleLayout from "src/components/layouts/TitleLayout";
-import SecondaryButton from "src/components/layouts/SecondaryButton";
 import TabLayout from "src/components/layouts/TabLayout";
 // Utils
 import { asRecord } from "../../utils/hostUtils";
@@ -110,7 +110,8 @@ const NetgroupsSettings = (props: PropsToGroupsSettings) => {
   const [isSaving, setSaving] = useState(false);
 
   // 'Save' handler method
-  const onSave = () => {
+  const onSave = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     const modifiedValues = props.modifiedValues();
     const payload = {
       groupName: cn,
@@ -171,40 +172,43 @@ const NetgroupsSettings = (props: PropsToGroupsSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton
-          dataCy="netgroups-tab-settings-button-refresh"
-          onClickHandler={props.onRefresh}
+        <Button
+          variant="secondary"
+          data-cy="netgroups-tab-settings-button-refresh"
+          onClick={props.onRefresh}
         >
           Refresh
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 1,
       element: (
-        <SecondaryButton
-          dataCy="netgroups-tab-settings-button-revert"
+        <Button
+          variant="secondary"
+          data-cy="netgroups-tab-settings-button-revert"
           isDisabled={!props.isModified}
-          onClickHandler={onRevert}
+          onClick={onRevert}
         >
           Revert
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 2,
       element: (
-        <SecondaryButton
-          dataCy="netgroups-tab-settings-button-save"
+        <Button
+          variant="primary"
+          data-cy="netgroups-tab-settings-button-save"
           isDisabled={!props.isModified || isSaving}
-          onClickHandler={onSave}
           isLoading={isSaving}
           spinnerAriaValueText="Saving"
-          spinnerAriaLabelledBy="Saving"
           spinnerAriaLabel="Saving"
+          type="submit"
+          form="netgroups-settings-form"
         >
           {isSaving ? "Saving" : "Save"}
-        </SecondaryButton>
+        </Button>
       ),
     },
   ];
@@ -222,6 +226,8 @@ const NetgroupsSettings = (props: PropsToGroupsSettings) => {
         <Form
           className="pf-v6-u-mt-sm pf-v6-u-mb-lg pf-v6-u-mr-md"
           isHorizontal
+          id="netgroups-settings-form"
+          onSubmit={onSave}
         >
           <FormGroup label="Description" fieldId="description">
             <IpaTextArea

--- a/src/pages/PasswordPolicies/PasswordPoliciesSettings.tsx
+++ b/src/pages/PasswordPolicies/PasswordPoliciesSettings.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 // PatternFly
 import {
+  Button,
   Flex,
   FlexItem,
   Form,
@@ -28,7 +29,6 @@ import {
 // Components
 import IpaTextInput from "src/components/Form/IpaTextInput";
 import TabLayout from "src/components/layouts/TabLayout";
-import SecondaryButton from "src/components/layouts/SecondaryButton";
 import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
 import IpaTextContent from "src/components/Form/IpaTextContent";
 
@@ -99,7 +99,8 @@ const PasswordPolicySettings = (props: PropsToPwPolicySettings) => {
   };
 
   // on Save handler method
-  const onSave = () => {
+  const onSave = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     setIsDataLoading(true);
     const modifiedValues = props.modifiedValues();
 
@@ -151,36 +152,40 @@ const PasswordPolicySettings = (props: PropsToPwPolicySettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton
-          onClickHandler={props.onRefresh}
-          dataCy="password-policies-button-refresh"
+        <Button
+          variant="secondary"
+          data-cy="password-policies-button-refresh"
+          onClick={props.onRefresh}
         >
           Refresh
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 1,
       element: (
-        <SecondaryButton
+        <Button
+          variant="secondary"
+          data-cy="password-policies-button-revert"
           isDisabled={!props.isModified || isDataLoading}
-          onClickHandler={onRevert}
-          dataCy="password-policies-button-revert"
+          onClick={onRevert}
         >
           Revert
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 2,
       element: (
-        <SecondaryButton
+        <Button
+          variant="primary"
+          data-cy="password-policies-button-save"
           isDisabled={!props.isModified || isDataLoading}
-          onClickHandler={onSave}
-          dataCy="password-policies-button-save"
+          type="submit"
+          form="password-policies-settings-form"
         >
           Save
-        </SecondaryButton>
+        </Button>
       ),
     },
   ];
@@ -201,7 +206,11 @@ const PasswordPolicySettings = (props: PropsToPwPolicySettings) => {
           <SidebarContent className="pf-v6-u-mr-xl">
             <Flex direction={{ default: "column", lg: "row" }}>
               <FlexItem flex={{ default: "flex_1" }}>
-                <Form className="pf-v6-u-mb-lg">
+                <Form
+                  className="pf-v6-u-mb-lg"
+                  id="password-policies-settings-form"
+                  onSubmit={onSave}
+                >
                   <FormGroup label="Group" fieldId="group" role="group">
                     <IpaTextContent
                       dataCy="password-policies-text-group"

--- a/src/pages/Services/ServicesSettings.tsx
+++ b/src/pages/Services/ServicesSettings.tsx
@@ -22,7 +22,6 @@ import IssueNewCertificate from "src/components/modals/CertificateModals/IssueNe
 // Layouts
 import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
 import TitleLayout from "src/components/layouts/TitleLayout";
-import SecondaryButton from "src/components/layouts/SecondaryButton";
 import KebabLayout from "src/components/layouts/KebabLayout";
 import ModalErrors from "src/components/errors/ModalErrors";
 import TabLayout from "src/components/layouts/TabLayout";
@@ -255,40 +254,42 @@ const ServicesSettings = (props: PropsToServicesSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton
-          dataCy="services-tab-settings-button-refresh"
-          onClickHandler={props.onRefresh}
+        <Button
+          data-cy="services-tab-settings-button-refresh"
+          variant="secondary"
+          onClick={props.onRefresh}
         >
           Refresh
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 1,
       element: (
-        <SecondaryButton
-          dataCy="services-tab-settings-button-revert"
+        <Button
+          data-cy="services-tab-settings-button-revert"
+          variant="secondary"
           isDisabled={!props.isModified}
-          onClickHandler={onRevert}
+          onClick={onRevert}
         >
           Revert
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 2,
       element: (
-        <SecondaryButton
-          dataCy="services-tab-settings-button-save"
+        <Button
+          data-cy="services-tab-settings-button-save"
+          variant="primary"
           isDisabled={!props.isModified || isSaving}
-          onClickHandler={onSave}
+          onClick={onSave}
           isLoading={isSaving}
           spinnerAriaValueText="Saving"
-          spinnerAriaLabelledBy="Saving"
           spinnerAriaLabel="Saving"
         >
           {isSaving ? "Saving" : "Save"}
-        </SecondaryButton>
+        </Button>
       ),
     },
     {

--- a/src/pages/SubordinateIDs/SubidsSettings.tsx
+++ b/src/pages/SubordinateIDs/SubidsSettings.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 // PatternFly
 import {
+  Button,
   Flex,
   FlexItem,
   Form,
@@ -25,7 +26,6 @@ import { SubidModPayload, useSubidModMutation } from "src/services/rpcSubIds";
 // Components
 import IpaTextInput from "src/components/Form/IpaTextInput";
 import TabLayout from "src/components/layouts/TabLayout";
-import SecondaryButton from "src/components/layouts/SecondaryButton";
 import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
 import IpaTextContent from "src/components/Form/IpaTextContent";
 
@@ -73,7 +73,8 @@ const SubidSettings = (props: PropsToSubidSettings) => {
   };
 
   // on Save handler method
-  const onSave = () => {
+  const onSave = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     setIsDataLoading(true);
     const modifiedValues = props.modifiedValues();
 
@@ -117,36 +118,40 @@ const SubidSettings = (props: PropsToSubidSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton
-          dataCy="subids-tab-settings-button-refresh"
-          onClickHandler={props.onRefresh}
+        <Button
+          variant="secondary"
+          data-cy="subids-tab-settings-button-refresh"
+          onClick={props.onRefresh}
         >
           Refresh
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 1,
       element: (
-        <SecondaryButton
-          dataCy="subids-tab-settings-button-revert"
+        <Button
+          variant="secondary"
+          data-cy="subids-tab-settings-button-revert"
           isDisabled={!props.isModified || isDataLoading}
-          onClickHandler={onRevert}
+          onClick={onRevert}
         >
           Revert
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 2,
       element: (
-        <SecondaryButton
-          dataCy="subids-tab-settings-button-save"
+        <Button
+          variant="primary"
+          data-cy="subids-tab-settings-button-save"
           isDisabled={!props.isModified || isDataLoading}
-          onClickHandler={onSave}
+          type="submit"
+          form="subids-settings-form"
         >
           Save
-        </SecondaryButton>
+        </Button>
       ),
     },
   ];
@@ -166,7 +171,11 @@ const SubidSettings = (props: PropsToSubidSettings) => {
           <SidebarContent className="pf-v6-u-mr-xl">
             <Flex direction={{ default: "column", lg: "row" }}>
               <FlexItem flex={{ default: "flex_1" }}>
-                <Form className="pf-v6-u-mb-lg">
+                <Form
+                  className="pf-v6-u-mb-lg"
+                  id="subids-settings-form"
+                  onSubmit={onSave}
+                >
                   <FormGroup label="Unique ID" fieldId="ipauniqueid">
                     <IpaTextInput
                       dataCy="subids-tab-settings-textbox-unique-id"

--- a/src/pages/SudoCmdGroups/SudoCmdGroupsSettings.tsx
+++ b/src/pages/SudoCmdGroups/SudoCmdGroupsSettings.tsx
@@ -1,11 +1,10 @@
 import React, { useState } from "react";
 // PatternFly
-import { Flex, Form, FormGroup } from "@patternfly/react-core";
+import { Button, Flex, Form, FormGroup } from "@patternfly/react-core";
 // Forms
 import IpaTextArea from "src/components/Form/IpaTextArea";
 // Layouts
 import TitleLayout from "src/components/layouts/TitleLayout";
-import SecondaryButton from "src/components/layouts/SecondaryButton";
 import TabLayout from "src/components/layouts/TabLayout";
 // Utils
 import { asRecord } from "../../utils/hostUtils";
@@ -47,7 +46,8 @@ const SudoCmdGroupsSettings = (props: PropsToSettings) => {
   const [isSaving, setSaving] = useState(false);
 
   // 'Save' handler method
-  const onSave = () => {
+  const onSave = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     const modifiedValues = props.modifiedValues();
     modifiedValues.cn = props.group.cn;
     setSaving(true);
@@ -99,40 +99,43 @@ const SudoCmdGroupsSettings = (props: PropsToSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton
-          dataCy="sudo-cmd-groups-tab-settings-button-refresh"
-          onClickHandler={props.onRefresh}
+        <Button
+          variant="secondary"
+          data-cy="sudo-cmd-groups-tab-settings-button-refresh"
+          onClick={props.onRefresh}
         >
           Refresh
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 1,
       element: (
-        <SecondaryButton
-          dataCy="sudo-cmd-groups-tab-settings-button-revert"
+        <Button
+          variant="secondary"
+          data-cy="sudo-cmd-groups-tab-settings-button-revert"
           isDisabled={!props.isModified}
-          onClickHandler={onRevert}
+          onClick={onRevert}
         >
           Revert
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 2,
       element: (
-        <SecondaryButton
-          dataCy="sudo-cmd-groups-tab-settings-button-save"
+        <Button
+          variant="primary"
+          data-cy="sudo-cmd-groups-tab-settings-button-save"
           isDisabled={!props.isModified || isSaving}
-          onClickHandler={onSave}
+          type="submit"
+          form="sudo-cmd-groups-settings-form"
           isLoading={isSaving}
           spinnerAriaValueText="Saving"
-          spinnerAriaLabelledBy="Saving"
           spinnerAriaLabel="Saving"
         >
           {isSaving ? "Saving" : "Save"}
-        </SecondaryButton>
+        </Button>
       ),
     },
   ];
@@ -147,7 +150,11 @@ const SudoCmdGroupsSettings = (props: PropsToSettings) => {
           id="sudocmdgroup-settings"
           text="Sudo command group settings"
         />
-        <Form className="pf-v6-u-mt-sm pf-v6-u-mb-lg pf-v6-u-mr-md">
+        <Form
+          className="pf-v6-u-mt-sm pf-v6-u-mb-lg pf-v6-u-mr-md"
+          id="sudo-cmd-groups-settings-form"
+          onSubmit={onSave}
+        >
           <FormGroup label="Description" fieldId="description">
             <IpaTextArea
               dataCy="sudo-cmd-groups-tab-settings-textbox-description"

--- a/src/pages/SudoCmds/SudoCmdsSettings.tsx
+++ b/src/pages/SudoCmds/SudoCmdsSettings.tsx
@@ -1,11 +1,10 @@
 import React, { useState } from "react";
 // PatternFly
-import { Flex, Form, FormGroup } from "@patternfly/react-core";
+import { Button, Flex, Form, FormGroup } from "@patternfly/react-core";
 // Forms
 import IpaTextArea from "src/components/Form/IpaTextArea";
 // Layouts
 import TitleLayout from "src/components/layouts/TitleLayout";
-import SecondaryButton from "src/components/layouts/SecondaryButton";
 import TabLayout from "src/components/layouts/TabLayout";
 // Utils
 import { asRecord } from "../../utils/hostUtils";
@@ -47,7 +46,8 @@ const SudoCmdsSettings = (props: PropsToSettings) => {
   const [isSaving, setSaving] = useState(false);
 
   // 'Save' handler method
-  const onSave = () => {
+  const onSave = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     const modifiedValues = props.modifiedValues();
     modifiedValues.sudocmd = props.cmd.sudocmd;
     setSaving(true);
@@ -99,40 +99,43 @@ const SudoCmdsSettings = (props: PropsToSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton
-          dataCy="sudo-cmds-tab-settings-button-refresh"
-          onClickHandler={props.onRefresh}
+        <Button
+          variant="secondary"
+          data-cy="sudo-cmds-tab-settings-button-refresh"
+          onClick={props.onRefresh}
         >
           Refresh
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 1,
       element: (
-        <SecondaryButton
-          dataCy="sudo-cmds-tab-settings-button-revert"
+        <Button
+          variant="secondary"
+          data-cy="sudo-cmds-tab-settings-button-revert"
           isDisabled={!props.isModified}
-          onClickHandler={onRevert}
+          onClick={onRevert}
         >
           Revert
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 2,
       element: (
-        <SecondaryButton
-          dataCy="sudo-cmds-tab-settings-button-save"
+        <Button
+          variant="primary"
+          data-cy="sudo-cmds-tab-settings-button-save"
           isDisabled={!props.isModified || isSaving}
-          onClickHandler={onSave}
+          type="submit"
+          form="sudo-cmds-settings-form"
           isLoading={isSaving}
           spinnerAriaValueText="Saving"
-          spinnerAriaLabelledBy="Saving"
           spinnerAriaLabel="Saving"
         >
           {isSaving ? "Saving" : "Save"}
-        </SecondaryButton>
+        </Button>
       ),
     },
   ];
@@ -147,7 +150,11 @@ const SudoCmdsSettings = (props: PropsToSettings) => {
           id="sudocmd-settings"
           text="Sudo command settings"
         />
-        <Form className="pf-v6-u-mt-sm pf-v6-u-mb-lg pf-v6-u-mr-md">
+        <Form
+          className="pf-v6-u-mt-sm pf-v6-u-mb-lg pf-v6-u-mr-md"
+          id="sudo-cmds-settings-form"
+          onSubmit={onSave}
+        >
           <FormGroup label="Description" fieldId="description">
             <IpaTextArea
               dataCy="sudo-cmds-tab-settings-textbox-description"

--- a/src/pages/SudoRules/SudoRulesSettings.tsx
+++ b/src/pages/SudoRules/SudoRulesSettings.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 // PatternFly
-import { DropdownItem, Flex } from "@patternfly/react-core";
+import { Button, DropdownItem, Flex } from "@patternfly/react-core";
 // Data types
 import { Metadata, SudoRule } from "src/utils/datatypes/globalDataTypes";
 // Redux
@@ -29,7 +29,6 @@ import { asRecord } from "src/utils/sudoRulesUtils";
 import { containsAny } from "src/utils/utils";
 // Components
 import TitleLayout from "src/components/layouts/TitleLayout";
-import SecondaryButton from "src/components/layouts/SecondaryButton";
 import KebabLayout from "src/components/layouts/KebabLayout";
 import TabLayout from "src/components/layouts/TabLayout";
 import SudoRuleGeneral from "src/components/SudoRuleSections/SudoRuleGeneral";
@@ -695,40 +694,42 @@ const SudoRulesSettings = (props: PropsToSudoRulesSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton
-          dataCy="sudo-rules-tab-settings-button-refresh"
-          onClickHandler={props.onRefresh}
+        <Button
+          data-cy="sudo-rules-tab-settings-button-refresh"
+          variant="secondary"
+          onClick={props.onRefresh}
         >
           Refresh
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 1,
       element: (
-        <SecondaryButton
-          dataCy="sudo-rules-tab-settings-button-revert"
+        <Button
+          data-cy="sudo-rules-tab-settings-button-revert"
+          variant="secondary"
           isDisabled={!props.isModified}
-          onClickHandler={onRevert}
+          onClick={onRevert}
         >
           Revert
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 2,
       element: (
-        <SecondaryButton
-          dataCy="sudo-rules-tab-settings-button-save"
+        <Button
+          data-cy="sudo-rules-tab-settings-button-save"
+          variant="primary"
           isDisabled={!props.isModified || isSaving}
-          onClickHandler={onSave}
+          onClick={onSave}
           isLoading={isSaving}
           spinnerAriaValueText="Saving"
-          spinnerAriaLabelledBy="Saving"
           spinnerAriaLabel="Saving"
         >
           {isSaving ? "Saving" : "Save"}
-        </SecondaryButton>
+        </Button>
       ),
     },
     {

--- a/src/pages/Trusts/GlobalTrustConfig.tsx
+++ b/src/pages/Trusts/GlobalTrustConfig.tsx
@@ -156,7 +156,6 @@ const GlobalTrustConfig = () => {
         <Button
           variant="primary"
           data-cy="trusts-global-config-button-save"
-          onClick={onSave}
           isDisabled={!trustsConfigData.modified || isDataLoading}
           form="trusts-global-config-form"
           type="submit"
@@ -202,7 +201,7 @@ const GlobalTrustConfig = () => {
         <SidebarContent className="pf-v6-u-mr-xl">
           <Flex direction={{ default: "column", lg: "row" }}>
             <FlexItem flex={{ default: "flex_1" }}>
-              <Form id="trusts-global-config-form">
+              <Form id="trusts-global-config-form" onSubmit={onSave}>
                 <FormGroup label="Domain" fieldId="cn">
                   <IpaTextInput
                     dataCy="trusts-global-config-textbox-domain"

--- a/src/pages/Trusts/TrustsSettings.tsx
+++ b/src/pages/Trusts/TrustsSettings.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 // PatternFly
 import {
+  Button,
   Flex,
   FlexItem,
   Form,
@@ -22,7 +23,6 @@ import { TrustModPayload, useTrustModMutation } from "src/services/rpcTrusts";
 // Components
 import IpaTextInput from "src/components/Form/IpaTextInput/IpaTextInput";
 import TabLayout from "src/components/layouts/TabLayout";
-import SecondaryButton from "src/components/layouts/SecondaryButton";
 import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
 import IpaTextboxList from "src/components/Form/IpaTextboxList";
 import TitleLayout from "src/components/layouts/TitleLayout";
@@ -91,7 +91,8 @@ const TrustsSettings = (props: TrustsSettingsProps) => {
   );
 
   // 'Save' handler method
-  const onSave = () => {
+  const onSave = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     setIsDataLoading(true);
     const modifiedValues = props.modifiedValues();
 
@@ -137,36 +138,40 @@ const TrustsSettings = (props: TrustsSettingsProps) => {
     {
       key: 0,
       element: (
-        <SecondaryButton
-          dataCy="trusts-tab-settings-button-refresh"
-          onClickHandler={props.onRefresh}
+        <Button
+          variant="secondary"
+          data-cy="trusts-tab-settings-button-refresh"
+          onClick={props.onRefresh}
         >
           Refresh
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 1,
       element: (
-        <SecondaryButton
-          dataCy="trusts-tab-settings-button-revert"
+        <Button
+          variant="secondary"
+          data-cy="trusts-tab-settings-button-revert"
           isDisabled={!props.isModified || isDataLoading}
-          onClickHandler={onRevert}
+          onClick={onRevert}
         >
           Revert
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 2,
       element: (
-        <SecondaryButton
-          dataCy="trusts-tab-settings-button-save"
+        <Button
+          variant="primary"
+          data-cy="trusts-tab-settings-button-save"
           isDisabled={!props.isModified || isDataLoading}
-          onClickHandler={onSave}
+          type="submit"
+          form="trusts-settings-form"
         >
           Save
-        </SecondaryButton>
+        </Button>
       ),
     },
   ];
@@ -199,7 +204,11 @@ const TrustsSettings = (props: TrustsSettingsProps) => {
           </JumpLinks>
         </SidebarPanel>
         <SidebarContent className="pf-v6-u-mr-xl">
-          <Form className="pf-v6-u-mb-lg">
+          <Form
+            className="pf-v6-u-mb-lg"
+            id="trusts-settings-form"
+            onSubmit={onSave}
+          >
             <Flex direction={{ default: "column", lg: "row" }}>
               <FlexItem flex={{ default: "flex_1" }}>
                 <TitleLayout

--- a/src/pages/UserGroups/UserGroupsSettings.tsx
+++ b/src/pages/UserGroups/UserGroupsSettings.tsx
@@ -17,7 +17,6 @@ import IpaTextArea from "../../components/Form/IpaTextArea";
 import { useNavigate } from "react-router";
 // Layouts
 import TitleLayout from "src/components/layouts/TitleLayout";
-import SecondaryButton from "src/components/layouts/SecondaryButton";
 import KebabLayout from "src/components/layouts/KebabLayout";
 import TabLayout from "src/components/layouts/TabLayout";
 // Utils
@@ -321,7 +320,8 @@ const UserGroupsSettings = (props: PropsToGroupsSettings) => {
   ];
 
   // 'Save' handler method
-  const onSave = () => {
+  const onSave = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     const modifiedValues = props.modifiedValues();
     modifiedValues.cn = props.userGroup.cn;
     setSaving(true);
@@ -372,40 +372,43 @@ const UserGroupsSettings = (props: PropsToGroupsSettings) => {
     {
       key: 0,
       element: (
-        <SecondaryButton
-          onClickHandler={props.onRefresh}
-          dataCy="user-groups-tab-settings-button-refresh"
+        <Button
+          variant="secondary"
+          data-cy="user-groups-tab-settings-button-refresh"
+          onClick={props.onRefresh}
         >
           Refresh
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 1,
       element: (
-        <SecondaryButton
+        <Button
+          variant="secondary"
+          data-cy="user-groups-tab-settings-button-revert"
           isDisabled={!props.isModified}
-          onClickHandler={onRevert}
-          dataCy="user-groups-tab-settings-button-revert"
+          onClick={onRevert}
         >
           Revert
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
       key: 2,
       element: (
-        <SecondaryButton
+        <Button
+          variant="primary"
+          data-cy="user-groups-tab-settings-button-save"
           isDisabled={!props.isModified || isSaving}
-          onClickHandler={onSave}
-          dataCy="user-groups-tab-settings-button-save"
+          type="submit"
+          form="user-groups-settings-form"
           isLoading={isSaving}
           spinnerAriaValueText="Saving"
-          spinnerAriaLabelledBy="Saving"
           spinnerAriaLabel="Saving"
         >
           {isSaving ? "Saving" : "Save"}
-        </SecondaryButton>
+        </Button>
       ),
     },
     {
@@ -438,6 +441,8 @@ const UserGroupsSettings = (props: PropsToGroupsSettings) => {
         <Form
           className="pf-v6-u-mt-sm pf-v6-u-mb-lg pf-v6-u-mr-md"
           isHorizontal
+          id="user-groups-settings-form"
+          onSubmit={onSave}
         >
           <FormGroup label="Description" fieldId="description">
             <IpaTextArea


### PR DESCRIPTION
## Summary
Replace the custom SecondaryButton wrapper with standard PatternFly Button components across all 27 settings pages, making Save buttons `variant="primary"` with `type="submit"` where feasible, and Refresh/Revert buttons `variant="secondary"` with `onClick`.

## Changes
- Replace SecondaryButton with PatternFly Button for Refresh, Revert, and Save across all settings toolbars
- Save button uses variant="primary" + type="submit" linked to Form onSubmit on pages with a top-level Form element
- Pages with forms only in child components keep onClick on Save to avoid nested HTML forms
- Fix DnsGlobalConfig and GlobalTrustConfig: remove redundant onClick, add missing onSubmit to Form
- Drop unsupported spinnerAriaLabelledBy prop; rename dataCy to data-cy, onClickHandler to onClick

Fixes: https://github.com/freeipa/freeipa-webui/issues/806

## Summary by Sourcery

Normalize settings toolbars to use PatternFly Buttons and form submissions consistently across settings pages.

Bug Fixes:
- Correct form submission wiring in DNS global and global trust configuration pages by relying on form onSubmit instead of button onClick.
- Prevent unintended browser form submissions by handling Save via form submit handlers that call event.preventDefault().

Enhancements:
- Replace the custom SecondaryButton wrapper with PatternFly Button components for Refresh, Revert, and Save actions across settings pages.
- Standardize Save buttons as primary submit buttons associated with their forms and Refresh/Revert as secondary click actions, improving accessibility and UI consistency.
- Align data attributes and props with project conventions by renaming dataCy to data-cy and dropping unsupported spinner accessibility props.