### PR TITLE
Add Cypress tests for sudo command handling

### DIFF
--- a/cypress/e2e/sudo_commands/sudo_cmd_handling.feature
+++ b/cypress/e2e/sudo_commands/sudo_cmd_handling.feature
@@ -1,0 +1,122 @@
+Feature: Sudo commands manipulation
+  Create and delete Sudo commands
+
+  @test
+  Scenario: Add a new sudo command
+    Given I am logged in as admin
+    And I am on "sudo-commands" page
+
+    When I click on the "sudo-commands-button-add" button
+    Then I should see "add-sudo-cmd-modal" modal
+
+    When I type in the "modal-textbox-command" textbox text "ls"
+    Then I should see "ls" in the "modal-textbox-command" textbox
+    And I type in the "modal-textbox-description" textbox text "my description"
+
+    When I click on the "modal-button-add" button
+    Then I should not see "add-sudo-cmd-modal" modal
+    And I should see "add-sudo-cmd-success" alert
+
+    When I search for "ls" in the data table
+    Then I should see "ls" entry in the data table
+    And I should see "ls" entry in the data table with attribute "Description" set to "my description"
+
+  @cleanup
+  Scenario: Cleanup: Delete sudo command
+    Given I delete sudo command "ls"
+
+  @test
+  Scenario: Add several commands
+    Given I am logged in as admin
+    And I am on "sudo-commands" page
+
+    When I click on the "sudo-commands-button-add" button
+    Then I should see "add-sudo-cmd-modal" modal
+
+    When I type in the "modal-textbox-command" textbox text "cp"
+    And I click on the "modal-button-add" button
+    Then I should not see "add-sudo-cmd-modal" modal
+    And I should see "add-sudo-cmd-success" alert
+
+    When I click on the "sudo-commands-button-add" button
+    Then I should see "add-sudo-cmd-modal" modal
+
+    When I type in the "modal-textbox-command" textbox text "rm"
+    And I click on the "modal-button-add" button
+    Then I should not see "add-sudo-cmd-modal" modal
+    And I should see "add-sudo-cmd-success" alert
+
+    When I search for "cp" in the data table
+    Then I should see "cp" entry in the data table
+    When I search for "rm" in the data table
+    Then I should see "rm" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup: Delete multiple sudo commands
+    Given I delete sudo command "cp"
+    And I delete sudo command "rm"
+
+  @seed
+  Scenario: Seed: Create sudo command for delete
+    Given sudo command "ls" exists
+
+  @test
+  Scenario: Delete a command
+    Given I am logged in as admin
+    And I am on "sudo-commands" page
+
+    When I select entry "ls" in the data table
+    Then I should see "ls" entry selected in the data table
+
+    When I click on the "sudo-commands-button-delete" button
+    Then I should see "delete-sudo-commands-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "delete-sudo-commands-modal" modal
+    And I should see "remove-sudo-commands-success" alert
+
+    When I search for "ls" in the data table
+    Then I should not see "ls" entry in the data table
+
+  @seed
+  Scenario: Seed: Create sudo commands for bulk delete
+    Given sudo command "cp" exists
+    And sudo command "rm" exists
+
+  @test
+  Scenario: Delete many commands
+    Given I am logged in as admin
+    And I am on "sudo-commands" page
+
+    When I select entry "cp" in the data table
+    Then I should see "cp" entry selected in the data table
+
+    When I select entry "rm" in the data table
+    Then I should see "rm" entry selected in the data table
+
+    When I click on the "sudo-commands-button-delete" button
+    Then I should see "delete-sudo-commands-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "delete-sudo-commands-modal" modal
+    And I should see "remove-sudo-commands-success" alert
+
+    When I search for "cp" in the data table
+    Then I should not see "cp" entry in the data table
+    When I search for "rm" in the data table
+    Then I should not see "rm" entry in the data table
+
+  @test
+  Scenario: Cancel creation of a command
+    Given I am logged in as admin
+    And I am on "sudo-commands" page
+
+    When I click on the "sudo-commands-button-add" button
+    Then I should see "add-sudo-cmd-modal" modal
+
+    When I type in the "modal-textbox-command" textbox text "cmd-cancel"
+    And I click on the "modal-button-cancel" button
+    Then I should not see "add-sudo-cmd-modal" modal
+
+    When I search for "cmd-cancel" in the data table
+    Then I should not see "cmd-cancel" entry in the data table

--- a/cypress/e2e/sudo_commands/sudo_commands.ts
+++ b/cypress/e2e/sudo_commands/sudo_commands.ts
@@ -1,0 +1,15 @@
+import { Given } from "@badeball/cypress-cucumber-preprocessor";
+
+Given("sudo command {string} exists", (cmdName: string) => {
+  cy.ipa({
+    command: "sudocmd-add",
+    name: cmdName,
+  });
+});
+
+Given("I delete sudo command {string}", (cmdName: string) => {
+  cy.ipa({
+    command: "sudocmd-del",
+    name: cmdName,
+  });
+});


### PR DESCRIPTION
## Summary
Add end-to-end Cypress tests for sudo command handling, adapting the legacy
sudo_cmd_handling tests to the modern @seed/@test/@cleanup step pattern.

## Changes
- Add sudo_cmd_handling.feature with scenarios for add, add-multiple, search,
  delete, bulk-delete, and cancel operations
- Add sudo_commands.ts step definitions for sudocmd-add/del via cy.ipa()

## Summary by Sourcery

Add end-to-end coverage for sudo command CRUD and search flows in the web UI using Cypress feature scenarios and shared step definitions.

Tests:
- Introduce sudo_cmd_handling.feature with scenarios covering creation, searching, deletion, bulk deletion, and cancellation of sudo commands.
- Add Cypress step definitions for sudo command setup, manipulation, and cleanup to support the new sudo command handling scenarios.