### PR TITLE
docs: add User groups section and links to product docs

### DIFF
--- a/src/assets/documentation/documentation-links.json
+++ b/src/assets/documentation/documentation-links.json
@@ -202,5 +202,11 @@
       "name": "Associating authentication indicators with an IdM service using IdM Web UI",
       "url": "https://red.ht/associating-auth-indicators-service"
     }
+  ],
+  "user-groups": [
+    {
+      "name": "Manage user groups",
+      "url": "https://red.ht/manage-user-groups"
+    }
   ]
 }


### PR DESCRIPTION
add User groups section and links to product docs

## Summary by Sourcery

Documentation:
- Document new User groups section in documentation links and connect to relevant product documentation pages.