### PR TITLE
Add Cypress tests for ID override group handling

### DIFF
--- a/cypress/e2e/common/user_group_management.ts
+++ b/cypress/e2e/common/user_group_management.ts
@@ -1,0 +1,15 @@
+import { Given } from "@badeball/cypress-cucumber-preprocessor";
+
+Given("user group {string} exists", (groupName: string) => {
+  cy.ipa({
+    command: "group-add",
+    name: groupName,
+  });
+});
+
+Given("I delete user group {string}", (groupName: string) => {
+  cy.ipa({
+    command: "group-del",
+    name: groupName,
+  });
+});

--- a/cypress/e2e/idoverride_groups/idoverride_groups.ts
+++ b/cypress/e2e/idoverride_groups/idoverride_groups.ts
@@ -1,0 +1,23 @@
+import { Given } from "@badeball/cypress-cucumber-preprocessor";
+
+Given(
+  "override group {string} exists in view {string}",
+  (groupName: string, viewName: string) => {
+    cy.ipa({
+      command: "idoverridegroup-add",
+      name: viewName,
+      specificOptions: `${groupName} --group-name=${groupName}`,
+    });
+  }
+);
+
+Given(
+  "I delete override group {string} from view {string}",
+  (groupName: string, viewName: string) => {
+    cy.ipa({
+      command: "idoverridegroup-del",
+      name: viewName,
+      specificOptions: groupName,
+    });
+  }
+);

--- a/cypress/e2e/idoverride_groups/idoverride_groups_handling.feature
+++ b/cypress/e2e/idoverride_groups/idoverride_groups_handling.feature
@@ -1,0 +1,66 @@
+Feature: ID Override group manipulation
+  Create, and delete ID override groups
+
+  @seed
+  Scenario: Seed: Create user group and ID view for add override group test
+    Given user group "overridegroup1" exists
+    And view "override_group_view" exists
+
+  @test
+  Scenario: Add a new override group
+    Given I am logged in as admin
+    And I am on "id-views/override_group_view/override-groups" page
+
+    When I click on the "id-views-tab-override-groups-button-add" button
+    Then I should see "add-id-override-group-modal" modal
+
+    When I select "overridegroup1" option in the "modal-override-group-dropdown" selector
+    Then I should see "overridegroup1" option in the "modal-override-group-dropdown" selector
+
+    When I type in the "modal-textbox-group-name" textbox text "myoverridegroup1"
+    Then I should see "myoverridegroup1" in the "modal-textbox-group-name" textbox
+
+    When I type in the "modal-textbox-group-description" textbox text "my description2"
+    Then I should see "my description2" in the "modal-textbox-group-description" textbox
+
+    When I click on the "modal-button-add" button
+    Then I should not see "add-id-override-group-modal" modal
+    And I should see "add-group-success" alert
+
+    When I search for "overridegroup1" in the data table
+    Then I should see "overridegroup1" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup: Delete override group, user group, and ID view
+    Given I delete override group "overridegroup1" from view "override_group_view"
+    And I delete user group "overridegroup1"
+    And I delete view "override_group_view"
+
+  @seed
+  Scenario: Seed: Create user group, ID view, and override group for delete test
+    Given user group "overridegroup2" exists
+    And view "override_group_view2" exists
+    And override group "overridegroup2" exists in view "override_group_view2"
+
+  @test
+  Scenario: Delete an override group
+    Given I am logged in as admin
+    And I am on "id-views/override_group_view2/override-groups" page
+
+    When I select entry "overridegroup2" in the data table
+    Then I should see "overridegroup2" entry selected in the data table
+
+    When I click on the "id-views-tab-override-groups-button-delete" button
+    Then I should see "delete-id-override-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "delete-id-override-modal" modal
+    And I should see "remove-id-override-groups-success" alert
+
+    When I search for "overridegroup2" in the data table
+    Then I should not see "overridegroup2" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup: Delete user group and ID view after delete override group test
+    Given I delete user group "overridegroup2"
+    And I delete view "override_group_view2"

--- a/cypress/e2e/user_groups/user_groups.ts
+++ b/cypress/e2e/user_groups/user_groups.ts
@@ -5,24 +5,6 @@ import { navigateTo } from "../common/navigation";
 import { selectOption } from "../common/ui/select";
 import { isOptionSelected } from "../common/ui/select";
 
-const createUserGroupExec = (groupName: string) => {
-  cy.ipa({
-    command: "group-add",
-    name: groupName,
-  });
-};
-
-Given("I delete user group {string}", (groupName: string) => {
-  cy.ipa({
-    command: "group-del",
-    name: groupName,
-  });
-});
-
-Given("user group {string} exists", (groupName: string) => {
-  createUserGroupExec(groupName);
-});
-
 type MemberType = "member_user" | "member_group" | "member_service";
 
 type MemberOfType =


### PR DESCRIPTION
## Summary
Add end-to-end Cypress tests for creating and deleting ID override groups, following the seed/test/cleanup pattern used by the existing override user tests.

## Changes
- Add seed/test/cleanup scenarios for adding and deleting ID override groups via the UI
- Step definitions use cy.ipa() for group-add, group-del, idoverridegroup-add, and idoverridegroup-del
- Seed sets --group-name on idoverridegroup-add so the entry is discoverable by table search


## Summary by Sourcery

Tests:
- Add Cypress feature scenarios for adding and deleting ID override groups with corresponding seed and cleanup steps for groups and views.
