### PR TITLE
Enhanced contextual links panel

### DIFF
--- a/src/components/ContextualHelpPanel/ContextualHelpPanel.tsx
+++ b/src/components/ContextualHelpPanel/ContextualHelpPanel.tsx
@@ -23,32 +23,29 @@ interface DocLink {
   url: string;
 }
 
-interface ContextualHelpPanelProps {
-  fromPage: string;
+export interface ContextualHelpPanelProps {
+  fromPage?: string;
   isExpanded: boolean;
   onClose: () => void;
   children: React.ReactNode;
 }
 
 const ContextualHelpPanel = (props: ContextualHelpPanelProps) => {
-  // URLs from JSON
-  const [urlList, setUrlList] = React.useState<DocLink[]>([]);
-
-  React.useEffect(() => {
-    const urlList: DocLink[] = [];
-
-    if (DocumentationLinks[props.fromPage].length === 0) {
-      setUrlList([]);
-    } else {
-      DocumentationLinks[props.fromPage].map((entry) => {
-        urlList.push({
-          name: entry.name,
-          url: entry.url,
-        });
-      });
-      setUrlList(urlList);
+  const urlList = React.useMemo<DocLink[]>(() => {
+    if (!props.fromPage) {
+      return [];
     }
-  }, []);
+
+    const links = DocumentationLinks[props.fromPage];
+    if (!links || links.length === 0) {
+      return [];
+    }
+
+    return links.map((entry) => ({
+      name: entry.name,
+      url: entry.url,
+    }));
+  }, [props.fromPage]);
 
   const drawerRef = React.useRef<HTMLDivElement>(null);
 

--- a/src/hooks/useContextualHelpPanel.tsx
+++ b/src/hooks/useContextualHelpPanel.tsx
@@ -1,0 +1,40 @@
+import { useState } from "react";
+// Components
+import type { ContextualHelpPanelProps } from "src/components/ContextualHelpPanel/ContextualHelpPanel";
+
+interface UseContextualHelpPanelOptions {
+  defaultPage?: string;
+}
+
+type HookPanelProps = Omit<ContextualHelpPanelProps, "children"> & {
+  fromPage: string;
+};
+
+interface UseContextualHelpPanelReturn {
+  isExpanded: boolean;
+  setIsExpanded: React.Dispatch<React.SetStateAction<boolean>>;
+  fromPage: string;
+  setFromPage: (page: string) => void;
+  panelProps: HookPanelProps;
+}
+
+export function useContextualHelpPanel(
+  options: UseContextualHelpPanelOptions = {}
+): UseContextualHelpPanelReturn {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [fromPage, setFromPage] = useState(options.defaultPage ?? "");
+
+  const panelProps: HookPanelProps = {
+    fromPage,
+    isExpanded,
+    onClose: () => setIsExpanded(false),
+  };
+
+  return {
+    isExpanded,
+    setIsExpanded,
+    fromPage,
+    setFromPage,
+    panelProps,
+  };
+}

--- a/src/pages/ActiveUsers/ActiveUsers.tsx
+++ b/src/pages/ActiveUsers/ActiveUsers.tsx
@@ -43,6 +43,7 @@ import DisableEnableUsers from "src/components/modals/UserModals/DisableEnableUs
 import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
+import { useContextualHelpPanel } from "src/hooks/useContextualHelpPanel";
 // Utils
 import { API_VERSION_BACKUP, isUserSelectable } from "src/utils/utils";
 // RPC client
@@ -605,16 +606,9 @@ const ActiveUsers = () => {
   };
 
   // Contextual links panel
-  const [isContextualPanelExpanded, setIsContextualPanelExpanded] =
-    React.useState(false);
-
-  const onOpenContextualPanel = () => {
-    setIsContextualPanelExpanded(!isContextualPanelExpanded);
-  };
-
-  const onCloseContextualPanel = () => {
-    setIsContextualPanelExpanded(false);
-  };
+  const contextualPanel = useContextualHelpPanel({
+    defaultPage: "active-users",
+  });
 
   // List of Toolbar items
   const toolbarItems: ToolbarItem[] = [
@@ -732,7 +726,7 @@ const ActiveUsers = () => {
       element: (
         <HelpTextWithIconLayout
           textContent="Help"
-          onClick={onOpenContextualPanel}
+          onClick={() => contextualPanel.setIsExpanded((prev) => !prev)}
         />
       ),
     },
@@ -752,11 +746,7 @@ const ActiveUsers = () => {
 
   // Render 'Active users'
   return (
-    <ContextualHelpPanel
-      fromPage="active-users"
-      isExpanded={isContextualPanelExpanded}
-      onClose={onCloseContextualPanel}
-    >
+    <ContextualHelpPanel {...contextualPanel.panelProps}>
       <div>
         <PageSection
           hasBodyWrapper={false}

--- a/src/pages/ActiveUsers/ActiveUsersTabs.tsx
+++ b/src/pages/ActiveUsers/ActiveUsersTabs.tsx
@@ -20,6 +20,7 @@ import ContextualHelpPanel from "src/components/ContextualHelpPanel/ContextualHe
 import DataSpinner from "src/components/layouts/DataSpinner";
 // Hooks
 import { useUserSettings } from "src/hooks/useUserSettingsData";
+import { useContextualHelpPanel } from "src/hooks/useContextualHelpPanel";
 // Icons
 import { LockIcon } from "@patternfly/react-icons";
 // Redux
@@ -66,23 +67,9 @@ const ActiveUsersTabs = ({ memberof }) => {
   }, [memberof]);
 
   // Contextual links panel
-  const [fromPageSelected, setFromPageSelected] = React.useState(
-    "active-users-settings"
-  );
-  const [isContextualPanelExpanded, setIsContextualPanelExpanded] =
-    React.useState(false);
-
-  const changeFromPage = (fromPage: string) => {
-    setFromPageSelected(fromPage);
-  };
-
-  const onOpenContextualPanel = () => {
-    setIsContextualPanelExpanded(!isContextualPanelExpanded);
-  };
-
-  const onCloseContextualPanel = () => {
-    setIsContextualPanelExpanded(false);
-  };
+  const contextualPanel = useContextualHelpPanel({
+    defaultPage: "active-users-settings",
+  });
 
   // Data loaded from DB
   const userSettingsData = useUserSettings(uid);
@@ -113,11 +100,7 @@ const ActiveUsersTabs = ({ memberof }) => {
 
   return (
     <>
-      <ContextualHelpPanel
-        fromPage={fromPageSelected}
-        isExpanded={isContextualPanelExpanded}
-        onClose={onCloseContextualPanel}
-      >
+      <ContextualHelpPanel {...contextualPanel.panelProps}>
         <PageSection hasBodyWrapper={false}>
           <BreadCrumb breadcrumbItems={breadcrumbItems} />
           <Content>
@@ -181,8 +164,10 @@ const ActiveUsersTabs = ({ memberof }) => {
                 idpData={userSettingsData.idpServers}
                 activeUsersList={userSettingsData.activeUsersList}
                 from="active-users"
-                changeFromPage={changeFromPage}
-                onOpenContextualPanel={onOpenContextualPanel}
+                changeFromPage={contextualPanel.setFromPage}
+                onOpenContextualPanel={() =>
+                  contextualPanel.setIsExpanded((prev) => !prev)
+                }
               />
             </Tab>
             <Tab

--- a/src/pages/Hosts/Hosts.tsx
+++ b/src/pages/Hosts/Hosts.tsx
@@ -43,6 +43,7 @@ import { API_VERSION_BACKUP, isHostSelectable } from "src/utils/utils";
 import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
+import { useContextualHelpPanel } from "src/hooks/useContextualHelpPanel";
 // Errors
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import { SerializedError } from "@reduxjs/toolkit";
@@ -534,16 +535,7 @@ const Hosts = () => {
   };
 
   // Contextual links panel
-  const [isContextualPanelExpanded, setIsContextualPanelExpanded] =
-    React.useState(false);
-
-  const onOpenContextualPanel = () => {
-    setIsContextualPanelExpanded(!isContextualPanelExpanded);
-  };
-
-  const onCloseContextualPanel = () => {
-    setIsContextualPanelExpanded(false);
-  };
+  const contextualPanel = useContextualHelpPanel({ defaultPage: "hosts" });
 
   // List of toolbar items
   const toolbarItems: ToolbarItem[] = [
@@ -637,7 +629,7 @@ const Hosts = () => {
       element: (
         <HelpTextWithIconLayout
           textContent="Help"
-          onClick={onOpenContextualPanel}
+          onClick={() => contextualPanel.setIsExpanded((prev) => !prev)}
         />
       ),
     },
@@ -656,11 +648,7 @@ const Hosts = () => {
   ];
 
   return (
-    <ContextualHelpPanel
-      fromPage="hosts"
-      isExpanded={isContextualPanelExpanded}
-      onClose={onCloseContextualPanel}
-    >
+    <ContextualHelpPanel {...contextualPanel.panelProps}>
       <div>
         <PageSection hasBodyWrapper={false}>
           <TitleLayout id="Hosts title" headingLevel="h1" text="Hosts" />

--- a/src/pages/Hosts/HostsTabs.tsx
+++ b/src/pages/Hosts/HostsTabs.tsx
@@ -16,6 +16,7 @@ import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
 import { Host } from "src/utils/datatypes/globalDataTypes";
 // Hooks
 import { useHostSettings } from "src/hooks/useHostSettingsData";
+import { useContextualHelpPanel } from "src/hooks/useContextualHelpPanel";
 // Redux
 import { useAppDispatch } from "src/store/hooks";
 import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
@@ -42,26 +43,13 @@ const HostsTabs = ({ section }) => {
   const [hostId, setHostId] = useState("");
 
   // Contextual links panel
-  const [fromPageSelected, setFromPageSelected] =
-    React.useState("hosts-settings");
-  const [isContextualPanelExpanded, setIsContextualPanelExpanded] =
-    React.useState(false);
-
-  const changeFromPage = (fromPage: string) => {
-    setFromPageSelected(fromPage);
-  };
-
-  const onOpenContextualPanel = () => {
-    setIsContextualPanelExpanded(!isContextualPanelExpanded);
-  };
-
-  const onCloseContextualPanel = () => {
-    setIsContextualPanelExpanded(false);
-  };
+  const contextualPanel = useContextualHelpPanel({
+    defaultPage: "hosts-settings",
+  });
 
   // - Close links panel when tab section is changed
   React.useEffect(() => {
-    setIsContextualPanelExpanded(false);
+    contextualPanel.setIsExpanded(false);
   }, [section]);
 
   // Data loaded from DB
@@ -137,11 +125,7 @@ const HostsTabs = ({ section }) => {
 
   return (
     <>
-      <ContextualHelpPanel
-        fromPage={fromPageSelected}
-        isExpanded={isContextualPanelExpanded}
-        onClose={onCloseContextualPanel}
-      >
+      <ContextualHelpPanel {...contextualPanel.panelProps}>
         <PageSection hasBodyWrapper={false}>
           <BreadCrumb breadcrumbItems={breadcrumbItems} />
           <TitleLayout
@@ -177,8 +161,10 @@ const HostsTabs = ({ section }) => {
                 isModified={hostSettingsData.modified}
                 onResetValues={hostSettingsData.resetValues}
                 modifiedValues={hostSettingsData.modifiedValues}
-                changeFromPage={changeFromPage}
-                onOpenContextualPanel={onOpenContextualPanel}
+                changeFromPage={contextualPanel.setFromPage}
+                onOpenContextualPanel={() =>
+                  contextualPanel.setIsExpanded((prev) => !prev)
+                }
               />
             </Tab>
             <Tab

--- a/src/pages/PreservedUsers/PreservedUsers.tsx
+++ b/src/pages/PreservedUsers/PreservedUsers.tsx
@@ -37,6 +37,7 @@ import RestorePreservedUsers from "src/components/modals/UserModals/RestorePrese
 import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
+import { useContextualHelpPanel } from "src/hooks/useContextualHelpPanel";
 // Errors
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import { SerializedError } from "@reduxjs/toolkit";
@@ -411,16 +412,9 @@ const PreservedUsers = () => {
   };
 
   // Contextual links panel
-  const [isContextualPanelExpanded, setIsContextualPanelExpanded] =
-    React.useState(false);
-
-  const onOpenContextualPanel = () => {
-    setIsContextualPanelExpanded(!isContextualPanelExpanded);
-  };
-
-  const onCloseContextualPanel = () => {
-    setIsContextualPanelExpanded(false);
-  };
+  const contextualPanel = useContextualHelpPanel({
+    defaultPage: "preserved-users",
+  });
 
   // List of Toolbar items
   const toolbarItems: ToolbarItem[] = [
@@ -512,7 +506,7 @@ const PreservedUsers = () => {
       element: (
         <HelpTextWithIconLayout
           textContent="Help"
-          onClick={onOpenContextualPanel}
+          onClick={() => contextualPanel.setIsExpanded((prev) => !prev)}
         />
       ),
     },
@@ -532,11 +526,7 @@ const PreservedUsers = () => {
 
   // Render 'Preserved users'
   return (
-    <ContextualHelpPanel
-      fromPage="preserved-users"
-      isExpanded={isContextualPanelExpanded}
-      onClose={onCloseContextualPanel}
-    >
+    <ContextualHelpPanel {...contextualPanel.panelProps}>
       <div>
         <PageSection hasBodyWrapper={false}>
           <TitleLayout

--- a/src/pages/PreservedUsers/PreservedUsersTabs.tsx
+++ b/src/pages/PreservedUsers/PreservedUsersTabs.tsx
@@ -9,6 +9,7 @@ import TitleLayout from "src/components/layouts/TitleLayout";
 import ContextualHelpPanel from "src/components/ContextualHelpPanel/ContextualHelpPanel";
 // Hooks
 import { useUserSettings } from "src/hooks/useUserSettingsData";
+import { useContextualHelpPanel } from "src/hooks/useContextualHelpPanel";
 // Redux
 import { useAppDispatch } from "src/store/hooks";
 import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
@@ -45,23 +46,9 @@ const PreservedUsersTabs = () => {
   }, [uid]);
 
   // Contextual links panel
-  const [fromPageSelected, setFromPageSelected] = React.useState(
-    "preserved-users-settings"
-  );
-  const [isContextualPanelExpanded, setIsContextualPanelExpanded] =
-    React.useState(false);
-
-  const changeFromPage = (fromPage: string) => {
-    setFromPageSelected(fromPage);
-  };
-
-  const onOpenContextualPanel = () => {
-    setIsContextualPanelExpanded(!isContextualPanelExpanded);
-  };
-
-  const onCloseContextualPanel = () => {
-    setIsContextualPanelExpanded(false);
-  };
+  const contextualPanel = useContextualHelpPanel({
+    defaultPage: "preserved-users-settings",
+  });
 
   // Data loaded from DB
   const userSettingsData = useUserSettings(uid);
@@ -90,11 +77,7 @@ const PreservedUsersTabs = () => {
 
   return (
     <>
-      <ContextualHelpPanel
-        fromPage={fromPageSelected}
-        isExpanded={isContextualPanelExpanded}
-        onClose={onCloseContextualPanel}
-      >
+      <ContextualHelpPanel {...contextualPanel.panelProps}>
         <PageSection hasBodyWrapper={false}>
           <BreadCrumb breadcrumbItems={breadcrumbItems} />
           <TitleLayout
@@ -135,8 +118,10 @@ const PreservedUsersTabs = () => {
                 radiusProxyData={userSettingsData.radiusServers}
                 idpData={userSettingsData.idpServers}
                 from="preserved-users"
-                changeFromPage={changeFromPage}
-                onOpenContextualPanel={onOpenContextualPanel}
+                changeFromPage={contextualPanel.setFromPage}
+                onOpenContextualPanel={() =>
+                  contextualPanel.setIsExpanded((prev) => !prev)
+                }
               />
             </Tab>
           </Tabs>

--- a/src/pages/Services/Services.tsx
+++ b/src/pages/Services/Services.tsx
@@ -38,6 +38,7 @@ import DeleteServices from "../../components/modals/DeleteServices";
 import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
+import { useContextualHelpPanel } from "src/hooks/useContextualHelpPanel";
 // Errors
 import useApiError from "../../hooks/useApiError";
 import GlobalErrors from "../../components/errors/GlobalErrors";
@@ -436,16 +437,7 @@ const Services = () => {
   };
 
   // Contextual links panel
-  const [isContextualPanelExpanded, setIsContextualPanelExpanded] =
-    React.useState(false);
-
-  const onOpenContextualPanel = () => {
-    setIsContextualPanelExpanded(!isContextualPanelExpanded);
-  };
-
-  const onCloseContextualPanel = () => {
-    setIsContextualPanelExpanded(false);
-  };
+  const contextualPanel = useContextualHelpPanel({ defaultPage: "services" });
 
   // List of toolbar items
   const toolbarItems: ToolbarItem[] = [
@@ -525,7 +517,7 @@ const Services = () => {
       element: (
         <HelpTextWithIconLayout
           textContent="Help"
-          onClick={onOpenContextualPanel}
+          onClick={() => contextualPanel.setIsExpanded((prev) => !prev)}
         />
       ),
     },
@@ -545,11 +537,7 @@ const Services = () => {
 
   // Render component
   return (
-    <ContextualHelpPanel
-      fromPage="services"
-      isExpanded={isContextualPanelExpanded}
-      onClose={onCloseContextualPanel}
-    >
+    <ContextualHelpPanel {...contextualPanel.panelProps}>
       <div>
         <PageSection hasBodyWrapper={false}>
           <TitleLayout id="Services title" headingLevel="h1" text="Services" />

--- a/src/pages/Services/ServicesTabs.tsx
+++ b/src/pages/Services/ServicesTabs.tsx
@@ -13,6 +13,7 @@ import { partialServiceToService } from "src/utils/serviceUtils";
 import ContextualHelpPanel from "src/components/ContextualHelpPanel/ContextualHelpPanel";
 // Hooks
 import { useServiceSettings } from "src/hooks/useServiceSettingsData";
+import { useContextualHelpPanel } from "src/hooks/useContextualHelpPanel";
 // Redux
 import { useAppDispatch } from "src/store/hooks";
 import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
@@ -42,26 +43,13 @@ const ServicesTabs = ({ section }) => {
   >([]);
 
   // Contextual links panel
-  const [fromPageSelected, setFromPageSelected] =
-    React.useState("services-settings");
-  const [isContextualPanelExpanded, setIsContextualPanelExpanded] =
-    React.useState(false);
-
-  const changeFromPage = (fromPage: string) => {
-    setFromPageSelected(fromPage);
-  };
-
-  const onOpenContextualPanel = () => {
-    setIsContextualPanelExpanded(!isContextualPanelExpanded);
-  };
-
-  const onCloseContextualPanel = () => {
-    setIsContextualPanelExpanded(false);
-  };
+  const contextualPanel = useContextualHelpPanel({
+    defaultPage: "services-settings",
+  });
 
   // - Close links panel when tab section is changed
   React.useEffect(() => {
-    setIsContextualPanelExpanded(false);
+    contextualPanel.setIsExpanded(false);
   }, [section]);
 
   // Data loaded from DB
@@ -126,11 +114,7 @@ const ServicesTabs = ({ section }) => {
 
   return (
     <>
-      <ContextualHelpPanel
-        fromPage={fromPageSelected}
-        isExpanded={isContextualPanelExpanded}
-        onClose={onCloseContextualPanel}
-      >
+      <ContextualHelpPanel {...contextualPanel.panelProps}>
         <PageSection hasBodyWrapper={false}>
           <BreadCrumb breadcrumbItems={breadcrumbItems} />
           <TitleLayout
@@ -166,8 +150,10 @@ const ServicesTabs = ({ section }) => {
                 onResetValues={serviceSettingsData.resetValues}
                 modifiedValues={serviceSettingsData.modifiedValues}
                 certData={certificates}
-                changeFromPage={changeFromPage}
-                onOpenContextualPanel={onOpenContextualPanel}
+                changeFromPage={contextualPanel.setFromPage}
+                onOpenContextualPanel={() =>
+                  contextualPanel.setIsExpanded((prev) => !prev)
+                }
               />
             </Tab>
             <Tab

--- a/src/pages/StageUsers/StageUsers.tsx
+++ b/src/pages/StageUsers/StageUsers.tsx
@@ -21,6 +21,7 @@ import { useAppSelector, useAppDispatch } from "src/store/hooks";
 import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
+import { useContextualHelpPanel } from "src/hooks/useContextualHelpPanel";
 // Layouts
 import TitleLayout from "src/components/layouts/TitleLayout";
 import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
@@ -415,16 +416,9 @@ const StageUsers = () => {
   };
 
   // Contextual links panel
-  const [isContextualPanelExpanded, setIsContextualPanelExpanded] =
-    React.useState(false);
-
-  const onOpenContextualPanel = () => {
-    setIsContextualPanelExpanded(!isContextualPanelExpanded);
-  };
-
-  const onCloseContextualPanel = () => {
-    setIsContextualPanelExpanded(false);
-  };
+  const contextualPanel = useContextualHelpPanel({
+    defaultPage: "stage-users",
+  });
 
   // List of Toolbar items
   const toolbarItems: ToolbarItem[] = [
@@ -516,7 +510,7 @@ const StageUsers = () => {
       element: (
         <HelpTextWithIconLayout
           textContent="Help"
-          onClick={onOpenContextualPanel}
+          onClick={() => contextualPanel.setIsExpanded((prev) => !prev)}
         />
       ),
     },
@@ -536,11 +530,7 @@ const StageUsers = () => {
 
   // Render 'Stage users'
   return (
-    <ContextualHelpPanel
-      fromPage="stage-users"
-      isExpanded={isContextualPanelExpanded}
-      onClose={onCloseContextualPanel}
-    >
+    <ContextualHelpPanel {...contextualPanel.panelProps}>
       <div>
         <PageSection hasBodyWrapper={false}>
           <TitleLayout

--- a/src/pages/StageUsers/StageUsersTabs.tsx
+++ b/src/pages/StageUsers/StageUsersTabs.tsx
@@ -9,6 +9,7 @@ import TitleLayout from "src/components/layouts/TitleLayout";
 import ContextualHelpPanel from "src/components/ContextualHelpPanel/ContextualHelpPanel";
 // Hooks
 import { useStageUserSettings } from "src/hooks/useUserSettingsData";
+import { useContextualHelpPanel } from "src/hooks/useContextualHelpPanel";
 // Redux
 import { useAppDispatch } from "src/store/hooks";
 import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
@@ -44,23 +45,9 @@ const StageUsersTabs = () => {
   }, [uid]);
 
   // Contextual links panel
-  const [fromPageSelected, setFromPageSelected] = React.useState(
-    "stage-users-settings"
-  );
-  const [isContextualPanelExpanded, setIsContextualPanelExpanded] =
-    React.useState(false);
-
-  const changeFromPage = (fromPage: string) => {
-    setFromPageSelected(fromPage);
-  };
-
-  const onOpenContextualPanel = () => {
-    setIsContextualPanelExpanded(!isContextualPanelExpanded);
-  };
-
-  const onCloseContextualPanel = () => {
-    setIsContextualPanelExpanded(false);
-  };
+  const contextualPanel = useContextualHelpPanel({
+    defaultPage: "stage-users-settings",
+  });
 
   // Data loaded from DB
   const userSettingsData = useStageUserSettings(uid);
@@ -89,11 +76,7 @@ const StageUsersTabs = () => {
 
   return (
     <>
-      <ContextualHelpPanel
-        fromPage={fromPageSelected}
-        isExpanded={isContextualPanelExpanded}
-        onClose={onCloseContextualPanel}
-      >
+      <ContextualHelpPanel {...contextualPanel.panelProps}>
         <PageSection hasBodyWrapper={false}>
           <BreadCrumb breadcrumbItems={breadcrumbItems} />
           <TitleLayout
@@ -134,8 +117,10 @@ const StageUsersTabs = () => {
                 radiusProxyData={userSettingsData.radiusServers}
                 idpData={userSettingsData.idpServers}
                 from="stage-users"
-                changeFromPage={changeFromPage}
-                onOpenContextualPanel={onOpenContextualPanel}
+                changeFromPage={contextualPanel.setFromPage}
+                onOpenContextualPanel={() =>
+                  contextualPanel.setIsExpanded((prev) => !prev)
+                }
               />
             </Tab>
           </Tabs>


### PR DESCRIPTION
The contextual help links panel has been enhanced to be used as a combination of **React component** (`ContextualHelpPanel`) + **custom hook** (`useContextualHelpPanel`). By splitting this functionality into two we ensure a better separation of concerns when using UI on one side and state + functionality on the other, and thus follow better practices. 

This PR has been implemented on the top of [this one](https://github.com/freeipa/freeipa-webui/pull/1119), as it is plan to use the newly created links with this component. There is a second part of this PR [here](https://github.com/freeipa/freeipa-webui/pull/1124) where the custom hook and the `ContextualHelpPanel` component is added in all existing pages and can be empty.