### PR TITLE
'Roles' main page

### DIFF
--- a/doc/designs/main-pages.md
+++ b/doc/designs/main-pages.md
@@ -11,11 +11,11 @@ Each file below covers a specific, self-contained topic (~100–200 lines). Load
 | File | Contents | Lines |
 |------|----------|-------|
 | [01-overview.md](main-pages/01-overview.md) | What is a main page, required & optional inputs, example prompt, what gets generated | ~85 |
-| [02-structure-and-anatomy.md](main-pages/02-structure-and-anatomy.md) | Folder structure, page anatomy (10-step pattern), required & optional imports | ~100 |
-| [03-walkthrough-init-fetch.md](main-pages/03-walkthrough-init-fetch.md) | Route setup, API version, data fetching with `useMemo` pattern, search handler | ~160 |
+| [02-structure-and-anatomy.md](main-pages/02-structure-and-anatomy.md) | Folder structure, page anatomy (10-step pattern), required & optional imports | ~105 |
+| [03-walkthrough-init-fetch.md](main-pages/03-walkthrough-init-fetch.md) | Route setup, API version, data fetching with `useMemo` pattern, `SearchDataResultType`, search handler | ~195 |
 | [04-walkthrough-selection-toolbar.md](main-pages/04-walkthrough-selection-toolbar.md) | Selection management, button state, modal state, data wrappers, toolbar items | ~200 |
 | [05-walkthrough-render-table-features.md](main-pages/05-walkthrough-render-table-features.md) | JSX render, `MainTable` usage, optional features (kebab menu, enable/disable) | ~200 |
-| [06-checklist-and-types.md](main-pages/06-checklist-and-types.md) | Files to create/modify checklist, data type definition, selectability function | ~80 |
+| [06-checklist-and-types.md](main-pages/06-checklist-and-types.md) | Files to create/modify checklist, `SearchDataResultType`, data type definition, selectability function | ~105 |
 | [07-add-modal.md](main-pages/07-add-modal.md) | Add modal structure, props interface, code organization, error handling, template | ~175 |
 | [07b-add-modal-fields.md](main-pages/07b-add-modal-fields.md) | Add modal field types, UI components, validation, naming conventions | ~130 |
 | [08-delete-modal-and-utils.md](main-pages/08-delete-modal-and-utils.md) | Delete modal props, `DeletedElementsTable`, entity utils file template | ~195 |

--- a/doc/designs/main-pages.md
+++ b/doc/designs/main-pages.md
@@ -6,20 +6,21 @@ Main pages live under `src/pages/<EntityName>/` and are named after the entity i
 
 ## Guide Files
 
-Each file below covers a specific, self-contained topic (~150–230 lines). Load only the file(s) relevant to your task.
+Each file below covers a specific, self-contained topic (~100–200 lines). Load only the file(s) relevant to your task.
 
 | File | Contents | Lines |
 |------|----------|-------|
-| [01-overview.md](main-pages/01-overview.md) | What is a main page, required & optional inputs, example prompt, what gets generated | ~100 |
-| [02-structure-and-anatomy.md](main-pages/02-structure-and-anatomy.md) | Folder structure, page anatomy (10-step pattern), required & optional imports | ~90 |
-| [03-walkthrough-init-fetch.md](main-pages/03-walkthrough-init-fetch.md) | Steps 1–8: route setup, API version, core state, data fetching patterns, response handling, refetch, search | ~210 |
-| [04-walkthrough-selection-toolbar.md](main-pages/04-walkthrough-selection-toolbar.md) | Steps 9–14: show rows, selection management, button state, modal state, data wrappers, toolbar items array | ~200 |
-| [05-walkthrough-render-table-features.md](main-pages/05-walkthrough-render-table-features.md) | Step 15: JSX render, `MainTable` usage, optional features (kebab menu, enable/disable, contextual help panel) | ~200 |
-| [06-checklist-and-types.md](main-pages/06-checklist-and-types.md) | Files to create/modify checklist, data type definition, selectability function, modal naming convention | ~90 |
-| [07-add-modal.md](main-pages/07-add-modal.md) | Add modal: available UI components, `InputWithValidation` details, field template, naming, action buttons, examples | ~185 |
-| [08-delete-modal-and-utils.md](main-pages/08-delete-modal-and-utils.md) | Delete modal (props, `DeletedElementsTable`) and entity utils file (`apiToEntity`, `createEmpty`, `asRecord`) | ~160 |
-| [09-rpc-service.md](main-pages/09-rpc-service.md) | RPC service file template (find+show pattern, add/delete/show/mod endpoints), API command naming, examples | ~190 |
-| [10-routing-and-conventions.md](main-pages/10-routing-and-conventions.md) | `AppRoutes.tsx` + `NavRoutes.ts` setup, `data-cy` naming, post-generation validation, common pitfalls | ~130 |
+| [01-overview.md](main-pages/01-overview.md) | What is a main page, required & optional inputs, example prompt, what gets generated | ~85 |
+| [02-structure-and-anatomy.md](main-pages/02-structure-and-anatomy.md) | Folder structure, page anatomy (10-step pattern), required & optional imports | ~100 |
+| [03-walkthrough-init-fetch.md](main-pages/03-walkthrough-init-fetch.md) | Route setup, API version, data fetching with `useMemo` pattern, search handler | ~160 |
+| [04-walkthrough-selection-toolbar.md](main-pages/04-walkthrough-selection-toolbar.md) | Selection management, button state, modal state, data wrappers, toolbar items | ~200 |
+| [05-walkthrough-render-table-features.md](main-pages/05-walkthrough-render-table-features.md) | JSX render, `MainTable` usage, optional features (kebab menu, enable/disable) | ~200 |
+| [06-checklist-and-types.md](main-pages/06-checklist-and-types.md) | Files to create/modify checklist, data type definition, selectability function | ~80 |
+| [07-add-modal.md](main-pages/07-add-modal.md) | Add modal structure, props interface, code organization, error handling, template | ~175 |
+| [07b-add-modal-fields.md](main-pages/07b-add-modal-fields.md) | Add modal field types, UI components, validation, naming conventions | ~130 |
+| [08-delete-modal-and-utils.md](main-pages/08-delete-modal-and-utils.md) | Delete modal props, `DeletedElementsTable`, entity utils file template | ~195 |
+| [09-rpc-service.md](main-pages/09-rpc-service.md) | RPC service file template (find+show pattern, add/delete/show/mod endpoints) | ~190 |
+| [10-routing-and-conventions.md](main-pages/10-routing-and-conventions.md) | `AppRoutes.tsx` + `NavRoutes.ts` setup, `data-cy` naming, common pitfalls | ~130 |
 
 ## Quick Reference
 
@@ -27,7 +28,7 @@ Each file below covers a specific, self-contained topic (~150–230 lines). Load
 
 **To implement a specific part:**
 - Main page component scaffold → [02](main-pages/02-structure-and-anatomy.md), [03](main-pages/03-walkthrough-init-fetch.md), [04](main-pages/04-walkthrough-selection-toolbar.md), [05](main-pages/05-walkthrough-render-table-features.md)
-- Add modal → [07-add-modal.md](main-pages/07-add-modal.md)
+- Add modal → [07-add-modal.md](main-pages/07-add-modal.md), [07b-add-modal-fields.md](main-pages/07b-add-modal-fields.md)
 - Delete modal → [08-delete-modal-and-utils.md](main-pages/08-delete-modal-and-utils.md)
 - Entity utils (`apiToEntity`, `createEmpty`) → [08-delete-modal-and-utils.md](main-pages/08-delete-modal-and-utils.md)
 - RPC service file → [09-rpc-service.md](main-pages/09-rpc-service.md)

--- a/doc/designs/main-pages/02-structure-and-anatomy.md
+++ b/doc/designs/main-pages/02-structure-and-anatomy.md
@@ -73,7 +73,10 @@ import useApiError from "src/hooks/useApiError";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import { SerializedError } from "@reduxjs/toolkit";
 // Data types
-import { MyEntity } from "src/utils/datatypes/globalDataTypes";
+import {
+  MyEntity,
+  SearchDataResultType,
+} from "src/utils/datatypes/globalDataTypes";
 // Utils
 import { API_VERSION_BACKUP, isMyEntitySelectable } from "src/utils/utils";
 // RPC client

--- a/doc/designs/main-pages/03-walkthrough-init-fetch.md
+++ b/doc/designs/main-pages/03-walkthrough-init-fetch.md
@@ -1,17 +1,13 @@
-# Main Pages — Walkthrough: Steps 1–8 (Init, State & Data Fetching)
+# Main Pages — Walkthrough: Init, State & Data Fetching
 
 > **Part of:** [Main Pages guide](../main-pages.md)
-> **See also:** [Structure & Imports](02-structure-and-anatomy.md) | [Steps 9–14: Selection & Toolbar](04-walkthrough-selection-toolbar.md)
+> **See also:** [Structure & Imports](02-structure-and-anatomy.md) | [Selection & Toolbar](04-walkthrough-selection-toolbar.md)
 
-## Step-by-Step Walkthrough
-
-### 1. Route & Browser Title
+## Step 1: Route & Browser Title
 
 ```tsx
 const MyEntities = () => {
   const dispatch = useAppDispatch();
-
-  // pathname must match the route segment in AppRoutes.tsx and NavRoutes.ts
   const { browserTitle } = useUpdateRoute({ pathname: "my-entities" });
 
   React.useEffect(() => {
@@ -19,13 +15,9 @@ const MyEntities = () => {
   }, [browserTitle]);
 ```
 
-The `pathname` value (e.g. `"my-entities"`) must be registered in:
-- `src/navigation/AppRoutes.tsx` — the `<Route>` tree
-- `src/navigation/NavRoutes.ts` — navigation metadata (group, breadcrumb, title)
+The `pathname` must be registered in `AppRoutes.tsx` and `NavRoutes.ts`.
 
-See [10-routing-and-conventions.md](10-routing-and-conventions.md) for the full routing setup.
-
-### 2. API Version & URL Parameters
+## Step 2: API Version & URL Parameters
 
 ```tsx
   const apiVersion = useAppSelector(
@@ -36,181 +28,132 @@ See [10-routing-and-conventions.md](10-routing-and-conventions.md) for the full 
     useListPageSearchParams();
 ```
 
-`useListPageSearchParams` keeps `page`, `perPage`, and `searchValue` in sync with URL query parameters (`?p=`, `?size=`, `?search=`).
-
-### 3. Core State
+## Step 3: Data Fetching Query
 
 ```tsx
-  const [entitiesList, setEntitiesList] = useState<MyEntity[]>([]);
-
-  const globalErrors = useApiError([]);
-  const modalErrors = useApiError([]);
-
-  const [totalCount, setTotalCount] = useState<number>(0);
-  const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
-
-  // Page indexes (for server-side pagination)
-  const firstIdx = Math.max(0, (page - 1) * perPage);
+  const firstIdx = (page - 1) * perPage;
   const lastIdx = page * perPage;
-```
 
-### 4. Data Fetching (Initial Load)
-
-There are **two patterns** for the initial data query:
-
-#### Pattern A: Generic query via `useGetting*Query` (most common)
-
-Used by ActiveUsers, Hosts, HBACRules, Netgroups, Services, etc.
-
-```tsx
   const dataResponse = useGettingMyEntitiesQuery({
-    searchValue: searchValue,
+    searchValue: "",
     sizeLimit: 0,
     apiVersion: apiVersion || API_VERSION_BACKUP,
     startIdx: firstIdx,
     stopIdx: lastIdx,
   } as GenericPayload);
 
-  const {
-    data: batchResponse,
-    isLoading: isBatchLoading,
-    error: batchError,
-  } = dataResponse;
+  const { data: batchResponse, isLoading, isFetching, error } = dataResponse;
 ```
 
-#### Pattern B: Domain-specific query (newer pattern)
+## Step 4: Derive State with useMemo (Recommended)
 
-Used by DnsZones, Trusts, etc. These have their own `useGet*FullDataQuery` with custom payloads.
-
-```tsx
-  const dataResponse = useGetMyEntitiesFullDataQuery({
-    searchValue,
-    apiVersion,
-    sizelimit: 100,
-    startIdx: firstIdx,
-    stopIdx: lastIdx,
-  });
-
-  const { data, isLoading, error } = dataResponse;
-```
-
-### 5. Handle API Response
+Use `useMemo` to derive `entitiesList` and `totalCount` from the query response — **do not** use `useEffect` + `useState` to sync state:
 
 ```tsx
-  useEffect(() => {
-    if (dataResponse.isFetching) {
-      setShowTableRows(false);
-      setTotalCount(0);
-      globalErrors.clear();
-      return;
+  // Search state (for mutation-based search)
+  const [isSearchActive, setIsSearchActive] = useState(false);
+  const [searchData, setSearchData] = useState<{ entities: MyEntity[]; totalCount: number } | null>(null);
+
+  // Derive entitiesList and totalCount
+  const { entitiesList, totalCount } = useMemo(() => {
+    if (isSearchActive && searchData) {
+      return { entitiesList: searchData.entities, totalCount: searchData.totalCount };
     }
 
-    // Success
-    if (dataResponse.isSuccess && dataResponse.data && batchResponse !== undefined) {
-      const listResult = batchResponse.result.results;
-      const totalCount = batchResponse.result.totalCount;
-      const listSize = batchResponse.result.count;
+    if (batchResponse?.result) {
+      const results = batchResponse.result.results;
       const entities: MyEntity[] = [];
-
-      for (let i = 0; i < listSize; i++) {
-        entities.push(listResult[i].result);
+      for (let i = 0; i < batchResponse.result.count; i++) {
+        entities.push(results[i].result);
       }
-
-      setTotalCount(totalCount);
-      setEntitiesList(entities);
-      setShowTableRows(true);
+      return { entitiesList: entities, totalCount: batchResponse.result.totalCount };
     }
 
-    // Error
-    if (!dataResponse.isLoading && dataResponse.isError && dataResponse.error !== undefined) {
+    return { entitiesList: [], totalCount: 0 };
+  }, [batchResponse, isSearchActive, searchData]);
+
+  // Derive showTableRows from loading states
+  const showTableRows = useMemo(() => {
+    if (isSearchActive) return !searchResult.isLoading;
+    return !isFetching && !isLoading;
+  }, [isFetching, isLoading, isSearchActive, searchResult.isLoading]);
+```
+
+This pattern avoids eslint warnings about calling `setState` in `useEffect`.
+
+## Step 5: Error Handling
+
+```tsx
+  const globalErrors = useApiError([]);
+
+  React.useEffect(() => {
+    if (isFetching) {
+      globalErrors.clear();
+    }
+  }, [isFetching]);
+
+  React.useEffect(() => {
+    if (!isLoading && !isFetching && dataResponse.isError) {
       window.location.reload();
     }
-  }, [dataResponse]);
+  }, [dataResponse.isError, isLoading, isFetching]);
 ```
 
-**Note:** If the entity requires transformation from API format, use a mapper function (e.g. `apiToTrust`, `apiToDnsZone`) inside the loop instead of pushing raw results. See [Entity Utils](08-delete-modal-and-utils.md).
-
-### 6. Refetch on Mount
-
-```tsx
-  React.useEffect(() => {
-    dataResponse.refetch();
-  }, []);
-```
-
-Some pages also refetch when `page` or `perPage` changes:
-
-```tsx
-  React.useEffect(() => {
-    dataResponse.refetch();
-  }, [page, perPage]);
-```
-
-### 7. Refresh Handler
+## Step 6: Refresh Handler
 
 ```tsx
   const refreshData = () => {
-    setShowTableRows(false);
-    setTotalCount(0);
+    setIsSearchActive(false);
+    setSearchData(null);
     clearSelectedEntities();
     dataResponse.refetch();
   };
+
+  React.useEffect(() => {
+    if (!isSearchActive) {
+      dataResponse.refetch();
+    }
+  }, [page, perPage]);
 ```
 
-### 8. Search (Explicit Submit)
-
-Two patterns exist:
-
-#### Pattern A: Using the generic `useSearchEntriesMutation`
+## Step 7: Search Handler
 
 ```tsx
-  const [retrieveEntries] = useSearchEntriesMutation({});
+  const [searchEntities, searchResult] = useSearchMyEntitiesEntriesMutation({});
+  const [searchDisabled, setSearchIsDisabled] = useState(false);
 
   const submitSearchValue = () => {
-    setShowTableRows(false);
     setSearchIsDisabled(true);
-    setTotalCount(0);
+    setIsSearchActive(true);
 
-    retrieveEntries({
-      searchValue: searchValue,
+    searchEntities({
+      searchValue,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
       startIdx: firstIdx,
       stopIdx: lastIdx,
-      entryType: "myentity",  // Must be a valid entryType in GenericPayload
-    } as GenericPayload).then((result) => {
+    }).then((result) => {
       if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
+        const searchError = result.data?.error;
 
         if (searchError) {
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for my entities",
-              variant: "danger",
-            })
-          );
+          dispatch(addAlert({
+            name: "submit-search-value-error",
+            title: searchError.message || "Error when searching",
+            variant: "danger",
+          }));
+          setIsSearchActive(false);
+          setSearchData(null);
         } else {
-          const listResult = result.data?.result.results || [];
-          const listSize = result.data?.result.count || 0;
-          const totalCount = result.data?.result.totalCount || 0;
+          const results = result.data?.result.results || [];
           const entities: MyEntity[] = [];
-
-          for (let i = 0; i < listSize; i++) {
-            entities.push(listResult[i].result);
+          for (let i = 0; i < results.length; i++) {
+            entities.push(results[i].result);
           }
-
-          setTotalCount(totalCount);
-          setEntitiesList(entities);
-          setShowTableRows(true);
+          setSearchData({
+            entities,
+            totalCount: result.data?.result.totalCount || 0,
+          });
         }
         setSearchIsDisabled(false);
       }
@@ -218,22 +161,19 @@ Two patterns exist:
   };
 ```
 
-**Important:** The `entryType` value must be registered in `GenericPayload` (in `src/services/rpc.ts`) and have corresponding `*_find` / `*_show` method mappings in the `searchEntries` mutation.
+## Legacy Pattern (Avoid)
 
-#### Pattern B: Domain-specific search mutation
+The older pattern using `useEffect` + `setState` triggers eslint warnings:
 
 ```tsx
-  const [searchEntry] = useSearchMyEntitiesEntriesMutation();
-
-  const submitSearchValue = () => {
-    searchEntry({
-      searchValue,
-      apiVersion,
-      sizelimit: 100,
-      startIdx: 0,
-      stopIdx: 200,
-    }).then((result) => {
-      // Same error handling pattern...
-    });
-  };
+// AVOID: This pattern causes @eslint-react/hooks-extra/no-direct-set-state-in-use-effect warnings
+useEffect(() => {
+  if (dataResponse.isSuccess && batchResponse) {
+    setEntitiesList(/* ... */);  // Warning!
+    setTotalCount(/* ... */);    // Warning!
+    setShowTableRows(true);      // Warning!
+  }
+}, [dataResponse]);
 ```
+
+Use the `useMemo` pattern from Step 4 instead.

--- a/doc/designs/main-pages/03-walkthrough-init-fetch.md
+++ b/doc/designs/main-pages/03-walkthrough-init-fetch.md
@@ -47,17 +47,32 @@ The `pathname` must be registered in `AppRoutes.tsx` and `NavRoutes.ts`.
 
 ## Step 4: Derive State with useMemo (Recommended)
 
-Use `useMemo` to derive `entitiesList` and `totalCount` from the query response — **do not** use `useEffect` + `useState` to sync state:
+Use `useMemo` to derive `elementsList` and `totalCount` from the query response — **do not** use `useEffect` + `useState` to sync state.
+
+The `SearchDataResultType<T>` generic type (from `src/utils/datatypes/globalDataTypes.ts`) standardizes the search state structure:
+
+```tsx
+export interface SearchDataResultType<T> {
+  elementsList: T[];
+  totalCount: number;
+}
+```
+
+Use it to type the search data state:
 
 ```tsx
   // Search state (for mutation-based search)
   const [isSearchActive, setIsSearchActive] = useState(false);
-  const [searchData, setSearchData] = useState<{ entities: MyEntity[]; totalCount: number } | null>(null);
+  const [searchData, setSearchData] =
+    useState<SearchDataResultType<MyEntity> | null>(null);
 
-  // Derive entitiesList and totalCount
-  const { entitiesList, totalCount } = useMemo(() => {
+  // Derive elementsList and totalCount
+  const { elementsList, totalCount } = useMemo(() => {
     if (isSearchActive && searchData) {
-      return { entitiesList: searchData.entities, totalCount: searchData.totalCount };
+      return {
+        elementsList: searchData.elementsList,
+        totalCount: searchData.totalCount,
+      };
     }
 
     if (batchResponse?.result) {
@@ -66,10 +81,10 @@ Use `useMemo` to derive `entitiesList` and `totalCount` from the query response 
       for (let i = 0; i < batchResponse.result.count; i++) {
         entities.push(results[i].result);
       }
-      return { entitiesList: entities, totalCount: batchResponse.result.totalCount };
+      return { elementsList: entities, totalCount: batchResponse.result.totalCount };
     }
 
-    return { entitiesList: [], totalCount: 0 };
+    return { elementsList: [], totalCount: 0 };
   }, [batchResponse, isSearchActive, searchData]);
 
   // Derive showTableRows from loading states
@@ -146,13 +161,14 @@ This pattern avoids eslint warnings about calling `setState` in `useEffect`.
           setSearchData(null);
         } else {
           const results = result.data?.result.results || [];
+          const searchTotalCount = result.data?.result.totalCount || 0;
           const entities: MyEntity[] = [];
           for (let i = 0; i < results.length; i++) {
             entities.push(results[i].result);
           }
           setSearchData({
-            entities,
-            totalCount: result.data?.result.totalCount || 0,
+            elementsList: entities,
+            totalCount: searchTotalCount,
           });
         }
         setSearchIsDisabled(false);

--- a/doc/designs/main-pages/06-checklist-and-types.md
+++ b/doc/designs/main-pages/06-checklist-and-types.md
@@ -35,6 +35,32 @@ When adding a brand-new main page, touch these files:
 
 ## Data Type Definition
 
+Add the entity interface to `src/utils/datatypes/globalDataTypes.ts`.
+
+### SearchDataResultType (Generic)
+
+The `SearchDataResultType<T>` generic interface is used to standardize search state across main pages. It provides a consistent structure for storing search results:
+
+```tsx
+export interface SearchDataResultType<T> {
+  elementsList: T[];
+  totalCount: number;
+}
+```
+
+**Usage in main page components:**
+
+```tsx
+import { MyEntity, SearchDataResultType } from "src/utils/datatypes/globalDataTypes";
+
+const [searchData, setSearchData] =
+  useState<SearchDataResultType<MyEntity> | null>(null);
+```
+
+This type is used in conjunction with the `useMemo` pattern for deriving `elementsList` and `totalCount` from either the query response or search results. See [Walkthrough: Init & Data Fetching](03-walkthrough-init-fetch.md) for the full pattern.
+
+### Entity Interface
+
 Add the entity interface to `src/utils/datatypes/globalDataTypes.ts`:
 
 ```tsx

--- a/doc/designs/main-pages/07-add-modal.md
+++ b/doc/designs/main-pages/07-add-modal.md
@@ -1,9 +1,9 @@
-# Main Pages — Add Modal Field Types & Templates
+# Main Pages — Add Modal Structure & Pattern
 
 > **Part of:** [Main Pages guide](../main-pages.md)
-> **See also:** [Checklist & Modal Naming](06-checklist-and-types.md) | [Delete Modal & Entity Utils](08-delete-modal-and-utils.md)
+> **See also:** [Add Modal Fields](07b-add-modal-fields.md) | [Delete Modal](08-delete-modal-and-utils.md)
 
-The Add modal (`src/components/modals/<EntityModals>/Add<Entity>Modal.tsx`) is built using `ModalWithFormLayout`, which accepts a `fields` array. Each field specifies an `id`, a `name` (label), a `pfComponent` (the PatternFly/custom UI component), and optionally `fieldRequired: true`.
+The Add modal (`src/components/modals/<EntityModals>/Add<Entity>Modal.tsx`) is built using `ModalWithFormLayout`.
 
 ## Standard Props Interface
 
@@ -36,174 +36,6 @@ interface PropsToAddModal {
 />
 ```
 
-## Complete Modal Template
-
-```tsx
-import React from "react";
-// PatternFly
-import { Button, TextArea } from "@patternfly/react-core";
-// Components
-import ModalWithFormLayout, {
-  Field,
-} from "src/components/layouts/ModalWithFormLayout";
-import InputRequiredText from "src/components/layouts/InputRequiredText";
-// RPC
-import { useAddEntityMutation } from "src/services/rpcEntity";
-// Redux
-import { useAppDispatch } from "src/store/hooks";
-// Hooks
-import { addAlert } from "src/store/Global/alerts-slice";
-// Errors
-import { SerializedError } from "@reduxjs/toolkit";
-
-interface PropsToAddModal {
-  isOpen: boolean;
-  onClose: () => void;
-  title: string;
-  onRefresh: () => void;
-}
-
-const AddEntityModal = (props: PropsToAddModal) => {
-  const dispatch = useAppDispatch();
-
-  // API calls
-  const [addEntity] = useAddEntityMutation();
-
-  // States
-  const [isAddButtonSpinning, setIsAddButtonSpinning] = React.useState(false);
-  const [entityName, setEntityName] = React.useState("");
-  const [description, setDescription] = React.useState("");
-
-  // Clear fields
-  const clearFields = () => {
-    setEntityName("");
-    setDescription("");
-  };
-
-  // 'Add' button handler
-  const onAdd = () => {
-    setIsAddButtonSpinning(true);
-
-    addEntity({
-      cn: entityName,
-      description: description || undefined,
-    }).then((response) => {
-      if ("data" in response) {
-        const data = response.data?.result;
-        const error = response.data?.error as SerializedError;
-
-        if (error) {
-          dispatch(
-            addAlert({
-              name: "add-entity-error",
-              title: error.message,
-              variant: "danger",
-            })
-          );
-        }
-
-        if (data) {
-          dispatch(
-            addAlert({
-              name: "add-entity-success",
-              title: "New entity added",
-              variant: "success",
-            })
-          );
-          // Reset fields
-          clearFields();
-          // Update data
-          props.onRefresh();
-          props.onClose();
-        }
-      }
-      // Reset button spinner
-      setIsAddButtonSpinning(false);
-    });
-  };
-
-  // Clean and close modal
-  const cleanAndCloseModal = () => {
-    clearFields();
-    props.onClose();
-  };
-
-  const fields: Field[] = [
-    {
-      id: "modal-form-entity-name",
-      name: "Entity name",
-      pfComponent: (
-        <InputRequiredText
-          dataCy="modal-textbox-entity-name"
-          id="modal-form-entity-name"
-          name="cn"
-          value={entityName}
-          onChange={setEntityName}
-          requiredHelperText="Required value"
-        />
-      ),
-      fieldRequired: true,
-    },
-    {
-      id: "modal-form-description",
-      name: "Description",
-      pfComponent: (
-        <TextArea
-          data-cy="modal-textbox-description"
-          id="modal-form-description"
-          name="description"
-          value={description}
-          aria-label="Description"
-          onChange={(_event, value: string) => setDescription(value)}
-          autoResize
-        />
-      ),
-    },
-  ];
-
-  // Actions
-  const modalActions: JSX.Element[] = [
-    <Button
-      data-cy="modal-button-add"
-      key="add-new"
-      isDisabled={isAddButtonSpinning || entityName === ""}
-      form="add-modal-form"
-      type="submit"
-    >
-      Add
-    </Button>,
-    <Button
-      data-cy="modal-button-cancel"
-      key="cancel-new"
-      variant="link"
-      onClick={cleanAndCloseModal}
-    >
-      Cancel
-    </Button>,
-  ];
-
-  return (
-    <>
-      <ModalWithFormLayout
-        dataCy="add-entity-modal"
-        variantType={"small"}
-        modalPosition={"top"}
-        offPosition={"76px"}
-        title={props.title}
-        formId="add-modal-form"
-        fields={fields}
-        show={props.isOpen}
-        onSubmit={() => onAdd()}
-        onClose={cleanAndCloseModal}
-        actions={modalActions}
-      />
-    </>
-  );
-};
-
-export default AddEntityModal;
-```
-
 ## Code Organization
 
 The Add modal follows this structure:
@@ -222,11 +54,7 @@ The Add modal follows this structure:
 
 ## Error Handling
 
-Use **alerts** for error handling — do not use a separate `ErrorModal` component. When an error occurs:
-
-1. Dispatch a danger alert with the error message
-2. Reset the button spinner
-3. Keep the modal open so the user can retry or cancel
+Use **alerts** for error handling — do not use a separate `ErrorModal` component:
 
 ```tsx
 if (error) {
@@ -240,185 +68,11 @@ if (error) {
 }
 ```
 
-When specifying **Add modal fields** in your prompt, provide each field as:
-
-```
-<ipa_attribute> → "<Label>" (<data_type>, <ui_component>, required|optional)
-```
-
-## Available UI Components
-
-| UI component | Import from | Data type | Use when |
-|-------------|-------------|-----------|----------|
-| `InputRequiredText` | `src/components/layouts/InputRequiredText` | `string` | Required single-line text (shows validation helper text). Use for the primary key and other mandatory string fields |
-| `TextInput` | `@patternfly/react-core` | `string` | Optional or secondary single-line text input |
-| `TextArea` | `@patternfly/react-core` | `string` | Multi-line text (e.g. description fields). Use `autoResize` prop |
-| `Checkbox` | `@patternfly/react-core` | `boolean` | Boolean flags (e.g. "Force", "Generate OTP") |
-| `Radio` | `@patternfly/react-core` | `string` | One-of-N choice from a small fixed set (e.g. authentication method, algorithm) |
-| `Select` + `SelectList` + `SelectOption` | `@patternfly/react-core` | `string` | Dropdown selection from a list of options |
-| `NumberSelector` | `src/components/Form/NumberInput` | `number` | Numeric input with increment/decrement (e.g. base ID, range size, priority) |
-| `PasswordInput` | `src/components/layouts/PasswordInput` | `string` | Password/secret fields with show/hide toggle |
-| `SimpleSelector` | `src/components/Form/SimpleSelector` | `string` | Simple dropdown selection (e.g. group picker) |
-| `InputWithValidation` | `src/components/layouts/InputWithValidation` | `string` | Text input with inline validation rules. Use when a field needs real-time format validation (e.g. allowed characters, valid IP address) |
-
-## Field Validation with `InputWithValidation`
-
-`InputWithValidation` is a text input that evaluates one or more validation rules as the user types and renders inline helper text showing pass/fail state for each rule. Use it instead of `TextInput` or `InputRequiredText` when the field has format constraints that should be validated before submission.
-
-**Usage in a modal field:**
-
-```tsx
-{
-  id: "modal-form-host-name",
-  name: "Host name",
-  pfComponent: (
-    <InputWithValidation
-      dataCy="modal-textbox-host-name"
-      id="modal-form-host-name"
-      name="modal-form-host-name"
-      value={hostName}
-      onChange={setHostName}
-      isRequired
-      rules={[
-        {
-          id: "valid-chars",
-          message: "Allowed characters are a-z, A-Z, 0-9, and -",
-          validate: (value: string) => /^[a-zA-Z0-9-]+$/.test(value),
-        },
-      ]}
-    />
-  ),
-  fieldRequired: true,
-}
-```
-
-Multiple rules can be specified — each renders its own helper text line:
-
-```tsx
-rules={[
-  {
-    id: "ruleCharacters",
-    message: "Only alphanumeric and special characters _-.$",
-    validate: (v: string) =>
-      /^[a-zA-Z]/.test(v.charAt(0)) && /^[a-zA-Z0-9._-]+$/.test(v.substring(1)),
-  },
-  {
-    id: "ruleLength",
-    message: "Must be at most 32 characters",
-    validate: (v: string) => v.length <= 32,
-  },
-]}
-```
-
-When specifying fields in your prompt, indicate validation with the `InputWithValidation` component and describe the constraint:
-
-```
-<ipa_attribute> → "<Label>" (string, InputWithValidation, required, validation: "a-z, A-Z, 0-9, and -")
-```
-
-**Existing examples:**
-
-| Entity | Field | Validation |
-|--------|-------|-----------|
-| Hosts (`AddHost.tsx`) | Host name | Allowed characters: `a-z, A-Z, 0-9, -` |
-| Hosts (`AddHost.tsx`) | IP address | Must be a valid IPv4 or IPv6 address |
-| Users (`AddUser.tsx`) | User login | Only alphanumeric and `_-.$`, first char must be a letter |
-| Users (`AddUser.tsx`) | First/Last name | No special characters or spaces |
-
-## Field Template
-
-```tsx
-const fields = [
-  {
-    id: "modal-form-<field-name>",
-    name: "<Label>",
-    pfComponent: (
-      <InputRequiredText                          // or TextInput, TextArea, Checkbox, etc.
-        dataCy="modal-textbox-<field-name>"
-        id="modal-form-<field-name>"
-        name="modal-form-<field-name>"
-        value={fieldState}
-        onChange={setFieldState}
-        requiredHelperText="Required value"       // only for InputRequiredText
-      />
-    ),
-    fieldRequired: true,                          // omit for optional fields
-  },
-  // ...more fields
-];
-```
-
-## Naming Conventions
-
-All naming follows kebab-case formatting for attributes and camelCase for JavaScript variables.
-
-### General Pattern
-
-```
-modal-{component-type}-{field-name}
-```
-
-### Element IDs (`id`)
-
-Form field IDs use the `modal-form-` prefix:
-
-```
-modal-form-{field-name}
-```
-
-Examples:
-
-```
-modal-form-user-login
-modal-form-description
-modal-form-first-name
-modal-form-ip-address
-```
-
-### Test Attributes (`data-cy` / `dataCy`)
-
-Test attributes indicate the component type after the `modal-` prefix:
-
-| Component Type | Pattern | Example |
-|----------------|---------|---------|
-| Text input | `modal-textbox-{field-name}` | `modal-textbox-user-login` |
-| Text area | `modal-textbox-{field-name}` | `modal-textbox-description` |
-| Checkbox | `modal-checkbox-{field-name}` | `modal-checkbox-force` |
-| Radio button | `modal-radio-{field-name}` | `modal-radio-auth-method` |
-| Select/Dropdown | `modal-select-{field-name}` | `modal-select-group` |
-| Number input | `modal-number-{field-name}` | `modal-number-base-id` |
-| Password input | `modal-textbox-{field-name}` | `modal-textbox-password` |
-
-### State Variables
-
-Use one `useState` per field, named in camelCase after the field:
-
-```tsx
-const [userLogin, setUserLogin] = useState("");
-const [description, setDescription] = useState("");
-const [firstName, setFirstName] = useState("");
-const [generateOtp, setGenerateOtp] = useState(false);
-```
-
-### Handler Functions
-
-Handler functions follow the `on{Action}` pattern:
-
-```tsx
-const onAdd = () => { /* ... */ };
-const cleanAndCloseModal = () => { /* ... */ };
-```
-
-### Best Practices
-
-1. **Consistency**: Always use kebab-case for `id` and `data-cy` attributes
-2. **Uniqueness**: Each `data-cy` value must be unique within the modal
-3. **Descriptive**: Use clear names that indicate the field's purpose
-4. **Match IPA attributes**: When possible, derive field names from the IPA attribute (e.g., `ipatokenowner` → `modal-form-owner`)
+When an error occurs: dispatch a danger alert, reset the spinner, keep the modal open.
 
 ## Modal Action Buttons
 
-The Add modal must only have two action buttons: **Add** and **Cancel**. Do **not** include an "Add and add another" button.
+Only two buttons: **Add** and **Cancel**.
 
 ```tsx
 const modalActions: JSX.Element[] = [
@@ -444,47 +98,110 @@ const modalActions: JSX.Element[] = [
 
 ## Button Disabled Logic
 
-The Add button should be disabled until all **required** fields are non-empty. Compute the disabled state inline or as a derived variable — do not use `useEffect` + `useState` for this.
-
-**Inline (preferred for simple conditions):**
+Compute disabled state inline — do not use `useEffect` + `useState`:
 
 ```tsx
-<Button
-  isDisabled={isAddButtonSpinning || requiredField === ""}
-  // ...
->
-```
+// Inline (preferred for simple conditions):
+isDisabled={isAddButtonSpinning || requiredField === ""}
 
-**Derived variable (for complex conditions):**
-
-```tsx
-const mandatoryEmpty =
-  requiredField1 === "" ||
-  requiredField2 === "" ||
-  (someCondition && requiredField3 === "");
-
+// Derived variable (for complex conditions):
+const mandatoryEmpty = requiredField1 === "" || requiredField2 === "";
 const disabledAdd = isAddButtonSpinning || mandatoryEmpty;
-
-// In modalActions:
-<Button isDisabled={disabledAdd}>
 ```
 
-## Existing Add Modal Examples
+## Compact Template
 
-**Reference implementations** (follow these patterns):
+```tsx
+import React from "react";
+import { Button, TextArea } from "@patternfly/react-core";
+import ModalWithFormLayout, { Field } from "src/components/layouts/ModalWithFormLayout";
+import InputRequiredText from "src/components/layouts/InputRequiredText";
+import { useAddEntityMutation } from "src/services/rpcEntity";
+import { useAppDispatch } from "src/store/hooks";
+import { addAlert } from "src/store/Global/alerts-slice";
+import { SerializedError } from "@reduxjs/toolkit";
+
+interface PropsToAddModal {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  onRefresh: () => void;
+}
+
+const AddEntityModal = (props: PropsToAddModal) => {
+  const dispatch = useAppDispatch();
+  const [addEntity] = useAddEntityMutation();
+
+  const [isAddButtonSpinning, setIsAddButtonSpinning] = React.useState(false);
+  const [entityName, setEntityName] = React.useState("");
+  const [description, setDescription] = React.useState("");
+
+  const clearFields = () => {
+    setEntityName("");
+    setDescription("");
+  };
+
+  const onAdd = () => {
+    setIsAddButtonSpinning(true);
+    addEntity({ cn: entityName, description: description || undefined }).then((response) => {
+      if ("data" in response) {
+        const error = response.data?.error as SerializedError;
+        if (error) {
+          dispatch(addAlert({ name: "add-entity-error", title: error.message, variant: "danger" }));
+        }
+        if (response.data?.result) {
+          dispatch(addAlert({ name: "add-entity-success", title: "New entity added", variant: "success" }));
+          clearFields();
+          props.onRefresh();
+          props.onClose();
+        }
+      }
+      setIsAddButtonSpinning(false);
+    });
+  };
+
+  const cleanAndCloseModal = () => { clearFields(); props.onClose(); };
+
+  const fields: Field[] = [
+    {
+      id: "modal-form-entity-name",
+      name: "Entity name",
+      pfComponent: (
+        <InputRequiredText dataCy="modal-textbox-entity-name" id="modal-form-entity-name"
+          name="cn" value={entityName} onChange={setEntityName} requiredHelperText="Required value" />
+      ),
+      fieldRequired: true,
+    },
+    {
+      id: "modal-form-description",
+      name: "Description",
+      pfComponent: (
+        <TextArea data-cy="modal-textbox-description" id="modal-form-description" name="description"
+          value={description} onChange={(_e, v) => setDescription(v)} autoResize />
+      ),
+    },
+  ];
+
+  const modalActions: JSX.Element[] = [
+    <Button data-cy="modal-button-add" key="add-new" isDisabled={isAddButtonSpinning || entityName === ""}
+      form="add-modal-form" type="submit">Add</Button>,
+    <Button data-cy="modal-button-cancel" key="cancel-new" variant="link" onClick={cleanAndCloseModal}>Cancel</Button>,
+  ];
+
+  return (
+    <ModalWithFormLayout dataCy="add-entity-modal" variantType="small" modalPosition="top" offPosition="76px"
+      title={props.title} formId="add-modal-form" fields={fields} show={props.isOpen}
+      onSubmit={() => onAdd()} onClose={cleanAndCloseModal} actions={modalActions} />
+  );
+};
+
+export default AddEntityModal;
+```
+
+## Reference Implementations
 
 | Entity | Modal file | Notes |
 |--------|-----------|-------|
-| Certificate Mapping Rules | `src/components/modals/CertificateMapping/AddRuleModal.tsx` | Clean pattern with alerts for errors |
-| DNS Zones | `src/components/modals/DnsZones/AddDnsZoneModal.tsx` | Uses custom Modal (not ModalWithFormLayout) |
-| DNS Forward Zones | `src/components/modals/DnsZones/AddDnsForwardZoneModal.tsx` | Uses custom Modal with radio-based field switching |
-| Roles | `src/components/modals/RoleModals/AddRoleModal.tsx` | Simple two-field modal with InputRequiredText |
-
-**Other examples:**
-
-| Entity | Modal file | Fields |
-|--------|-----------|--------|
-| HBAC Rules | `src/components/modals/HbacModals/AddHBACRule.tsx` | Rule name (InputRequiredText, required), Description (TextArea, optional) |
-| Hosts | `src/components/modals/HostModals/AddHost.tsx` | Host name (InputWithValidation, required), Description (TextInput), Class (TextInput), IP Address (InputWithValidation), Force (Checkbox), Generate OTP (Checkbox) |
-| Trusts | `src/pages/Trusts/AddTrustModal.tsx` | Domain name (TextInput, required), Two-way (Checkbox), External (Checkbox), Auth method (Radio), Admin account (TextInput), Passwords (PasswordInput), Range type (Radio), Base ID (NumberSelector), Range size (NumberSelector) |
-| Users | `src/components/modals/UserModals/AddUser.tsx` | User login (InputRequiredText, required), First name (InputRequiredText, required), Last name (InputRequiredText, required), Class (TextInput), No private group (Checkbox), GID (TypeAheadSelectWithCreate), New password (PasswordInput), Verify password (PasswordInput) |
+| Roles | `src/components/modals/RoleModals/AddRoleModal.tsx` | Simple two-field modal |
+| Certificate Mapping | `src/components/modals/CertificateMapping/AddRuleModal.tsx` | Clean pattern with alerts |
+| DNS Zones | `src/components/modals/DnsZones/AddDnsZoneModal.tsx` | Uses custom Modal component |

--- a/doc/designs/main-pages/07-add-modal.md
+++ b/doc/designs/main-pages/07-add-modal.md
@@ -5,6 +5,241 @@
 
 The Add modal (`src/components/modals/<EntityModals>/Add<Entity>Modal.tsx`) is built using `ModalWithFormLayout`, which accepts a `fields` array. Each field specifies an `id`, a `name` (label), a `pfComponent` (the PatternFly/custom UI component), and optionally `fieldRequired: true`.
 
+## Standard Props Interface
+
+All Add modals use a consistent props interface with **all props required** (no optionals):
+
+```tsx
+interface PropsToAddModal {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  onRefresh: () => void;
+}
+```
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `isOpen` | `boolean` | Controls modal visibility |
+| `onClose` | `() => void` | Callback to close the modal |
+| `title` | `string` | Modal title displayed in the header |
+| `onRefresh` | `() => void` | Callback to refresh the parent table after successful addition |
+
+**Usage in the parent page:**
+
+```tsx
+<AddEntityModal
+  isOpen={showAddModal}
+  onClose={() => setShowAddModal(false)}
+  title="Add entity"
+  onRefresh={refreshData}
+/>
+```
+
+## Complete Modal Template
+
+```tsx
+import React from "react";
+// PatternFly
+import { Button, TextArea } from "@patternfly/react-core";
+// Components
+import ModalWithFormLayout, {
+  Field,
+} from "src/components/layouts/ModalWithFormLayout";
+import InputRequiredText from "src/components/layouts/InputRequiredText";
+// RPC
+import { useAddEntityMutation } from "src/services/rpcEntity";
+// Redux
+import { useAppDispatch } from "src/store/hooks";
+// Hooks
+import { addAlert } from "src/store/Global/alerts-slice";
+// Errors
+import { SerializedError } from "@reduxjs/toolkit";
+
+interface PropsToAddModal {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  onRefresh: () => void;
+}
+
+const AddEntityModal = (props: PropsToAddModal) => {
+  const dispatch = useAppDispatch();
+
+  // API calls
+  const [addEntity] = useAddEntityMutation();
+
+  // States
+  const [isAddButtonSpinning, setIsAddButtonSpinning] = React.useState(false);
+  const [entityName, setEntityName] = React.useState("");
+  const [description, setDescription] = React.useState("");
+
+  // Clear fields
+  const clearFields = () => {
+    setEntityName("");
+    setDescription("");
+  };
+
+  // 'Add' button handler
+  const onAdd = () => {
+    setIsAddButtonSpinning(true);
+
+    addEntity({
+      cn: entityName,
+      description: description || undefined,
+    }).then((response) => {
+      if ("data" in response) {
+        const data = response.data?.result;
+        const error = response.data?.error as SerializedError;
+
+        if (error) {
+          dispatch(
+            addAlert({
+              name: "add-entity-error",
+              title: error.message,
+              variant: "danger",
+            })
+          );
+        }
+
+        if (data) {
+          dispatch(
+            addAlert({
+              name: "add-entity-success",
+              title: "New entity added",
+              variant: "success",
+            })
+          );
+          // Reset fields
+          clearFields();
+          // Update data
+          props.onRefresh();
+          props.onClose();
+        }
+      }
+      // Reset button spinner
+      setIsAddButtonSpinning(false);
+    });
+  };
+
+  // Clean and close modal
+  const cleanAndCloseModal = () => {
+    clearFields();
+    props.onClose();
+  };
+
+  const fields: Field[] = [
+    {
+      id: "modal-form-entity-name",
+      name: "Entity name",
+      pfComponent: (
+        <InputRequiredText
+          dataCy="modal-textbox-entity-name"
+          id="modal-form-entity-name"
+          name="cn"
+          value={entityName}
+          onChange={setEntityName}
+          requiredHelperText="Required value"
+        />
+      ),
+      fieldRequired: true,
+    },
+    {
+      id: "modal-form-description",
+      name: "Description",
+      pfComponent: (
+        <TextArea
+          data-cy="modal-textbox-description"
+          id="modal-form-description"
+          name="description"
+          value={description}
+          aria-label="Description"
+          onChange={(_event, value: string) => setDescription(value)}
+          autoResize
+        />
+      ),
+    },
+  ];
+
+  // Actions
+  const modalActions: JSX.Element[] = [
+    <Button
+      data-cy="modal-button-add"
+      key="add-new"
+      isDisabled={isAddButtonSpinning || entityName === ""}
+      form="add-modal-form"
+      type="submit"
+    >
+      Add
+    </Button>,
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-new"
+      variant="link"
+      onClick={cleanAndCloseModal}
+    >
+      Cancel
+    </Button>,
+  ];
+
+  return (
+    <>
+      <ModalWithFormLayout
+        dataCy="add-entity-modal"
+        variantType={"small"}
+        modalPosition={"top"}
+        offPosition={"76px"}
+        title={props.title}
+        formId="add-modal-form"
+        fields={fields}
+        show={props.isOpen}
+        onSubmit={() => onAdd()}
+        onClose={cleanAndCloseModal}
+        actions={modalActions}
+      />
+    </>
+  );
+};
+
+export default AddEntityModal;
+```
+
+## Code Organization
+
+The Add modal follows this structure:
+
+1. **Imports** — PatternFly components, layout components, RPC hooks, Redux, alerts
+2. **Props interface** — Standard `PropsToAddModal` with four required props
+3. **Component body:**
+   - API mutation hook
+   - State declarations (spinner, form fields)
+   - `clearFields()` — resets all form fields
+   - `onAdd()` — the add handler (API call, success/error alerts, refresh, close)
+   - `cleanAndCloseModal()` — clears fields and closes modal
+   - `fields` array — form field definitions
+   - `modalActions` array — Add and Cancel buttons
+4. **Return** — `ModalWithFormLayout` component
+
+## Error Handling
+
+Use **alerts** for error handling — do not use a separate `ErrorModal` component. When an error occurs:
+
+1. Dispatch a danger alert with the error message
+2. Reset the button spinner
+3. Keep the modal open so the user can retry or cancel
+
+```tsx
+if (error) {
+  dispatch(
+    addAlert({
+      name: "add-entity-error",
+      title: error.message,
+      variant: "danger",
+    })
+  );
+}
+```
+
 When specifying **Add modal fields** in your prompt, provide each field as:
 
 ```
@@ -189,15 +424,16 @@ The Add modal must only have two action buttons: **Add** and **Cancel**. Do **no
 const modalActions: JSX.Element[] = [
   <Button
     data-cy="modal-button-add"
-    key="add-new-<entity>"
-    isDisabled={buttonDisabled}
-    onClick={onAdd}
+    key="add-new"
+    isDisabled={isAddButtonSpinning || requiredField === ""}
+    form="add-modal-form"
+    type="submit"
   >
     Add
   </Button>,
   <Button
     data-cy="modal-button-cancel"
-    key="cancel-new-<entity>"
+    key="cancel-new"
     variant="link"
     onClick={cleanAndCloseModal}
   >
@@ -208,21 +444,43 @@ const modalActions: JSX.Element[] = [
 
 ## Button Disabled Logic
 
-The Add button should be disabled until all **required** fields are non-empty:
+The Add button should be disabled until all **required** fields are non-empty. Compute the disabled state inline or as a derived variable — do not use `useEffect` + `useState` for this.
+
+**Inline (preferred for simple conditions):**
 
 ```tsx
-const [buttonDisabled, setButtonDisabled] = useState(true);
+<Button
+  isDisabled={isAddButtonSpinning || requiredField === ""}
+  // ...
+>
+```
 
-useEffect(() => {
-  if (requiredField1 === "" || requiredField2 === "") {
-    setButtonDisabled(true);
-  } else {
-    setButtonDisabled(false);
-  }
-}, [requiredField1, requiredField2]);
+**Derived variable (for complex conditions):**
+
+```tsx
+const mandatoryEmpty =
+  requiredField1 === "" ||
+  requiredField2 === "" ||
+  (someCondition && requiredField3 === "");
+
+const disabledAdd = isAddButtonSpinning || mandatoryEmpty;
+
+// In modalActions:
+<Button isDisabled={disabledAdd}>
 ```
 
 ## Existing Add Modal Examples
+
+**Reference implementations** (follow these patterns):
+
+| Entity | Modal file | Notes |
+|--------|-----------|-------|
+| Certificate Mapping Rules | `src/components/modals/CertificateMapping/AddRuleModal.tsx` | Clean pattern with alerts for errors |
+| DNS Zones | `src/components/modals/DnsZones/AddDnsZoneModal.tsx` | Uses custom Modal (not ModalWithFormLayout) |
+| DNS Forward Zones | `src/components/modals/DnsZones/AddDnsForwardZoneModal.tsx` | Uses custom Modal with radio-based field switching |
+| Roles | `src/components/modals/RoleModals/AddRoleModal.tsx` | Simple two-field modal with InputRequiredText |
+
+**Other examples:**
 
 | Entity | Modal file | Fields |
 |--------|-----------|--------|

--- a/doc/designs/main-pages/07b-add-modal-fields.md
+++ b/doc/designs/main-pages/07b-add-modal-fields.md
@@ -1,0 +1,142 @@
+# Main Pages — Add Modal Field Types & Naming
+
+> **Part of:** [Main Pages guide](../main-pages.md)
+> **See also:** [Add Modal Structure](07-add-modal.md) | [Delete Modal](08-delete-modal-and-utils.md)
+
+## Specifying Fields
+
+When specifying Add modal fields in your prompt:
+
+```
+<ipa_attribute> → "<Label>" (<data_type>, <ui_component>, required|optional)
+```
+
+## Available UI Components
+
+| UI component | Import from | Use when |
+|-------------|-------------|----------|
+| `InputRequiredText` | `src/components/layouts/InputRequiredText` | Required single-line text with validation helper |
+| `TextInput` | `@patternfly/react-core` | Optional single-line text |
+| `TextArea` | `@patternfly/react-core` | Multi-line text (use `autoResize`) |
+| `Checkbox` | `@patternfly/react-core` | Boolean flags |
+| `Radio` | `@patternfly/react-core` | One-of-N choice |
+| `Select` + `SelectList` + `SelectOption` | `@patternfly/react-core` | Dropdown selection |
+| `NumberSelector` | `src/components/Form/NumberInput` | Numeric with increment/decrement |
+| `PasswordInput` | `src/components/layouts/PasswordInput` | Password with show/hide |
+| `SimpleSelector` | `src/components/Form/SimpleSelector` | Simple dropdown |
+| `InputWithValidation` | `src/components/layouts/InputWithValidation` | Text with inline validation rules |
+
+## Field Validation with `InputWithValidation`
+
+Use when fields have format constraints:
+
+```tsx
+{
+  id: "modal-form-host-name",
+  name: "Host name",
+  pfComponent: (
+    <InputWithValidation
+      dataCy="modal-textbox-host-name"
+      id="modal-form-host-name"
+      name="modal-form-host-name"
+      value={hostName}
+      onChange={setHostName}
+      isRequired
+      rules={[
+        {
+          id: "valid-chars",
+          message: "Allowed characters are a-z, A-Z, 0-9, and -",
+          validate: (value: string) => /^[a-zA-Z0-9-]+$/.test(value),
+        },
+      ]}
+    />
+  ),
+  fieldRequired: true,
+}
+```
+
+**Existing validation examples:**
+
+| Entity | Field | Validation |
+|--------|-------|-----------|
+| Hosts | Host name | `a-z, A-Z, 0-9, -` |
+| Hosts | IP address | Valid IPv4 or IPv6 |
+| Users | User login | Alphanumeric and `_-.$`, first char must be letter |
+
+## Naming Conventions
+
+### Element IDs (`id`)
+
+```
+modal-form-{field-name}
+```
+
+Examples: `modal-form-user-login`, `modal-form-description`
+
+### Test Attributes (`data-cy` / `dataCy`)
+
+| Component Type | Pattern | Example |
+|----------------|---------|---------|
+| Text input | `modal-textbox-{field-name}` | `modal-textbox-user-login` |
+| Text area | `modal-textbox-{field-name}` | `modal-textbox-description` |
+| Checkbox | `modal-checkbox-{field-name}` | `modal-checkbox-force` |
+| Radio button | `modal-radio-{field-name}` | `modal-radio-auth-method` |
+| Select/Dropdown | `modal-select-{field-name}` | `modal-select-group` |
+| Number input | `modal-number-{field-name}` | `modal-number-base-id` |
+
+### State Variables
+
+Use camelCase, one `useState` per field:
+
+```tsx
+const [userLogin, setUserLogin] = React.useState("");
+const [description, setDescription] = React.useState("");
+const [generateOtp, setGenerateOtp] = React.useState(false);
+```
+
+### Handler Functions
+
+Use `on{Action}` pattern:
+
+```tsx
+const onAdd = () => { /* ... */ };
+const cleanAndCloseModal = () => { /* ... */ };
+```
+
+## Field Template
+
+```tsx
+const fields: Field[] = [
+  {
+    id: "modal-form-<field-name>",
+    name: "<Label>",
+    pfComponent: (
+      <InputRequiredText
+        dataCy="modal-textbox-<field-name>"
+        id="modal-form-<field-name>"
+        name="<ipa-attribute>"
+        value={fieldState}
+        onChange={setFieldState}
+        requiredHelperText="Required value"
+      />
+    ),
+    fieldRequired: true,  // omit for optional fields
+  },
+];
+```
+
+## Best Practices
+
+1. **Consistency**: Use kebab-case for `id` and `data-cy` attributes
+2. **Uniqueness**: Each `data-cy` value must be unique within the modal
+3. **Descriptive**: Use clear names that indicate the field's purpose
+4. **Match IPA attributes**: Derive field names from IPA attribute (e.g., `ipatokenowner` → `modal-form-owner`)
+
+## Other Add Modal Examples
+
+| Entity | Modal file | Fields |
+|--------|-----------|--------|
+| HBAC Rules | `src/components/modals/HbacModals/AddHBACRule.tsx` | Rule name, Description |
+| Hosts | `src/components/modals/HostModals/AddHost.tsx` | Host name, Description, Class, IP, Force, OTP |
+| Trusts | `src/pages/Trusts/AddTrustModal.tsx` | Domain, Auth method, Admin, Passwords, Range type |
+| Users | `src/components/modals/UserModals/AddUser.tsx` | Login, First/Last name, Class, GID, Passwords |

--- a/doc/designs/main-pages/08-delete-modal-and-utils.md
+++ b/doc/designs/main-pages/08-delete-modal-and-utils.md
@@ -74,6 +74,24 @@ When rendering the delete modal from the main page, pass `columnNames` and `keyN
 />
 ```
 
+### Return Statement
+
+Always use a direct `return (...)` statement — do not assign JSX to an intermediate variable:
+
+```tsx
+// Correct:
+return (
+  <>
+    <ModalWithFormLayout ... />
+    {isModalErrorOpen && <ErrorModal ... />}
+  </>
+);
+
+// Avoid:
+const modalDelete: JSX.Element = (...);
+return modalDelete;
+```
+
 ### Existing Examples
 
 | Entity | Delete modal file | Props pattern |

--- a/doc/designs/main-pages/09-rpc-service.md
+++ b/doc/designs/main-pages/09-rpc-service.md
@@ -12,18 +12,20 @@ Create `src/services/rpcMyEntities.ts` with RTK Query endpoints. This file defin
 **All entity-specific endpoints must be defined in a dedicated `src/services/rpc<Entity>.ts` file**, never in `src/services/rpc.ts`. The base `rpc.ts` file is reserved for shared/generic infrastructure only:
 - The base `createApi` definition and tag types
 - Generic payloads (`GenericPayload`) and shared types (`Command`, `BatchRPCResponse`, etc.)
-- The generic `useSearchEntriesMutation` and `useGettingGenericQuery` hooks
+- The generic `useGettingGenericQuery` hook (for initial data loading)
 - Shared helper functions (`getCommand`, `getBatchCommand`)
 
-When creating a new entity, the only changes to `rpc.ts` should be:
-1. Adding the entity's `entryType` value to the `GenericPayload` union (if using the generic search mutation)
-2. Adding a cache tag to `tagTypes` (if the entity-specific service file uses `providesTags` / `invalidatesTags`)
+**Do NOT modify `rpc.ts`** when adding a new entity. Specifically:
+- Do NOT add new `entryType` values to `GenericPayload` or `useSearchEntriesMutation` — define a dedicated search mutation in the entity's `rpc<Entity>.ts` file instead
+- Only add a cache tag to `tagTypes` if the entity-specific service file uses `providesTags` / `invalidatesTags`
 
-Entity-specific queries, mutations, and hooks are defined using `api.injectEndpoints()` in the entity's own file (e.g. `rpcHBACRules.ts`, `rpcTrusts.ts`, `rpcSelinuxUserMaps.ts`).
+Entity-specific queries, mutations, and hooks are defined using `api.injectEndpoints()` in the entity's own file (e.g. `rpcRoles.ts`, `rpcTrusts.ts`, `rpcSelinuxUserMaps.ts`).
 
 ## Minimum Endpoints for a Main Page
 
-A main page needs at least a **query** for listing entries and either uses the generic `useSearchEntriesMutation` from `rpc.ts` or defines its own **search mutation**.
+A main page needs at least:
+1. A **query** for initial data loading — can use the generic `useGettingGenericQuery` wrapper from the entity's service file
+2. A **search mutation** for explicit search submissions — must be defined in `rpc<Entity>.ts` using the two-step find+show pattern
 
 ## Template
 
@@ -213,7 +215,8 @@ Individual command docs: `https://freeipa.readthedocs.io/en/latest/api/<entity>_
 
 | Entity | Service file | Key hooks |
 |--------|-------------|-----------|
-| Hosts | `src/services/rpcHosts.ts` | `useGettingHostQuery`, `useAutoMemberRebuildHostsMutation` |
+| Roles | `src/services/rpcRoles.ts` | `useGettingRolesQuery`, `useSearchRolesEntriesMutation`, `useAddRoleMutation`, `useDeleteRolesMutation` |
 | Trusts | `src/services/rpcTrusts.ts` | `useGetTrustsFullDataQuery`, `useSearchTrustsEntriesMutation`, `useAddTrustMutation` |
 | DNS Zones | `src/services/rpcDnsZones.ts` | `useGetDnsZonesFullDataQuery`, `useSearchDnsZonesEntriesMutation` |
+| Hosts | `src/services/rpcHosts.ts` | `useGettingHostQuery`, `useAutoMemberRebuildHostsMutation` |
 | HBAC Rules | `src/services/rpcHBACRules.ts` | `useGettingHbacRulesQuery` |

--- a/src/components/modals/RoleModals/AddRoleModal.tsx
+++ b/src/components/modals/RoleModals/AddRoleModal.tsx
@@ -1,0 +1,163 @@
+import React from "react";
+// PatternFly
+import { Button, TextArea } from "@patternfly/react-core";
+// Components
+import ModalWithFormLayout, {
+  Field,
+} from "src/components/layouts/ModalWithFormLayout";
+import InputRequiredText from "src/components/layouts/InputRequiredText";
+// RPC
+import { useAddRoleMutation } from "src/services/rpcRoles";
+// Redux
+import { useAppDispatch } from "src/store/hooks";
+// Hooks
+import { addAlert } from "src/store/Global/alerts-slice";
+// Errors
+import { SerializedError } from "@reduxjs/toolkit";
+
+interface PropsToAddModal {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  onRefresh: () => void;
+}
+
+const AddRoleModal = (props: PropsToAddModal) => {
+  const dispatch = useAppDispatch();
+
+  // API calls
+  const [addRole] = useAddRoleMutation();
+
+  // States
+  const [isAddButtonSpinning, setIsAddButtonSpinning] = React.useState(false);
+  const [roleName, setRoleName] = React.useState("");
+  const [description, setDescription] = React.useState("");
+
+  // Clear fields
+  const clearFields = () => {
+    setRoleName("");
+    setDescription("");
+  };
+
+  // 'Add' button handler
+  const onAddRole = () => {
+    setIsAddButtonSpinning(true);
+
+    addRole({
+      cn: roleName,
+      description: description || undefined,
+    }).then((response) => {
+      if ("data" in response) {
+        const data = response.data?.result;
+        const error = response.data?.error as SerializedError;
+
+        if (error) {
+          dispatch(
+            addAlert({
+              name: "add-role-error",
+              title: error.message,
+              variant: "danger",
+            })
+          );
+        }
+
+        if (data) {
+          dispatch(
+            addAlert({
+              name: "add-role-success",
+              title: "New role added",
+              variant: "success",
+            })
+          );
+          // Reset fields
+          clearFields();
+          // Update data
+          props.onRefresh();
+          props.onClose();
+        }
+      }
+      // Reset button spinner
+      setIsAddButtonSpinning(false);
+    });
+  };
+
+  // Clean and close modal
+  const cleanAndCloseModal = () => {
+    clearFields();
+    props.onClose();
+  };
+
+  const fields: Field[] = [
+    {
+      id: "modal-form-role-name",
+      name: "Role name",
+      pfComponent: (
+        <InputRequiredText
+          dataCy="modal-textbox-role-name"
+          id="modal-form-role-name"
+          name="cn"
+          value={roleName}
+          onChange={setRoleName}
+          requiredHelperText="Required value"
+        />
+      ),
+      fieldRequired: true,
+    },
+    {
+      id: "modal-form-role-description",
+      name: "Description",
+      pfComponent: (
+        <TextArea
+          data-cy="modal-textbox-description"
+          id="modal-form-role-description"
+          name="description"
+          value={description}
+          aria-label="Role description"
+          onChange={(_event, value: string) => setDescription(value)}
+          autoResize
+        />
+      ),
+    },
+  ];
+
+  // Actions
+  const modalActions: JSX.Element[] = [
+    <Button
+      data-cy="modal-button-add"
+      key="add-new"
+      isDisabled={isAddButtonSpinning || roleName === ""}
+      form="add-modal-form"
+      type="submit"
+    >
+      Add
+    </Button>,
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-new"
+      variant="link"
+      onClick={cleanAndCloseModal}
+    >
+      Cancel
+    </Button>,
+  ];
+
+  return (
+    <>
+      <ModalWithFormLayout
+        dataCy="add-role-modal"
+        variantType={"small"}
+        modalPosition={"top"}
+        offPosition={"76px"}
+        title={props.title}
+        formId="add-modal-form"
+        fields={fields}
+        show={props.isOpen}
+        onSubmit={() => onAddRole()}
+        onClose={cleanAndCloseModal}
+        actions={modalActions}
+      />
+    </>
+  );
+};
+
+export default AddRoleModal;

--- a/src/components/modals/RoleModals/DeleteRolesModal.tsx
+++ b/src/components/modals/RoleModals/DeleteRolesModal.tsx
@@ -1,0 +1,210 @@
+import React, { useState } from "react";
+// PatternFly
+import { Content, ContentVariants, Button } from "@patternfly/react-core";
+// Layouts
+import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
+// Tables
+import DeletedElementsTable from "src/components/tables/DeletedElementsTable";
+// Hooks
+import { addAlert } from "src/store/Global/alerts-slice";
+// Redux
+import { useAppDispatch } from "src/store/hooks";
+import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
+import { SerializedError } from "@reduxjs/toolkit";
+// Data types
+import { ErrorData, Role } from "src/utils/datatypes/globalDataTypes";
+// Modals
+import ErrorModal from "src/components/modals/ErrorModal";
+import { BatchRPCResponse } from "src/services/rpc";
+import { useDeleteRolesMutation } from "src/services/rpcRoles";
+
+interface PropsToDeleteRoles {
+  show: boolean;
+  handleModalToggle: () => void;
+  elementsToDelete: Role[];
+  clearSelectedElements: () => void;
+  columnNames: string[];
+  keyNames: string[];
+  onRefresh?: () => void;
+  updateIsDeleteButtonDisabled: (value: boolean) => void;
+  updateIsDeletion: (value: boolean) => void;
+}
+
+const DeleteRolesModal = (props: PropsToDeleteRoles) => {
+  const dispatch = useAppDispatch();
+
+  const [executeRolesDelCommand] = useDeleteRolesMutation();
+
+  const [spinning, setBtnSpinning] = React.useState<boolean>(false);
+
+  const fields = [
+    {
+      id: "question-text",
+      pfComponent: (
+        <Content component={ContentVariants.p}>
+          Are you sure you want to remove the selected roles?
+        </Content>
+      ),
+    },
+    {
+      id: "deleted-roles-table",
+      pfComponent: (
+        <DeletedElementsTable
+          mode="passing_full_data"
+          elementsToDelete={props.elementsToDelete}
+          columnNames={props.columnNames}
+          columnIds={props.keyNames}
+          elementType="Role"
+          idAttr="cn"
+        />
+      ),
+    },
+  ];
+
+  const closeModal = () => {
+    props.handleModalToggle();
+  };
+
+  const [isModalErrorOpen, setIsModalErrorOpen] = useState(false);
+  const [errorTitle, setErrorTitle] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const closeAndCleanErrorParameters = () => {
+    setIsModalErrorOpen(false);
+    setErrorTitle("");
+    setErrorMessage("");
+  };
+
+  const onCloseErrorModal = () => {
+    closeAndCleanErrorParameters();
+  };
+
+  const errorModalActions = [
+    <Button
+      key="cancel"
+      variant="link"
+      onClick={onCloseErrorModal}
+      data-cy="modal-button-ok"
+    >
+      OK
+    </Button>,
+  ];
+
+  const handleAPIError = (error: FetchBaseQueryError | SerializedError) => {
+    if ("code" in error) {
+      setErrorTitle("IPA error " + error.code + ": " + error.name);
+      if (error.message !== undefined) {
+        setErrorMessage(error.message);
+      }
+    } else if ("data" in error) {
+      const errorData = error.data as ErrorData;
+      const errorCode = errorData.code as string;
+      const errorName = errorData.name as string;
+      const errorMessage = errorData.error as string;
+
+      setErrorTitle("IPA error " + errorCode + ": " + errorName);
+      setErrorMessage(errorMessage);
+    }
+    setIsModalErrorOpen(true);
+  };
+
+  const deleteRoles = () => {
+    setBtnSpinning(true);
+
+    executeRolesDelCommand(props.elementsToDelete).then((response) => {
+      if ("data" in response) {
+        const data = response.data as BatchRPCResponse;
+        const result = data.result;
+
+        if (result) {
+          if ("error" in result.results[0] && result.results[0].error) {
+            const errorData = {
+              code: result.results[0].error_code,
+              name: result.results[0].error_name,
+              error: result.results[0].error,
+            } as ErrorData;
+
+            const error = {
+              status: "CUSTOM_ERROR",
+              data: errorData,
+            } as FetchBaseQueryError;
+
+            handleAPIError(error);
+            setBtnSpinning(false);
+          } else {
+            props.clearSelectedElements();
+            props.updateIsDeleteButtonDisabled(true);
+            props.updateIsDeletion(true);
+
+            dispatch(
+              addAlert({
+                name: "remove-roles-success",
+                title: "Roles removed",
+                variant: "success",
+              })
+            );
+
+            setBtnSpinning(false);
+            closeModal();
+            if (props.onRefresh !== undefined) {
+              props.onRefresh();
+            }
+          }
+        }
+      }
+    });
+  };
+
+  const modalActionsDelete: JSX.Element[] = [
+    <Button
+      key="delete-roles"
+      variant="danger"
+      onClick={deleteRoles}
+      form="delete-roles-modal"
+      spinnerAriaValueText="Deleting"
+      spinnerAriaLabel="Deleting"
+      isLoading={spinning}
+      isDisabled={spinning}
+      data-cy="modal-button-delete"
+    >
+      {spinning ? "Deleting" : "Delete"}
+    </Button>,
+    <Button
+      key="cancel-delete-roles"
+      variant="link"
+      onClick={closeModal}
+      data-cy="modal-button-cancel"
+    >
+      Cancel
+    </Button>,
+  ];
+
+  return (
+    <>
+      <ModalWithFormLayout
+        dataCy="delete-roles-modal"
+        variantType="medium"
+        modalPosition="top"
+        offPosition="76px"
+        title="Remove roles"
+        formId="delete-roles-modal"
+        fields={fields}
+        show={props.show}
+        onClose={closeModal}
+        actions={modalActionsDelete}
+      />
+      {isModalErrorOpen && (
+        <ErrorModal
+          dataCy="delete-roles-modal-error"
+          title={errorTitle}
+          isOpen={isModalErrorOpen}
+          onClose={onCloseErrorModal}
+          actions={errorModalActions}
+          errorMessage={errorMessage}
+        />
+      )}
+    </>
+  );
+};
+
+export default DeleteRolesModal;

--- a/src/components/modals/RoleModals/DeleteRolesModal.tsx
+++ b/src/components/modals/RoleModals/DeleteRolesModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 // PatternFly
 import { Content, ContentVariants, Button } from "@patternfly/react-core";
 // Layouts
@@ -18,24 +18,29 @@ import ErrorModal from "src/components/modals/ErrorModal";
 import { BatchRPCResponse } from "src/services/rpc";
 import { useDeleteRolesMutation } from "src/services/rpcRoles";
 
-interface PropsToDeleteRoles {
-  show: boolean;
-  handleModalToggle: () => void;
+interface DeleteRolesModalProps {
+  isOpen: boolean;
+  onClose: () => void;
   elementsToDelete: Role[];
   clearSelectedElements: () => void;
   columnNames: string[];
   keyNames: string[];
-  onRefresh?: () => void;
+  onRefresh: () => void;
   updateIsDeleteButtonDisabled: (value: boolean) => void;
   updateIsDeletion: (value: boolean) => void;
 }
 
-const DeleteRolesModal = (props: PropsToDeleteRoles) => {
+const DeleteRolesModal = (props: DeleteRolesModalProps) => {
   const dispatch = useAppDispatch();
 
+  // RPC calls
   const [executeRolesDelCommand] = useDeleteRolesMutation();
 
+  // States
   const [spinning, setBtnSpinning] = React.useState<boolean>(false);
+  const [isModalErrorOpen, setIsModalErrorOpen] = React.useState(false);
+  const [errorTitle, setErrorTitle] = React.useState("");
+  const [errorMessage, setErrorMessage] = React.useState("");
 
   const fields = [
     {
@@ -61,35 +66,7 @@ const DeleteRolesModal = (props: PropsToDeleteRoles) => {
     },
   ];
 
-  const closeModal = () => {
-    props.handleModalToggle();
-  };
-
-  const [isModalErrorOpen, setIsModalErrorOpen] = useState(false);
-  const [errorTitle, setErrorTitle] = useState("");
-  const [errorMessage, setErrorMessage] = useState("");
-
-  const closeAndCleanErrorParameters = () => {
-    setIsModalErrorOpen(false);
-    setErrorTitle("");
-    setErrorMessage("");
-  };
-
-  const onCloseErrorModal = () => {
-    closeAndCleanErrorParameters();
-  };
-
-  const errorModalActions = [
-    <Button
-      key="cancel"
-      variant="link"
-      onClick={onCloseErrorModal}
-      data-cy="modal-button-ok"
-    >
-      OK
-    </Button>,
-  ];
-
+  // Handle API error data
   const handleAPIError = (error: FetchBaseQueryError | SerializedError) => {
     if ("code" in error) {
       setErrorTitle("IPA error " + error.code + ": " + error.name);
@@ -100,15 +77,22 @@ const DeleteRolesModal = (props: PropsToDeleteRoles) => {
       const errorData = error.data as ErrorData;
       const errorCode = errorData.code as string;
       const errorName = errorData.name as string;
-      const errorMessage = errorData.error as string;
+      const errorMsg = errorData.error as string;
 
       setErrorTitle("IPA error " + errorCode + ": " + errorName);
-      setErrorMessage(errorMessage);
+      setErrorMessage(errorMsg);
     }
     setIsModalErrorOpen(true);
   };
 
-  const deleteRoles = () => {
+  const closeAndCleanErrorParameters = () => {
+    setIsModalErrorOpen(false);
+    setErrorTitle("");
+    setErrorMessage("");
+  };
+
+  // Delete handler
+  const onDeleteRoles = () => {
     setBtnSpinning(true);
 
     executeRolesDelCommand(props.elementsToDelete).then((response) => {
@@ -130,7 +114,6 @@ const DeleteRolesModal = (props: PropsToDeleteRoles) => {
             } as FetchBaseQueryError;
 
             handleAPIError(error);
-            setBtnSpinning(false);
           } else {
             props.clearSelectedElements();
             props.updateIsDeleteButtonDisabled(true);
@@ -144,22 +127,21 @@ const DeleteRolesModal = (props: PropsToDeleteRoles) => {
               })
             );
 
-            setBtnSpinning(false);
-            closeModal();
-            if (props.onRefresh !== undefined) {
-              props.onRefresh();
-            }
+            props.onClose();
+            props.onRefresh();
           }
         }
       }
+      setBtnSpinning(false);
     });
   };
 
-  const modalActionsDelete: JSX.Element[] = [
+  // Modal actions
+  const modalActions: JSX.Element[] = [
     <Button
       key="delete-roles"
       variant="danger"
-      onClick={deleteRoles}
+      onClick={onDeleteRoles}
       form="delete-roles-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
@@ -172,10 +154,22 @@ const DeleteRolesModal = (props: PropsToDeleteRoles) => {
     <Button
       key="cancel-delete-roles"
       variant="link"
-      onClick={closeModal}
+      onClick={props.onClose}
       data-cy="modal-button-cancel"
     >
       Cancel
+    </Button>,
+  ];
+
+  // Error modal actions
+  const errorModalActions = [
+    <Button
+      key="cancel"
+      variant="link"
+      onClick={closeAndCleanErrorParameters}
+      data-cy="modal-button-ok"
+    >
+      OK
     </Button>,
   ];
 
@@ -189,16 +183,16 @@ const DeleteRolesModal = (props: PropsToDeleteRoles) => {
         title="Remove roles"
         formId="delete-roles-modal"
         fields={fields}
-        show={props.show}
-        onClose={closeModal}
-        actions={modalActionsDelete}
+        show={props.isOpen}
+        onClose={props.onClose}
+        actions={modalActions}
       />
       {isModalErrorOpen && (
         <ErrorModal
           dataCy="delete-roles-modal-error"
           title={errorTitle}
           isOpen={isModalErrorOpen}
-          onClose={onCloseErrorModal}
+          onClose={closeAndCleanErrorParameters}
           actions={errorModalActions}
           errorMessage={errorMessage}
         />

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -78,6 +78,7 @@ import GlobalTrustConfig from "src/pages/Trusts/GlobalTrustConfig";
 import OtpTokens from "src/pages/OtpTokens/OtpTokens";
 import TopologyGraph from "src/pages/Topology/TopologyGraph";
 import OtpTokensTabs from "src/pages/OtpTokens/OtpTokensTabs";
+import Roles from "src/pages/Roles/Roles";
 
 // Renders routes (React)
 export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
@@ -555,6 +556,9 @@ export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
               </Route>
               <Route path="topology-graph">
                 <Route path="" element={<TopologyGraph />} />
+              </Route>
+              <Route path="roles">
+                <Route path="" element={<Roles />} />
               </Route>
               <Route path="configuration" element={<Configuration />} />
               {/* Redirect to Active users page if user is logged in and navigates to the root page */}

--- a/src/navigation/NavRoutes.ts
+++ b/src/navigation/NavRoutes.ts
@@ -67,6 +67,8 @@ const TrustsGroupRef = "trusts";
 const TrustsGlobalConfigGroupRef = "trusts-config";
 // - Topology
 const TopologyGroupRef = "topology-graph";
+// - Roles
+const RolesGroupRef = "roles";
 // - Configuration
 const ConfigRef = "configuration";
 
@@ -455,6 +457,13 @@ export const getNavigationRoutes = (
               items: [],
             },
           ],
+        },
+        {
+          label: "Roles",
+          group: RolesGroupRef,
+          title: `${BASE_TITLE} - Roles`,
+          path: "roles",
+          items: [],
         },
         {
           label: "Configuration",

--- a/src/pages/Roles/Roles.tsx
+++ b/src/pages/Roles/Roles.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useMemo, useState } from "react";
 // PatternFly
 import {
   Flex,
@@ -66,13 +66,8 @@ const Roles = () => {
   const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
     useListPageSearchParams();
 
-  const [rolesList, setRolesList] = useState<Role[]>([]);
-
   const globalErrors = useApiError([]);
   const modalErrors = useApiError([]);
-
-  const [totalCount, setTotalCount] = useState<number>(0);
-  const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
   const firstIdx = (page - 1) * perPage;
   const lastIdx = page * perPage;
@@ -88,24 +83,31 @@ const Roles = () => {
   const {
     data: batchResponse,
     isLoading: isBatchLoading,
+    isFetching,
     error: batchError,
   } = rolesDataResponse;
 
-  useEffect(() => {
-    if (rolesDataResponse.isFetching) {
-      setShowTableRows(false);
-      setTotalCount(0);
-      globalErrors.clear();
-      return;
+  // Search state - overrides query data when active
+  const [searchRoles, searchResult] = useSearchRolesEntriesMutation({});
+  const [isSearchActive, setIsSearchActive] = useState(false);
+  const [searchData, setSearchData] = useState<{
+    roles: Role[];
+    totalCount: number;
+  } | null>(null);
+
+  // Derive rolesList and totalCount from query response or search results
+  const { rolesList, totalCount } = useMemo(() => {
+    // If search is active and has results, use search data
+    if (isSearchActive && searchData) {
+      return {
+        rolesList: searchData.roles,
+        totalCount: searchData.totalCount,
+      };
     }
 
-    if (
-      rolesDataResponse.isSuccess &&
-      rolesDataResponse.data &&
-      batchResponse !== undefined
-    ) {
+    // Otherwise derive from query response
+    if (batchResponse?.result) {
       const rolesListResult = batchResponse.result.results;
-      const totalCount = batchResponse.result.totalCount;
       const rolesListSize = batchResponse.result.count;
       const roles: Role[] = [];
 
@@ -113,29 +115,53 @@ const Roles = () => {
         roles.push(rolesListResult[i].result);
       }
 
-      setTotalCount(totalCount);
-      setRolesList(roles);
-      setShowTableRows(true);
+      return {
+        rolesList: roles,
+        totalCount: batchResponse.result.totalCount,
+      };
     }
 
+    return { rolesList: [], totalCount: 0 };
+  }, [batchResponse, isSearchActive, searchData]);
+
+  // Derive showTableRows from loading states
+  const showTableRows = useMemo(() => {
+    if (isSearchActive) {
+      return !searchResult.isLoading;
+    }
+    return !isFetching && !isBatchLoading;
+  }, [isFetching, isBatchLoading, isSearchActive, searchResult.isLoading]);
+
+  // Clear errors when fetching starts
+  React.useEffect(() => {
+    if (isFetching) {
+      globalErrors.clear();
+    }
+  }, [isFetching]);
+
+  // Handle query errors
+  React.useEffect(() => {
     if (
-      !rolesDataResponse.isLoading &&
+      !isBatchLoading &&
+      !isFetching &&
       rolesDataResponse.isError &&
       rolesDataResponse.error !== undefined
     ) {
       window.location.reload();
     }
-  }, [rolesDataResponse]);
+  }, [rolesDataResponse.isError, isBatchLoading, isFetching]);
 
   const refreshData = () => {
-    setShowTableRows(false);
-    setTotalCount(0);
+    setIsSearchActive(false);
+    setSearchData(null);
     clearSelectedRoles();
     rolesDataResponse.refetch();
   };
 
   React.useEffect(() => {
-    rolesDataResponse.refetch();
+    if (!isSearchActive) {
+      rolesDataResponse.refetch();
+    }
   }, [page, perPage]);
 
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
@@ -151,12 +177,12 @@ const Roles = () => {
     setSelectedRoles([]);
   };
 
-  const [searchRoles] = useSearchRolesEntriesMutation({});
+  const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
   const submitSearchValue = () => {
-    setShowTableRows(false);
     setSearchIsDisabled(true);
-    setTotalCount(0);
+    setIsSearchActive(true);
+
     searchRoles({
       searchValue: searchValue,
       sizeLimit: 0,
@@ -183,31 +209,27 @@ const Roles = () => {
               variant: "danger",
             })
           );
+          setIsSearchActive(false);
+          setSearchData(null);
         } else {
           const rolesListResult = result.data?.result.results || [];
           const rolesListSize = result.data?.result.count || 0;
-          const totalCount = result.data?.result.totalCount || 0;
+          const searchTotalCount = result.data?.result.totalCount || 0;
           const roles: Role[] = [];
 
           for (let i = 0; i < rolesListSize; i++) {
             roles.push(rolesListResult[i].result);
           }
-          setTotalCount(totalCount);
-          setRolesList(roles);
-          setShowTableRows(true);
+
+          setSearchData({
+            roles,
+            totalCount: searchTotalCount,
+          });
         }
         setSearchIsDisabled(false);
       }
     });
   };
-
-  const [showTableRows, setShowTableRows] = useState(!isBatchLoading);
-
-  useEffect(() => {
-    if (showTableRows !== !isBatchLoading) {
-      setShowTableRows(!isBatchLoading);
-    }
-  }, [isBatchLoading]);
 
   const [showAddModal, setShowAddModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -254,7 +276,13 @@ const Roles = () => {
     updatePage: setPage,
     updatePerPage: setPerPage,
     updateSelectedPerPage: setSelectedPerPage,
-    updateShownElementsList: setRolesList,
+    updateShownElementsList: (roles: Role[]) => {
+      if (isSearchActive) {
+        setSearchData((prev) =>
+          prev ? { ...prev, roles } : { roles, totalCount: 0 }
+        );
+      }
+    },
     totalCount,
   };
 
@@ -439,8 +467,8 @@ const Roles = () => {
         onRefresh={refreshData}
       />
       <DeleteRolesModal
-        show={showDeleteModal}
-        handleModalToggle={() => setShowDeleteModal(!showDeleteModal)}
+        isOpen={showDeleteModal}
+        onClose={() => setShowDeleteModal(false)}
         elementsToDelete={selectedRoles}
         clearSelectedElements={clearSelectedRoles}
         columnNames={columnNames}

--- a/src/pages/Roles/Roles.tsx
+++ b/src/pages/Roles/Roles.tsx
@@ -1,0 +1,457 @@
+import React, { useEffect, useState } from "react";
+// PatternFly
+import {
+  Flex,
+  FlexItem,
+  PageSection,
+  PaginationVariant,
+  ToolbarItemVariant,
+} from "@patternfly/react-core";
+// PatternFly table
+import {
+  InnerScrollContainer,
+  OuterScrollContainer,
+} from "@patternfly/react-table";
+// Data types
+import { Role } from "src/utils/datatypes/globalDataTypes";
+import { ToolbarItem } from "src/components/layouts/ToolbarLayout";
+// Redux
+import { useAppDispatch, useAppSelector } from "src/store/hooks";
+// Layouts
+import TitleLayout from "src/components/layouts/TitleLayout";
+import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
+import SecondaryButton from "src/components/layouts/SecondaryButton";
+import ToolbarLayout from "src/components/layouts/ToolbarLayout";
+import SearchInputLayout from "src/components/layouts/SearchInputLayout";
+// Tables
+import MainTable from "src/components/tables/MainTable";
+// Components
+import PaginationLayout from "src/components/layouts/PaginationLayout";
+import BulkSelectorPrep from "src/components/BulkSelectorPrep";
+// Modals
+import AddRoleModal from "src/components/modals/RoleModals/AddRoleModal";
+import DeleteRolesModal from "src/components/modals/RoleModals/DeleteRolesModal";
+// Hooks
+import { addAlert } from "src/store/Global/alerts-slice";
+import useUpdateRoute from "src/hooks/useUpdateRoute";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
+// Utils
+import { API_VERSION_BACKUP, isRoleSelectable } from "src/utils/utils";
+// RPC client
+import { GenericPayload } from "src/services/rpc";
+import {
+  useGettingRolesQuery,
+  useSearchRolesEntriesMutation,
+} from "src/services/rpcRoles";
+// Errors
+import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
+import { SerializedError } from "@reduxjs/toolkit";
+import useApiError from "src/hooks/useApiError";
+import GlobalErrors from "src/components/errors/GlobalErrors";
+import ModalErrors from "src/components/errors/ModalErrors";
+
+const Roles = () => {
+  const dispatch = useAppDispatch();
+
+  const { browserTitle } = useUpdateRoute({ pathname: "roles" });
+
+  React.useEffect(() => {
+    document.title = browserTitle;
+  }, [browserTitle]);
+
+  const apiVersion = useAppSelector(
+    (state) => state.global.environment.api_version
+  ) as string;
+
+  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+    useListPageSearchParams();
+
+  const [rolesList, setRolesList] = useState<Role[]>([]);
+
+  const globalErrors = useApiError([]);
+  const modalErrors = useApiError([]);
+
+  const [totalCount, setTotalCount] = useState<number>(0);
+  const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
+
+  const firstIdx = (page - 1) * perPage;
+  const lastIdx = page * perPage;
+
+  const rolesDataResponse = useGettingRolesQuery({
+    searchValue: "",
+    sizeLimit: 0,
+    apiVersion: apiVersion || API_VERSION_BACKUP,
+    startIdx: firstIdx,
+    stopIdx: lastIdx,
+  } as GenericPayload);
+
+  const {
+    data: batchResponse,
+    isLoading: isBatchLoading,
+    error: batchError,
+  } = rolesDataResponse;
+
+  useEffect(() => {
+    if (rolesDataResponse.isFetching) {
+      setShowTableRows(false);
+      setTotalCount(0);
+      globalErrors.clear();
+      return;
+    }
+
+    if (
+      rolesDataResponse.isSuccess &&
+      rolesDataResponse.data &&
+      batchResponse !== undefined
+    ) {
+      const rolesListResult = batchResponse.result.results;
+      const totalCount = batchResponse.result.totalCount;
+      const rolesListSize = batchResponse.result.count;
+      const roles: Role[] = [];
+
+      for (let i = 0; i < rolesListSize; i++) {
+        roles.push(rolesListResult[i].result);
+      }
+
+      setTotalCount(totalCount);
+      setRolesList(roles);
+      setShowTableRows(true);
+    }
+
+    if (
+      !rolesDataResponse.isLoading &&
+      rolesDataResponse.isError &&
+      rolesDataResponse.error !== undefined
+    ) {
+      window.location.reload();
+    }
+  }, [rolesDataResponse]);
+
+  const refreshData = () => {
+    setShowTableRows(false);
+    setTotalCount(0);
+    clearSelectedRoles();
+    rolesDataResponse.refetch();
+  };
+
+  React.useEffect(() => {
+    rolesDataResponse.refetch();
+  }, [page, perPage]);
+
+  const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
+    useState<boolean>(true);
+
+  const [isDeletion, setIsDeletion] = useState(false);
+
+  const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
+
+  const [selectedRoles, setSelectedRoles] = useState<Role[]>([]);
+
+  const clearSelectedRoles = () => {
+    setSelectedRoles([]);
+  };
+
+  const [searchRoles] = useSearchRolesEntriesMutation({});
+
+  const submitSearchValue = () => {
+    setShowTableRows(false);
+    setSearchIsDisabled(true);
+    setTotalCount(0);
+    searchRoles({
+      searchValue: searchValue,
+      sizeLimit: 0,
+      apiVersion: apiVersion || API_VERSION_BACKUP,
+      startIdx: firstIdx,
+      stopIdx: lastIdx,
+    }).then((result) => {
+      if ("data" in result) {
+        const searchError = result.data?.error as
+          | FetchBaseQueryError
+          | SerializedError;
+
+        if (searchError) {
+          let error: string | undefined = "";
+          if ("error" in searchError) {
+            error = searchError.error;
+          } else if ("message" in searchError) {
+            error = searchError.message;
+          }
+          dispatch(
+            addAlert({
+              name: "submit-search-value-error",
+              title: error || "Error when searching for roles",
+              variant: "danger",
+            })
+          );
+        } else {
+          const rolesListResult = result.data?.result.results || [];
+          const rolesListSize = result.data?.result.count || 0;
+          const totalCount = result.data?.result.totalCount || 0;
+          const roles: Role[] = [];
+
+          for (let i = 0; i < rolesListSize; i++) {
+            roles.push(rolesListResult[i].result);
+          }
+          setTotalCount(totalCount);
+          setRolesList(roles);
+          setShowTableRows(true);
+        }
+        setSearchIsDisabled(false);
+      }
+    });
+  };
+
+  const [showTableRows, setShowTableRows] = useState(!isBatchLoading);
+
+  useEffect(() => {
+    if (showTableRows !== !isBatchLoading) {
+      setShowTableRows(!isBatchLoading);
+    }
+  }, [isBatchLoading]);
+
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  const selectableRolesTable = rolesList.filter(isRoleSelectable);
+
+  const updateSelectedRoles = (roles: Role[], isSelected: boolean) => {
+    let newSelectedRoles: Role[] = [];
+    if (isSelected) {
+      newSelectedRoles = JSON.parse(JSON.stringify(selectedRoles));
+      for (let i = 0; i < roles.length; i++) {
+        if (selectedRoles.find((s) => s.cn[0] === roles[i].cn[0])) {
+          continue;
+        }
+        newSelectedRoles.push(roles[i]);
+      }
+    } else {
+      for (let i = 0; i < selectedRoles.length; i++) {
+        let found = false;
+        for (let ii = 0; ii < roles.length; ii++) {
+          if (selectedRoles[i].cn[0] === roles[ii].cn[0]) {
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          newSelectedRoles.push(selectedRoles[i]);
+        }
+      }
+    }
+    setSelectedRoles(newSelectedRoles);
+    setIsDeleteButtonDisabled(newSelectedRoles.length === 0);
+  };
+
+  const setRoleSelected = (role: Role, isSelecting = true) => {
+    if (isRoleSelectable(role)) {
+      updateSelectedRoles([role], isSelecting);
+    }
+  };
+
+  const paginationData = {
+    page,
+    perPage,
+    updatePage: setPage,
+    updatePerPage: setPerPage,
+    updateSelectedPerPage: setSelectedPerPage,
+    updateShownElementsList: setRolesList,
+    totalCount,
+  };
+
+  const bulkSelectorData = {
+    selected: selectedRoles,
+    updateSelected: updateSelectedRoles,
+    selectableTable: selectableRolesTable,
+    nameAttr: "cn",
+  };
+
+  const buttonsData = {
+    updateIsDeleteButtonDisabled: setIsDeleteButtonDisabled,
+  };
+
+  const selectedPerPageData = {
+    selectedPerPage,
+    updateSelectedPerPage: setSelectedPerPage,
+  };
+
+  const searchValueData = {
+    searchValue,
+    updateSearchValue: setSearchValue,
+    submitSearchValue,
+  };
+
+  const columnNames = ["Role name", "Description"];
+  const keyNames = ["cn", "description"];
+
+  const toolbarItems: ToolbarItem[] = [
+    {
+      key: 0,
+      element: (
+        <BulkSelectorPrep
+          list={rolesList}
+          shownElementsList={rolesList}
+          elementData={bulkSelectorData}
+          buttonsData={buttonsData}
+          selectedPerPageData={selectedPerPageData}
+        />
+      ),
+    },
+    {
+      key: 1,
+      element: (
+        <SearchInputLayout
+          dataCy="search"
+          name="search"
+          ariaLabel="Search roles"
+          placeholder="Search"
+          searchValueData={searchValueData}
+          isDisabled={searchDisabled}
+        />
+      ),
+      toolbarItemVariant: ToolbarItemVariant.label,
+      toolbarItemGap: { default: "gapMd" },
+    },
+    {
+      key: 2,
+      toolbarItemVariant: ToolbarItemVariant.separator,
+    },
+    {
+      key: 3,
+      element: (
+        <SecondaryButton
+          onClickHandler={refreshData}
+          isDisabled={!showTableRows}
+          dataCy="roles-button-refresh"
+        >
+          Refresh
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 4,
+      element: (
+        <SecondaryButton
+          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          onClickHandler={() => setShowDeleteModal(true)}
+          dataCy="roles-button-delete"
+        >
+          Delete
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 5,
+      element: (
+        <SecondaryButton
+          onClickHandler={() => setShowAddModal(true)}
+          isDisabled={!showTableRows}
+          dataCy="roles-button-add"
+        >
+          Add
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 6,
+      toolbarItemVariant: ToolbarItemVariant.separator,
+    },
+    {
+      key: 7,
+      element: <HelpTextWithIconLayout textContent="Help" />,
+    },
+    {
+      key: 8,
+      element: (
+        <PaginationLayout
+          list={rolesList}
+          paginationData={paginationData}
+          widgetId="pagination-options-menu-top"
+          isCompact={true}
+        />
+      ),
+      toolbarItemAlignment: { default: "alignEnd" },
+    },
+  ];
+
+  return (
+    <div>
+      <PageSection hasBodyWrapper={false}>
+        <TitleLayout id="roles-title" headingLevel="h1" text="Roles" />
+      </PageSection>
+      <PageSection hasBodyWrapper={false} isFilled={false}>
+        <Flex direction={{ default: "column" }}>
+          <FlexItem>
+            <ToolbarLayout toolbarItems={toolbarItems} />
+          </FlexItem>
+          <FlexItem style={{ flex: "0 0 auto" }}>
+            <OuterScrollContainer>
+              <InnerScrollContainer
+                style={{ height: "60vh", overflow: "auto" }}
+              >
+                {batchError !== undefined && batchError ? (
+                  <GlobalErrors errors={globalErrors.getAll()} />
+                ) : (
+                  <MainTable
+                    tableTitle="Roles table"
+                    shownElementsList={rolesList}
+                    pk="cn"
+                    keyNames={keyNames}
+                    columnNames={columnNames}
+                    hasCheckboxes={true}
+                    pathname="roles"
+                    showTableRows={showTableRows}
+                    showLink={false}
+                    elementsData={{
+                      isElementSelectable: isRoleSelectable,
+                      selectedElements: selectedRoles,
+                      selectableElementsTable: selectableRolesTable,
+                      setElementsSelected: setRoleSelected,
+                      clearSelectedElements: clearSelectedRoles,
+                    }}
+                    buttonsData={{
+                      updateIsDeleteButtonDisabled: setIsDeleteButtonDisabled,
+                      isDeletion,
+                      updateIsDeletion: setIsDeletion,
+                    }}
+                    paginationData={{
+                      selectedPerPage,
+                      updateSelectedPerPage: setSelectedPerPage,
+                    }}
+                  />
+                )}
+              </InnerScrollContainer>
+            </OuterScrollContainer>
+          </FlexItem>
+          <FlexItem style={{ flex: "0 0 auto", position: "sticky", bottom: 0 }}>
+            <PaginationLayout
+              list={rolesList}
+              paginationData={paginationData}
+              variant={PaginationVariant.bottom}
+              widgetId="pagination-options-menu-bottom"
+            />
+          </FlexItem>
+        </Flex>
+      </PageSection>
+      <AddRoleModal
+        isOpen={showAddModal}
+        onClose={() => setShowAddModal(false)}
+        title="Add role"
+        onRefresh={refreshData}
+      />
+      <DeleteRolesModal
+        show={showDeleteModal}
+        handleModalToggle={() => setShowDeleteModal(!showDeleteModal)}
+        elementsToDelete={selectedRoles}
+        clearSelectedElements={clearSelectedRoles}
+        columnNames={columnNames}
+        keyNames={keyNames}
+        onRefresh={refreshData}
+        updateIsDeleteButtonDisabled={setIsDeleteButtonDisabled}
+        updateIsDeletion={setIsDeletion}
+      />
+      <ModalErrors errors={modalErrors.getAll()} dataCy="roles-modal-error" />
+    </div>
+  );
+};
+
+export default Roles;

--- a/src/pages/Roles/Roles.tsx
+++ b/src/pages/Roles/Roles.tsx
@@ -13,7 +13,10 @@ import {
   OuterScrollContainer,
 } from "@patternfly/react-table";
 // Data types
-import { Role } from "src/utils/datatypes/globalDataTypes";
+import {
+  Role,
+  SearchDataResultType,
+} from "src/utils/datatypes/globalDataTypes";
 import { ToolbarItem } from "src/components/layouts/ToolbarLayout";
 // Redux
 import { useAppDispatch, useAppSelector } from "src/store/hooks";
@@ -90,17 +93,15 @@ const Roles = () => {
   // Search state - overrides query data when active
   const [searchRoles, searchResult] = useSearchRolesEntriesMutation({});
   const [isSearchActive, setIsSearchActive] = useState(false);
-  const [searchData, setSearchData] = useState<{
-    roles: Role[];
-    totalCount: number;
-  } | null>(null);
+  const [searchData, setSearchData] =
+    useState<SearchDataResultType<Role> | null>(null);
 
   // Derive rolesList and totalCount from query response or search results
-  const { rolesList, totalCount } = useMemo(() => {
+  const { elementsList, totalCount } = useMemo(() => {
     // If search is active and has results, use search data
     if (isSearchActive && searchData) {
       return {
-        rolesList: searchData.roles,
+        elementsList: searchData.elementsList,
         totalCount: searchData.totalCount,
       };
     }
@@ -116,12 +117,12 @@ const Roles = () => {
       }
 
       return {
-        rolesList: roles,
+        elementsList: roles,
         totalCount: batchResponse.result.totalCount,
       };
     }
 
-    return { rolesList: [], totalCount: 0 };
+    return { elementsList: [], totalCount: 0 };
   }, [batchResponse, isSearchActive, searchData]);
 
   // Derive showTableRows from loading states
@@ -222,7 +223,7 @@ const Roles = () => {
           }
 
           setSearchData({
-            roles,
+            elementsList: roles,
             totalCount: searchTotalCount,
           });
         }
@@ -234,7 +235,7 @@ const Roles = () => {
   const [showAddModal, setShowAddModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
 
-  const selectableRolesTable = rolesList.filter(isRoleSelectable);
+  const selectableRolesTable = elementsList.filter(isRoleSelectable);
 
   const updateSelectedRoles = (roles: Role[], isSelected: boolean) => {
     let newSelectedRoles: Role[] = [];
@@ -279,7 +280,9 @@ const Roles = () => {
     updateShownElementsList: (roles: Role[]) => {
       if (isSearchActive) {
         setSearchData((prev) =>
-          prev ? { ...prev, roles } : { roles, totalCount: 0 }
+          prev
+            ? { ...prev, elementsList: roles }
+            : { elementsList: roles, totalCount: 0 }
         );
       }
     },
@@ -316,8 +319,8 @@ const Roles = () => {
       key: 0,
       element: (
         <BulkSelectorPrep
-          list={rolesList}
-          shownElementsList={rolesList}
+          list={elementsList}
+          shownElementsList={elementsList}
           elementData={bulkSelectorData}
           buttonsData={buttonsData}
           selectedPerPageData={selectedPerPageData}
@@ -391,7 +394,7 @@ const Roles = () => {
       key: 8,
       element: (
         <PaginationLayout
-          list={rolesList}
+          list={elementsList}
           paginationData={paginationData}
           widgetId="pagination-options-menu-top"
           isCompact={true}
@@ -421,7 +424,7 @@ const Roles = () => {
                 ) : (
                   <MainTable
                     tableTitle="Roles table"
-                    shownElementsList={rolesList}
+                    shownElementsList={elementsList}
                     pk="cn"
                     keyNames={keyNames}
                     columnNames={columnNames}
@@ -452,7 +455,7 @@ const Roles = () => {
           </FlexItem>
           <FlexItem style={{ flex: "0 0 auto", position: "sticky", bottom: 0 }}>
             <PaginationLayout
-              list={rolesList}
+              list={elementsList}
               paginationData={paginationData}
               variant={PaginationVariant.bottom}
               widgetId="pagination-options-menu-bottom"

--- a/src/services/rpcRoles.ts
+++ b/src/services/rpcRoles.ts
@@ -2,26 +2,45 @@ import {
   api,
   Command,
   getBatchCommand,
+  getCommand,
   BatchRPCResponse,
+  FindRPCResponse,
   useGettingGenericQuery,
 } from "./rpc";
 import { apiToRole } from "src/utils/rolesUtils";
 import { API_VERSION_BACKUP } from "../utils/utils";
-import { Role } from "../utils/datatypes/globalDataTypes";
+import { Role, cnType } from "../utils/datatypes/globalDataTypes";
+import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 
 /**
- * Roles-related endpoints: addToRoles, removeFromRoles, getRolesInfoByName
+ * Roles-related endpoints: addToRoles, removeFromRoles, getRolesInfoByName, addRole, deleteRoles
  *
  * API commands:
+ * - role_find: https://freeipa.readthedocs.io/en/latest/api/role_find.html
+ * - role_show: https://freeipa.readthedocs.io/en/latest/api/role_show.html
+ * - role_add: https://freeipa.readthedocs.io/en/latest/api/role_add.html
+ * - role_del: https://freeipa.readthedocs.io/en/latest/api/role_del.html
  * - role_add_member: https://freeipa.readthedocs.io/en/latest/api/role_add_member.html
  * - role_remove_member: https://freeipa.readthedocs.io/en/latest/api/role_remove_member.html
- * - role_show: https://freeipa.readthedocs.io/en/latest/api/role_show.html
  */
 
 interface RoleShowPayload {
   roleNamesList: string[];
   no_members?: boolean;
   version: string;
+}
+
+interface RoleAddPayload {
+  cn: string;
+  description?: string;
+}
+
+interface RolesSearchPayload {
+  searchValue: string;
+  sizeLimit: number;
+  apiVersion: string;
+  startIdx: number;
+  stopIdx: number;
 }
 
 const extendedApi = api.injectEndpoints({
@@ -102,11 +121,101 @@ const extendedApi = api.injectEndpoints({
         return roleList;
       },
     }),
+    /**
+     * Add a new role via `role_add`
+     * @param {RoleAddPayload} - Payload with role cn and optional description
+     * @returns {FindRPCResponse} - Response from API
+     */
+    addRole: build.mutation<FindRPCResponse, RoleAddPayload>({
+      query: (payload) => {
+        const params: Record<string, unknown> = {
+          version: API_VERSION_BACKUP,
+        };
+        if (payload.description) {
+          params.description = payload.description;
+        }
+        return getCommand({
+          method: "role_add",
+          params: [[payload.cn], params],
+        });
+      },
+    }),
+    /**
+     * Delete roles via batch `role_del`
+     * @param {Role[]} - Array of roles to delete
+     * @returns {BatchRPCResponse} - Batch response
+     */
+    deleteRoles: build.mutation<BatchRPCResponse, Role[]>({
+      query: (roles) => {
+        const commands: Command[] = roles.map((role) => ({
+          method: "role_del",
+          params: [[role.cn], {}],
+        }));
+        return getBatchCommand(commands, API_VERSION_BACKUP);
+      },
+    }),
+    /**
+     * Search roles via two-step role_find + role_show pattern
+     * @param {RolesSearchPayload} - Search parameters
+     * @returns {BatchRPCResponse} - Batch response with role data
+     */
+    searchRolesEntries: build.mutation<BatchRPCResponse, RolesSearchPayload>({
+      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
+        const { searchValue, sizeLimit, apiVersion, startIdx, stopIdx } =
+          payloadData;
+
+        const params = {
+          pkey_only: true,
+          sizelimit: sizeLimit,
+          version: apiVersion,
+          all: true,
+        };
+
+        // Step 1: Find role IDs
+        const findCommand: Command = {
+          method: "role_find",
+          params: [[searchValue], params],
+        };
+
+        const findResult = await fetchWithBQ(getCommand(findCommand));
+        if (findResult.error) {
+          return { error: findResult.error as FetchBaseQueryError };
+        }
+
+        const findResponse = findResult.data as FindRPCResponse;
+        const totalCount = findResponse.result.result.length as number;
+        const ids: string[] = [];
+
+        for (let i = startIdx; i < totalCount && i < stopIdx; i++) {
+          const roleId = findResponse.result.result[i] as cnType;
+          ids.push(roleId.cn[0] as string);
+        }
+
+        // Step 2: Batch show for each role
+        const showCommands: Command[] = ids.map((id) => ({
+          method: "role_show",
+          params: [[id], { no_members: true }],
+        }));
+
+        const showResult = await fetchWithBQ(
+          getBatchCommand(showCommands, apiVersion)
+        );
+
+        const response = showResult.data as BatchRPCResponse;
+        if (response) {
+          response.result.totalCount = totalCount;
+        }
+
+        return response
+          ? { data: response }
+          : { error: showResult.error as FetchBaseQueryError };
+      },
+    }),
   }),
   overrideExisting: false,
 });
 
-export const useGettingRolesQuery = (payloadData, options) => {
+export const useGettingRolesQuery = (payloadData, options?) => {
   payloadData["objName"] = "role";
   payloadData["objAttr"] = "cn";
   return useGettingGenericQuery(payloadData, options);
@@ -116,4 +225,7 @@ export const {
   useAddToRolesMutation,
   useRemoveFromRolesMutation,
   useGetRolesInfoByNameQuery,
+  useAddRoleMutation,
+  useDeleteRolesMutation,
+  useSearchRolesEntriesMutation,
 } = extendedApi;

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -2,6 +2,11 @@
 
 import { ValidatedOptions } from "@patternfly/react-core";
 
+export interface SearchDataResultType<T> {
+  elementsList: T[];
+  totalCount: number;
+}
+
 export interface User {
   [key: string]: unknown; // to fulfill Record<string, unknown> type
   // identity

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -13,6 +13,7 @@ import {
   IdRange,
   Metadata,
   Netgroup,
+  Role,
   Service,
   SudoCmd,
   SudoCmdGroup,
@@ -206,6 +207,8 @@ export const isAutomemberUserGroupSelectable = (automember: AutomemberEntry) =>
   automember.automemberRule != "";
 
 export const isPwPolicySelectable = (pwPolicy: PwPolicy) => pwPolicy.cn !== "";
+
+export const isRoleSelectable = (role: Role) => role.cn !== "";
 
 export const isIdpServerSelectable = (idpServer: IDPServer) =>
   idpServer.cn !== "";


### PR DESCRIPTION
The 'Roles' main page will show the list of available roles in the table, as well as providing action buttons to add/delete
elements. This functionality has been implemented using the `main-pages.md` agent.

## Summary by Sourcery

Add a Roles main page with list, search, and add/delete capabilities wired to new role RPC endpoints and navigation entries.

New Features:
- Introduce a Roles main page that lists roles in a table with pagination, search, and bulk selection controls.
- Add modals for creating a new role and deleting selected roles, including user feedback and error handling.
- Expose new navigation routes and menu entries to access the Roles page.

Enhancements:
- Extend the roles RPC service with endpoints for adding, deleting, and searching roles using the FreeIPA role APIs.
- Document the main-page RPC service pattern for roles and update the design guide with roles-specific examples.
- Add a utility helper to determine if a role entry is selectable in UI tables.

Documentation:
- Update main pages RPC service design documentation to describe entity-specific search mutations and list roles service hooks as a reference example.