### PR TITLE
[POC] Topology graph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@patternfly/react-core": "^6.4.0",
         "@patternfly/react-icons": "^6.4.0",
         "@patternfly/react-table": "^6.4.0",
+        "@patternfly/react-topology": "^6.4.0",
         "@reduxjs/toolkit": "^2.6.1",
         "qrcode.react": "^4.2.0",
         "react": "^18.0.0",
@@ -1159,6 +1160,24 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/@dagrejs/dagre": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-1.1.2.tgz",
+      "integrity": "sha512-F09dphqvHsbe/6C2t2unbmpr5q41BNPEfJCdn8Z7aEBpVSy/zFQ/b4SWsweQjWNsYMDvE2ffNUN8X0CeFsEGNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dagrejs/graphlib": "2.2.2"
+      }
+    },
+    "node_modules/@dagrejs/graphlib": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-2.2.2.tgz",
+      "integrity": "sha512-CbyGpCDKsiTg/wuk79S7Muoj8mghDGAESWGxcSyhHX5jD35vYMBZochYVFzlHxynpE9unpu6O+4ZuhrLxASsOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">17.0.0"
       }
     },
     "node_modules/@dependents/detective-less": {
@@ -2545,6 +2564,31 @@
       "integrity": "sha512-iZthBoXSGQ/+PfGTdPFJVulaJZI3rwE+7A/whOXPGp3Jyq3k6X52pr1+5nlO6WHasbZ9FyeZGqXf4fazUZNjbw==",
       "license": "MIT"
     },
+    "node_modules/@patternfly/react-topology": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-topology/-/react-topology-6.4.0.tgz",
+      "integrity": "sha512-Uy2ofRnI0apYiPWUYIAlXifl+4QPx/sqsVku1WglCkqjMPwuR8vC/GTIJEq2qW7mucDAcWSTFAPc5+zqyPRrlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dagrejs/dagre": "1.1.2",
+        "@patternfly/react-core": "^6.0.0",
+        "@patternfly/react-icons": "^6.0.0",
+        "@patternfly/react-styles": "^6.0.0",
+        "@types/d3": "^7.4.0",
+        "@types/d3-force": "^1.2.1",
+        "d3": "^7.8.0",
+        "mobx": "^6.9.0",
+        "mobx-react": "^7.6.0",
+        "point-in-svg-path": "^1.0.1",
+        "popper.js": "^1.16.1",
+        "tslib": "^2.0.0",
+        "webcola": "3.4.0"
+      },
+      "peerDependencies": {
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "dev": true,
@@ -3278,6 +3322,259 @@
         "@types/deep-eql": "*"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-1.2.7.tgz",
+      "integrity": "sha512-zySqZfnxn67RVEGWzpD9dQA0AbNIp4Rj0qGvAuUdUNfGLrwuGCbEGAGze5hEdNaHJKQT2gTqr6j+qAzncm11ew==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "dev": true,
@@ -3286,6 +3583,12 @@
     "node_modules/@types/estree": {
       "version": "1.0.7",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -5050,6 +5353,416 @@
         "node": ">= 6"
       }
     },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/dashdash": {
       "version": "1.14.1",
       "dev": true,
@@ -5258,6 +5971,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/delayed-stream": {
@@ -7430,6 +8152,18 @@
         "node": ">=8.12.0"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "dev": true,
@@ -7551,6 +8285,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/interpret": {
@@ -8910,6 +9653,63 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/mobx": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.15.0.tgz",
+      "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mobx"
+      }
+    },
+    "node_modules/mobx-react": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/mobx-react/-/mobx-react-7.6.0.tgz",
+      "integrity": "sha512-+HQUNuh7AoQ9ZnU6c4rvbiVVl+wEkb9WqYsVDzGLng+Dqj1XntHu79PvEWKtSMoMj67vFp/ZPXcElosuJO8ckA==",
+      "license": "MIT",
+      "dependencies": {
+        "mobx-react-lite": "^3.4.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mobx"
+      },
+      "peerDependencies": {
+        "mobx": "^6.1.0",
+        "react": "^16.8.0 || ^17 || ^18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mobx-react-lite": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-3.4.3.tgz",
+      "integrity": "sha512-NkJREyFTSUXR772Qaai51BnE1voWx56LOL80xG7qkZr6vo8vEaLF3sz1JNUVh+rxmUzxYaqOhfuxTfqUh0FXUg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mobx"
+      },
+      "peerDependencies": {
+        "mobx": "^6.1.0",
+        "react": "^16.8.0 || ^17 || ^18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/mocha": {
       "version": "11.6.0",
       "dev": true,
@@ -9600,6 +10400,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/point-in-svg-path": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/point-in-svg-path/-/point-in-svg-path-1.0.2.tgz",
+      "integrity": "sha512-+Smsf7B9e7eRFHIwpN+4rE8inF2APbFWeywPfUgbeh02xdJSkbTz6Pqdt7A36wVCR+CnLbaNkRnBjgOpF5RMVQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=8.x.x"
+      }
+    },
+    "node_modules/popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -10382,6 +11202,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.39.0",
       "dev": true,
@@ -10496,6 +11322,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/rxjs": {
       "version": "7.8.2",
       "dev": true,
@@ -10574,7 +11406,6 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/sass-lookup": {
@@ -12365,6 +13196,61 @@
       "dependencies": {
         "defaults": "^1.0.3"
       }
+    },
+    "node_modules/webcola": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/webcola/-/webcola-3.4.0.tgz",
+      "integrity": "sha512-4BiLXjXw3SJHo3Xd+rF+7fyClT6n7I+AR6TkBqyQ4kTsePSAMDLRCXY1f3B/kXJeP9tYn4G1TblxTO+jAt0gaw==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-dispatch": "^1.0.3",
+        "d3-drag": "^1.0.4",
+        "d3-shape": "^1.3.5",
+        "d3-timer": "^1.0.5"
+      }
+    },
+    "node_modules/webcola/node_modules/d3-dispatch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
+      "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/webcola/node_modules/d3-drag": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.5.tgz",
+      "integrity": "sha512-rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-dispatch": "1",
+        "d3-selection": "1"
+      }
+    },
+    "node_modules/webcola/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/webcola/node_modules/d3-selection": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.2.tgz",
+      "integrity": "sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/webcola/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/webcola/node_modules/d3-timer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@patternfly/react-core": "^6.4.0",
     "@patternfly/react-icons": "^6.4.0",
     "@patternfly/react-table": "^6.4.0",
+    "@patternfly/react-topology": "^6.4.0",
     "@reduxjs/toolkit": "^2.6.1",
     "qrcode.react": "^4.2.0",
     "react": "^18.0.0",

--- a/src/components/TopologyVisualization/TopologyVisualization.tsx
+++ b/src/components/TopologyVisualization/TopologyVisualization.tsx
@@ -1,0 +1,177 @@
+import React from "react";
+import {
+  ColaLayout,
+  ComponentFactory,
+  DefaultEdge,
+  DefaultGroup,
+  DefaultNode,
+  Graph,
+  GraphComponent,
+  graphDropTargetSpec,
+  isEdge,
+  isNode,
+  Layout,
+  LayoutFactory,
+  ModelKind,
+  nodeDragSourceSpec,
+  nodeDropTargetSpec,
+  SELECTION_EVENT,
+  Visualization,
+  VisualizationProvider,
+  VisualizationSurface,
+  withPanZoom,
+  withDndDrop,
+  withDragNode,
+  withTargetDrag,
+  Edge,
+  GraphElement,
+  DragObjectWithType,
+  Node as TopologyNode,
+  NodeModel,
+  EdgeModel,
+} from "@patternfly/react-topology";
+import { ServerIcon } from "@patternfly/react-icons";
+
+// Types
+interface CustomNodeProps {
+  element: GraphElement;
+}
+
+interface SuffixEdgeClass {
+  ca: string;
+  domain: string;
+}
+
+interface TopologyVisualizationProps {
+  nodes: NodeModel[];
+  edges: EdgeModel[];
+}
+
+// Constants
+const CONNECTOR_TARGET_DROP = "connector-target-drop";
+
+const SUFFIX_EDGE_CLASS: SuffixEdgeClass = {
+  ca: "topology-ca-blue-edge",
+  domain: "topology-domain-orange-edge",
+};
+
+// Layout factory
+const createLayoutFactory = (): LayoutFactory => {
+  return (type: string, graph: Graph): Layout => {
+    switch (type) {
+      case "Cola":
+        return new ColaLayout(graph);
+      default:
+        return new ColaLayout(graph, { layoutOnDrag: false });
+    }
+  };
+};
+
+// Custom node component
+const CustomStyledNode = ({ element }: CustomNodeProps) => {
+  if (!isNode(element)) return null;
+  return (
+    <DefaultNode element={element} className="topology-node-server">
+      <g transform={`translate(23, 23)`}>
+        <ServerIcon width={25} height={25} />
+      </g>
+    </DefaultNode>
+  );
+};
+
+// Custom edge component
+const CustomStyledEdge = (props: { element: GraphElement }) => {
+  if (!isEdge(props.element)) return null;
+  const data = props.element.getData();
+  const suffixClassName = SUFFIX_EDGE_CLASS[data?.suffixType] || "";
+  return <DefaultEdge {...props} className={suffixClassName} />;
+};
+
+// Component factory
+const createComponentFactory = (): ComponentFactory => {
+  return (kind: ModelKind, type: string) => {
+    switch (type) {
+      case "group":
+        return DefaultGroup;
+      default:
+        switch (kind) {
+          case ModelKind.graph:
+            return withDndDrop(graphDropTargetSpec())(
+              withPanZoom()(GraphComponent)
+            );
+          case ModelKind.node:
+            return withDndDrop(nodeDropTargetSpec())(
+              withDragNode(nodeDragSourceSpec("node", true, true))(
+                CustomStyledNode
+              )
+            );
+          case ModelKind.edge:
+            return withTargetDrag<
+              DragObjectWithType,
+              Node,
+              { dragging?: boolean },
+              {
+                element: GraphElement;
+              }
+            >({
+              item: { type: CONNECTOR_TARGET_DROP },
+              begin: (_monitor, props) => {
+                props.element.raise();
+                return props.element;
+              },
+              drag: (event, _monitor, props) => {
+                (props.element as Edge).setEndPoint(event.x, event.y);
+              },
+              end: (dropResult, monitor, props) => {
+                if (monitor.didDrop() && dropResult && props) {
+                  (props.element as Edge).setTarget(
+                    dropResult as unknown as TopologyNode<NodeModel>
+                  );
+                }
+                (props.element as Edge).setEndPoint();
+              },
+              collect: (monitor) => ({
+                dragging: monitor.isDragging(),
+              }),
+            })(CustomStyledEdge);
+          default:
+            throw Error(`Unexpected ModelKind ${kind satisfies never}.`);
+        }
+    }
+  };
+};
+
+/**
+ * Component for rendering PatternFly Topology visualization
+ * Encapsulates controller initialization, factories, and event handling
+ */
+const TopologyVisualization = ({
+  nodes,
+  edges,
+}: TopologyVisualizationProps) => {
+  const [selectedIds, setSelectedIds] = React.useState<string[]>([]);
+
+  const controller = React.useMemo(() => {
+    const newController = new Visualization();
+    newController.registerLayoutFactory(createLayoutFactory());
+    newController.registerComponentFactory(createComponentFactory());
+    newController.addEventListener(SELECTION_EVENT, setSelectedIds);
+    newController.fromModel(
+      {
+        nodes,
+        edges,
+        graph: { id: "model-graph", type: "graph", layout: "Cola" },
+      },
+      false
+    );
+    return newController;
+  }, [nodes, edges, setSelectedIds]);
+
+  return (
+    <VisualizationProvider controller={controller}>
+      <VisualizationSurface state={{ selectedIds }} />
+    </VisualizationProvider>
+  );
+};
+
+export default TopologyVisualization;

--- a/src/hooks/useTopologyGraph.tsx
+++ b/src/hooks/useTopologyGraph.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+// RPC
+import { useFindTopologyFullDataQuery } from "src/services/rpcTopology";
+import { useFindServerQuery } from "src/services/rpcServer";
+// Data types
+import {
+  TopologySuffix,
+  TopologySegment,
+  IpaServer,
+} from "src/utils/datatypes/globalDataTypes";
+
+type TopologyGraphData = {
+  isLoading: boolean;
+  refetch: () => void;
+  servers: IpaServer[];
+  topologySuffixes: TopologySuffix[];
+  topologySegments: TopologySegment[];
+};
+
+const useTopologyGraph = (): TopologyGraphData => {
+  const [topologySuffixes, setTopologySuffixes] = React.useState<
+    TopologySuffix[]
+  >([]);
+  const [topologySegments, setTopologySegments] = React.useState<
+    TopologySegment[]
+  >([]);
+  const [servers, setServers] = React.useState<IpaServer[]>([]);
+
+  // [API call] Topology suffix & segments
+  const {
+    refetch: refetchTopology,
+    data: topologyData,
+    isLoading: isTopologyDataLoading,
+  } = useFindTopologyFullDataQuery({
+    cn: "",
+    sizelimit: 100,
+  });
+
+  // [API call] Server
+  const {
+    refetch: refetchServer,
+    data: serverData,
+    isLoading: isServerDataLoading,
+  } = useFindServerQuery({
+    cn: "",
+    sizelimit: 100,
+  });
+
+  React.useEffect(() => {
+    if (!isTopologyDataLoading && !isServerDataLoading) {
+      setTopologySuffixes(topologyData?.topologySuffixes || []);
+      setTopologySegments(
+        topologyData?.topologySegments.filter(
+          (s): s is TopologySegment => s !== null
+        ) || []
+      );
+      setServers(serverData || []);
+    }
+  }, [isTopologyDataLoading, isServerDataLoading, topologyData, serverData]);
+
+  return {
+    isLoading: isTopologyDataLoading || isServerDataLoading,
+    refetch: () => {
+      refetchTopology();
+      refetchServer();
+    },
+    topologySuffixes,
+    topologySegments,
+    servers,
+  };
+};
+
+export { useTopologyGraph };

--- a/src/main.css
+++ b/src/main.css
@@ -43,3 +43,21 @@ code {
   background-color: rgb(222, 243, 255);
   padding: 0.2em;
 }
+
+.topology-ca-blue-edge {
+  &.pf-topology__edge,
+  .pf-topology-connector-arrow {
+    --edge--stroke: rgb(0, 128, 255);
+  }
+}
+
+.topology-domain-orange-edge {
+  &.pf-topology__edge,
+  .pf-topology-connector-arrow {
+    --edge--stroke: rgb(255, 165, 0);
+  }
+}
+
+.topology-node-server {
+  --pf-topology__node--Color: rgb(8, 152, 0);
+}

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -76,6 +76,7 @@ import TrustsTabs from "src/pages/Trusts/TrustsTabs";
 import IdRangesTabs from "src/pages/IdRanges/IdRangesTabs";
 import GlobalTrustConfig from "src/pages/Trusts/GlobalTrustConfig";
 import OtpTokens from "src/pages/OtpTokens/OtpTokens";
+import TopologyGraph from "src/pages/Topology/TopologyGraph";
 
 // Renders routes (React)
 export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
@@ -544,6 +545,9 @@ export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
               </Route>
               <Route path="trusts-config">
                 <Route path="" element={<GlobalTrustConfig />} />
+              </Route>
+              <Route path="topology-graph">
+                <Route path="" element={<TopologyGraph />} />
               </Route>
               <Route path="configuration" element={<Configuration />} />
               {/* Redirect to Active users page if user is logged in and navigates to the root page */}

--- a/src/navigation/NavRoutes.ts
+++ b/src/navigation/NavRoutes.ts
@@ -65,6 +65,8 @@ const DNSGlobalConfigGroupRef = "dns-global-config";
 // - Trusts
 const TrustsGroupRef = "trusts";
 const TrustsGlobalConfigGroupRef = "trusts-config";
+// - Topology
+const TopologyGroupRef = "topology-graph";
 // - Configuration
 const ConfigRef = "configuration";
 
@@ -438,6 +440,21 @@ export const getNavigationRoutes = (
           title: `${BASE_TITLE} - ID ranges`,
           path: "id-ranges",
           items: [],
+        },
+        {
+          label: "Topology",
+          group: TopologyGroupRef,
+          title: `${BASE_TITLE} - Topology`,
+          path: "topology-graph",
+          items: [
+            {
+              label: "Topology graph",
+              group: TopologyGroupRef,
+              title: `${BASE_TITLE} - Topology graph`,
+              path: "topology-graph",
+              items: [],
+            },
+          ],
         },
         {
           label: "Configuration",

--- a/src/pages/Topology/TopologyGraph.tsx
+++ b/src/pages/Topology/TopologyGraph.tsx
@@ -1,0 +1,128 @@
+import React from "react";
+// PatternFly
+import { PageSection } from "@patternfly/react-core";
+import {
+  EdgeStyle,
+  NodeShape,
+  NodeModel,
+  EdgeModel,
+  NodeStatus,
+} from "@patternfly/react-topology";
+// Components
+import TitleLayout from "src/components/layouts/TitleLayout";
+import ToolbarLayout, {
+  ToolbarItem,
+} from "src/components/layouts/ToolbarLayout";
+import SecondaryButton from "src/components/layouts/SecondaryButton";
+import DataSpinner from "src/components/layouts/DataSpinner";
+import TopologyVisualization from "src/components/TopologyVisualization/TopologyVisualization";
+// Hooks
+import { useTopologyGraph } from "src/hooks/useTopologyGraph";
+import useUpdateRoute from "src/hooks/useUpdateRoute";
+
+// Constants
+const NODE_SHAPE = NodeShape.ellipse;
+const NODE_DIAMETER = 70;
+
+// Main component
+const TopologyGraph = () => {
+  const { isLoading, refetch, servers, topologySegments } = useTopologyGraph();
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  const { browserTitle } = useUpdateRoute({ pathname: "topology-graph" });
+
+  // Set the page title to be shown in the browser tab
+  React.useEffect(() => {
+    document.title = browserTitle;
+  }, [browserTitle]);
+
+  // Transform server data to node models
+  const nodes: NodeModel[] = React.useMemo(
+    () =>
+      servers.map((server) => ({
+        id: `node-${server.cn}`,
+        type: "node",
+        label: server.cn,
+        status: NodeStatus.info,
+        width: NODE_DIAMETER,
+        height: NODE_DIAMETER,
+        shape: NODE_SHAPE,
+        data: { badge: "Server" },
+      })),
+    [servers]
+  );
+
+  // Transform topology segments to edge models
+  const edges: EdgeModel[] = React.useMemo(
+    () =>
+      topologySegments.map((segment) => ({
+        id: `edge-${segment.iparepltoposegmentleftnode}-${segment.iparepltoposegmentrightnode}`,
+        type: "edge",
+        source: `node-${segment.iparepltoposegmentleftnode}`,
+        target: `node-${segment.iparepltoposegmentrightnode}`,
+        edgeStyle: EdgeStyle.default,
+        data: { suffixType: segment.suffixType },
+      })),
+    [topologySegments]
+  );
+
+  // Toolbar items
+  const toolbarItems: ToolbarItem[] = [
+    {
+      key: 0,
+      element: (
+        <SecondaryButton
+          dataCy="topology-graph-button-refresh"
+          onClickHandler={refetch}
+        >
+          Refresh
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 1,
+      element: (
+        <SecondaryButton
+          dataCy="topology-graph-button-add"
+          onClickHandler={() => {}}
+        >
+          Add
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 2,
+      element: (
+        <SecondaryButton
+          dataCy="topology-graph-button-delete"
+          onClickHandler={() => {}}
+        >
+          Delete
+        </SecondaryButton>
+      ),
+    },
+  ];
+
+  // Spinner on loading state
+  if (isLoading) {
+    return <DataSpinner />;
+  }
+
+  return (
+    <>
+      <PageSection hasBodyWrapper={false}>
+        <TitleLayout
+          id="topology-graph-page"
+          headingLevel="h1"
+          text="Topology Graph"
+        />
+      </PageSection>
+      <PageSection hasBodyWrapper={false} isFilled={true}>
+        <ToolbarLayout toolbarItems={toolbarItems} />
+        <TopologyVisualization nodes={nodes} edges={edges} />
+      </PageSection>
+    </>
+  );
+};
+
+export default TopologyGraph;

--- a/src/services/rpcServer.ts
+++ b/src/services/rpcServer.ts
@@ -1,0 +1,74 @@
+import { api, FindRPCResponse, getCommand } from "./rpc";
+// utils
+import { API_VERSION_BACKUP } from "../utils/utils";
+import { IpaServer } from "src/utils/datatypes/globalDataTypes";
+import { apiToIpaServer } from "src/utils/ipaServerUtils";
+
+/**
+ * Topology-related endpoints: useServerFindQuery
+ *
+ * API commands:
+ * - server_find: https://freeipa.readthedocs.io/en/latest/api/server_find.html
+ */
+
+interface ServerFindPayload {
+  cn: string;
+  ipamindomainlevel?: number;
+  ipamaxdomainlevel?: number;
+  no_members?: boolean;
+  topologysuffix?: string[];
+  no_topologysuffix?: string[];
+  in_location?: string[];
+  not_in_location?: string[];
+  servrole?: string[];
+  timelimit?: number;
+  sizelimit?: number;
+  pkey_only?: boolean;
+  version?: string;
+}
+
+const extendedApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    /**
+     * Find server
+     * @param {ServerFindPayload} payload - The payload containing the search parameters
+     * @returns {IpaServer} - The server
+     */
+    findServer: build.query<IpaServer[], ServerFindPayload>({
+      query: (payload) => {
+        const params: Record<string, unknown> = {
+          version: payload.version || API_VERSION_BACKUP,
+        };
+
+        // Fields handled separately (cn is first arg, version already set)
+        const excludedFields = new Set(["cn", "version"]);
+
+        Object.entries(payload).forEach(([key, value]) => {
+          if (
+            !excludedFields.has(key) &&
+            value !== undefined &&
+            value !== null
+          ) {
+            params[key] = value;
+          }
+        });
+
+        return getCommand({
+          method: "server_find",
+          params: [[payload.cn], params],
+        });
+      },
+      transformResponse: (response: FindRPCResponse) => {
+        const servers = response.result.result as unknown as Record<
+          string,
+          unknown
+        >[];
+        const serversList = servers.map((server) => apiToIpaServer(server));
+        return serversList;
+      },
+    }),
+  }),
+  overrideExisting: false,
+});
+
+export const { useFindServerQuery } = extendedApi;

--- a/src/services/rpcTopology.ts
+++ b/src/services/rpcTopology.ts
@@ -1,0 +1,125 @@
+import { api, FindRPCResponse, getCommand } from "./rpc";
+// utils
+import { API_VERSION_BACKUP } from "../utils/utils";
+import {
+  cnType,
+  TopologySegment,
+  TopologySuffix,
+} from "src/utils/datatypes/globalDataTypes";
+import { apiToTopologySuffix } from "src/utils/topologyUtils";
+
+/**
+ * Topology-related endpoints: findTopologyFullDataQuery
+ *
+ * API commands:
+ * - topologysuffix_find: https://freeipa.readthedocs.io/en/latest/api/topologysuffix_find.html
+ * - topologysegment_find: https://freeipa.readthedocs.io/en/latest/api/topologysegment_find.html
+ */
+
+interface TopologyFullDataPayload {
+  cn: string;
+  sizelimit: number;
+  version?: string;
+}
+
+interface TopologyFullData {
+  topologySuffixes: TopologySuffix[];
+  topologySegments: (TopologySegment | null)[];
+}
+
+const extendedApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    /**
+     * Find topology full data
+     * @param {string} cn - The CN of the topology
+     * @returns {TopologyFullData} - The topology full data
+     */
+    findTopologyFullData: build.query<
+      TopologyFullData,
+      TopologyFullDataPayload
+    >({
+      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
+        const { cn, sizelimit, version } = payloadData;
+
+        const params = {
+          sizelimit,
+          version: version || API_VERSION_BACKUP,
+        };
+
+        // Make call using 'fetchWithBQ'
+        const getResultTopology = await fetchWithBQ(
+          getCommand({
+            method: "topologysuffix_find",
+            params: [[cn], params],
+          })
+        );
+
+        // Return possible errors
+        if (getResultTopology.error) {
+          return { error: getResultTopology.error };
+        }
+
+        // If no error: cast and assign 'data'
+        const responseDataTopology = getResultTopology.data as FindRPCResponse;
+
+        const topologyIds: string[] = [];
+        const topologyItemsCount = responseDataTopology.result.result
+          .length as number;
+
+        for (let i = 0; i < topologyItemsCount && i < sizelimit; i++) {
+          const topologyId = responseDataTopology.result.result[i] as cnType;
+          const { cn } = topologyId;
+          topologyIds.push(cn[0] as string);
+        }
+
+        const topologySuffixes: TopologySuffix[] = [];
+        for (let i = 0; i < topologyItemsCount && i < sizelimit; i++) {
+          topologySuffixes.push(
+            apiToTopologySuffix(
+              responseDataTopology.result.result[i] as Record<string, unknown>
+            )
+          );
+        }
+
+        // Find the topology segments and feed them with the data we just got
+        const topologySegments: (TopologySegment | null)[] = [];
+        for (const topologyId of topologyIds) {
+          const getTopologySegmentsResult = await fetchWithBQ(
+            getCommand({
+              method: "topologysegment_find",
+              params: [[topologyId], params],
+            })
+          );
+
+          if (getTopologySegmentsResult.error) {
+            return { error: getTopologySegmentsResult.error };
+          }
+
+          const responseDataTopologySegments =
+            getTopologySegmentsResult.data as FindRPCResponse;
+          const segmentsArray = responseDataTopologySegments.result
+            .result as unknown as Record<string, unknown>[];
+          if (segmentsArray.length === 0) {
+            topologySegments.push(null);
+          } else {
+            for (const segmentData of segmentsArray) {
+              const segment = segmentData as unknown as TopologySegment;
+              segment.suffixType = topologyId;
+              topologySegments.push(segment);
+            }
+          }
+        }
+
+        return {
+          data: {
+            topologySuffixes,
+            topologySegments,
+          },
+        };
+      },
+    }),
+  }),
+  overrideExisting: false,
+});
+
+export const { useFindTopologyFullDataQuery } = extendedApi;

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -1176,3 +1176,38 @@ export const DEFAULT_ERROR_VALIDATION_DATA: ErrorValidationData = {
   message: "",
   pfError: ValidatedOptions.default,
 };
+
+export type TopologyDirection = "both" | "left-right" | "right-left";
+export type TopologyEnabled = "on" | "off";
+
+export interface TopologySegment {
+  cn: string;
+  iparepltoposegmentleftnode: string;
+  iparepltoposegmentrightnode: string;
+  iparepltoposegmentdirection: TopologyDirection;
+  nsds5replicastripattrs: string;
+  nsds5replicatedattributelist: string;
+  nsds5replicatedattributelisttotal: string;
+  nsds5replicatimeout: number; // Maximum value: 2147483647
+  nsds5replicaenabled: TopologyEnabled;
+  suffixType: string;
+}
+
+export interface TopologySuffix {
+  cn: string;
+  iparepltopoconfroot: string;
+  dn: string;
+}
+
+export interface IpaServer {
+  cn: string;
+  iparepltopomanagedsuffix: string[];
+  iparepltopomanagedsuffix_topologysuffix: TopologySuffix[];
+  ipamindomainlevel: number; // Minimum value: -2147483648 | Maximum value: 2147483647
+  ipamaxdomainlevel: number; // Minimum value: -2147483648 | Maximum value: 2147483647
+  ipalocation_location: string; // Type: DNSName
+  ipaserviceweight: number; // Maximum value: 65535
+  service_relative_weight: string;
+  enabled_role_servrole: string[];
+  dn: string;
+}

--- a/src/utils/ipaServerUtils.ts
+++ b/src/utils/ipaServerUtils.ts
@@ -1,0 +1,46 @@
+import { IpaServer } from "./datatypes/globalDataTypes";
+import { convertApiObj } from "./ipaObjectUtils";
+
+const simpleValues = new Set([
+  "cn",
+  "iparepltopomanagedsuffix",
+  "iparepltopomanagedsuffix_topologysuffix",
+  "ipamindomainlevel",
+  "ipamaxdomainlevel",
+  "ipalocation_location",
+  "ipaserviceweight",
+  "service_relative_weight",
+  "enabled_role_servrole",
+  "dn",
+]);
+const dateValues = new Set([]);
+
+export function apiToIpaServer(apiRecord: Record<string, unknown>): IpaServer {
+  const converted = convertApiObj(
+    apiRecord,
+    simpleValues,
+    dateValues
+  ) as Partial<IpaServer>;
+  return partialIpaServerToIpaServer(converted);
+}
+
+function partialIpaServerToIpaServer(
+  partialIpaServer: Partial<IpaServer>
+): IpaServer {
+  return { ...createEmptyIpaServer(), ...partialIpaServer };
+}
+
+export function createEmptyIpaServer(): IpaServer {
+  return {
+    cn: "",
+    iparepltopomanagedsuffix: [],
+    iparepltopomanagedsuffix_topologysuffix: [],
+    ipamindomainlevel: 0,
+    ipamaxdomainlevel: 0,
+    ipalocation_location: "",
+    ipaserviceweight: 0,
+    service_relative_weight: "",
+    enabled_role_servrole: [],
+    dn: "",
+  };
+}

--- a/src/utils/topologyUtils.tsx
+++ b/src/utils/topologyUtils.tsx
@@ -1,0 +1,51 @@
+import { TopologySuffix, TopologySegment } from "./datatypes/globalDataTypes";
+import { convertApiObj } from "./ipaObjectUtils";
+
+// Topology suffix simple values
+const topologySuffixSimpleValues = new Set([
+  "cn",
+  "iparepltopoconfroot",
+  "pkeyOnly",
+  "version",
+]);
+const topologySuffixDateValues = new Set([]);
+
+export function apiToTopologySuffix(
+  apiRecord: Record<string, unknown>
+): TopologySuffix {
+  const converted = convertApiObj(
+    apiRecord,
+    topologySuffixSimpleValues,
+    topologySuffixDateValues
+  ) as Partial<TopologySuffix>;
+  return partialTopologySuffixToTopologySuffix(converted);
+}
+
+export function partialTopologySuffixToTopologySuffix(
+  partialTopologySuffix: Partial<TopologySuffix>
+): TopologySuffix {
+  return { ...createEmptyTopologySuffix(), ...partialTopologySuffix };
+}
+
+function createEmptyTopologySuffix(): TopologySuffix {
+  return {
+    cn: "",
+    iparepltopoconfroot: "",
+    dn: "",
+  };
+}
+
+export function createEmptyTopologySegment(): TopologySegment {
+  return {
+    cn: "",
+    iparepltoposegmentleftnode: "",
+    iparepltoposegmentrightnode: "",
+    iparepltoposegmentdirection: "both",
+    nsds5replicastripattrs: "",
+    nsds5replicatedattributelist: "",
+    nsds5replicatedattributelisttotal: "",
+    nsds5replicatimeout: 0,
+    nsds5replicaenabled: "on",
+    suffixType: "",
+  };
+}


### PR DESCRIPTION

<img width="1904" height="984" alt="image" src="https://github.com/user-attachments/assets/47f65b03-9dda-4efa-9126-d0bc1b78905f" />


This is a PoC to demostrate how the
`Topology graph` page utility will
look like by using the
`patternfly-topology` library[1].

[1] - https://www.patternfly.org/topology/about-topology

## Summary by Sourcery

Introduce a new topology graph page that visualizes FreeIPA server topology using PatternFly topology components and supporting RPC/data utilities.

New Features:
- Add a Topology navigation section and Topology graph page that renders server and segment relationships as an interactive topology diagram.
- Expose hooks and RPC endpoints to fetch topology suffixes, segments, and servers for use by the topology graph.

Enhancements:
- Define shared data types and conversion utilities for topology suffixes, topology segments, and IPA servers.
- Apply custom styling for topology nodes and edges to distinguish different suffix types in the graph.

Build:
- Add @patternfly/react-topology as a frontend dependency for graph visualization.