### PR TITLE
Roles > 'Privileges' page

### DIFF
--- a/doc/designs/sub-pages/03-tabs-component.md
+++ b/doc/designs/sub-pages/03-tabs-component.md
@@ -68,7 +68,6 @@ If found → render Tabs with entity data
 import React from "react";
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 import { useNavigate } from "react-router";
-import { URL_PREFIX } from "src/navigation/NavRoutes";
 import { NotFound } from "src/components/errors/PageErrors";
 import { use<Entity>Settings } from "src/hooks/use<Entity>SettingsData";
 import TitleLayout from "src/components/layouts/TitleLayout";
@@ -142,8 +141,8 @@ Breadcrumbs help users understand their location in the app hierarchy. They're u
 React.useEffect(() => {
   setId(<primaryKey>);
   setBreadcrumbItems([
-    { name: "<Entity display name>", url: URL_PREFIX + "/" + pathname },
-    { name: <primaryKey>, url: URL_PREFIX + "/" + pathname + "/" + <primaryKey>, isActive: true },
+    { name: "<Entity display name>", url: "/" + pathname },
+    { name: <primaryKey>, url: "/" + pathname + "/" + <primaryKey>, isActive: true },
   ]);
 }, [<primaryKey>]);
 ```

--- a/src/components/tables/MembershipTable.tsx
+++ b/src/components/tables/MembershipTable.tsx
@@ -29,6 +29,10 @@ import { MinusIcon } from "@patternfly/react-icons";
 // React Router DOM
 import { Link } from "react-router";
 
+interface PrivilegeItem {
+  cn: string;
+}
+
 type EntryDataTypes =
   | HBACRule
   | HBACService
@@ -36,6 +40,7 @@ type EntryDataTypes =
   | Host
   | HostGroup
   | Netgroup
+  | PrivilegeItem
   | Role
   | Service
   | SubId
@@ -54,6 +59,7 @@ type FromTypes =
   | "host-groups"
   | "idoverrideuser"
   | "netgroups"
+  | "privileges"
   | "roles"
   | "services"
   | "sudo-rules"
@@ -76,6 +82,9 @@ interface MemberTableProps {
 // Types that use string arrays instead of objects
 const STRING_ARRAY_TYPES = ["external", "sysaccount", "idoverrideuser"];
 
+// Track those types that don't have links
+const NO_LINK_TYPES: string[] = ["roles", "privileges"];
+
 // Body
 const TableBody = (props: {
   list: EntryDataTypes[]; // More types can be added here
@@ -92,6 +101,14 @@ const TableBody = (props: {
   // Check if this is a string array type (external, sysaccount, idoverrideuser)
   const isStringArray = STRING_ARRAY_TYPES.includes(props.from);
 
+  const shouldRenderLink = (from: string, isStringArray: boolean) =>
+    !isStringArray && !NO_LINK_TYPES.includes(from);
+
+  const getItemLink = (from: string, itemId: string) =>
+    from === "services"
+      ? `/${from}/${encodeURIComponent(itemId)}`
+      : `/${from}/${itemId}`;
+
   return (
     <>
       {list.map((item, index) => {
@@ -99,7 +116,7 @@ const TableBody = (props: {
         const itemId = isStringArray ? (item as string) : item[idKey];
 
         return (
-          <Tr key={index} id={itemId}>
+          <Tr key={itemId} id={itemId}>
             {props.showCheckboxColumn && (
               <Td
                 select={{
@@ -111,23 +128,12 @@ const TableBody = (props: {
               />
             )}
             <Td>
-              {props.from === "roles" || isStringArray ? (
-                // String arrays and roles don't have links
-                itemId
-              ) : (
-                <Link
-                  to={
-                    "/" +
-                    props.from +
-                    "/" +
-                    (props.from === "services"
-                      ? encodeURIComponent(itemId)
-                      : itemId)
-                  }
-                  state={item}
-                >
+              {shouldRenderLink(props.from, isStringArray) ? (
+                <Link to={getItemLink(props.from, itemId)} state={item}>
                   {itemId}
                 </Link>
+              ) : (
+                itemId
               )}
             </Td>
             {/* For string arrays, we don't show additional columns */}

--- a/src/hooks/useRolesSettingsData.tsx
+++ b/src/hooks/useRolesSettingsData.tsx
@@ -81,7 +81,7 @@ const useRoleSettings = (roleId: string): RoleSettingsData => {
   }, [role, originalRole]);
 
   const onResetValues = () => {
-    setOriginalRole({ ...role });
+    setRole({ ...originalRole });
     setModified(false);
   };
 

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -594,6 +594,10 @@ export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
                     path="member_sysaccount"
                     element={<RolesTabs section="member_sysaccount" />}
                   />
+                  <Route
+                    path="privileges"
+                    element={<RolesTabs section="privileges" />}
+                  />
                 </Route>
               </Route>
               <Route path="configuration" element={<Configuration />} />

--- a/src/pages/Roles/RolesPrivileges.tsx
+++ b/src/pages/Roles/RolesPrivileges.tsx
@@ -1,0 +1,313 @@
+import React, { useEffect, useMemo } from "react";
+// PatternFly
+import { Pagination, PaginationVariant } from "@patternfly/react-core";
+// Data types
+import { Role } from "src/utils/datatypes/globalDataTypes";
+// Components
+import MemberOfToolbar from "src/components/MemberOf/MemberOfToolbar";
+import MemberTable from "src/components/tables/MembershipTable";
+import MemberOfAddModal, {
+  AvailableItems,
+} from "src/components/MemberOf/MemberOfAddModal";
+import MemberOfDeleteModal from "src/components/MemberOf/MemberOfDeleteModal";
+// Layouts
+import TabLayout from "src/components/layouts/TabLayout";
+// Redux
+import { useAppDispatch } from "src/store/hooks";
+// Hooks
+import { addAlert } from "src/store/Global/alerts-slice";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
+import useUpdateRoute from "src/hooks/useUpdateRoute";
+// RPC
+import { ErrorResult } from "src/services/rpc";
+import {
+  useGetRoleByIdQuery,
+  useGetPrivilegesQuery,
+  useAddPrivilegeToRoleMutation,
+  useRemovePrivilegeFromRoleMutation,
+} from "src/services/rpcRoles";
+// Utils
+import { paginate } from "src/utils/utils";
+
+interface PropsToRolesPrivileges {
+  role: Role;
+}
+
+interface PrivilegeItem {
+  cn: string;
+}
+
+const RolesPrivileges = (props: PropsToRolesPrivileges) => {
+  const dispatch = useAppDispatch();
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  useUpdateRoute({ pathname: "roles", noBreadcrumb: true });
+
+  // Get role data with privileges
+  const roleQuery = useGetRoleByIdQuery(props.role.cn);
+  const roleData = roleQuery.data || {};
+
+  const role = useMemo<Partial<Role>>(() => {
+    if (!roleQuery.isFetching && roleData) {
+      return { ...roleData };
+    }
+    return {};
+  }, [roleData, roleQuery.isFetching]);
+
+  // Get parameters from URL
+  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+    useListPageSearchParams();
+
+  // Other states
+  const [privilegesSelected, setPrivilegesSelected] = React.useState<string[]>(
+    []
+  );
+
+  // Get privilege names from role
+  const privilegeNames = useMemo(
+    () => role.memberof_privilege || [],
+    [role.memberof_privilege]
+  );
+
+  // Column configuration
+  const columnNames = ["Privilege name"];
+  const properties: string[] = [];
+
+  const privileges = useMemo((): PrivilegeItem[] => {
+    let toLoad = [...privilegeNames];
+    toLoad.sort();
+
+    // Filter by search
+    if (searchValue) {
+      toLoad = toLoad.filter((name) =>
+        name.toLowerCase().includes(searchValue.toLowerCase())
+      );
+    }
+
+    // Apply paging
+    toLoad = paginate(toLoad, page, perPage);
+
+    return toLoad.map((name) => ({ cn: name }));
+  }, [privilegeNames, searchValue, page, perPage]);
+
+  // Computed "states"
+  const showTableRows = !roleQuery.isFetching;
+
+  // Dialogs and actions
+  const [showAddModal, setShowAddModal] = React.useState(false);
+  const [showDeleteModal, setShowDeleteModal] = React.useState(false);
+  const [spinning, setSpinning] = React.useState(false);
+
+  // Buttons functionality
+  const isRefreshButtonEnabled = !roleQuery.isFetching;
+  const isDeleteButtonEnabled =
+    privilegesSelected.length > 0 && isRefreshButtonEnabled;
+  const isAddButtonEnabled = isRefreshButtonEnabled;
+
+  // API calls
+  const [addPrivilegeToRole] = useAddPrivilegeToRoleMutation();
+  const [removePrivilegeFromRole] = useRemovePrivilegeFromRoleMutation();
+  const [adderSearchValue, setAdderSearchValue] = React.useState("");
+  const [availableItems, setAvailableItems] = React.useState<AvailableItems[]>(
+    []
+  );
+
+  // Load available privileges (only when modal is open)
+  const privilegesQuery = useGetPrivilegesQuery(adderSearchValue, {
+    skip: !showAddModal,
+  });
+
+  // Trigger available privileges search
+  useEffect(() => {
+    if (showAddModal) {
+      privilegesQuery.refetch();
+    }
+  }, [showAddModal, adderSearchValue, role]);
+
+  // Update available privileges
+  useEffect(() => {
+    if (privilegesQuery.data && !privilegesQuery.isFetching) {
+      const results = (privilegesQuery.data.result?.result ||
+        []) as unknown as Array<{
+        cn: string[] | string;
+      }>;
+      let items: AvailableItems[] = results.map((priv) => ({
+        key: Array.isArray(priv.cn) ? priv.cn[0] : priv.cn,
+        title: Array.isArray(priv.cn) ? priv.cn[0] : priv.cn,
+      }));
+
+      // Filter out already assigned privileges
+      items = items.filter((item) => !privilegeNames.includes(item.key));
+
+      setAvailableItems(items);
+    }
+  }, [privilegesQuery.data, privilegesQuery.isFetching, privilegeNames]);
+
+  // Refresh data
+  const onRefreshData = () => {
+    setPrivilegesSelected([]);
+    roleQuery.refetch();
+  };
+
+  // Add privileges to role
+  const onAddPrivilege = (items: AvailableItems[]) => {
+    const newPrivilegeNames = items.map((item) => item.key);
+    if (props.role.cn === undefined || newPrivilegeNames.length === 0) {
+      return;
+    }
+
+    setSpinning(true);
+    addPrivilegeToRole({
+      roleCn: props.role.cn,
+      privileges: newPrivilegeNames,
+    }).then((response) => {
+      if ("data" in response) {
+        if (response.data?.result) {
+          dispatch(
+            addAlert({
+              name: "add-privilege-success",
+              title: `Added privileges to role '${props.role.cn}'`,
+              variant: "success",
+            })
+          );
+          onRefreshData();
+          setShowAddModal(false);
+        } else if (response.data?.error) {
+          const errorMessage = response.data.error as unknown as ErrorResult;
+          dispatch(
+            addAlert({
+              name: "add-privilege-error",
+              title: errorMessage.message,
+              variant: "danger",
+            })
+          );
+        }
+      }
+      setSpinning(false);
+    });
+  };
+
+  // Remove privileges from role
+  const onDeletePrivilege = () => {
+    if (props.role.cn === undefined || privilegesSelected.length === 0) {
+      return;
+    }
+
+    setSpinning(true);
+    removePrivilegeFromRole({
+      roleCn: props.role.cn,
+      privileges: privilegesSelected,
+    }).then((response) => {
+      if ("data" in response) {
+        if (response.data?.result) {
+          dispatch(
+            addAlert({
+              name: "remove-privilege-success",
+              title: `Removed privileges from role '${props.role.cn}'`,
+              variant: "success",
+            })
+          );
+          onRefreshData();
+          setShowDeleteModal(false);
+          setPage(1);
+        } else if (response.data?.error) {
+          const errorMessage = response.data.error as unknown as ErrorResult;
+          dispatch(
+            addAlert({
+              name: "remove-privilege-error",
+              title: errorMessage.message,
+              variant: "danger",
+            })
+          );
+        }
+      }
+      setSpinning(false);
+    });
+  };
+
+  // Get filtered privilege names count for pagination
+  const getFilteredCount = (): number => {
+    if (!searchValue) {
+      return privilegeNames.length;
+    }
+    return privilegeNames.filter((name) =>
+      name.toLowerCase().includes(searchValue.toLowerCase())
+    ).length;
+  };
+
+  return (
+    <TabLayout id="privileges">
+      <MemberOfToolbar
+        searchText={searchValue}
+        onSearchTextChange={setSearchValue}
+        onSearch={() => {}}
+        searchPlaceholder="Search privileges"
+        searchAriaLabel="Search privileges"
+        refreshButtonEnabled={isRefreshButtonEnabled}
+        onRefreshButtonClick={onRefreshData}
+        deleteButtonEnabled={isDeleteButtonEnabled}
+        onDeleteButtonClick={() => setShowDeleteModal(true)}
+        addButtonEnabled={isAddButtonEnabled}
+        onAddButtonClick={() => setShowAddModal(true)}
+        helpIconEnabled={true}
+        totalItems={getFilteredCount()}
+        perPage={perPage}
+        page={page}
+        onPerPageChange={setPerPage}
+        onPageChange={setPage}
+      />
+      <MemberTable
+        entityList={privileges}
+        idKey="cn"
+        from="privileges"
+        columnNamesToShow={columnNames}
+        propertiesToShow={properties}
+        checkedItems={privilegesSelected}
+        onCheckItemsChange={setPrivilegesSelected}
+        showTableRows={showTableRows}
+      />
+      {getFilteredCount() > 0 && (
+        <Pagination
+          className="pf-v6-u-pb-0 pf-v6-u-pr-md"
+          itemCount={getFilteredCount()}
+          widgetId="pagination-options-menu-bottom"
+          perPage={perPage}
+          page={page}
+          variant={PaginationVariant.bottom}
+          onSetPage={(_e, page) => setPage(page)}
+          onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+        />
+      )}
+      <MemberOfAddModal
+        showModal={showAddModal}
+        onCloseModal={() => setShowAddModal(false)}
+        availableItems={availableItems}
+        onAdd={onAddPrivilege}
+        onSearchTextChange={setAdderSearchValue}
+        title={`Add privileges to role '${props.role.cn}'`}
+        ariaLabel="Add privileges to role modal"
+        spinning={spinning}
+      />
+      <MemberOfDeleteModal
+        showModal={showDeleteModal}
+        onCloseModal={() => setShowDeleteModal(false)}
+        title={`Remove privileges from role '${props.role.cn}'`}
+        onDelete={onDeletePrivilege}
+        spinning={spinning}
+      >
+        <MemberTable
+          entityList={privileges.filter((priv) =>
+            privilegesSelected.includes(priv.cn)
+          )}
+          from="privileges"
+          idKey="cn"
+          columnNamesToShow={columnNames}
+          propertiesToShow={properties}
+          showTableRows
+        />
+      </MemberOfDeleteModal>
+    </TabLayout>
+  );
+};
+
+export default RolesPrivileges;

--- a/src/pages/Roles/RolesTabs.tsx
+++ b/src/pages/Roles/RolesTabs.tsx
@@ -9,12 +9,12 @@ import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
 import TitleLayout from "src/components/layouts/TitleLayout";
 import DataSpinner from "src/components/layouts/DataSpinner";
 import RolesMembers from "./RolesMembers";
+import RolesPrivileges from "./RolesPrivileges";
 import { partialRoleToRole } from "src/utils/rolesUtils";
 // Hooks
 import { useRoleSettings } from "src/hooks/useRolesSettingsData";
 import useContextualHelpTopic from "src/hooks/useContextualHelpTopic";
 // Navigation
-import { URL_PREFIX } from "src/navigation/NavRoutes";
 import { NotFound } from "src/components/errors/PageErrors";
 import { CnParams, useSafeParams } from "src/utils/paramsUtils";
 // Redux
@@ -28,6 +28,20 @@ import {
 interface RolesTabsProps {
   section: string;
 }
+
+// Central mapping between tab keys and routes
+const TAB_ROUTES: Record<string, (cn: string) => string> = {
+  settings: (cn) => `/roles/${cn}`,
+  member: (cn) => `/roles/${cn}/member_user`,
+  privileges: (cn) => `/roles/${cn}/privileges`,
+};
+
+// Normalize section -> tab key
+const getTabKeyFromSection = (section?: string): string => {
+  if (!section) return "settings";
+  if (section.startsWith("member_")) return "member";
+  return section in TAB_ROUTES ? section : "settings";
+};
 
 const RolesTabs = ({ section }: RolesTabsProps) => {
   const { cn } = useSafeParams<CnParams>(["cn"]);
@@ -48,16 +62,18 @@ const RolesTabs = ({ section }: RolesTabsProps) => {
   const roleSettingsData = useRoleSettings(cn);
 
   // Tab
-  const [activeTabKey, setActiveTabKey] = useState("settings");
+  const [activeTabKey, setActiveTabKey] = useState(() =>
+    getTabKeyFromSection(section)
+  );
 
   const handleTabClick = (
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
-    if (tabIndex === "settings") {
-      navigate("/roles/" + cn);
-    } else if (tabIndex === "member") {
-      navigate("/roles/" + cn + "/member_user");
+    const tabKey = String(tabIndex);
+    const toPath = TAB_ROUTES[tabKey];
+    if (toPath) {
+      navigate(toPath(cn));
     }
   };
 
@@ -66,11 +82,11 @@ const RolesTabs = ({ section }: RolesTabsProps) => {
     const currentPath: BreadCrumbItem[] = [
       {
         name: "Roles",
-        url: URL_PREFIX + "/roles",
+        url: "/roles",
       },
       {
         name: cn,
-        url: URL_PREFIX + "/roles/" + cn,
+        url: "/roles/" + cn,
         isActive: true,
       },
     ];
@@ -82,14 +98,10 @@ const RolesTabs = ({ section }: RolesTabsProps) => {
   // Redirect to the settings page if the section is not defined
   React.useEffect(() => {
     if (!section) {
-      navigate(URL_PREFIX + "/roles/" + cn);
+      navigate(TAB_ROUTES.settings(cn));
     }
-    if (section.startsWith("member_")) {
-      setActiveTabKey("member");
-    } else {
-      setActiveTabKey(section);
-    }
-  }, [section]);
+    setActiveTabKey(getTabKeyFromSection(section));
+  }, [section, cn, navigate]);
 
   if (roleSettingsData.isLoading || roleSettingsData.role.cn === undefined) {
     return <DataSpinner />;
@@ -154,6 +166,13 @@ const RolesTabs = ({ section }: RolesTabsProps) => {
               role={partialRoleToRole(roleSettingsData.role)}
               tabSection={section}
             />
+          </Tab>
+          <Tab
+            eventKey={"privileges"}
+            name={"privileges-details"}
+            title={<TabTitleText>Privileges</TabTitleText>}
+          >
+            <RolesPrivileges role={partialRoleToRole(roleSettingsData.role)} />
           </Tab>
         </Tabs>
       </PageSection>

--- a/src/services/rpcRoles.ts
+++ b/src/services/rpcRoles.ts
@@ -49,6 +49,11 @@ export interface RoleMemberPayload {
   idsToAdd: string[];
 }
 
+interface RolePrivilegePayload {
+  roleCn: string;
+  privileges: string[];
+}
+
 const extendedApi = api.injectEndpoints({
   endpoints: (build) => ({
     /**
@@ -285,6 +290,54 @@ const extendedApi = api.injectEndpoints({
         });
       },
     }),
+    /**
+     * Get available privileges via `privilege_find`
+     * @param {string} searchValue - Search value for filtering privileges
+     * @returns {FindRPCResponse} - Response from API
+     */
+    getPrivileges: build.query<FindRPCResponse, string>({
+      query: (searchValue) =>
+        getCommand({
+          method: "privilege_find",
+          params: [
+            [searchValue],
+            { no_members: true, version: API_VERSION_BACKUP },
+          ],
+        }),
+    }),
+    /**
+     * Add privilege to a role via `role_add_privilege`
+     * @param {RolePrivilegePayload} - Payload with role cn and privileges to add
+     * @returns {FindRPCResponse} - Response from API
+     */
+    addPrivilegeToRole: build.mutation<FindRPCResponse, RolePrivilegePayload>({
+      query: (payload) =>
+        getCommand({
+          method: "role_add_privilege",
+          params: [
+            [payload.roleCn],
+            { privilege: payload.privileges, version: API_VERSION_BACKUP },
+          ],
+        }),
+    }),
+    /**
+     * Remove privilege from a role via `role_remove_privilege`
+     * @param {RolePrivilegePayload} - Payload with role cn and privileges to remove
+     * @returns {FindRPCResponse} - Response from API
+     */
+    removePrivilegeFromRole: build.mutation<
+      FindRPCResponse,
+      RolePrivilegePayload
+    >({
+      query: (payload) =>
+        getCommand({
+          method: "role_remove_privilege",
+          params: [
+            [payload.roleCn],
+            { privilege: payload.privileges, version: API_VERSION_BACKUP },
+          ],
+        }),
+    }),
   }),
   overrideExisting: false,
 });
@@ -317,4 +370,7 @@ export const {
   useGetRoleByIdQuery,
   useAddAsMemberRoleMutation,
   useRemoveAsMemberRoleMutation,
+  useGetPrivilegesQuery,
+  useAddPrivilegeToRoleMutation,
+  useRemovePrivilegeFromRoleMutation,
 } = extendedApi;

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -216,6 +216,7 @@ export interface Role {
   member_service: string[];
   member_idoverrideuser: string[];
   member_sysaccount: string[];
+  memberof_privilege: string[];
 }
 
 export interface SysAccount {

--- a/src/utils/rolesUtils.tsx
+++ b/src/utils/rolesUtils.tsx
@@ -37,6 +37,7 @@ export function apiToRole(apiRecord: Record<string, unknown>): Role {
     member_service: (apiRecord.member_service as string[]) || [],
     member_idoverrideuser: (apiRecord.member_idoverrideuser as string[]) || [],
     member_sysaccount: (apiRecord.member_sysaccount as string[]) || [],
+    memberof_privilege: (apiRecord.memberof_privilege as string[]) || [],
   };
 }
 
@@ -59,6 +60,7 @@ export function createEmptyRole(): Role {
     member_service: [],
     member_idoverrideuser: [],
     member_sysaccount: [],
+    memberof_privilege: [],
   };
 
   return role;


### PR DESCRIPTION
This PR has been created at the top of https://github.com/freeipa/freeipa-webui/pull/1126 and must be merged first.

## Summary by Sourcery

Add full role detail view with editable settings, member management, and privilege assignment, plus shared contextual help handling and support for ID override users and system accounts.

New Features:
- Expose role detail routes with tabs for settings, members, and privileges.
- Allow editing and saving role settings via role_mod.
- Enable viewing and managing role members across users, groups, hosts, host groups, services, user ID overrides, and system accounts.
- Provide a privileges tab to search, add, and remove privileges associated with a role.
- Add search endpoints and UI support for ID override users and system accounts when assigning them to roles.

Bug Fixes:
- Prevent RPC ID override queries from crashing when no results are returned by safely defaulting to empty arrays.

Enhancements:
- Extend membership tables to handle non-object member lists (external, sysaccount, idoverrideuser, privileges) without links and extra columns.
- Augment role data model and conversion utilities with member arrays and privileges to support richer role operations.
- Refactor contextual help panel usage into a dedicated hook and make the panel robust to missing fromPage values.
- Wire role memberships into existing member management components so they can be reused for role-related operations.