### PR TITLE
Integration tests: Add new test for privileges main page

### DIFF
--- a/cypress/e2e/privileges/privileges.feature
+++ b/cypress/e2e/privileges/privileges.feature
@@ -1,0 +1,114 @@
+Feature: Privileges manipulation
+  Create and delete privileges
+
+  @test
+  Scenario: Add a new privilege
+    Given I am logged in as admin
+    And I am on "privileges" page
+
+    When I click on the "privileges-button-add" button
+    Then I should see "add-privilege-modal" modal
+
+    When I type in the "modal-textbox-privilege-name" textbox text "a_privilege1"
+    Then I should see "a_privilege1" in the "modal-textbox-privilege-name" textbox
+
+    When I type in the "modal-textbox-description" textbox text "my description"
+    Then I should see "my description" in the "modal-textbox-description" textbox
+
+    When I click on the "modal-button-add" button
+    Then I should not see "add-privilege-modal" modal
+    And I should see "add-privilege-success" alert
+
+    When I search for "a_privilege1" in the data table
+    Then I should see "a_privilege1" entry in the data table
+    And I should see "a_privilege1" entry in the data table with attribute "description" set to "my description"
+
+  @cleanup
+  Scenario: Cleanup: Delete a privilege
+    Given I delete privilege "a_privilege1"
+
+  @seed
+  Scenario: Seed: Create privileges used in tests
+    Given privilege "a_privilege2" exists
+
+  @test
+  Scenario: Search for a privilege
+    Given I am logged in as admin
+    And I am on "privileges" page
+
+    When I search for "a_privilege2" in the data table
+    Then I should see "a_privilege2" entry in the data table
+    And I should not see "a_privilege1" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup: Delete seeded privileges
+    Given I delete privilege "a_privilege2"
+
+  @seed
+  Scenario: Seed: Create privileges used in tests
+    Given privilege "a_privilege1" exists
+
+  @test
+  Scenario: Delete a privilege
+    Given I am logged in as admin
+    And I am on "privileges" page
+
+    When I search for "a_privilege1" in the data table
+    Then I should see "a_privilege1" entry in the data table
+    When I select entry "a_privilege1" in the data table
+    Then I should see "a_privilege1" entry selected in the data table
+
+    When I click on the "privileges-button-delete" button
+    Then I should see "delete-privileges-modal" modal
+    And I should see "a_privilege1" entry in the data table
+
+    When I click on the "modal-button-delete" button
+    Then I should see "remove-privileges-success" alert
+    And I should not see "delete-privileges-modal" modal
+    And I should not see "a_privilege1" entry in the data table
+
+  @seed
+  Scenario: Seed: Create privileges used in tests
+    Given privilege "a_privilege2" exists
+    And privilege "a_privilege3" exists
+
+  @test
+  Scenario: Delete many privileges
+    Given I am logged in as admin
+    And I am on "privileges" page
+
+    When I search for "a_privilege2" in the data table
+    Then I should see "a_privilege2" entry in the data table
+    When I select entry "a_privilege2" in the data table
+    Then I should see "a_privilege2" entry selected in the data table
+
+    When I search for "a_privilege3" in the data table
+    Then I should see "a_privilege3" entry in the data table
+    When I select entry "a_privilege3" in the data table
+    Then I should see "a_privilege3" entry selected in the data table
+
+    When I click on the "privileges-button-delete" button
+    Then I should see "delete-privileges-modal" modal
+    And I should see "a_privilege2" entry in the data table
+    And I should see "a_privilege3" entry in the data table
+
+    When I click on the "modal-button-delete" button
+    Then I should see "remove-privileges-success" alert
+    And I should not see "delete-privileges-modal" modal
+    And I should not see "a_privilege2" entry in the data table
+    And I should not see "a_privilege3" entry in the data table
+
+  @test
+  Scenario: Cancel creation of a privilege
+    Given I am logged in as admin
+    And I am on "privileges" page
+
+    When I click on the "privileges-button-add" button
+    Then I should see "add-privilege-modal" modal
+
+    When I type in the "modal-textbox-privilege-name" textbox text "a_privilege_cancel"
+    Then I should see "a_privilege_cancel" in the "modal-textbox-privilege-name" textbox
+
+    When I click on the "modal-button-cancel" button
+    Then I should not see "add-privilege-modal" modal
+    And I should not see "a_privilege_cancel" entry in the data table

--- a/cypress/e2e/privileges/privileges.ts
+++ b/cypress/e2e/privileges/privileges.ts
@@ -1,0 +1,15 @@
+import { Given } from "@badeball/cypress-cucumber-preprocessor";
+
+Given("privilege {string} exists", (privilegeName: string) => {
+  cy.ipa({
+    command: "privilege-add",
+    name: privilegeName,
+  });
+});
+
+Given("I delete privilege {string}", (privilegeName: string) => {
+  cy.ipa({
+    command: "privilege-del",
+    name: privilegeName,
+  });
+});


### PR DESCRIPTION
Followed hbac_service.feature which main page is very similar

This PR is built on top of #1134 , can be reviewed but we will have to wait for the rebase for the checks to pass 

## Summary by Sourcery

Add integration tests for privileges main page covering privilege creation, search, deletion, bulk deletion, and cancel flows.

New Features:
- Introduce a Cypress Cucumber feature spec for privileges CRUD operations on the main page.
- Add step definitions to seed and delete privileges via IPA commands for test setup and cleanup.

Tests:
- Add end-to-end scenarios for adding, searching, deleting single and multiple privileges, and cancelling privilege creation on the privileges page.