### PR TITLE
Add Roles > 'Members' page

### DIFF
--- a/src/components/Members/MembersHostGroups.tsx
+++ b/src/components/Members/MembersHostGroups.tsx
@@ -28,6 +28,10 @@ import {
   useAddAsMemberNGMutation,
   useRemoveAsMemberNGMutation,
 } from "src/services/rpcNetgroups";
+import {
+  useAddAsMemberRoleMutation,
+  useRemoveAsMemberRoleMutation,
+} from "src/services/rpcRoles";
 import { apiToHostGroup } from "src/utils/hostGroupUtils";
 
 interface PropsToMembersHostGroups {
@@ -165,13 +169,21 @@ const MembersHostGroups = (props: PropsToMembersHostGroups) => {
 
   // Add new member to 'HostGroup'
   // API calls
-  let [addMembers] = useAddAsMemberHGMutation();
+  const [addMembersHG] = useAddAsMemberHGMutation();
+  const [addMembersNG] = useAddAsMemberNGMutation();
+  const [addMembersRole] = useAddAsMemberRoleMutation();
+  const [removeMembersHG] = useRemoveAsMemberHGMutation();
+  const [removeMembersNG] = useRemoveAsMemberNGMutation();
+  const [removeMembersRole] = useRemoveAsMemberRoleMutation();
+
+  let addMembers = addMembersHG;
+  let removeMembers = removeMembersHG;
   if (props.from === "netgroup") {
-    [addMembers] = useAddAsMemberNGMutation();
-  }
-  let [removeMembers] = useRemoveAsMemberHGMutation();
-  if (props.from === "netgroup") {
-    [removeMembers] = useRemoveAsMemberNGMutation();
+    addMembers = addMembersNG;
+    removeMembers = removeMembersNG;
+  } else if (props.from === "roles") {
+    addMembers = addMembersRole;
+    removeMembers = removeMembersRole;
   }
   const [adderSearchValue, setAdderSearchValue] = React.useState("");
   const [availableHostGroups, setAvailableHostGroups] = React.useState<

--- a/src/components/Members/MembersHosts.tsx
+++ b/src/components/Members/MembersHosts.tsx
@@ -30,6 +30,10 @@ import {
   useAddAsMemberNGMutation,
   useRemoveAsMemberNGMutation,
 } from "src/services/rpcNetgroups";
+import {
+  useAddAsMemberRoleMutation,
+  useRemoveAsMemberRoleMutation,
+} from "src/services/rpcRoles";
 import { apiToHost } from "src/utils/hostUtils";
 
 interface PropsToMembersHosts {
@@ -162,13 +166,21 @@ const MembersHosts = (props: PropsToMembersHosts) => {
 
   // Add new member to 'Host'
   // API calls
-  let [addMembers] = useAddAsMemberHGMutation();
+  const [addMembersHG] = useAddAsMemberHGMutation();
+  const [addMembersNG] = useAddAsMemberNGMutation();
+  const [addMembersRole] = useAddAsMemberRoleMutation();
+  const [removeMembersHG] = useRemoveAsMemberHGMutation();
+  const [removeMembersNG] = useRemoveAsMemberNGMutation();
+  const [removeMembersRole] = useRemoveAsMemberRoleMutation();
+
+  let addMembers = addMembersHG;
+  let removeMembers = removeMembersHG;
   if (props.from === "netgroup") {
-    [addMembers] = useAddAsMemberNGMutation();
-  }
-  let [removeMembers] = useRemoveAsMemberHGMutation();
-  if (props.from === "netgroup") {
-    [removeMembers] = useRemoveAsMemberNGMutation();
+    addMembers = addMembersNG;
+    removeMembers = removeMembersNG;
+  } else if (props.from === "roles") {
+    addMembers = addMembersRole;
+    removeMembers = removeMembersRole;
   }
   const [adderSearchValue, setAdderSearchValue] = React.useState("");
   const [availableHosts, setAvailableHosts] = React.useState<Host[]>([]);

--- a/src/components/Members/MembersServices.tsx
+++ b/src/components/Members/MembersServices.tsx
@@ -27,6 +27,10 @@ import {
   useAddAsMemberMutation,
   useRemoveAsMemberMutation,
 } from "src/services/rpcUserGroups";
+import {
+  useAddAsMemberRoleMutation,
+  useRemoveAsMemberRoleMutation,
+} from "src/services/rpcRoles";
 
 interface PropsToMembersServices {
   entity: Partial<UserGroup>;
@@ -143,8 +147,17 @@ const MembersServices = (props: PropsToMembersServices) => {
 
   // Add new member to 'Service'
   // API calls
-  const [addMemberToService] = useAddAsMemberMutation();
-  const [removeMembersFromServices] = useRemoveAsMemberMutation();
+  const [addMemberToServiceUG] = useAddAsMemberMutation();
+  const [removeMembersFromServicesUG] = useRemoveAsMemberMutation();
+  const [addMemberToServiceRole] = useAddAsMemberRoleMutation();
+  const [removeMembersFromServicesRole] = useRemoveAsMemberRoleMutation();
+
+  const addMemberToService =
+    props.from === "roles" ? addMemberToServiceRole : addMemberToServiceUG;
+  const removeMembersFromServices =
+    props.from === "roles"
+      ? removeMembersFromServicesRole
+      : removeMembersFromServicesUG;
   const [adderSearchValue, setAdderSearchValue] = React.useState("");
   const [availableServices, setAvailableServices] = React.useState<Service[]>(
     []

--- a/src/components/Members/MembersSystemAccount.tsx
+++ b/src/components/Members/MembersSystemAccount.tsx
@@ -1,0 +1,264 @@
+import React, { useMemo } from "react";
+// PatternFly
+import { Pagination, PaginationVariant } from "@patternfly/react-core";
+// Components
+import MemberOfToolbar from "../MemberOf/MemberOfToolbar";
+import MemberOfAddModal, { AvailableItems } from "../MemberOf/MemberOfAddModal";
+import MemberOfDeleteModal from "../MemberOf/MemberOfDeleteModal";
+import MemberTable from "src/components/tables/MembershipTable";
+// Data types
+import { Role } from "src/utils/datatypes/globalDataTypes";
+// Redux
+import { useAppDispatch } from "src/store/hooks";
+// Hooks
+import { addAlert } from "src/store/Global/alerts-slice";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
+// Utils
+import { paginate } from "src/utils/utils";
+// RPC
+import { ErrorResult } from "src/services/rpc";
+import {
+  RoleMemberPayload,
+  useAddAsMemberRoleMutation,
+  useRemoveAsMemberRoleMutation,
+} from "src/services/rpcRoles";
+import { useGetSysaccountsQuery } from "src/services/rpcSystemAccounts";
+
+interface PropsToMembersSystemAccount {
+  entity: Partial<Role>;
+  id: string;
+  from: string;
+  isDataLoading: boolean;
+  onRefreshData: () => void;
+  member_sysaccount: string[];
+}
+
+const MembersSystemAccount = (props: PropsToMembersSystemAccount) => {
+  const dispatch = useAppDispatch();
+
+  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+    useListPageSearchParams();
+
+  const [selectedItems, setSelectedItems] = React.useState<string[]>([]);
+
+  const member_sysaccount = props.member_sysaccount || [];
+
+  const getItemsToShow = (): string[] => {
+    let toShow = [...member_sysaccount];
+    toShow.sort();
+
+    if (searchValue) {
+      toShow = toShow.filter((name) =>
+        name.toLowerCase().includes(searchValue.toLowerCase())
+      );
+    }
+
+    toShow = paginate(toShow, page, perPage);
+
+    return toShow;
+  };
+
+  const itemsToShow = getItemsToShow();
+
+  const columnNames = ["System account"];
+  const someItemSelected = selectedItems.length > 0;
+  const showTableRows = itemsToShow.length > 0;
+
+  const [showAddModal, setShowAddModal] = React.useState(false);
+  const [showDeleteModal, setShowDeleteModal] = React.useState(false);
+  const [spinning, setSpinning] = React.useState(false);
+
+  const isRefreshButtonEnabled = !props.isDataLoading;
+  const isDeleteEnabled = someItemSelected;
+  const isAddButtonEnabled = isRefreshButtonEnabled;
+
+  const [addMembers] = useAddAsMemberRoleMutation();
+  const [removeMembers] = useRemoveAsMemberRoleMutation();
+
+  const [adderSearchValue, setAdderSearchValue] = React.useState("");
+
+  const sysaccountsQuery = useGetSysaccountsQuery(adderSearchValue);
+
+  React.useEffect(() => {
+    if (showAddModal) {
+      sysaccountsQuery.refetch();
+    }
+  }, [showAddModal, adderSearchValue, props.entity]);
+
+  const availableItems = useMemo<AvailableItems[]>(() => {
+    if (sysaccountsQuery.data && !sysaccountsQuery.isFetching) {
+      const sysaccounts = sysaccountsQuery.data;
+      const items: AvailableItems[] = sysaccounts.map((sa) => ({
+        key: sa.uid,
+        title: sa.uid + (sa.description ? ` (${sa.description})` : ""),
+      }));
+
+      return items.filter(
+        (item) => !member_sysaccount.includes(item.key) && item.key !== props.id
+      );
+    }
+    return [];
+  }, [
+    sysaccountsQuery.data,
+    sysaccountsQuery.isFetching,
+    member_sysaccount,
+    props.id,
+  ]);
+
+  const onAddSystemAccount = (items: AvailableItems[]) => {
+    const newSysaccountNames = items.map((item) => item.key);
+    if (props.id === undefined || newSysaccountNames.length === 0) {
+      return;
+    }
+
+    const payload: RoleMemberPayload = {
+      entryName: props.id,
+      entityType: "sysaccount",
+      idsToAdd: newSysaccountNames,
+    };
+
+    setSpinning(true);
+    addMembers(payload).then((response) => {
+      if ("data" in response) {
+        if (response.data?.result) {
+          dispatch(
+            addAlert({
+              name: "add-member-success",
+              title: "Assigned system accounts to role '" + props.id + "'",
+              variant: "success",
+            })
+          );
+          props.onRefreshData();
+          setShowAddModal(false);
+        } else if (response.data?.error) {
+          const errorMessage = response.data.error as unknown as ErrorResult;
+          dispatch(
+            addAlert({
+              name: "add-member-error",
+              title: errorMessage.message,
+              variant: "danger",
+            })
+          );
+        }
+      }
+      setSpinning(false);
+    });
+  };
+
+  const onDeleteSystemAccount = () => {
+    const payload: RoleMemberPayload = {
+      entryName: props.id,
+      entityType: "sysaccount",
+      idsToAdd: selectedItems,
+    };
+
+    setSpinning(true);
+    removeMembers(payload).then((response) => {
+      if ("data" in response) {
+        if (response.data?.result) {
+          dispatch(
+            addAlert({
+              name: "remove-members-success",
+              title: "Removed system accounts from role '" + props.id + "'",
+              variant: "success",
+            })
+          );
+          props.onRefreshData();
+          setSelectedItems([]);
+          setShowDeleteModal(false);
+          setPage(1);
+        } else if (response.data?.error) {
+          const errorMessage = response.data.error as unknown as ErrorResult;
+          dispatch(
+            addAlert({
+              name: "remove-members-error",
+              title: errorMessage.message,
+              variant: "danger",
+            })
+          );
+        }
+      }
+      setSpinning(false);
+    });
+  };
+
+  return (
+    <>
+      <MemberOfToolbar
+        searchText={searchValue}
+        onSearchTextChange={setSearchValue}
+        onSearch={() => {}}
+        searchPlaceholder="Search system accounts"
+        searchAriaLabel="Search system accounts"
+        refreshButtonEnabled={isRefreshButtonEnabled}
+        onRefreshButtonClick={props.onRefreshData}
+        deleteButtonEnabled={isDeleteEnabled}
+        onDeleteButtonClick={() => setShowDeleteModal(true)}
+        addButtonEnabled={isAddButtonEnabled}
+        onAddButtonClick={() => setShowAddModal(true)}
+        helpIconEnabled={true}
+        totalItems={member_sysaccount.length}
+        perPage={perPage}
+        page={page}
+        onPerPageChange={setPerPage}
+        onPageChange={setPage}
+      />
+      <MemberTable
+        entityList={itemsToShow}
+        idKey="id"
+        from="sysaccount"
+        columnNamesToShow={columnNames}
+        propertiesToShow={itemsToShow}
+        checkedItems={selectedItems}
+        onCheckItemsChange={setSelectedItems}
+        showTableRows={showTableRows}
+      />
+      <Pagination
+        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
+        itemCount={member_sysaccount.length}
+        widgetId="pagination-options-menu-bottom"
+        perPage={perPage}
+        page={page}
+        variant={PaginationVariant.bottom}
+        onSetPage={(_e, page) => setPage(page)}
+        onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+      />
+      {showAddModal && (
+        <MemberOfAddModal
+          showModal={showAddModal}
+          onCloseModal={() => setShowAddModal(false)}
+          availableItems={availableItems}
+          onAdd={onAddSystemAccount}
+          onSearchTextChange={setAdderSearchValue}
+          title={"Assign system accounts to role: " + props.id}
+          ariaLabel="Add system account to role modal"
+          spinning={spinning}
+        />
+      )}
+      {showDeleteModal && someItemSelected && (
+        <MemberOfDeleteModal
+          showModal={showDeleteModal}
+          onCloseModal={() => setShowDeleteModal(false)}
+          title={"Remove system accounts from role: " + props.id}
+          onDelete={onDeleteSystemAccount}
+          spinning={spinning}
+        >
+          <MemberTable
+            entityList={member_sysaccount.filter((item) =>
+              selectedItems.includes(item)
+            )}
+            idKey="id"
+            from="sysaccount"
+            columnNamesToShow={columnNames}
+            propertiesToShow={member_sysaccount.filter((item) =>
+              selectedItems.includes(item)
+            )}
+            showTableRows
+          />
+        </MemberOfDeleteModal>
+      )}
+    </>
+  );
+};
+
+export default MembersSystemAccount;

--- a/src/components/Members/MembersUserGroups.tsx
+++ b/src/components/Members/MembersUserGroups.tsx
@@ -28,6 +28,10 @@ import {
   useAddAsMemberNGMutation,
   useRemoveAsMemberNGMutation,
 } from "src/services/rpcNetgroups";
+import {
+  useAddAsMemberRoleMutation,
+  useRemoveAsMemberRoleMutation,
+} from "src/services/rpcRoles";
 import { apiToGroup } from "src/utils/groupUtils";
 
 interface PropsToMembersUsergroups {
@@ -162,13 +166,21 @@ const MembersUserGroups = (props: PropsToMembersUsergroups) => {
 
   // Add new member to 'UserGroup'
   // API calls
-  let [addMembers] = useAddAsMemberMutation();
+  const [addMembersUG] = useAddAsMemberMutation();
+  const [addMembersNG] = useAddAsMemberNGMutation();
+  const [addMembersRole] = useAddAsMemberRoleMutation();
+  const [removeMembersUG] = useRemoveAsMemberMutation();
+  const [removeMembersNG] = useRemoveAsMemberNGMutation();
+  const [removeMembersRole] = useRemoveAsMemberRoleMutation();
+
+  let addMembers = addMembersUG;
+  let removeMembers = removeMembersUG;
   if (props.from === "netgroup") {
-    [addMembers] = useAddAsMemberNGMutation();
-  }
-  let [removeMembers] = useRemoveAsMemberMutation();
-  if (props.from === "netgroup") {
-    [removeMembers] = useRemoveAsMemberNGMutation();
+    addMembers = addMembersNG;
+    removeMembers = removeMembersNG;
+  } else if (props.from === "roles") {
+    addMembers = addMembersRole;
+    removeMembers = removeMembersRole;
   }
   const [adderSearchValue, setAdderSearchValue] = React.useState("");
   const [availableUserGroups, setAvailableUserGroups] = React.useState<

--- a/src/components/Members/MembersUserIdOverride.tsx
+++ b/src/components/Members/MembersUserIdOverride.tsx
@@ -1,0 +1,275 @@
+import React, { useMemo } from "react";
+// PatternFly
+import { Pagination, PaginationVariant } from "@patternfly/react-core";
+// Components
+import MemberOfToolbar from "../MemberOf/MemberOfToolbar";
+import MemberOfAddModal, { AvailableItems } from "../MemberOf/MemberOfAddModal";
+import MemberOfDeleteModal from "../MemberOf/MemberOfDeleteModal";
+import MemberTable from "src/components/tables/MembershipTable";
+// Data types
+import { Role } from "src/utils/datatypes/globalDataTypes";
+// Redux
+import { useAppDispatch } from "src/store/hooks";
+// Hooks
+import { addAlert } from "src/store/Global/alerts-slice";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
+// Utils
+import { paginate } from "src/utils/utils";
+// RPC
+import { ErrorResult } from "src/services/rpc";
+import {
+  RoleMemberPayload,
+  useAddAsMemberRoleMutation,
+  useRemoveAsMemberRoleMutation,
+} from "src/services/rpcRoles";
+import { useSearchIdOverrideUsersQuery } from "src/services/rpcIdOverrides";
+
+const DEFAULT_ID_VIEW = "Default Trust View";
+
+interface PropsToMembersUserIdOverride {
+  entity: Partial<Role>;
+  id: string;
+  from: string;
+  isDataLoading: boolean;
+  onRefreshData: () => void;
+  member_idoverrideuser: string[];
+}
+
+const MembersUserIdOverride = (props: PropsToMembersUserIdOverride) => {
+  const dispatch = useAppDispatch();
+
+  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+    useListPageSearchParams();
+
+  const [selectedItems, setSelectedItems] = React.useState<string[]>([]);
+
+  const member_idoverrideuser = props.member_idoverrideuser || [];
+
+  const getItemsToShow = (): string[] => {
+    let toShow = [...member_idoverrideuser];
+    toShow.sort();
+
+    if (searchValue) {
+      toShow = toShow.filter((name) =>
+        name.toLowerCase().includes(searchValue.toLowerCase())
+      );
+    }
+
+    toShow = paginate(toShow, page, perPage);
+
+    return toShow;
+  };
+
+  const itemsToShow = getItemsToShow();
+
+  const columnNames = ["User ID override"];
+  const someItemSelected = selectedItems.length > 0;
+  const showTableRows = itemsToShow.length > 0;
+
+  const [showAddModal, setShowAddModal] = React.useState(false);
+  const [showDeleteModal, setShowDeleteModal] = React.useState(false);
+  const [spinning, setSpinning] = React.useState(false);
+
+  const isRefreshButtonEnabled = !props.isDataLoading;
+  const isDeleteEnabled = someItemSelected;
+  const isAddButtonEnabled = isRefreshButtonEnabled;
+
+  const [addMembers] = useAddAsMemberRoleMutation();
+  const [removeMembers] = useRemoveAsMemberRoleMutation();
+
+  const [adderSearchValue, setAdderSearchValue] = React.useState("");
+
+  const idOverrideUsersQuery = useSearchIdOverrideUsersQuery({
+    idView: DEFAULT_ID_VIEW,
+    searchValue: adderSearchValue,
+  });
+
+  React.useEffect(() => {
+    if (showAddModal) {
+      idOverrideUsersQuery.refetch();
+    }
+  }, [showAddModal, adderSearchValue, props.entity]);
+
+  const availableItems = useMemo<AvailableItems[]>(() => {
+    if (idOverrideUsersQuery.data && !idOverrideUsersQuery.isFetching) {
+      const overrideUsers = idOverrideUsersQuery.data;
+      const items: AvailableItems[] = overrideUsers.map((user) => {
+        const displayName =
+          user.ipaoriginaluid || user.uid || user.ipaanchoruuid;
+        return {
+          key: displayName,
+          title:
+            displayName + (user.description ? ` (${user.description})` : ""),
+        };
+      });
+
+      return items.filter(
+        (item) =>
+          !member_idoverrideuser.includes(item.key) && item.key !== props.id
+      );
+    }
+    return [];
+  }, [
+    idOverrideUsersQuery.data,
+    idOverrideUsersQuery.isFetching,
+    member_idoverrideuser,
+    props.id,
+  ]);
+
+  const onAddIdOverrideUser = (items: AvailableItems[]) => {
+    const newIdOverrideNames = items.map((item) => item.key);
+    if (props.id === undefined || newIdOverrideNames.length === 0) {
+      return;
+    }
+
+    const payload: RoleMemberPayload = {
+      entryName: props.id,
+      entityType: "idoverrideuser",
+      idsToAdd: newIdOverrideNames,
+    };
+
+    setSpinning(true);
+    addMembers(payload).then((response) => {
+      if ("data" in response) {
+        if (response.data?.result) {
+          dispatch(
+            addAlert({
+              name: "add-member-success",
+              title: "Assigned ID override users to role '" + props.id + "'",
+              variant: "success",
+            })
+          );
+          props.onRefreshData();
+          setShowAddModal(false);
+        } else if (response.data?.error) {
+          const errorMessage = response.data.error as unknown as ErrorResult;
+          dispatch(
+            addAlert({
+              name: "add-member-error",
+              title: errorMessage.message,
+              variant: "danger",
+            })
+          );
+        }
+      }
+      setSpinning(false);
+    });
+  };
+
+  const onDeleteIdOverrideUser = () => {
+    const payload: RoleMemberPayload = {
+      entryName: props.id,
+      entityType: "idoverrideuser",
+      idsToAdd: selectedItems,
+    };
+
+    setSpinning(true);
+    removeMembers(payload).then((response) => {
+      if ("data" in response) {
+        if (response.data?.result) {
+          dispatch(
+            addAlert({
+              name: "remove-members-success",
+              title: "Removed ID override users from role '" + props.id + "'",
+              variant: "success",
+            })
+          );
+          props.onRefreshData();
+          setSelectedItems([]);
+          setShowDeleteModal(false);
+          setPage(1);
+        } else if (response.data?.error) {
+          const errorMessage = response.data.error as unknown as ErrorResult;
+          dispatch(
+            addAlert({
+              name: "remove-members-error",
+              title: errorMessage.message,
+              variant: "danger",
+            })
+          );
+        }
+      }
+      setSpinning(false);
+    });
+  };
+
+  return (
+    <>
+      <MemberOfToolbar
+        searchText={searchValue}
+        onSearchTextChange={setSearchValue}
+        onSearch={() => {}}
+        searchPlaceholder="Search user ID overrides"
+        searchAriaLabel="Search user ID overrides"
+        refreshButtonEnabled={isRefreshButtonEnabled}
+        onRefreshButtonClick={props.onRefreshData}
+        deleteButtonEnabled={isDeleteEnabled}
+        onDeleteButtonClick={() => setShowDeleteModal(true)}
+        addButtonEnabled={isAddButtonEnabled}
+        onAddButtonClick={() => setShowAddModal(true)}
+        helpIconEnabled={true}
+        totalItems={member_idoverrideuser.length}
+        perPage={perPage}
+        page={page}
+        onPerPageChange={setPerPage}
+        onPageChange={setPage}
+      />
+      <MemberTable
+        entityList={itemsToShow}
+        idKey="id"
+        from="idoverrideuser"
+        columnNamesToShow={columnNames}
+        propertiesToShow={itemsToShow}
+        checkedItems={selectedItems}
+        onCheckItemsChange={setSelectedItems}
+        showTableRows={showTableRows}
+      />
+      <Pagination
+        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
+        itemCount={member_idoverrideuser.length}
+        widgetId="pagination-options-menu-bottom"
+        perPage={perPage}
+        page={page}
+        variant={PaginationVariant.bottom}
+        onSetPage={(_e, page) => setPage(page)}
+        onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+      />
+      {showAddModal && (
+        <MemberOfAddModal
+          showModal={showAddModal}
+          onCloseModal={() => setShowAddModal(false)}
+          availableItems={availableItems}
+          onAdd={onAddIdOverrideUser}
+          onSearchTextChange={setAdderSearchValue}
+          title={"Assign ID override users to role: " + props.id}
+          ariaLabel="Add ID override user to role modal"
+          spinning={spinning}
+        />
+      )}
+      {showDeleteModal && someItemSelected && (
+        <MemberOfDeleteModal
+          showModal={showDeleteModal}
+          onCloseModal={() => setShowDeleteModal(false)}
+          title={"Remove ID override users from role: " + props.id}
+          onDelete={onDeleteIdOverrideUser}
+          spinning={spinning}
+        >
+          <MemberTable
+            entityList={member_idoverrideuser.filter((item) =>
+              selectedItems.includes(item)
+            )}
+            idKey="id"
+            from="idoverrideuser"
+            columnNamesToShow={columnNames}
+            propertiesToShow={member_idoverrideuser.filter((item) =>
+              selectedItems.includes(item)
+            )}
+            showTableRows
+          />
+        </MemberOfDeleteModal>
+      )}
+    </>
+  );
+};
+
+export default MembersUserIdOverride;

--- a/src/components/Members/MembersUsers.tsx
+++ b/src/components/Members/MembersUsers.tsx
@@ -31,6 +31,10 @@ import {
   useAddAsMemberNGMutation,
   useRemoveAsMemberNGMutation,
 } from "src/services/rpcNetgroups";
+import {
+  useAddAsMemberRoleMutation,
+  useRemoveAsMemberRoleMutation,
+} from "src/services/rpcRoles";
 
 interface PropsToMembersUsers {
   entity: Partial<UserGroup>;
@@ -78,13 +82,21 @@ const MembersUsers = (props: PropsToMembersUsers) => {
     membershipDirection === "direct" ? member_user : memberindirect_user;
   userNames = [...userNames];
 
-  let [addMembers] = useAddAsMemberMutation();
+  const [addMembersUG] = useAddAsMemberMutation();
+  const [addMembersNG] = useAddAsMemberNGMutation();
+  const [addMembersRole] = useAddAsMemberRoleMutation();
+  const [removeMembersUG] = useRemoveAsMemberMutation();
+  const [removeMembersNG] = useRemoveAsMemberNGMutation();
+  const [removeMembersRole] = useRemoveAsMemberRoleMutation();
+
+  let addMembers = addMembersUG;
+  let removeMembers = removeMembersUG;
   if (props.from === "netgroup") {
-    [addMembers] = useAddAsMemberNGMutation();
-  }
-  let [removeMembers] = useRemoveAsMemberMutation();
-  if (props.from === "netgroup") {
-    [removeMembers] = useRemoveAsMemberNGMutation();
+    addMembers = addMembersNG;
+    removeMembers = removeMembersNG;
+  } else if (props.from === "roles") {
+    addMembers = addMembersRole;
+    removeMembers = removeMembersRole;
   }
 
   const getUsersNameToLoad = (): string[] => {

--- a/src/components/tables/MembershipTable.tsx
+++ b/src/components/tables/MembershipTable.tsx
@@ -10,6 +10,7 @@ import {
   HostGroup,
   HBACRule,
   HBACService,
+  HBACServiceGroup,
   Netgroup,
   Role,
   SudoRule,
@@ -31,6 +32,7 @@ import { Link } from "react-router";
 type EntryDataTypes =
   | HBACRule
   | HBACService
+  | HBACServiceGroup
   | Host
   | HostGroup
   | Netgroup
@@ -50,11 +52,13 @@ type FromTypes =
   | "hbac-services"
   | "hosts"
   | "host-groups"
+  | "idoverrideuser"
   | "netgroups"
-  | "roles" // Not in AppRoutes yet (no Link)
+  | "roles"
   | "services"
   | "sudo-rules"
   | "sudo-commands"
+  | "sysaccount"
   | "user-groups"
   | "external";
 
@@ -69,6 +73,9 @@ interface MemberTableProps {
   showTableRows: boolean;
 }
 
+// Types that use string arrays instead of objects
+const STRING_ARRAY_TYPES = ["external", "sysaccount", "idoverrideuser"];
+
 // Body
 const TableBody = (props: {
   list: EntryDataTypes[]; // More types can be added here
@@ -81,71 +88,82 @@ const TableBody = (props: {
   onCheckboxChange: (checked: boolean, entityName: string) => void;
 }) => {
   const { list, idKey, propertiesToShow } = props;
+
+  // Check if this is a string array type (external, sysaccount, idoverrideuser)
+  const isStringArray = STRING_ARRAY_TYPES.includes(props.from);
+
   return (
     <>
-      {list.map((item, index) => (
-        <Tr key={index} id={item[idKey]}>
-          {props.showCheckboxColumn && (
-            <Td
-              select={{
-                rowIndex: index,
-                onSelect: (_e, isSelected) =>
-                  props.onCheckboxChange(isSelected, item[idKey]),
-                isSelected: props.checkedItems.includes(item[idKey]),
-              }}
-            />
-          )}
-          <Td>
-            {props.from === "roles" ? (
-              // Temporary until Roles are implemented
-              item[idKey]
-            ) : (
-              <Link
-                to={
-                  "/" +
-                  props.from +
-                  "/" +
-                  (props.from === "services"
-                    ? encodeURIComponent(item[idKey])
-                    : item[idKey])
-                }
-                state={item}
-              >
-                {item[idKey]}
-              </Link>
+      {list.map((item, index) => {
+        // For string arrays, the item itself is the identifier
+        const itemId = isStringArray ? (item as string) : item[idKey];
+
+        return (
+          <Tr key={index} id={itemId}>
+            {props.showCheckboxColumn && (
+              <Td
+                select={{
+                  rowIndex: index,
+                  onSelect: (_e, isSelected) =>
+                    props.onCheckboxChange(isSelected, itemId),
+                  isSelected: props.checkedItems.includes(itemId),
+                }}
+              />
             )}
-          </Td>
-          {propertiesToShow.map((propertyName, index) => {
-            // Handle special cases: 'nsaccountlock' is a boolean
-            if (
-              propertyName === "nsaccountlock" ||
-              propertyName === "ipaenabledflag"
-            ) {
-              if (
-                (propertyName === "nsaccountlock" && item[propertyName]) ||
-                (propertyName === "ipaenabledflag" && !item[propertyName])
-              ) {
-                return (
-                  <Td key={index}>
-                    <MinusIcon /> {" Disabled"}
-                  </Td>
-                );
-              } else {
-                return (
-                  <Td key={index}>
-                    <CheckIcon /> {" Enabled"}
-                  </Td>
-                );
-              }
-            } else if (propertyName !== idKey) {
-              // Rest of the cases
-              return (
-                <Td key={index}>{parseEmptyString(item[propertyName])}</Td>
-              );
-            }
-          })}
-        </Tr>
-      ))}
+            <Td>
+              {props.from === "roles" || isStringArray ? (
+                // String arrays and roles don't have links
+                itemId
+              ) : (
+                <Link
+                  to={
+                    "/" +
+                    props.from +
+                    "/" +
+                    (props.from === "services"
+                      ? encodeURIComponent(itemId)
+                      : itemId)
+                  }
+                  state={item}
+                >
+                  {itemId}
+                </Link>
+              )}
+            </Td>
+            {/* For string arrays, we don't show additional columns */}
+            {!isStringArray &&
+              propertiesToShow.map((propertyName, index) => {
+                // Handle special cases: 'nsaccountlock' is a boolean
+                if (
+                  propertyName === "nsaccountlock" ||
+                  propertyName === "ipaenabledflag"
+                ) {
+                  if (
+                    (propertyName === "nsaccountlock" && item[propertyName]) ||
+                    (propertyName === "ipaenabledflag" && !item[propertyName])
+                  ) {
+                    return (
+                      <Td key={index}>
+                        <MinusIcon /> {" Disabled"}
+                      </Td>
+                    );
+                  } else {
+                    return (
+                      <Td key={index}>
+                        <CheckIcon /> {" Enabled"}
+                      </Td>
+                    );
+                  }
+                } else if (propertyName !== idKey) {
+                  // Rest of the cases
+                  return (
+                    <Td key={index}>{parseEmptyString(item[propertyName])}</Td>
+                  );
+                }
+              })}
+          </Tr>
+        );
+      })}
     </>
   );
 };

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -564,7 +564,37 @@ export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
               </Route>
               <Route path="roles">
                 <Route path="" element={<Roles />} />
-                <Route path=":cn" element={<RolesTabs section="settings" />} />
+                <Route path=":cn">
+                  <Route path="" element={<RolesTabs section="settings" />} />
+                  <Route
+                    path="member_user"
+                    element={<RolesTabs section="member_user" />}
+                  />
+                  <Route
+                    path="member_group"
+                    element={<RolesTabs section="member_group" />}
+                  />
+                  <Route
+                    path="member_host"
+                    element={<RolesTabs section="member_host" />}
+                  />
+                  <Route
+                    path="member_hostgroup"
+                    element={<RolesTabs section="member_hostgroup" />}
+                  />
+                  <Route
+                    path="member_service"
+                    element={<RolesTabs section="member_service" />}
+                  />
+                  <Route
+                    path="member_idoverrideuser"
+                    element={<RolesTabs section="member_idoverrideuser" />}
+                  />
+                  <Route
+                    path="member_sysaccount"
+                    element={<RolesTabs section="member_sysaccount" />}
+                  />
+                </Route>
               </Route>
               <Route path="configuration" element={<Configuration />} />
               {/* Redirect to Active users page if user is logged in and navigates to the root page */}

--- a/src/pages/Roles/RolesMembers.tsx
+++ b/src/pages/Roles/RolesMembers.tsx
@@ -1,0 +1,246 @@
+import React, { useMemo } from "react";
+// PatternFly
+import { Badge, Tab, Tabs, TabTitleText } from "@patternfly/react-core";
+// Data types
+import { Role } from "src/utils/datatypes/globalDataTypes";
+// Layouts
+import TabLayout from "src/components/layouts/TabLayout";
+// Navigation
+import { useNavigate } from "react-router";
+// Hooks
+import useUpdateRoute from "src/hooks/useUpdateRoute";
+// RPC
+import { useGetRoleByIdQuery } from "src/services/rpcRoles";
+// 'Members' sections
+import MembersUsers from "src/components/Members/MembersUsers";
+import MembersUserGroups from "src/components/Members/MembersUserGroups";
+import MembersHosts from "src/components/Members/MembersHosts";
+import MembersHostGroups from "src/components/Members/MembersHostGroups";
+import MembersServices from "src/components/Members/MembersServices";
+import MembersUserIdOverride from "src/components/Members/MembersUserIdOverride";
+import MembersSystemAccount from "src/components/Members/MembersSystemAccount";
+
+interface PropsToRolesMembers {
+  role: Role;
+  tabSection: string;
+}
+
+const RolesMembers = (props: PropsToRolesMembers) => {
+  const navigate = useNavigate();
+
+  const roleQuery = useGetRoleByIdQuery(props.role.cn);
+  const roleData = roleQuery.data || {};
+
+  const role = useMemo<Partial<Role>>(() => {
+    if (!roleQuery.isFetching && roleData) {
+      return { ...roleData };
+    }
+    return {};
+  }, [roleData, roleQuery.isFetching]);
+
+  const onRefreshRoleData = () => {
+    roleQuery.refetch();
+  };
+
+  useUpdateRoute({ pathname: "roles", noBreadcrumb: true });
+
+  const userCount = role.member_user ? role.member_user.length : 0;
+  const groupCount = role.member_group ? role.member_group.length : 0;
+  const hostCount = role.member_host ? role.member_host.length : 0;
+  const hostGroupCount = role.member_hostgroup
+    ? role.member_hostgroup.length
+    : 0;
+  const serviceCount = role.member_service ? role.member_service.length : 0;
+  const idOverrideCount = role.member_idoverrideuser
+    ? role.member_idoverrideuser.length
+    : 0;
+  const sysAccountCount = role.member_sysaccount
+    ? role.member_sysaccount.length
+    : 0;
+
+  const handleTabClick = (
+    _event: React.MouseEvent<HTMLElement, MouseEvent>,
+    tabIndex: number | string
+  ) => {
+    navigate("/roles/" + props.role.cn + "/" + tabIndex);
+  };
+
+  return (
+    <div style={{ height: `var(--memberof-calc)` }}>
+      <TabLayout id="members">
+        <Tabs
+          activeKey={props.tabSection}
+          onSelect={handleTabClick}
+          isBox={false}
+          mountOnEnter
+          unmountOnExit
+        >
+          <Tab
+            eventKey={"member_user"}
+            name="member_user"
+            title={
+              <TabTitleText>
+                Users{" "}
+                <Badge key={0} id="user_count" isRead>
+                  {userCount}
+                </Badge>
+              </TabTitleText>
+            }
+          >
+            <MembersUsers
+              entity={role}
+              id={role.cn as string}
+              from="roles"
+              isDataLoading={roleQuery.isFetching}
+              onRefreshData={onRefreshRoleData}
+              member_user={role.member_user || []}
+              membershipDisabled={true}
+              setDirection={() => {}}
+              direction="direct"
+            />
+          </Tab>
+          <Tab
+            eventKey={"member_group"}
+            name="member_group"
+            title={
+              <TabTitleText>
+                User groups{" "}
+                <Badge key={1} id="group_count" isRead>
+                  {groupCount}
+                </Badge>
+              </TabTitleText>
+            }
+          >
+            <MembersUserGroups
+              entity={role}
+              id={role.cn as string}
+              from="roles"
+              isDataLoading={roleQuery.isFetching}
+              onRefreshData={onRefreshRoleData}
+              member_group={role.member_group || []}
+              membershipDisabled={true}
+              setDirection={() => {}}
+              direction="direct"
+            />
+          </Tab>
+          <Tab
+            eventKey={"member_host"}
+            name="member_host"
+            title={
+              <TabTitleText>
+                Hosts{" "}
+                <Badge key={2} id="host_count" isRead>
+                  {hostCount}
+                </Badge>
+              </TabTitleText>
+            }
+          >
+            <MembersHosts
+              entity={role}
+              id={role.cn as string}
+              from="roles"
+              isDataLoading={roleQuery.isFetching}
+              onRefreshData={onRefreshRoleData}
+              member_host={role.member_host || []}
+              membershipDisabled={true}
+              setDirection={() => {}}
+              direction="direct"
+            />
+          </Tab>
+          <Tab
+            eventKey={"member_hostgroup"}
+            name="member_hostgroup"
+            title={
+              <TabTitleText>
+                Host groups{" "}
+                <Badge key={3} id="hostgroup_count" isRead>
+                  {hostGroupCount}
+                </Badge>
+              </TabTitleText>
+            }
+          >
+            <MembersHostGroups
+              entity={role}
+              id={role.cn as string}
+              from="roles"
+              isDataLoading={roleQuery.isFetching}
+              onRefreshData={onRefreshRoleData}
+              member_hostgroup={role.member_hostgroup || []}
+              membershipDisabled={true}
+              setDirection={() => {}}
+              direction="direct"
+            />
+          </Tab>
+          <Tab
+            eventKey={"member_service"}
+            name="member_service"
+            title={
+              <TabTitleText>
+                Services{" "}
+                <Badge key={4} id="service_count" isRead>
+                  {serviceCount}
+                </Badge>
+              </TabTitleText>
+            }
+          >
+            <MembersServices
+              entity={role}
+              id={role.cn as string}
+              from="roles"
+              isDataLoading={roleQuery.isFetching}
+              onRefreshData={onRefreshRoleData}
+              member_service={role.member_service || []}
+              membershipDisabled={true}
+              setDirection={() => {}}
+              direction="direct"
+            />
+          </Tab>
+          <Tab
+            eventKey={"member_idoverrideuser"}
+            name="member_idoverrideuser"
+            title={
+              <TabTitleText>
+                User ID override{" "}
+                <Badge key={5} id="idoverride_count" isRead>
+                  {idOverrideCount}
+                </Badge>
+              </TabTitleText>
+            }
+          >
+            <MembersUserIdOverride
+              entity={role}
+              id={role.cn as string}
+              from="roles"
+              isDataLoading={roleQuery.isFetching}
+              onRefreshData={onRefreshRoleData}
+              member_idoverrideuser={role.member_idoverrideuser || []}
+            />
+          </Tab>
+          <Tab
+            eventKey={"member_sysaccount"}
+            name="member_sysaccount"
+            title={
+              <TabTitleText>
+                System accounts{" "}
+                <Badge key={6} id="sysaccount_count" isRead>
+                  {sysAccountCount}
+                </Badge>
+              </TabTitleText>
+            }
+          >
+            <MembersSystemAccount
+              entity={role}
+              id={role.cn as string}
+              from="roles"
+              isDataLoading={roleQuery.isFetching}
+              onRefreshData={onRefreshRoleData}
+              member_sysaccount={role.member_sysaccount || []}
+            />
+          </Tab>
+        </Tabs>
+      </TabLayout>
+    </div>
+  );
+};
+
+export default RolesMembers;

--- a/src/pages/Roles/RolesTabs.tsx
+++ b/src/pages/Roles/RolesTabs.tsx
@@ -9,15 +9,17 @@ import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
 import TitleLayout from "src/components/layouts/TitleLayout";
 import ContextualHelpPanel from "src/components/ContextualHelpPanel/ContextualHelpPanel";
 import DataSpinner from "src/components/layouts/DataSpinner";
+import RolesMembers from "./RolesMembers";
+import { partialRoleToRole } from "src/utils/rolesUtils";
 // Hooks
 import { useRoleSettings } from "src/hooks/useRolesSettingsData";
-// Redux
-import { useAppDispatch } from "src/store/hooks";
-import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
 // Navigation
 import { URL_PREFIX } from "src/navigation/NavRoutes";
 import { NotFound } from "src/components/errors/PageErrors";
 import { CnParams, useSafeParams } from "src/utils/paramsUtils";
+// Redux
+import { useAppDispatch } from "src/store/hooks";
+import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
 
 interface RolesTabsProps {
   section: string;
@@ -61,6 +63,8 @@ const RolesTabs = ({ section }: RolesTabsProps) => {
   ) => {
     if (tabIndex === "settings") {
       navigate("/roles/" + cn);
+    } else if (tabIndex === "member") {
+      navigate("/roles/" + cn + "/member_user");
     }
   };
 
@@ -87,7 +91,11 @@ const RolesTabs = ({ section }: RolesTabsProps) => {
     if (!section) {
       navigate(URL_PREFIX + "/roles/" + cn);
     }
-    setActiveTabKey(section);
+    if (section.startsWith("member_")) {
+      setActiveTabKey("member");
+    } else {
+      setActiveTabKey(section);
+    }
   }, [section]);
 
   if (roleSettingsData.isLoading || roleSettingsData.role.cn === undefined) {
@@ -147,6 +155,16 @@ const RolesTabs = ({ section }: RolesTabsProps) => {
                 onResetValues={roleSettingsData.resetValues}
                 modifiedValues={roleSettingsData.modifiedValues}
                 onOpenContextualPanel={onOpenContextualPanel}
+              />
+            </Tab>
+            <Tab
+              eventKey={"member"}
+              name={"member-details"}
+              title={<TabTitleText>Members</TabTitleText>}
+            >
+              <RolesMembers
+                role={partialRoleToRole(roleSettingsData.role)}
+                tabSection={section}
               />
             </Tab>
           </Tabs>

--- a/src/services/rpcIdOverrides.ts
+++ b/src/services/rpcIdOverrides.ts
@@ -226,8 +226,12 @@ const extendedApi = api.injectEndpoints({
         };
         return getCommand(findCmd);
       },
-      transformResponse: (response: FindRPCResponse): IDViewOverrideUser[] =>
-        response.result.result as unknown as IDViewOverrideUser[],
+      transformResponse: (response: FindRPCResponse): IDViewOverrideUser[] => {
+        if (response.result?.result) {
+          return response.result.result as unknown as IDViewOverrideUser[];
+        }
+        return [];
+      },
     }),
     gettingIDOverrideGroups: build.query<IDViewOverrideGroup[], string>({
       query: (idview) => {
@@ -237,8 +241,12 @@ const extendedApi = api.injectEndpoints({
         };
         return getCommand(findCmd);
       },
-      transformResponse: (response: FindRPCResponse): IDViewOverrideGroup[] =>
-        response.result.result as unknown as IDViewOverrideGroup[],
+      transformResponse: (response: FindRPCResponse): IDViewOverrideGroup[] => {
+        if (response.result?.result) {
+          return response.result.result as unknown as IDViewOverrideGroup[];
+        }
+        return [];
+      },
     }),
     // Refresh entries by search value (mutation instead of query)
     searchOverrideEntries: build.mutation<BatchRPCResponse, IDOverridePayload>({
@@ -302,6 +310,38 @@ const extendedApi = api.injectEndpoints({
             };
       },
     }),
+    /**
+     * Search for ID override users with search support
+     * @param {object} payload - Search parameters
+     * @param payload.idView - The ID view name (e.g., "Default Trust View")
+     * @param payload.searchValue - Search string
+     * @returns {IDViewOverrideUser[]} - List of ID override users
+     */
+    searchIdOverrideUsers: build.query<
+      IDViewOverrideUser[],
+      { idView: string; searchValue: string }
+    >({
+      query: ({ idView, searchValue }) => {
+        const findCmd: Command = {
+          method: "idoverrideuser_find",
+          params: [
+            [idView, searchValue],
+            {
+              version: API_VERSION_BACKUP,
+              no_members: true,
+              sizelimit: 100,
+            },
+          ],
+        };
+        return getCommand(findCmd);
+      },
+      transformResponse: (response: FindRPCResponse): IDViewOverrideUser[] => {
+        if (response.result?.result) {
+          return response.result.result as unknown as IDViewOverrideUser[];
+        }
+        return [];
+      },
+    }),
   }),
   overrideExisting: false,
 });
@@ -314,4 +354,5 @@ export const {
   useGettingIDOverrideUsersQuery,
   useGettingIDOverrideGroupsQuery,
   useSearchOverrideEntriesMutation,
+  useSearchIdOverrideUsersQuery,
 } = extendedApi;

--- a/src/services/rpcRoles.ts
+++ b/src/services/rpcRoles.ts
@@ -43,6 +43,12 @@ interface RolesSearchPayload {
   stopIdx: number;
 }
 
+export interface RoleMemberPayload {
+  entryName: string;
+  entityType: string;
+  idsToAdd: string[];
+}
+
 const extendedApi = api.injectEndpoints({
   endpoints: (build) => ({
     /**
@@ -229,6 +235,56 @@ const extendedApi = api.injectEndpoints({
           : { error: showResult.error as FetchBaseQueryError };
       },
     }),
+    /**
+     * Get a single role by cn (with members)
+     * @param {string} cn - Role cn
+     * @returns {Role} - Role data with members
+     */
+    getRoleById: build.query<Role, string>({
+      query: (cn) => {
+        return getCommand({
+          method: "role_show",
+          params: [[cn], { all: true, rights: true }],
+        });
+      },
+      transformResponse: (response: FindRPCResponse): Role => {
+        return apiToRole(response.result.result);
+      },
+    }),
+    /**
+     * Add members to a role
+     * @param {RoleMemberPayload} - Payload with role name, entity type, and IDs to add
+     * @returns {FindRPCResponse} - Response from API
+     */
+    addAsMemberRole: build.mutation<FindRPCResponse, RoleMemberPayload>({
+      query: (payload) => {
+        const params: Record<string, unknown> = {
+          version: API_VERSION_BACKUP,
+          [payload.entityType]: payload.idsToAdd,
+        };
+        return getCommand({
+          method: "role_add_member",
+          params: [[payload.entryName], params],
+        });
+      },
+    }),
+    /**
+     * Remove members from a role
+     * @param {RoleMemberPayload} - Payload with role name, entity type, and IDs to remove
+     * @returns {FindRPCResponse} - Response from API
+     */
+    removeAsMemberRole: build.mutation<FindRPCResponse, RoleMemberPayload>({
+      query: (payload) => {
+        const params: Record<string, unknown> = {
+          version: API_VERSION_BACKUP,
+          [payload.entityType]: payload.idsToAdd,
+        };
+        return getCommand({
+          method: "role_remove_member",
+          params: [[payload.entryName], params],
+        });
+      },
+    }),
   }),
   overrideExisting: false,
 });
@@ -258,4 +314,7 @@ export const {
   useDeleteRolesMutation,
   useSearchRolesEntriesMutation,
   useSaveRoleMutation,
+  useGetRoleByIdQuery,
+  useAddAsMemberRoleMutation,
+  useRemoveAsMemberRoleMutation,
 } = extendedApi;

--- a/src/services/rpcSystemAccounts.ts
+++ b/src/services/rpcSystemAccounts.ts
@@ -1,0 +1,57 @@
+import { api, getCommand, FindRPCResponse } from "./rpc";
+import { API_VERSION_BACKUP } from "../utils/utils";
+import { SysAccount } from "../utils/datatypes/globalDataTypes";
+
+/**
+ * System accounts-related endpoints
+ *
+ * API commands:
+ * - sysaccount_find: https://freeipa.readthedocs.io/en/latest/api/sysaccount_find.html
+ * - sysaccount_show: https://freeipa.readthedocs.io/en/latest/api/sysaccount_show.html
+ * - sysaccount_add: https://freeipa.readthedocs.io/en/latest/api/sysaccount_add.html
+ * - sysaccount_del: https://freeipa.readthedocs.io/en/latest/api/sysaccount_del.html
+ * - sysaccount_mod: https://freeipa.readthedocs.io/en/latest/api/sysaccount_mod.html
+ */
+
+const extendedApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    /**
+     * Search for system accounts
+     * @param {string} searchValue - Search criteria
+     * @returns {SysAccount[]} - List of system accounts
+     */
+    getSysaccounts: build.query<SysAccount[], string>({
+      query: (searchValue) => {
+        return getCommand({
+          method: "sysaccount_find",
+          params: [
+            [searchValue],
+            {
+              version: API_VERSION_BACKUP,
+              sizelimit: 100,
+              all: true,
+            },
+          ],
+        });
+      },
+      transformResponse: (response: FindRPCResponse): SysAccount[] => {
+        const sysaccounts: SysAccount[] = [];
+        const results = response.result.result as unknown as Record<
+          string,
+          unknown
+        >[];
+        for (const result of results) {
+          sysaccounts.push({
+            uid: (result.uid as string[])?.[0] || "",
+            dn: result.dn as string,
+            description: (result.description as string[])?.[0] || "",
+          });
+        }
+        return sysaccounts;
+      },
+    }),
+  }),
+  overrideExisting: false,
+});
+
+export const { useGetSysaccountsQuery } = extendedApi;

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -209,6 +209,19 @@ export interface Role {
   cn: string;
   description: string;
   dn: string;
+  member_user: string[];
+  member_group: string[];
+  member_host: string[];
+  member_hostgroup: string[];
+  member_service: string[];
+  member_idoverrideuser: string[];
+  member_sysaccount: string[];
+}
+
+export interface SysAccount {
+  uid: string;
+  dn: string;
+  description: string;
 }
 
 export interface HBACRulesOld {

--- a/src/utils/rolesUtils.tsx
+++ b/src/utils/rolesUtils.tsx
@@ -26,23 +26,40 @@ export function apiToRole(apiRecord: Record<string, unknown>): Role {
     simpleValues,
     dateValues
   ) as Partial<Role>;
-  return partialRoleToRole(converted) as Role;
-}
 
-export function partialRoleToRole(partialGroup: Partial<Role>): Role {
   return {
     ...createEmptyRole(),
-    ...partialGroup,
+    ...converted,
+    member_user: (apiRecord.member_user as string[]) || [],
+    member_group: (apiRecord.member_group as string[]) || [],
+    member_host: (apiRecord.member_host as string[]) || [],
+    member_hostgroup: (apiRecord.member_hostgroup as string[]) || [],
+    member_service: (apiRecord.member_service as string[]) || [],
+    member_idoverrideuser: (apiRecord.member_idoverrideuser as string[]) || [],
+    member_sysaccount: (apiRecord.member_sysaccount as string[]) || [],
   };
 }
 
-// Get empty User object initialized with default values
+export function partialRoleToRole(partialRole: Partial<Role>): Role {
+  return {
+    ...createEmptyRole(),
+    ...partialRole,
+  };
+}
+
 export function createEmptyRole(): Role {
-  const group: Role = {
+  const role: Role = {
     cn: "",
     description: "",
     dn: "",
+    member_user: [],
+    member_group: [],
+    member_host: [],
+    member_hostgroup: [],
+    member_service: [],
+    member_idoverrideuser: [],
+    member_sysaccount: [],
   };
 
-  return group;
+  return role;
 }


### PR DESCRIPTION
The 'Members' page should manage the
entities from which a role can be
member to. Those are:
- Users
- User groups
- Hosts
- Host groups
- Services
- User ID override
- System accounts

Assisted-by: Claude <noreply@anthropic.com>

## Summary by Sourcery

Add role member management UI and APIs, enabling viewing and editing of role memberships across multiple entity types, including new User ID override and system account members.

New Features:
- Introduce role member tabs page with per-type subroutes for managing users, groups, hosts, host groups, services, user ID overrides, and system accounts associated with a role.
- Add role detail fetching API with member lists and mutations for adding and removing members of various entity types.
- Support listing and assigning system accounts and ID override users as role members via new dedicated member components and backend queries.

Enhancements:
- Update membership table component to handle simple string-based member lists and enable linking for roles in the roles table.
- Extend role data model and utilities to include typed member arrays and provide empty-role initialization helpers.
- Wire existing member management components (users, groups, hosts, host groups, services) to work when invoked from roles as the owning entity.