### PR TITLE
Add 'Automount locations' main page

### DIFF
--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -76,6 +76,7 @@ import TrustsTabs from "src/pages/Trusts/TrustsTabs";
 import IdRangesTabs from "src/pages/IdRanges/IdRangesTabs";
 import GlobalTrustConfig from "src/pages/Trusts/GlobalTrustConfig";
 import OtpTokens from "src/pages/OtpTokens/OtpTokens";
+import AutomountLocations from "src/pages/AutomountLocations/AutomountLocations";
 import TopologyGraph from "src/pages/Topology/TopologyGraph";
 import OtpTokensTabs from "src/pages/OtpTokens/OtpTokensTabs";
 import Roles from "src/pages/Roles/Roles";
@@ -529,6 +530,9 @@ export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
               </Route>
               <Route path="dns-global-config">
                 <Route path="" element={<DnsGlobalConfig />} />
+              </Route>
+              <Route path="automount-locations">
+                <Route path="" element={<AutomountLocations />} />
               </Route>
               <Route path="id-ranges">
                 <Route path="" element={<IdRanges />} />

--- a/src/navigation/NavRoutes.ts
+++ b/src/navigation/NavRoutes.ts
@@ -56,6 +56,8 @@ const CertificateMappingGroupRef = "cert-id-mapping-rules";
 const CertificateMappingConfigGroupRef = "cert-id-mapping-global-config";
 const CertificateMappingMatchGroupRef = "cert-id-mapping-match";
 // NETWORK SERVICES
+// - Automount
+const AutomountLocationsGroupRef = "automount-locations";
 // - DNS zones
 const DNSZonesGroupRef = "dns-zones";
 const DNSForwardZonesGroupRef = "dns-forward-zones";
@@ -366,8 +368,8 @@ export const getNavigationRoutes = (
       group: "",
       title: `${BASE_TITLE} - Network services`,
       path: "",
-      items:
-        dnsIsEnabled === true
+      items: [
+        ...(dnsIsEnabled === true
           ? [
               {
                 label: "DNS",
@@ -406,7 +408,15 @@ export const getNavigationRoutes = (
                 ],
               },
             ]
-          : [],
+          : []),
+        {
+          label: "Automount locations",
+          group: AutomountLocationsGroupRef,
+          title: `${BASE_TITLE} - Automount locations`,
+          path: "automount-locations",
+          items: [],
+        },
+      ],
     },
     {
       label: "IPA Server",

--- a/src/pages/AutomountLocations/AddAutomountLocationModal.tsx
+++ b/src/pages/AutomountLocations/AddAutomountLocationModal.tsx
@@ -1,0 +1,153 @@
+import React from "react";
+// PatternFly
+import { Button } from "@patternfly/react-core";
+// Components
+import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
+import InputRequiredText from "src/components/layouts/InputRequiredText";
+// Redux
+import { useAppDispatch } from "src/store/hooks";
+// RPC
+import { addAlert } from "src/store/Global/alerts-slice";
+import {
+  AutomountLocationAddPayload,
+  useAddAutomountLocationMutation,
+} from "src/services/rpcAutomountLocations";
+// Errors
+import { SerializedError } from "@reduxjs/toolkit";
+
+interface PropsToAddAutomountLocationModal {
+  isOpen: boolean;
+  onClose: () => void;
+  onRefresh: () => void;
+}
+
+const AddAutomountLocationModal = (props: PropsToAddAutomountLocationModal) => {
+  const dispatch = useAppDispatch();
+
+  const [addLocation] = useAddAutomountLocationMutation();
+
+  // States
+  const [isAddButtonSpinning, setIsAddButtonSpinning] =
+    React.useState<boolean>(false);
+  const [locationName, setLocationName] = React.useState<string>("");
+
+  const isButtonDisabled = isAddButtonSpinning || locationName.length === 0;
+
+  const clearFields = () => {
+    setLocationName("");
+  };
+
+  const cleanAndCloseModal = () => {
+    clearFields();
+    props.onClose();
+  };
+
+  const onAddLocation = () => {
+    setIsAddButtonSpinning(true);
+
+    const payload: AutomountLocationAddPayload = {
+      locationName: locationName,
+    };
+
+    addLocation(payload)
+      .then((response) => {
+        if ("error" in response) {
+          const error = response.error as SerializedError;
+          dispatch(
+            addAlert({
+              name: "add-automount-location-error",
+              title: error.message || "Failed to add automount location",
+              variant: "danger",
+            })
+          );
+          return;
+        }
+
+        if ("data" in response) {
+          const error = response.data?.error as SerializedError;
+
+          if (error) {
+            dispatch(
+              addAlert({
+                name: "add-automount-location-error",
+                title: error.message || "Failed to add automount location",
+                variant: "danger",
+              })
+            );
+            return;
+          }
+
+          dispatch(
+            addAlert({
+              name: "add-automount-location-success",
+              title: "New automount location added",
+              variant: "success",
+            })
+          );
+          clearFields();
+          props.onRefresh();
+          props.onClose();
+        }
+      })
+      .finally(() => {
+        setIsAddButtonSpinning(false);
+      });
+  };
+
+  const fields = [
+    {
+      id: "modal-form-automount-location-name",
+      name: "Location name",
+      pfComponent: (
+        <InputRequiredText
+          dataCy="modal-textbox-automount-location-name"
+          id="modal-form-automount-location-name"
+          name="modal-form-automount-location-name"
+          value={locationName}
+          onChange={setLocationName}
+          requiredHelperText="Required value"
+        />
+      ),
+      fieldRequired: true,
+    },
+  ];
+
+  const modalActions: JSX.Element[] = [
+    <Button
+      data-cy="modal-button-add"
+      key="add-new-automount-location"
+      isDisabled={isButtonDisabled}
+      isLoading={isAddButtonSpinning}
+      type="submit"
+      onClick={onAddLocation}
+    >
+      Add
+    </Button>,
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-new-automount-location"
+      variant="link"
+      onClick={cleanAndCloseModal}
+    >
+      Cancel
+    </Button>,
+  ];
+
+  return (
+    <ModalWithFormLayout
+      dataCy="add-automount-location-modal"
+      variantType="small"
+      modalPosition="top"
+      offPosition="76px"
+      title="Add automount location"
+      formId="add-automount-location-modal"
+      fields={fields}
+      show={props.isOpen}
+      onSubmit={onAddLocation}
+      onClose={cleanAndCloseModal}
+      actions={modalActions}
+    />
+  );
+};
+
+export default AddAutomountLocationModal;

--- a/src/pages/AutomountLocations/AutomountLocations.tsx
+++ b/src/pages/AutomountLocations/AutomountLocations.tsx
@@ -1,0 +1,458 @@
+import React from "react";
+// PatternFly
+import {
+  Flex,
+  FlexItem,
+  PageSection,
+  PaginationVariant,
+  ToolbarItemVariant,
+} from "@patternfly/react-core";
+import {
+  InnerScrollContainer,
+  OuterScrollContainer,
+} from "@patternfly/react-table";
+// Data types
+import { AutomountLocation } from "src/utils/datatypes/globalDataTypes";
+// Hooks
+import { addAlert } from "src/store/Global/alerts-slice";
+import useUpdateRoute from "src/hooks/useUpdateRoute";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
+import useApiError from "src/hooks/useApiError";
+// Redux
+import { useAppSelector, useAppDispatch } from "src/store/hooks";
+// RPC
+import {
+  useGetAutomountLocationsFullDataQuery,
+  useSearchAutomountLocationsEntriesMutation,
+} from "src/services/rpcAutomountLocations";
+// Utils
+import { apiToAutomountLocation } from "src/utils/automountLocationUtils";
+import { isAutomountLocationSelectable } from "src/utils/utils";
+// React router
+import { useNavigate } from "react-router";
+// Components
+import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
+import { SerializedError } from "@reduxjs/toolkit";
+import ToolbarLayout, {
+  ToolbarItem,
+} from "src/components/layouts/ToolbarLayout";
+import SearchInputLayout from "src/components/layouts/SearchInputLayout";
+import SecondaryButton from "src/components/layouts/SecondaryButton";
+import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
+import TitleLayout from "src/components/layouts/TitleLayout";
+import GlobalErrors from "src/components/errors/GlobalErrors";
+import MainTable from "src/components/tables/MainTable";
+import BulkSelectorPrep from "src/components/BulkSelectorPrep";
+import AddAutomountLocationModal from "./AddAutomountLocationModal";
+import DeleteAutomountLocationsModal from "./DeleteAutomountLocationsModal";
+
+const AutomountLocations = () => {
+  const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+
+  const { browserTitle } = useUpdateRoute({
+    pathname: "automount-locations",
+  });
+
+  React.useEffect(() => {
+    document.title = browserTitle;
+  }, [browserTitle]);
+
+  // Retrieve API version from environment data
+  const apiVersion = useAppSelector(
+    (state) => state.global.environment.api_version
+  ) as string;
+
+  // URL parameters: page number, page size, search value
+  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+    useListPageSearchParams();
+
+  // Handle API calls errors
+  const globalErrors = useApiError([]);
+
+  // Page indexes
+  const firstIdx = (page - 1) * perPage;
+  const lastIdx = page * perPage;
+
+  // States
+  const [isSearchDisabled, setIsSearchDisabled] = React.useState(false);
+
+  // API calls
+  const locationsResponse = useGetAutomountLocationsFullDataQuery({
+    searchValue,
+    apiVersion,
+    sizelimit: 0,
+    startIdx: firstIdx,
+    stopIdx: lastIdx,
+  });
+
+  const { data, isLoading, error } = locationsResponse;
+
+  // Process data and update state when response changes
+  React.useEffect(() => {
+    if (locationsResponse.isFetching) {
+      globalErrors.clear();
+      return;
+    }
+
+    if (
+      !locationsResponse.isLoading &&
+      locationsResponse.isError &&
+      locationsResponse.error !== undefined
+    ) {
+      navigate("/login");
+      window.location.reload();
+    }
+  }, [locationsResponse, navigate, globalErrors]);
+
+  // Compute locations data from API response
+  const locations = React.useMemo(() => {
+    if (
+      locationsResponse.isSuccess &&
+      locationsResponse.data &&
+      data !== undefined
+    ) {
+      const listResult = data.result.results;
+      const listSize = data.result.count;
+      const elementsList: AutomountLocation[] = [];
+
+      for (let i = 0; i < listSize; i++) {
+        elementsList.push(apiToAutomountLocation(listResult[i].result));
+      }
+
+      return elementsList;
+    }
+    return [];
+  }, [data, locationsResponse.isSuccess, locationsResponse.data]);
+
+  // Compute total count from API response
+  const totalCount = React.useMemo(() => {
+    if (locationsResponse.isSuccess && locationsResponse.data) {
+      return locationsResponse.data.result.totalCount;
+    }
+    return 0;
+  }, [locationsResponse.isSuccess, locationsResponse.data]);
+
+  // Compute derived state for showTableRows
+  const showTableRows = React.useMemo(() => {
+    if (locationsResponse.isFetching) {
+      return false;
+    }
+    return !isLoading;
+  }, [locationsResponse.isFetching, isLoading]);
+
+  // Selected elements
+  const [selectedElements, setSelectedElements] = React.useState<
+    AutomountLocation[]
+  >([]);
+  const [selectedPerPage, setSelectedPerPage] = React.useState<number>(0);
+
+  // Refresh button handling
+  const refreshData = () => {
+    setSelectedElements([]);
+    locationsResponse.refetch();
+  };
+
+  // 'Delete' button state
+  const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
+    React.useState<boolean>(true);
+
+  const [isDeletion, setIsDeletion] = React.useState<boolean>(false);
+
+  // Table-related shared functionality
+  const selectableLocationsTable = locations.filter(
+    isAutomountLocationSelectable
+  );
+
+  const updateSelectedLocations = (
+    items: AutomountLocation[],
+    isSelected: boolean
+  ) => {
+    let newSelected: AutomountLocation[] = [];
+    if (isSelected) {
+      newSelected = JSON.parse(JSON.stringify(selectedElements));
+      for (let i = 0; i < items.length; i++) {
+        if (selectedElements.find((selected) => selected.cn === items[i].cn)) {
+          continue;
+        }
+        newSelected.push(items[i]);
+      }
+    } else {
+      for (let i = 0; i < selectedElements.length; i++) {
+        let found = false;
+        for (let ii = 0; ii < items.length; ii++) {
+          if (selectedElements[i].cn === items[ii].cn) {
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          newSelected.push(selectedElements[i]);
+        }
+      }
+    }
+    setSelectedElements(newSelected);
+    setIsDeleteButtonDisabled(newSelected.length === 0);
+  };
+
+  const setLocationSelected = (
+    location: AutomountLocation,
+    isSelecting = true
+  ) => {
+    if (isAutomountLocationSelectable(location)) {
+      updateSelectedLocations([location], isSelecting);
+    }
+  };
+
+  // Always refetch data when the component is loaded.
+  React.useEffect(() => {
+    locationsResponse.refetch();
+  }, []);
+
+  // Search API call
+  const [searchEntry] = useSearchAutomountLocationsEntriesMutation();
+
+  const submitSearchValue = () => {
+    setIsSearchDisabled(true);
+    searchEntry({
+      searchValue,
+      apiVersion,
+      sizelimit: 0,
+      startIdx: 0,
+      stopIdx: perPage,
+    }).then((result) => {
+      if ("data" in result) {
+        const searchError = result.data?.error as
+          | FetchBaseQueryError
+          | SerializedError;
+
+        if (searchError) {
+          let error: string | undefined = "";
+          if ("error" in searchError) {
+            error = searchError.error;
+          } else if ("message" in searchError) {
+            error = searchError.message;
+          }
+          dispatch(
+            addAlert({
+              name: "submit-search-value-error",
+              title: error || "Error when searching for automount locations",
+              variant: "danger",
+            })
+          );
+        }
+        setIsSearchDisabled(false);
+      }
+    });
+  };
+
+  // Data wrappers
+  const paginationData = {
+    page,
+    perPage,
+    updatePage: setPage,
+    updatePerPage: setPerPage,
+    updateSelectedPerPage: setSelectedPerPage,
+    totalCount,
+  };
+
+  const searchValueData = {
+    searchValue,
+    updateSearchValue: setSearchValue,
+    submitSearchValue,
+  };
+
+  const bulkSelectorData = {
+    selected: selectedElements,
+    updateSelected: updateSelectedLocations,
+    selectableTable: selectableLocationsTable,
+    nameAttr: "cn",
+  };
+
+  const selectedPerPageData = {
+    selectedPerPage,
+    updateSelectedPerPage: setSelectedPerPage,
+  };
+
+  // Modals functionality
+  const [showAddModal, setShowAddModal] = React.useState<boolean>(false);
+  const [showDeleteModal, setShowDeleteModal] = React.useState<boolean>(false);
+
+  // List of Toolbar items
+  const toolbarItems: ToolbarItem[] = [
+    {
+      key: 0,
+      element: (
+        <BulkSelectorPrep
+          list={locations}
+          shownElementsList={locations}
+          elementData={bulkSelectorData}
+          buttonsData={{
+            updateIsDeleteButtonDisabled: setIsDeleteButtonDisabled,
+          }}
+          selectedPerPageData={selectedPerPageData}
+        />
+      ),
+    },
+    {
+      key: 1,
+      element: (
+        <SearchInputLayout
+          dataCy="search"
+          name="search"
+          ariaLabel="Search automount locations"
+          placeholder="Search automount locations"
+          searchValueData={searchValueData}
+          isDisabled={isSearchDisabled}
+        />
+      ),
+      toolbarItemVariant: ToolbarItemVariant.label,
+      toolbarItemGap: { default: "gapMd" },
+    },
+    {
+      key: 2,
+      toolbarItemVariant: ToolbarItemVariant.separator,
+    },
+    {
+      key: 3,
+      element: (
+        <SecondaryButton
+          dataCy="automount-locations-button-refresh"
+          onClickHandler={refreshData}
+          isDisabled={!showTableRows}
+        >
+          Refresh
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 4,
+      element: (
+        <SecondaryButton
+          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          dataCy="automount-locations-button-delete"
+          onClickHandler={() => setShowDeleteModal(true)}
+        >
+          Delete
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 5,
+      element: (
+        <SecondaryButton
+          isDisabled={!showTableRows}
+          dataCy="automount-locations-button-add"
+          onClickHandler={() => setShowAddModal(true)}
+        >
+          Add
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 6,
+      toolbarItemVariant: ToolbarItemVariant.separator,
+    },
+    {
+      key: 7,
+      element: <HelpTextWithIconLayout textContent="Help" />,
+    },
+    {
+      key: 8,
+      element: (
+        <PaginationLayout
+          list={locations}
+          paginationData={paginationData}
+          widgetId="pagination-options-menu-top"
+          isCompact={true}
+        />
+      ),
+      toolbarItemAlignment: { default: "alignEnd" },
+    },
+  ];
+
+  return (
+    <div>
+      <PageSection hasBodyWrapper={false}>
+        <TitleLayout
+          id="Automount locations title"
+          headingLevel="h1"
+          text="Automount locations"
+        />
+      </PageSection>
+      <PageSection hasBodyWrapper={false} isFilled={false}>
+        <Flex direction={{ default: "column" }}>
+          <FlexItem>
+            <ToolbarLayout toolbarItems={toolbarItems} />
+          </FlexItem>
+          <FlexItem style={{ flex: "0 0 auto" }}>
+            <OuterScrollContainer>
+              <InnerScrollContainer
+                style={{ height: "55vh", overflow: "auto" }}
+              >
+                {error !== undefined && error ? (
+                  <GlobalErrors errors={globalErrors.getAll()} />
+                ) : (
+                  <MainTable
+                    tableTitle="Automount locations table"
+                    shownElementsList={locations}
+                    pk="cn"
+                    keyNames={["cn"]}
+                    columnNames={["Location name"]}
+                    hasCheckboxes={true}
+                    pathname="automount-locations"
+                    showTableRows={showTableRows}
+                    showLink={false}
+                    elementsData={{
+                      isElementSelectable: isAutomountLocationSelectable,
+                      selectedElements,
+                      selectableElementsTable: selectableLocationsTable,
+                      setElementsSelected: setLocationSelected,
+                      clearSelectedElements: () => setSelectedElements([]),
+                    }}
+                    buttonsData={{
+                      updateIsDeleteButtonDisabled: (value) =>
+                        setIsDeleteButtonDisabled(value),
+                      isDeletion,
+                      updateIsDeletion: (value) => setIsDeletion(value),
+                      isDisableEnableOp: false,
+                    }}
+                    paginationData={{
+                      selectedPerPage,
+                      updateSelectedPerPage: setSelectedPerPage,
+                    }}
+                  />
+                )}
+              </InnerScrollContainer>
+            </OuterScrollContainer>
+          </FlexItem>
+          <FlexItem style={{ flex: "0 0 auto", position: "sticky", bottom: 0 }}>
+            <PaginationLayout
+              list={locations}
+              paginationData={paginationData}
+              variant={PaginationVariant.bottom}
+              widgetId="pagination-options-menu-bottom"
+            />
+          </FlexItem>
+        </Flex>
+      </PageSection>
+      <AddAutomountLocationModal
+        isOpen={showAddModal}
+        onClose={() => setShowAddModal(false)}
+        onRefresh={refreshData}
+      />
+      <DeleteAutomountLocationsModal
+        isOpen={showDeleteModal}
+        onClose={() => setShowDeleteModal(false)}
+        elementsToDelete={selectedElements}
+        clearSelectedElements={() => setSelectedElements([])}
+        onRefresh={refreshData}
+        updateIsDeleteButtonDisabled={setIsDeleteButtonDisabled}
+        updateIsDeletion={setIsDeletion}
+      />
+    </div>
+  );
+};
+
+export default AutomountLocations;

--- a/src/pages/AutomountLocations/AutomountLocations.tsx
+++ b/src/pages/AutomountLocations/AutomountLocations.tsx
@@ -14,25 +14,19 @@ import {
 // Data types
 import { AutomountLocation } from "src/utils/datatypes/globalDataTypes";
 // Hooks
-import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import useApiError from "src/hooks/useApiError";
 // Redux
-import { useAppSelector, useAppDispatch } from "src/store/hooks";
+import { useAppSelector } from "src/store/hooks";
 // RPC
-import {
-  useGetAutomountLocationsFullDataQuery,
-  useSearchAutomountLocationsEntriesMutation,
-} from "src/services/rpcAutomountLocations";
+import { useGetAutomountLocationsFullDataQuery } from "src/services/rpcAutomountLocations";
 // Utils
 import { apiToAutomountLocation } from "src/utils/automountLocationUtils";
 import { isAutomountLocationSelectable } from "src/utils/utils";
 // React router
 import { useNavigate } from "react-router";
 // Components
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 import ToolbarLayout, {
   ToolbarItem,
 } from "src/components/layouts/ToolbarLayout";
@@ -49,7 +43,6 @@ import DeleteAutomountLocationsModal from "./DeleteAutomountLocationsModal";
 
 const AutomountLocations = () => {
   const navigate = useNavigate();
-  const dispatch = useAppDispatch();
 
   const { browserTitle } = useUpdateRoute({
     pathname: "automount-locations",
@@ -75,21 +68,21 @@ const AutomountLocations = () => {
   const firstIdx = (page - 1) * perPage;
   const lastIdx = page * perPage;
 
-  // States
-  const [isSearchDisabled, setIsSearchDisabled] = React.useState(false);
-
   // API calls
-  const locationsResponse = useGetAutomountLocationsFullDataQuery({
-    searchValue,
-    apiVersion,
-    sizelimit: 0,
-    startIdx: firstIdx,
-    stopIdx: lastIdx,
-  });
+  const locationsResponse = useGetAutomountLocationsFullDataQuery(
+    {
+      searchValue,
+      apiVersion,
+      sizelimit: 100,
+      startIdx: firstIdx,
+      stopIdx: lastIdx,
+    },
+    { refetchOnMountOrArgChange: true }
+  );
 
   const { data, isLoading, error } = locationsResponse;
 
-  // Process data and update state when response changes
+  // Handle auth errors
   React.useEffect(() => {
     if (locationsResponse.isFetching) {
       globalErrors.clear();
@@ -106,41 +99,24 @@ const AutomountLocations = () => {
     }
   }, [locationsResponse, navigate, globalErrors]);
 
-  // Compute locations data from API response
+  // Derive locations from API response
   const locations = React.useMemo(() => {
-    if (
-      locationsResponse.isSuccess &&
-      locationsResponse.data &&
-      data !== undefined
-    ) {
-      const listResult = data.result.results;
-      const listSize = data.result.count;
+    if (locationsResponse.isSuccess && data) {
       const elementsList: AutomountLocation[] = [];
-
-      for (let i = 0; i < listSize; i++) {
-        elementsList.push(apiToAutomountLocation(listResult[i].result));
+      for (let i = 0; i < data.result.count; i++) {
+        elementsList.push(
+          apiToAutomountLocation(data.result.results[i].result)
+        );
       }
-
       return elementsList;
     }
     return [];
-  }, [data, locationsResponse.isSuccess, locationsResponse.data]);
+  }, [locationsResponse.isSuccess, data]);
 
-  // Compute total count from API response
-  const totalCount = React.useMemo(() => {
-    if (locationsResponse.isSuccess && locationsResponse.data) {
-      return locationsResponse.data.result.totalCount;
-    }
-    return 0;
-  }, [locationsResponse.isSuccess, locationsResponse.data]);
+  const totalCount =
+    locationsResponse.isSuccess && data ? data.result.totalCount : 0;
 
-  // Compute derived state for showTableRows
-  const showTableRows = React.useMemo(() => {
-    if (locationsResponse.isFetching) {
-      return false;
-    }
-    return !isLoading;
-  }, [locationsResponse.isFetching, isLoading]);
+  const showTableRows = !locationsResponse.isFetching && !isLoading;
 
   // Selected elements
   const [selectedElements, setSelectedElements] = React.useState<
@@ -169,14 +145,18 @@ const AutomountLocations = () => {
     items: AutomountLocation[],
     isSelected: boolean
   ) => {
-    let newSelected: AutomountLocation[] = [];
+    let newSelectedLocations: AutomountLocation[] = [];
     if (isSelected) {
-      newSelected = JSON.parse(JSON.stringify(selectedElements));
+      newSelectedLocations = JSON.parse(JSON.stringify(selectedElements));
       for (let i = 0; i < items.length; i++) {
-        if (selectedElements.find((selected) => selected.cn === items[i].cn)) {
+        if (
+          selectedElements.find(
+            (selectedLocation) => selectedLocation.cn === items[i].cn
+          )
+        ) {
           continue;
         }
-        newSelected.push(items[i]);
+        newSelectedLocations.push(items[i]);
       }
     } else {
       for (let i = 0; i < selectedElements.length; i++) {
@@ -188,12 +168,12 @@ const AutomountLocations = () => {
           }
         }
         if (!found) {
-          newSelected.push(selectedElements[i]);
+          newSelectedLocations.push(selectedElements[i]);
         }
       }
     }
-    setSelectedElements(newSelected);
-    setIsDeleteButtonDisabled(newSelected.length === 0);
+    setSelectedElements(newSelectedLocations);
+    setIsDeleteButtonDisabled(newSelectedLocations.length === 0);
   };
 
   const setLocationSelected = (
@@ -203,48 +183,6 @@ const AutomountLocations = () => {
     if (isAutomountLocationSelectable(location)) {
       updateSelectedLocations([location], isSelecting);
     }
-  };
-
-  // Always refetch data when the component is loaded.
-  React.useEffect(() => {
-    locationsResponse.refetch();
-  }, []);
-
-  // Search API call
-  const [searchEntry] = useSearchAutomountLocationsEntriesMutation();
-
-  const submitSearchValue = () => {
-    setIsSearchDisabled(true);
-    searchEntry({
-      searchValue,
-      apiVersion,
-      sizelimit: 0,
-      startIdx: 0,
-      stopIdx: perPage,
-    }).then((result) => {
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for automount locations",
-              variant: "danger",
-            })
-          );
-        }
-        setIsSearchDisabled(false);
-      }
-    });
   };
 
   // Data wrappers
@@ -260,7 +198,6 @@ const AutomountLocations = () => {
   const searchValueData = {
     searchValue,
     updateSearchValue: setSearchValue,
-    submitSearchValue,
   };
 
   const bulkSelectorData = {
@@ -268,11 +205,6 @@ const AutomountLocations = () => {
     updateSelected: updateSelectedLocations,
     selectableTable: selectableLocationsTable,
     nameAttr: "cn",
-  };
-
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage: setSelectedPerPage,
   };
 
   // Modals functionality
@@ -291,7 +223,10 @@ const AutomountLocations = () => {
           buttonsData={{
             updateIsDeleteButtonDisabled: setIsDeleteButtonDisabled,
           }}
-          selectedPerPageData={selectedPerPageData}
+          selectedPerPageData={{
+            selectedPerPage,
+            updateSelectedPerPage: setSelectedPerPage,
+          }}
         />
       ),
     },
@@ -304,7 +239,6 @@ const AutomountLocations = () => {
           ariaLabel="Search automount locations"
           placeholder="Search automount locations"
           searchValueData={searchValueData}
-          isDisabled={isSearchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/AutomountLocations/DeleteAutomountLocationsModal.tsx
+++ b/src/pages/AutomountLocations/DeleteAutomountLocationsModal.tsx
@@ -1,0 +1,178 @@
+import React from "react";
+// PatternFly
+import {
+  Button,
+  Content,
+  ContentVariants,
+  Spinner,
+} from "@patternfly/react-core";
+import useApiError from "src/hooks/useApiErrorModals";
+// Redux
+import { useAppDispatch } from "src/store/hooks";
+// RPC
+import { addAlert } from "src/store/Global/alerts-slice";
+import { useDeleteAutomountLocationsMutation } from "src/services/rpcAutomountLocations";
+// Data types
+import {
+  AutomountLocation,
+  ErrorData,
+} from "src/utils/datatypes/globalDataTypes";
+import { BatchRPCResponse } from "src/services/rpc";
+import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
+// Components
+import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
+import DeletedElementsTable from "src/components/tables/DeletedElementsTable";
+
+interface DeleteAutomountLocationsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  elementsToDelete: AutomountLocation[];
+  clearSelectedElements: () => void;
+  onRefresh: () => void;
+  updateIsDeleteButtonDisabled: (value: boolean) => void;
+  updateIsDeletion: (value: boolean) => void;
+}
+
+const DeleteAutomountLocationsModal = (
+  props: DeleteAutomountLocationsModalProps
+) => {
+  const dispatch = useAppDispatch();
+
+  const [deleteLocations] = useDeleteAutomountLocationsMutation();
+
+  // States
+  const [spinning, setBtnSpinning] = React.useState<boolean>(false);
+  const { handleAPIError, ErrorModalComponent } = useApiError();
+
+  const onDelete = () => {
+    setBtnSpinning(true);
+
+    const elementsToDelete = props.elementsToDelete.map((element) =>
+      element.cn.toString()
+    );
+
+    deleteLocations(elementsToDelete)
+      .then((response) => {
+        if ("data" in response) {
+          const data = response.data as BatchRPCResponse;
+          const result = data.result;
+
+          if (result) {
+            if ("error" in result.results[0] && result.results[0].error) {
+              const errorData = {
+                code: result.results[0].error_code,
+                name: result.results[0].error_name,
+                error: result.results[0].error,
+              } as ErrorData;
+
+              const error = {
+                status: "CUSTOM_ERROR",
+                data: errorData,
+              } as FetchBaseQueryError;
+
+              handleAPIError(error);
+            } else {
+              props.clearSelectedElements();
+              props.updateIsDeleteButtonDisabled(true);
+              props.updateIsDeletion(true);
+
+              dispatch(
+                addAlert({
+                  name: "remove-automount-locations-success",
+                  title: "Automount locations removed",
+                  variant: "success",
+                })
+              );
+
+              props.onClose();
+              props.onRefresh();
+            }
+          }
+        }
+        if ("error" in response) {
+          const error = response.error as FetchBaseQueryError;
+          handleAPIError(error);
+        }
+      })
+      .finally(() => {
+        setBtnSpinning(false);
+      });
+  };
+
+  const fields = [
+    {
+      id: "question-text",
+      pfComponent: (
+        <Content component={ContentVariants.p}>
+          Are you sure you want to delete the selected automount locations?
+        </Content>
+      ),
+    },
+    {
+      id: "deleted-automount-locations-table",
+      pfComponent: (
+        <DeletedElementsTable
+          mode="passing_id"
+          elementsToDelete={props.elementsToDelete.map((element) =>
+            element.cn.toString()
+          )}
+          columnNames={["Location name"]}
+          columnIds={["cn"]}
+          elementType="automount location"
+          idAttr="cn"
+        />
+      ),
+    },
+  ];
+
+  const modalActionsDelete: JSX.Element[] = [
+    <Button
+      data-cy="modal-button-delete"
+      key="delete-automount-locations"
+      variant="danger"
+      onClick={onDelete}
+      form="delete-automount-locations-modal"
+      spinnerAriaValueText="Deleting"
+      spinnerAriaLabel="Deleting"
+      isLoading={spinning}
+      isDisabled={spinning}
+    >
+      {spinning ? (
+        <>
+          <Spinner size="sm" />
+          {"Deleting"}
+        </>
+      ) : (
+        "Delete"
+      )}
+    </Button>,
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-delete-automount-locations"
+      variant="link"
+      onClick={props.onClose}
+    >
+      Cancel
+    </Button>,
+  ];
+
+  return (
+    <>
+      <ModalWithFormLayout
+        dataCy="automount-locations-delete-modal"
+        variantType="medium"
+        modalPosition="top"
+        offPosition="76px"
+        title="Remove automount locations"
+        formId="delete-automount-locations-modal"
+        fields={fields}
+        show={props.isOpen}
+        onClose={props.onClose}
+        actions={modalActionsDelete}
+      />
+      {ErrorModalComponent}
+    </>
+  );
+};
+
+export default DeleteAutomountLocationsModal;

--- a/src/services/rpcAutomountLocations.ts
+++ b/src/services/rpcAutomountLocations.ts
@@ -1,0 +1,202 @@
+import {
+  api,
+  Command,
+  getBatchCommand,
+  BatchRPCResponse,
+  FindRPCResponse,
+  getCommand,
+} from "./rpc";
+import { API_VERSION_BACKUP } from "src/utils/utils";
+import { AutomountLocation } from "src/utils/datatypes/globalDataTypes";
+import { apiToAutomountLocation } from "src/utils/automountLocationUtils";
+
+/**
+ * Automount location-related endpoints
+ *
+ * API commands:
+ * - automountlocation_find: https://freeipa.readthedocs.io/en/latest/api/automountlocation_find.html
+ * - automountlocation_show: https://freeipa.readthedocs.io/en/latest/api/automountlocation_show.html
+ * - automountlocation_add: https://freeipa.readthedocs.io/en/latest/api/automountlocation_add.html
+ * - automountlocation_del: https://freeipa.readthedocs.io/en/latest/api/automountlocation_del.html
+ */
+
+interface AutomountLocationsFullDataPayload {
+  searchValue: string;
+  apiVersion?: string;
+  sizelimit: number;
+  startIdx: number;
+  stopIdx: number;
+}
+
+interface FindLocationArgs {
+  cn: string[];
+}
+
+export interface AutomountLocationAddPayload {
+  locationName: string;
+  version?: string;
+}
+
+const extendedApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    getAutomountLocationsFullData: build.query<
+      BatchRPCResponse,
+      AutomountLocationsFullDataPayload
+    >({
+      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
+        const { searchValue, apiVersion, sizelimit, startIdx, stopIdx } =
+          payloadData;
+        const apiVersionUsed = apiVersion || API_VERSION_BACKUP;
+
+        // Step 1: Find location IDs via automountlocation_find
+        const findParams = {
+          pkey_only: true,
+          sizelimit: sizelimit,
+          version: apiVersionUsed,
+        };
+
+        const findCommand: Command = {
+          method: "automountlocation_find",
+          params: [[searchValue], findParams],
+        };
+
+        const findResult = await fetchWithBQ(getCommand(findCommand));
+
+        if (findResult.error) {
+          return { error: findResult.error };
+        }
+
+        const findResponse = findResult.data as FindRPCResponse;
+        const totalItemsCount = findResponse.result.count as number;
+        const pageItemsCount = findResponse.result.result.length as number;
+
+        const locationIds: string[] = [];
+        for (let i = startIdx; i < pageItemsCount && i < stopIdx; i++) {
+          const loc = findResponse.result.result[i] as FindLocationArgs;
+          locationIds.push(loc.cn[0]);
+        }
+
+        // Step 2: Show each location via automountlocation_show
+        const showCommands: Command[] = locationIds.map((locId) => ({
+          method: "automountlocation_show",
+          params: [[locId], {}],
+        }));
+
+        const showResult = await fetchWithBQ(
+          getBatchCommand(showCommands, apiVersionUsed)
+        );
+
+        if (showResult.error) {
+          return { error: showResult.error };
+        }
+
+        const response = showResult.data as BatchRPCResponse;
+        if (response) {
+          response.result.totalCount = totalItemsCount;
+        }
+
+        return { data: response };
+      },
+    }),
+    searchAutomountLocationsEntries: build.mutation<
+      BatchRPCResponse,
+      AutomountLocationsFullDataPayload
+    >({
+      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
+        const { searchValue, apiVersion, sizelimit, startIdx, stopIdx } =
+          payloadData;
+        const apiVersionUsed = apiVersion || API_VERSION_BACKUP;
+
+        const findParams = {
+          pkey_only: true,
+          sizelimit: sizelimit,
+          version: apiVersionUsed,
+        };
+
+        const findCommand: Command = {
+          method: "automountlocation_find",
+          params: [[searchValue], findParams],
+        };
+
+        const findResult = await fetchWithBQ(getCommand(findCommand));
+
+        if (findResult.error) {
+          return { error: findResult.error };
+        }
+
+        const findResponse = findResult.data as FindRPCResponse;
+        const totalItemsCount = findResponse.result.count as number;
+        const pageItemsCount = findResponse.result.result.length as number;
+
+        const locationIds: string[] = [];
+        for (let i = startIdx; i < pageItemsCount && i < stopIdx; i++) {
+          const loc = findResponse.result.result[i] as FindLocationArgs;
+          locationIds.push(loc.cn[0]);
+        }
+
+        const showCommands: Command[] = locationIds.map((locId) => ({
+          method: "automountlocation_show",
+          params: [[locId], {}],
+        }));
+
+        const showResult = await fetchWithBQ(
+          getBatchCommand(showCommands, apiVersionUsed)
+        );
+
+        if (showResult.error) {
+          return { error: showResult.error };
+        }
+
+        const response = showResult.data as BatchRPCResponse;
+        if (response) {
+          response.result.totalCount = totalItemsCount;
+        }
+
+        return { data: response };
+      },
+    }),
+    addAutomountLocation: build.mutation<
+      FindRPCResponse,
+      AutomountLocationAddPayload
+    >({
+      query: (payload) => {
+        const params: Record<string, unknown> = {
+          version: payload.version || API_VERSION_BACKUP,
+        };
+
+        return getCommand({
+          method: "automountlocation_add",
+          params: [[payload.locationName], params],
+        });
+      },
+    }),
+    deleteAutomountLocations: build.mutation<BatchRPCResponse, string[]>({
+      query: (locationNames) => {
+        const commands: Command[] = locationNames.map((name) => ({
+          method: "automountlocation_del",
+          params: [[name], {}],
+        }));
+
+        return getBatchCommand(commands, API_VERSION_BACKUP);
+      },
+    }),
+    automountLocationShow: build.query<AutomountLocation, string>({
+      query: (locationName) => {
+        return getCommand({
+          method: "automountlocation_show",
+          params: [[locationName], { all: true, rights: true }],
+        });
+      },
+      transformResponse: (response: FindRPCResponse): AutomountLocation =>
+        apiToAutomountLocation(response.result.result),
+    }),
+  }),
+  overrideExisting: false,
+});
+
+export const {
+  useGetAutomountLocationsFullDataQuery,
+  useSearchAutomountLocationsEntriesMutation,
+  useAddAutomountLocationMutation,
+  useDeleteAutomountLocationsMutation,
+} = extendedApi;

--- a/src/services/rpcAutomountLocations.ts
+++ b/src/services/rpcAutomountLocations.ts
@@ -196,7 +196,6 @@ const extendedApi = api.injectEndpoints({
 
 export const {
   useGetAutomountLocationsFullDataQuery,
-  useSearchAutomountLocationsEntriesMutation,
   useAddAutomountLocationMutation,
   useDeleteAutomountLocationsMutation,
 } = extendedApi;

--- a/src/utils/automountLocationUtils.tsx
+++ b/src/utils/automountLocationUtils.tsx
@@ -1,0 +1,29 @@
+import { AutomountLocation } from "src/utils/datatypes/globalDataTypes";
+import { convertApiObj } from "src/utils/ipaObjectUtils";
+
+const simpleValues = new Set(["cn", "dn"]);
+const dateValues = new Set([]);
+
+export const apiToAutomountLocation = (
+  apiRecord: Record<string, unknown>
+): AutomountLocation => {
+  const converted = convertApiObj(
+    apiRecord,
+    simpleValues,
+    dateValues
+  ) as Partial<AutomountLocation>;
+  return partialAutomountLocationToAutomountLocation(converted);
+};
+
+export const partialAutomountLocationToAutomountLocation = (
+  partial: Partial<AutomountLocation>
+): AutomountLocation => {
+  return { ...createEmptyAutomountLocation(), ...partial };
+};
+
+export const createEmptyAutomountLocation = (): AutomountLocation => {
+  return {
+    cn: "",
+    dn: "",
+  };
+};

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -1186,6 +1186,11 @@ export interface OtpToken {
   uri: string;
 }
 
+export interface AutomountLocation {
+  cn: string;
+  dn: string;
+}
+
 export type ErrorValidationData = {
   isError: boolean;
   message: string;

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -31,6 +31,7 @@ import {
   TrustDomain,
   OtpToken,
   SELinuxUserMap,
+  AutomountLocation,
 } from "./datatypes/globalDataTypes";
 // Errors
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
@@ -234,6 +235,9 @@ export const isTrustSelectable = (trust: Trust) => trust.cn !== "";
 
 export const isTrustDomainSelectable = (trustDomain: TrustDomain) =>
   trustDomain.cn !== "";
+
+export const isAutomountLocationSelectable = (location: AutomountLocation) =>
+  location.cn !== "";
 
 export const isOtpTokenSelectable = (otpToken: OtpToken) =>
   otpToken.ipatokenuniqueid !== "";


### PR DESCRIPTION
## Summary by Sourcery

Add a new Automount locations management page and wire it into navigation and routing.

New Features:
- Introduce an Automount locations main page with listing, search, pagination, and bulk selection actions.
- Add modals to create and delete automount locations from the UI.
- Expose RPC endpoints for listing, searching, creating, showing, and deleting automount locations via the backend API.

Enhancements:
- Extend navigation and routing to include Automount locations under Network services.
- Add shared utilities and data types for AutomountLocation entities and their API conversions.