### PR TITLE
OTP tokens > 'Settings' page

### DIFF
--- a/src/hooks/useOtpTokensSettingsData.tsx
+++ b/src/hooks/useOtpTokensSettingsData.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+// RPC
+import { useGetOtpTokenQuery } from "src/services/rpcOtpTokens";
+import { useGetActiveUsersQuery } from "src/services/rpcUsers";
+import { useGetObjectMetadataQuery } from "src/services/rpc";
+// Data types
+import { Metadata, OtpToken, User } from "src/utils/datatypes/globalDataTypes";
+import { apiToOtpToken, createEmptyOtpToken } from "src/utils/otpTokensUtils";
+
+type OtpTokensSettingsData = {
+  isLoading: boolean;
+  isFetching: boolean;
+  refetch: () => void;
+  modified: boolean;
+  setModified: (modified: boolean) => void;
+  otpToken: OtpToken;
+  users: User[];
+  metadata: Metadata;
+  originalOtpToken: OtpToken;
+  setOtpToken: (otpToken: OtpToken) => void;
+  modifiedValues: () => Partial<OtpToken>;
+  resetValues: () => void;
+};
+
+const useOtpTokensSettingsData = (
+  otpTokenId: string
+): OtpTokensSettingsData => {
+  // [API call] Metadata
+  const metadataQuery = useGetObjectMetadataQuery();
+  const metadata = metadataQuery.data || {};
+  const metadataLoading = metadataQuery.isLoading;
+
+  // [API call] OTP token
+  const otpTokenQuery = useGetOtpTokenQuery(otpTokenId);
+  const otpTokenData = otpTokenQuery.data;
+  const isOtpTokenLoading = otpTokenQuery.isLoading;
+
+  // [API call] Active users
+  const activeUsersQuery = useGetActiveUsersQuery();
+  const activeUsers = activeUsersQuery.data;
+  const isActiveUsersLoading = activeUsersQuery.isLoading;
+
+  // States
+  const [otpToken, setOtpToken] = React.useState<OtpToken>(createEmptyOtpToken);
+  const [originalOtpToken, setOriginalOtpToken] =
+    React.useState<OtpToken>(createEmptyOtpToken);
+  const [users, setUsers] = React.useState<User[]>([]);
+  const [modified, setModified] = React.useState(false);
+
+  React.useEffect(() => {
+    if (otpTokenData && !otpTokenQuery.isFetching) {
+      const otpTokenResult: OtpToken = apiToOtpToken(
+        otpTokenData.result.result
+      );
+      setOtpToken(otpTokenResult);
+      setOriginalOtpToken(otpTokenResult);
+    }
+  }, [otpTokenData, otpTokenQuery.isFetching]);
+
+  React.useEffect(() => {
+    if (activeUsers && !activeUsersQuery.isFetching) {
+      setUsers(activeUsers);
+    }
+  }, [activeUsers, activeUsersQuery.isFetching]);
+
+  const settings: OtpTokensSettingsData = {
+    isLoading: metadataLoading || isOtpTokenLoading || isActiveUsersLoading,
+    isFetching: otpTokenQuery.isFetching || activeUsersQuery.isFetching,
+    refetch: () => {
+      metadataQuery.refetch();
+      otpTokenQuery.refetch();
+      activeUsersQuery.refetch();
+    },
+    modified,
+    setModified,
+    otpToken,
+    users,
+    metadata,
+    originalOtpToken,
+    setOtpToken,
+    modifiedValues: () => otpToken,
+    resetValues: () => {},
+  };
+
+  const getModifiedValues = (): Partial<OtpToken> => {
+    const modifiedValues = {};
+    Object.keys(otpToken).forEach((key) => {
+      if (originalOtpToken[key] !== otpToken[key]) {
+        modifiedValues[key] = otpToken[key];
+      }
+    });
+    return modifiedValues;
+  };
+  settings.modifiedValues = getModifiedValues;
+
+  // Detect any change in 'originalOtpToken' and 'otpToken' objects
+  React.useEffect(() => {
+    let modified = false;
+
+    for (const [key, value] of Object.entries(otpToken)) {
+      if (Array.isArray(value)) {
+        if (JSON.stringify(originalOtpToken[key]) !== JSON.stringify(value)) {
+          modified = true;
+          break;
+        }
+      } else if (originalOtpToken[key] !== value) {
+        modified = true;
+        break;
+      }
+    }
+    setModified(modified);
+  }, [otpTokenData, otpToken, originalOtpToken]);
+
+  // Reset values
+  const onResetValues = () => {
+    setModified(false);
+  };
+  settings.resetValues = onResetValues;
+
+  return settings;
+};
+
+export { useOtpTokensSettingsData };

--- a/src/hooks/useOtpTokensSettingsData.tsx
+++ b/src/hooks/useOtpTokensSettingsData.tsx
@@ -49,11 +49,13 @@ const useOtpTokensSettingsData = (
 
   React.useEffect(() => {
     if (otpTokenData && !otpTokenQuery.isFetching) {
-      const otpTokenResult: OtpToken = apiToOtpToken(
-        otpTokenData.result.result
-      );
-      setOtpToken(otpTokenResult);
-      setOriginalOtpToken(otpTokenResult);
+      if (otpTokenData.result?.result) {
+        const otpTokenResult: OtpToken = apiToOtpToken(
+          otpTokenData.result.result
+        );
+        setOtpToken(otpTokenResult);
+        setOriginalOtpToken(otpTokenResult);
+      }
     }
   }, [otpTokenData, otpTokenQuery.isFetching]);
 

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -77,6 +77,7 @@ import IdRangesTabs from "src/pages/IdRanges/IdRangesTabs";
 import GlobalTrustConfig from "src/pages/Trusts/GlobalTrustConfig";
 import OtpTokens from "src/pages/OtpTokens/OtpTokens";
 import TopologyGraph from "src/pages/Topology/TopologyGraph";
+import OtpTokensTabs from "src/pages/OtpTokens/OtpTokensTabs";
 
 // Renders routes (React)
 export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
@@ -455,6 +456,12 @@ export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
               </Route>
               <Route path="otp-tokens">
                 <Route path="" element={<OtpTokens />} />
+                <Route path=":ipatokenuniqueid">
+                  <Route
+                    path=""
+                    element={<OtpTokensTabs section="settings" />}
+                  />
+                </Route>
               </Route>
               <Route path="identity-provider-references">
                 <Route path="" element={<IdpReferences />} />

--- a/src/pages/OtpTokens/DeleteOtpTokensModal.tsx
+++ b/src/pages/OtpTokens/DeleteOtpTokensModal.tsx
@@ -21,8 +21,10 @@ import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
 import DeletedElementsTable from "src/components/tables/DeletedElementsTable";
 import { SerializedError } from "@reduxjs/toolkit";
 import ErrorModal from "src/components/modals/ErrorModal";
+import { useNavigate } from "react-router";
 
 interface DeleteOtpTokensModalProps {
+  from: "main" | "settings";
   isOpen: boolean;
   onClose: () => void;
   elementsToDelete: OtpToken[];
@@ -36,6 +38,7 @@ interface DeleteOtpTokensModalProps {
 
 const DeleteOtpTokensModal = (props: DeleteOtpTokensModalProps) => {
   const dispatch = useAppDispatch();
+  const navigate = useNavigate();
 
   // RPC calls
   const [deleteOtpTokens] = useDeleteOtpTokensMutation();
@@ -123,6 +126,11 @@ const DeleteOtpTokensModal = (props: DeleteOtpTokensModalProps) => {
                   variant: "success",
                 })
               );
+              if (props.from === "settings") {
+                navigate("/otp-tokens");
+              } else {
+                props.onRefresh();
+              }
             }
           }
         }
@@ -130,7 +138,6 @@ const DeleteOtpTokensModal = (props: DeleteOtpTokensModalProps) => {
       .finally(() => {
         setBtnSpinning(false);
         props.onClose();
-        props.onRefresh();
       });
   };
 

--- a/src/pages/OtpTokens/EnableDisableOtpTokensModal.tsx
+++ b/src/pages/OtpTokens/EnableDisableOtpTokensModal.tsx
@@ -34,9 +34,9 @@ const EnableDisableOtpTokensModal = (
 
   // RPC calls
   const [modifyOtpTokens] = useModifyOtpTokensMutation();
+
   // Enable/Disable operation
   const onEnableDisable = () => {
-    // const operation = props.operation === "enable" ? enableOtpTokens : disableOtpTokens;
     const payload: OtpTokensModifyPayload[] = props.elementsList.map(
       (element) => ({
         ipatokenuniqueid: element,

--- a/src/pages/OtpTokens/OtpTokens.tsx
+++ b/src/pages/OtpTokens/OtpTokens.tsx
@@ -476,7 +476,7 @@ const OtpTokens = () => {
                     hasCheckboxes={true}
                     pathname="otp-tokens"
                     showTableRows={showTableRows}
-                    showLink={false}
+                    showLink={true}
                     elementsData={{
                       isElementSelectable: isOtpTokenSelectable,
                       selectedElements,

--- a/src/pages/OtpTokens/OtpTokens.tsx
+++ b/src/pages/OtpTokens/OtpTokens.tsx
@@ -152,6 +152,12 @@ const OtpTokens = () => {
     });
   };
 
+  // Refresh data every time the component is rendered to ensure
+  // the data is up to date when the user is deleting from the settings page
+  React.useEffect(() => {
+    refreshData();
+  }, []);
+
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
     React.useState<boolean>(true);
@@ -524,6 +530,7 @@ const OtpTokens = () => {
         onRefresh={refreshData}
       />
       <DeleteOtpTokensModal
+        from="main"
         isOpen={showDeleteModal}
         onClose={() => setShowDeleteModal(false)}
         elementsToDelete={selectedElements}

--- a/src/pages/OtpTokens/OtpTokensSettings.tsx
+++ b/src/pages/OtpTokens/OtpTokensSettings.tsx
@@ -2,6 +2,7 @@ import React from "react";
 // PatternFly
 import {
   Button,
+  DropdownItem,
   Flex,
   FlexItem,
   Form,
@@ -36,6 +37,9 @@ import { addAlert } from "src/store/Global/alerts-slice";
 import TitleLayout from "src/components/layouts/TitleLayout";
 // Utils
 import { toGeneralizedTime } from "src/utils/utils";
+import KebabLayout from "src/components/layouts/KebabLayout";
+import EnableDisableOtpTokensModal from "./EnableDisableOtpTokensModal";
+import DeleteOtpTokensModal from "./DeleteOtpTokensModal";
 
 interface OtpTokensSettingsProps {
   otpToken: OtpToken;
@@ -187,6 +191,46 @@ const OtpTokensSettings = (props: OtpTokensSettingsProps) => {
       });
   };
 
+  // Kebab
+  const [isKebabOpen, setIsKebabOpen] = React.useState(false);
+  const [isEnableDisableModalOpen, setIsEnableDisableModalOpen] =
+    React.useState(false);
+  const [operation, setOperation] = React.useState<"enable" | "disable">(
+    "disable"
+  );
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = React.useState(false);
+
+  const openEnableDisableModal = (op: "enable" | "disable") => {
+    setOperation(op);
+    setIsEnableDisableModalOpen(true);
+  };
+
+  const kebabItems = [
+    <DropdownItem
+      data-cy="otp-tokens-tab-settings-kebab-enable"
+      key="enable"
+      onClick={() => openEnableDisableModal("enable")}
+      isDisabled={props.otpToken.ipatokendisabled === false}
+    >
+      Enable token
+    </DropdownItem>,
+    <DropdownItem
+      data-cy="otp-tokens-tab-settings-kebab-disable"
+      key="disable"
+      onClick={() => openEnableDisableModal("disable")}
+      isDisabled={props.otpToken.ipatokendisabled === true}
+    >
+      Disable token
+    </DropdownItem>,
+    <DropdownItem
+      data-cy="otp-tokens-tab-settings-kebab-delete"
+      key="delete"
+      onClick={() => setIsDeleteModalOpen(true)}
+    >
+      Delete
+    </DropdownItem>,
+  ];
+
   // Toolbar
   const toolbarFields = [
     {
@@ -225,6 +269,21 @@ const OtpTokensSettings = (props: OtpTokensSettingsProps) => {
         >
           Save
         </Button>
+      ),
+    },
+    {
+      key: 3,
+      element: (
+        <KebabLayout
+          dataCy="otp-tokens-tab-settings-kebab"
+          direction={"up"}
+          onDropdownSelect={() => setIsKebabOpen(!isKebabOpen)}
+          onKebabToggle={() => setIsKebabOpen(!isKebabOpen)}
+          idKebab="toggle-action-buttons"
+          isKebabOpen={isKebabOpen}
+          dropdownItems={kebabItems}
+          isDisabled={isDataLoading}
+        />
       ),
     },
   ];
@@ -477,6 +536,27 @@ const OtpTokensSettings = (props: OtpTokensSettingsProps) => {
           </Form>
         </SidebarContent>
       </Sidebar>
+      <EnableDisableOtpTokensModal
+        isOpen={isEnableDisableModalOpen}
+        onClose={() => setIsEnableDisableModalOpen(false)}
+        elementsList={[ipaObject["ipatokenuniqueid"]]}
+        setElementsList={() => {}}
+        operation={operation}
+        setShowTableRows={() => {}}
+        onRefresh={props.onRefresh}
+      />
+      <DeleteOtpTokensModal
+        from="settings"
+        isOpen={isDeleteModalOpen}
+        onClose={() => setIsDeleteModalOpen(false)}
+        elementsToDelete={[props.otpToken]}
+        clearSelectedElements={() => {}}
+        columnNames={["Unique ID", "Owner", "Description"]}
+        keyNames={["ipatokenuniqueid", "ipatokenowner", "description"]}
+        onRefresh={props.onRefresh}
+        updateIsDeleteButtonDisabled={() => {}}
+        updateIsDeletion={() => {}}
+      />
     </TabLayout>
   );
 };

--- a/src/pages/OtpTokens/OtpTokensSettings.tsx
+++ b/src/pages/OtpTokens/OtpTokensSettings.tsx
@@ -1,0 +1,484 @@
+import React from "react";
+// PatternFly
+import {
+  Button,
+  Flex,
+  FlexItem,
+  Form,
+  FormGroup,
+  Sidebar,
+  SidebarContent,
+  SidebarPanel,
+} from "@patternfly/react-core";
+// Redux
+import { useAppDispatch } from "src/store/hooks";
+// RPC
+import {
+  OtpTokensModifyPayload,
+  useModifyOtpTokensMutation,
+} from "src/services/rpcOtpTokens";
+import { BatchResult } from "src/services/rpc";
+// Data types
+import { OtpToken, Metadata, User } from "src/utils/datatypes/globalDataTypes";
+// Hooks
+import useUpdateRoute from "src/hooks/useUpdateRoute";
+// Icons
+import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
+// Components
+import TabLayout from "src/components/layouts/TabLayout";
+import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
+import IpaCalendar from "src/components/Form/IpaCalendar";
+import IpaTextArea from "src/components/Form/IpaTextArea";
+import IpaTextInput from "src/components/Form/IpaTextInput";
+import { apiToOtpToken, asRecord } from "src/utils/otpTokensUtils";
+import IpaSelect from "src/components/Form/IpaSelect";
+import { addAlert } from "src/store/Global/alerts-slice";
+import TitleLayout from "src/components/layouts/TitleLayout";
+// Utils
+import { toGeneralizedTime } from "src/utils/utils";
+
+interface OtpTokensSettingsProps {
+  otpToken: OtpToken;
+  originalOtpToken: OtpToken;
+  users: Partial<User>[];
+  metadata: Metadata;
+  onOtpTokenChange: (otpToken: OtpToken) => void;
+  onRefresh: () => void;
+  isDataLoading: boolean;
+  modifiedValues: () => Partial<OtpToken>;
+  isModified: boolean;
+  onResetValues: () => void;
+  pathname: string;
+}
+
+const OtpTokensSettings = (props: OtpTokensSettingsProps) => {
+  const dispatch = useAppDispatch();
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  useUpdateRoute({ pathname: props.pathname });
+
+  // States
+  const [isDataLoading, setIsDataLoading] = React.useState(false);
+
+  // RPC calls
+  const [modifyOtpToken] = useModifyOtpTokensMutation();
+
+  const { ipaObject, recordOnChange } = asRecord(
+    props.otpToken,
+    props.onOtpTokenChange
+  );
+
+  // 'Revert' handler method
+  const onRevert = () => {
+    props.onOtpTokenChange(props.originalOtpToken);
+    props.onRefresh();
+    dispatch(
+      addAlert({
+        name: "revert-success",
+        title: "OTP token data reverted",
+        variant: "success",
+      })
+    );
+  };
+
+  // Rules for fields validation
+  const validCharsRules = [
+    {
+      id: "valid-chars",
+      message: "Leading and trailing spaces are not allowed",
+      validate: (value: string) =>
+        !value.startsWith(" ") && !value.endsWith(" "),
+    },
+  ];
+
+  // Check if vendor field passes validation
+  const isVendorValid = React.useMemo(() => {
+    const vendorValue = ipaObject["ipatokenvendor"] as string | undefined;
+    if (!vendorValue) return true;
+    return validCharsRules.every((rule) => rule.validate(vendorValue));
+  }, [ipaObject["ipatokenvendor"]]);
+
+  // Date fields that need to be converted to LDAP generalized time format
+  const dateFields = new Set(["ipatokennotbefore", "ipatokennotafter"]);
+
+  // Helper method to build the payload based on values
+  const buildPayload = (
+    modifiedValues: Partial<OtpToken>,
+    keyArray: string[]
+  ): OtpTokensModifyPayload => {
+    const payload: OtpTokensModifyPayload = {
+      ipatokenuniqueid: props.otpToken.ipatokenuniqueid || "",
+    };
+
+    keyArray.forEach((key) => {
+      if (modifiedValues[key] !== undefined) {
+        if (modifiedValues[key] === "") {
+          payload[key] = [];
+        } else if (dateFields.has(key) && modifiedValues[key] instanceof Date) {
+          payload[key] = toGeneralizedTime(modifiedValues[key] as Date);
+        } else {
+          payload[key] = modifiedValues[key];
+        }
+      }
+    });
+    return payload;
+  };
+
+  // 'Save' handler method
+  const onSave = () => {
+    setIsDataLoading(true);
+    const modifiedValues = props.modifiedValues();
+
+    const payload = buildPayload(modifiedValues, [
+      "ipatokenowner",
+      "description",
+      "ipatokennotbefore",
+      "ipatokennotafter",
+      "ipatokenvendor",
+      "ipatokenmodel",
+      "ipatokenserial",
+    ]);
+
+    modifyOtpToken([payload])
+      .then((response) => {
+        if ("data" in response) {
+          const data = response.data;
+          if (data?.error) {
+            dispatch(
+              addAlert({
+                name: "error",
+                title: data.error,
+                variant: "danger",
+              })
+            );
+          }
+          if (data?.result) {
+            const results = data.result.results as unknown as BatchResult[];
+            const firstResult = results?.[0];
+
+            if (firstResult?.result) {
+              props.onOtpTokenChange(apiToOtpToken(firstResult.result));
+            }
+
+            if (firstResult?.error) {
+              dispatch(
+                addAlert({
+                  name: "error",
+                  title: firstResult.error as string,
+                  variant: "danger",
+                })
+              );
+            } else if (firstResult?.result) {
+              dispatch(
+                addAlert({
+                  name: "success",
+                  title: `OTP token '${props.otpToken.ipatokenuniqueid}' updated`,
+                  variant: "success",
+                })
+              );
+              props.onResetValues();
+              props.onRefresh();
+            }
+          }
+        }
+      })
+      .finally(() => {
+        setIsDataLoading(false);
+      });
+  };
+
+  // Toolbar
+  const toolbarFields = [
+    {
+      key: 0,
+      element: (
+        <Button
+          variant="secondary"
+          data-cy="otp-tokens-tab-settings-button-refresh"
+          onClick={props.onRefresh}
+        >
+          Refresh
+        </Button>
+      ),
+    },
+    {
+      key: 1,
+      element: (
+        <Button
+          variant="secondary"
+          data-cy="otp-tokens-tab-settings-button-revert"
+          onClick={onRevert}
+          isDisabled={!props.isModified || isDataLoading}
+        >
+          Revert
+        </Button>
+      ),
+    },
+    {
+      key: 2,
+      element: (
+        <Button
+          variant="primary"
+          data-cy="otp-tokens-tab-settings-button-save"
+          onClick={onSave}
+          isDisabled={!props.isModified || isDataLoading || !isVendorValid}
+        >
+          Save
+        </Button>
+      ),
+    },
+  ];
+
+  return (
+    <TabLayout
+      id="settings-page"
+      toolbarItems={toolbarFields}
+      dataCy="otp-tokens-settings"
+    >
+      <Sidebar isPanelRight>
+        <SidebarPanel variant="sticky">
+          <HelpTextWithIconLayout
+            textContent="Help"
+            icon={
+              <OutlinedQuestionCircleIcon className="pf-v6-u-primary-color-100 pf-v6-u-mr-sm" />
+            }
+          />
+        </SidebarPanel>
+        <SidebarContent className="pf-v6-u-mr-xl">
+          <TitleLayout
+            key={0}
+            id="otp-token-settings"
+            text="OTP token settings"
+            headingLevel="h2"
+            className="pf-v6-u-mt-md pf-v6-u-mb-lg"
+          />
+          <Form className="pf-v6-u-mb-lg">
+            <Flex direction={{ default: "column", lg: "row" }}>
+              <FlexItem flex={{ default: "flex_1" }}>
+                <FormGroup
+                  label="Unique ID"
+                  data-cy="otp-tokens-tab-settings-textbox-ipatokenuniqueid"
+                  role="ipatokenuniqueid"
+                  className="pf-v6-u-mb-md"
+                >
+                  <IpaTextInput
+                    dataCy="otp-tokens-tab-settings-textbox-ipatokenuniqueid"
+                    name={"ipatokenuniqueid"}
+                    ariaLabel={"Unique ID text input"}
+                    ipaObject={ipaObject}
+                    onChange={recordOnChange}
+                    objectName="otptoken"
+                    metadata={props.metadata}
+                  />
+                </FormGroup>
+                <FormGroup
+                  label="Type"
+                  data-cy="otp-tokens-tab-settings-textbox-type"
+                  role="type"
+                  className="pf-v6-u-mb-md"
+                >
+                  <IpaTextInput
+                    dataCy="otp-tokens-tab-settings-textbox-type"
+                    name={"type"}
+                    ariaLabel={"Type text input"}
+                    ipaObject={ipaObject}
+                    onChange={recordOnChange}
+                    objectName="otptoken"
+                    metadata={props.metadata}
+                  />
+                </FormGroup>
+                <FormGroup
+                  label="Description"
+                  data-cy="otp-tokens-tab-settings-textbox-description"
+                  role="description"
+                  className="pf-v6-u-mb-md"
+                >
+                  <IpaTextArea
+                    name={"description"}
+                    aria-label={"Description text input"}
+                    ipaObject={ipaObject}
+                    onChange={recordOnChange}
+                    objectName="otptoken"
+                    metadata={props.metadata}
+                    dataCy="otp-tokens-tab-settings-textbox-description"
+                  />
+                </FormGroup>
+                <FormGroup
+                  label="Owner"
+                  data-cy="otp-tokens-tab-settings-textbox-ipatokenowner"
+                  role="ipatokenowner"
+                  className="pf-v6-u-mb-md"
+                >
+                  <IpaSelect
+                    dataCy="otp-tokens-tab-settings-select-ipatokenowner"
+                    name={"ipatokenowner"}
+                    ariaLabel={"Owner select"}
+                    ipaObject={ipaObject}
+                    onChange={recordOnChange}
+                    objectName="otptoken"
+                    metadata={props.metadata}
+                    options={props.users.map(
+                      (user) => user.uid?.toString() || ""
+                    )}
+                  />
+                </FormGroup>
+                <FormGroup
+                  label="Validity start"
+                  data-cy="otp-tokens-tab-settings-textbox-ipatokennotbefore"
+                  role="validity-start"
+                  className="pf-v6-u-mb-md"
+                >
+                  <IpaCalendar
+                    name={"ipatokennotbefore"}
+                    ariaLabel={"Validity start date"}
+                    ipaObject={ipaObject}
+                    onChange={recordOnChange}
+                    objectName="otptoken"
+                    metadata={props.metadata}
+                    dataCy="otp-tokens-tab-settings-calendar-ipatokennotbefore"
+                  />
+                </FormGroup>
+                <FormGroup
+                  label="Validity end"
+                  data-cy="otp-tokens-tab-settings-textbox-ipatokennotafter"
+                  role="validity-end"
+                  className="pf-v6-u-mb-md"
+                >
+                  <IpaCalendar
+                    name={"ipatokennotafter"}
+                    ariaLabel={"Validity end date"}
+                    ipaObject={ipaObject}
+                    onChange={recordOnChange}
+                    objectName="otptoken"
+                    metadata={props.metadata}
+                    dataCy="otp-tokens-tab-settings-calendar-ipatokennotafter"
+                  />
+                </FormGroup>
+              </FlexItem>
+              <FlexItem flex={{ default: "flex_1" }}>
+                <FormGroup
+                  label="Vendor"
+                  data-cy="otp-tokens-tab-settings-textbox-ipatokenvendor"
+                  role="vendor"
+                  className="pf-v6-u-mb-md"
+                >
+                  <IpaTextInput
+                    dataCy="otp-tokens-tab-settings-textbox-ipatokenvendor"
+                    name={"ipatokenvendor"}
+                    ariaLabel={"Vendor text input"}
+                    ipaObject={ipaObject}
+                    onChange={recordOnChange}
+                    objectName="otptoken"
+                    metadata={props.metadata}
+                    rules={validCharsRules}
+                  />
+                </FormGroup>
+                <FormGroup
+                  label="Model"
+                  data-cy="otp-tokens-tab-settings-textbox-ipatokenmodel"
+                  role="model"
+                  className="pf-v6-u-mb-md"
+                >
+                  <IpaTextInput
+                    dataCy="otp-tokens-tab-settings-textbox-ipatokenmodel"
+                    name={"ipatokenmodel"}
+                    ariaLabel={"Model text input"}
+                    ipaObject={ipaObject}
+                    onChange={recordOnChange}
+                    objectName="otptoken"
+                    metadata={props.metadata}
+                    rules={validCharsRules}
+                  />
+                </FormGroup>
+                <FormGroup
+                  label="Serial"
+                  data-cy="otp-tokens-tab-settings-textbox-ipatokenserial"
+                  role="serial"
+                  className="pf-v6-u-mb-md"
+                >
+                  <IpaTextInput
+                    dataCy="otp-tokens-tab-settings-textbox-ipatokenmodel"
+                    name={"ipatokenserial"}
+                    ariaLabel={"Serial text input"}
+                    ipaObject={ipaObject}
+                    onChange={recordOnChange}
+                    objectName="otptoken"
+                    metadata={props.metadata}
+                    rules={validCharsRules}
+                  />
+                </FormGroup>
+                <FormGroup
+                  label="Algorithm"
+                  data-cy="otp-tokens-tab-settings-textbox-ipatokenotpalgorithm"
+                  role="algorithm"
+                  className="pf-v6-u-mb-md"
+                >
+                  <IpaTextInput
+                    dataCy="otp-tokens-tab-settings-textbox-ipatokenmodel"
+                    name={"ipatokenotpalgorithm"}
+                    ariaLabel={"Algorithm text input"}
+                    ipaObject={ipaObject}
+                    onChange={recordOnChange}
+                    objectName="otptoken"
+                    metadata={props.metadata}
+                    rules={validCharsRules}
+                  />
+                </FormGroup>
+                <FormGroup
+                  label="Digits"
+                  data-cy="otp-tokens-tab-settings-textbox-ipatokenotpdigits"
+                  role="digits"
+                  className="pf-v6-u-mb-md"
+                >
+                  <IpaTextInput
+                    dataCy="otp-tokens-tab-settings-textbox-ipatokenotpdigits"
+                    name={"ipatokenotpdigits"}
+                    ariaLabel={"Digits text input"}
+                    ipaObject={ipaObject}
+                    onChange={recordOnChange}
+                    objectName="otptoken"
+                    metadata={props.metadata}
+                  />
+                </FormGroup>
+                <FormGroup
+                  label="Clock offset (seconds)"
+                  data-cy="otp-tokens-tab-settings-textbox-ipatokentotpclockoffset"
+                  role="clock-offset"
+                  className="pf-v6-u-mb-md"
+                >
+                  <IpaTextInput
+                    dataCy="otp-tokens-tab-settings-textbox-ipatokentotpclockoffset"
+                    name={"ipatokentotpclockoffset"}
+                    ariaLabel={"Clock offset text input"}
+                    ipaObject={ipaObject}
+                    onChange={recordOnChange}
+                    objectName="otptoken"
+                    metadata={props.metadata}
+                  />
+                </FormGroup>
+                <FormGroup
+                  label="Clock interval (seconds)"
+                  data-cy="otp-tokens-tab-settings-textbox-ipatokentotptimestep"
+                  role="clock-interval"
+                  className="pf-v6-u-mb-md"
+                >
+                  <IpaTextInput
+                    dataCy="otp-tokens-tab-settings-textbox-ipatokentotptimestep"
+                    name={"ipatokentotptimestep"}
+                    ariaLabel={"Clock interval text input"}
+                    ipaObject={ipaObject}
+                    onChange={recordOnChange}
+                    objectName="otptoken"
+                    metadata={props.metadata}
+                  />
+                </FormGroup>
+              </FlexItem>
+            </Flex>
+          </Form>
+        </SidebarContent>
+      </Sidebar>
+    </TabLayout>
+  );
+};
+
+export default OtpTokensSettings;

--- a/src/pages/OtpTokens/OtpTokensTabs.tsx
+++ b/src/pages/OtpTokens/OtpTokensTabs.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+// PatternFly
+import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
+// React Router DOM
+import { useNavigate } from "react-router";
+// Navigation
+import { URL_PREFIX } from "src/navigation/NavRoutes";
+import { NotFound } from "src/components/errors/PageErrors";
+// Hooks
+import { useOtpTokensSettingsData } from "src/hooks/useOtpTokensSettingsData";
+// Components
+import TitleLayout from "src/components/layouts/TitleLayout";
+import DataSpinner from "src/components/layouts/DataSpinner";
+import BreadCrumb, {
+  BreadCrumbItem,
+} from "src/components/layouts/BreadCrumb/BreadCrumb";
+import { IpatokenuniqueidParams, useSafeParams } from "src/utils/paramsUtils";
+import OtpTokensSettings from "./OtpTokensSettings";
+
+const OtpTokensTabs = ({ section }: { section: string }) => {
+  const { ipatokenuniqueid } = useSafeParams<IpatokenuniqueidParams>([
+    "ipatokenuniqueid",
+  ]);
+  const navigate = useNavigate();
+  const pathname = "otp-tokens";
+
+  // Data loaded from the API
+  const otpTokensSettingsData = useOtpTokensSettingsData(ipatokenuniqueid);
+
+  const handleTabClick = (
+    _event: React.MouseEvent<HTMLElement, MouseEvent>,
+    tabIndex: number | string
+  ) => {
+    if (tabIndex === "settings") {
+      navigate("/" + pathname + "/" + ipatokenuniqueid);
+    }
+  };
+
+  const breadcrumbItems: BreadCrumbItem[] = [
+    {
+      name: "Otp tokens",
+      url: URL_PREFIX + "/" + pathname,
+    },
+    {
+      name: ipatokenuniqueid,
+      url: URL_PREFIX + "/" + pathname + "/" + ipatokenuniqueid,
+      isActive: true,
+    },
+  ];
+
+  if (otpTokensSettingsData.isLoading || !otpTokensSettingsData.otpToken) {
+    return <DataSpinner />;
+  }
+
+  if (
+    !otpTokensSettingsData.isLoading &&
+    Object.keys(otpTokensSettingsData.otpToken).length === 0
+  ) {
+    return <NotFound />;
+  }
+
+  return (
+    <>
+      <PageSection hasBodyWrapper={false}>
+        <BreadCrumb breadcrumbItems={breadcrumbItems} />
+        <TitleLayout
+          id={ipatokenuniqueid}
+          preText="OTP token:"
+          text={ipatokenuniqueid}
+          headingLevel="h1"
+        />
+      </PageSection>
+      <PageSection hasBodyWrapper={false} type="tabs" isFilled>
+        <Tabs
+          activeKey={section}
+          onSelect={handleTabClick}
+          variant="secondary"
+          isBox
+          className="pf-v6-u-ml-lg"
+          mountOnEnter
+          unmountOnExit
+        >
+          <Tab
+            eventKey={"settings"}
+            name="settings-details"
+            title={<TabTitleText>Settings</TabTitleText>}
+            data-cy="otp-tokens-tab-settings"
+          >
+            <OtpTokensSettings
+              otpToken={otpTokensSettingsData.otpToken}
+              originalOtpToken={otpTokensSettingsData.originalOtpToken}
+              users={otpTokensSettingsData.users}
+              metadata={otpTokensSettingsData.metadata}
+              onOtpTokenChange={otpTokensSettingsData.setOtpToken}
+              onRefresh={otpTokensSettingsData.refetch}
+              isDataLoading={otpTokensSettingsData.isLoading}
+              isModified={otpTokensSettingsData.modified}
+              modifiedValues={otpTokensSettingsData.modifiedValues}
+              onResetValues={otpTokensSettingsData.resetValues}
+              pathname={pathname}
+            />
+          </Tab>
+        </Tabs>
+      </PageSection>
+    </>
+  );
+};
+export default OtpTokensTabs;

--- a/src/services/rpcOtpTokens.ts
+++ b/src/services/rpcOtpTokens.ts
@@ -302,6 +302,22 @@ const extendedApi = api.injectEndpoints({
         },
       }
     ),
+    /**
+     * Show OTP token
+     * @param {string} otpTokenId - The ID of the OTP token
+     * @returns {FindRPCResponse} - The OTP token
+     * */
+    getOtpToken: build.query<FindRPCResponse, string>({
+      query: (otpTokenId) => {
+        return getCommand({
+          method: "otptoken_show",
+          params: [
+            [otpTokenId],
+            { all: true, rights: true, version: API_VERSION_BACKUP },
+          ],
+        });
+      },
+    }),
   }),
   overrideExisting: false,
 });
@@ -311,4 +327,5 @@ export const {
   useSearchOtpTokensEntriesMutation,
   useDeleteOtpTokensMutation,
   useModifyOtpTokensMutation,
+  useGetOtpTokenQuery,
 } = extendedApi;

--- a/src/utils/otpTokensUtils.tsx
+++ b/src/utils/otpTokensUtils.tsx
@@ -41,6 +41,12 @@ export function apiToOtpToken(apiRecord: Record<string, unknown>): OtpToken {
     dateValues,
     complexValues
   ) as Partial<OtpToken>;
+
+  // As `convertApiObj` converts the value to a string,
+  //  we need to convert it back to a boolean
+  converted.ipatokendisabled =
+    converted.ipatokendisabled?.toString() === "true";
+
   return partialOtpTokenToOtpToken(converted);
 }
 

--- a/src/utils/otpTokensUtils.tsx
+++ b/src/utils/otpTokensUtils.tsx
@@ -2,8 +2,8 @@ import { OtpToken } from "./datatypes/globalDataTypes";
 import { convertApiObj } from "./ipaObjectUtils";
 
 export const asRecord = (
-  element: Partial<OtpToken>,
-  onElementChange: (element: Partial<OtpToken>) => void
+  element: OtpToken,
+  onElementChange: (element: OtpToken) => void
 ) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const ipaObject = element as Record<string, any>;
@@ -24,7 +24,6 @@ const simpleValues = new Set([
   "ipatokenvendor",
   "ipatokenmodel",
   "ipatokenserial",
-  "ipatokenotpkey",
   "ipatokenotpalgorithm",
   "ipatokenotpdigits",
   "ipatokentotpclockoffset",

--- a/src/utils/paramsUtils.ts
+++ b/src/utils/paramsUtils.ts
@@ -9,6 +9,10 @@ export type CnParams = {
   cn: string;
 };
 
+export type IpatokenuniqueidParams = {
+  ipatokenuniqueid: string;
+};
+
 type Params = Record<string, string | undefined>;
 
 export const useSafeParams = <T extends Params>(


### PR DESCRIPTION
The OTP tokens > 'Settings' page must allow showing and modifying a given token parameters.

## Summary by Sourcery

Add a settings view for individual OTP tokens with routing, data loading, and editing capabilities.

New Features:
- Display a settings page for a specific OTP token, accessible via a dedicated route with breadcrumb navigation and tabs.
- Allow viewing and editing key OTP token attributes such as owner, validity, vendor, model, serial, and algorithm from the UI.

Enhancements:
- Expose an API query for fetching a single OTP token with full details and rights.
- Enable navigation from the OTP tokens list to individual token detail pages via row links.
- Provide a reusable hook to load and manage OTP token settings data, including users, metadata, and modified state tracking.