### PR TITLE
Update react-router

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-redux": "^9.2.0",
-        "react-router": "^7.12.0",
+        "react-router": "^7.14.2",
         "tiny-invariant": "^1.3.3"
       },
       "devDependencies": {
@@ -10769,9 +10769,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.12.0.tgz",
-      "integrity": "sha512-kTPDYPFzDVGIIGNLS5VJykK0HfHLY5MF3b+xj0/tTyNYL1gF1qs7u67Z9jEhQk2sQ98SUaHxlG31g1JtF7IfVw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
+      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-redux": "^9.2.0",
-    "react-router": "^7.12.0",
+    "react-router": "^7.14.2",
     "tiny-invariant": "^1.3.3"
   },
   "scripts": {


### PR DESCRIPTION
Bumping react-router version, due to a vulnerability. Shouldn't be breaking, soon CI will start failing otherwise.

## Summary by Sourcery

Build:
- Bump react-router from 7.12.0 to 7.14.2 in package.json and lockfile to pick up security fixes.