### PR TITLE
Fix search showing limited results

### DIFF
--- a/cypress/e2e/common/user_management.ts
+++ b/cypress/e2e/common/user_management.ts
@@ -1,6 +1,6 @@
 import { When, Then, Given } from "@badeball/cypress-cucumber-preprocessor";
-import { loginAsAdmin, logout } from "./authentication";
 import { entryExists, searchForEntry } from "./data_tables";
+import { IPA_PREFIX_INTERACTIVE } from "cypress/support/utils";
 
 const fillUser = (
   firstName: string,
@@ -57,13 +57,21 @@ Then("I should see user {string} in the user list", (username: string) => {
   validateUser(username);
 });
 
+export const createUserExec = (
+  login: string,
+  firstName: string,
+  lastName: string,
+  password: string
+) => {
+  // Password can't be passed, therefore we have to pipe it and use different interface
+  const ipaCmd = `${IPA_PREFIX_INTERACTIVE} user-add "${login}" --first="${firstName}" --last="${lastName}" --password`;
+  cy.exec(`echo "${password}" | ${ipaCmd}`);
+};
+
 Given(
   "User {string} {string} {string} exists and is using password {string}",
   (login: string, firstName: string, lastName: string, password: string) => {
-    loginAsAdmin();
-    createUser(firstName, lastName, password, login);
-    validateUser(login);
-    logout();
+    createUserExec(login, firstName, lastName, password);
   }
 );
 

--- a/cypress/e2e/users/preserved_users.ts
+++ b/cypress/e2e/users/preserved_users.ts
@@ -1,40 +1,5 @@
 import { Given } from "@badeball/cypress-cucumber-preprocessor";
-import { loginAsAdmin, logout } from "../common/authentication";
-import {
-  selectEntry,
-  searchForEntry,
-  entryDoesNotExist,
-  entryExists,
-  isSelected,
-} from "../common/data_tables";
-import { navigateTo } from "../common/navigation";
-import { createUser, validateUser } from "../common/user_management";
-
-const preserveUser = (username: string) => {
-  searchForEntry(username);
-  entryExists(username);
-
-  selectEntry(username);
-  isSelected(username);
-
-  cy.dataCy("active-users-button-delete").click();
-  cy.dataCy("delete-users-modal").should("exist");
-
-  cy.dataCy("modal-radio-preserve").click();
-  cy.dataCy("modal-radio-preserve").should("be.checked");
-  cy.dataCy("preserve-users-modal").should("exist");
-
-  cy.dataCy("modal-button-preserve").click();
-  cy.dataCy("preserve-users-modal").should("not.exist");
-
-  searchForEntry(username);
-  entryDoesNotExist(username);
-
-  navigateTo("preserved-users");
-
-  searchForEntry(username);
-  entryExists(username);
-};
+import { createUserExec } from "../common/user_management";
 
 Given("I delete preserved user {string}", (username: string) => {
   cy.ipa({
@@ -47,10 +12,11 @@ Given("I delete preserved user {string}", (username: string) => {
 Given(
   "Preserved user {string} {string} {string} exists and is using password {string}",
   (login: string, firstName: string, lastName: string, password: string) => {
-    loginAsAdmin();
-    createUser(firstName, lastName, password, login);
-    validateUser(login);
-    preserveUser(login);
-    logout();
+    createUserExec(login, firstName, lastName, password);
+    cy.ipa({
+      command: "user-del",
+      name: login,
+      specificOptions: "--preserve",
+    });
   }
 );

--- a/cypress/e2e/users/users.ts
+++ b/cypress/e2e/users/users.ts
@@ -1,32 +1,6 @@
 import { Given, Then } from "@badeball/cypress-cucumber-preprocessor";
-import { createUser, validateUser } from "../common/user_management";
-import { loginAsAdmin, logout } from "../common/authentication";
-import {
-  entryExists,
-  isElementDisabled,
-  isElementEnabled,
-  isSelected,
-  searchForEntry,
-  selectEntry,
-} from "../common/data_tables";
-
-const disableUser = (login: string) => {
-  searchForEntry(login);
-  entryExists(login);
-
-  selectEntry(login);
-  isSelected(login);
-
-  cy.dataCy("active-users-button-disable").click();
-  cy.dataCy("disable-users-modal").should("exist");
-
-  cy.dataCy("modal-button-disable").click();
-  cy.dataCy("disable-users-modal").should("not.exist");
-
-  searchForEntry(login);
-  entryExists(login);
-  isDisabled(login);
-};
+import { createUserExec } from "../common/user_management";
+import { isElementDisabled, isElementEnabled } from "../common/data_tables";
 
 const USER_STATUS_LABEL = "Status";
 
@@ -52,10 +26,10 @@ Then("I should see {string} user in the data table enabled", (name: string) => {
 Given(
   "Disabled user {string} {string} {string} exists and is using password {string}",
   (login: string, firstName: string, lastName: string, password: string) => {
-    loginAsAdmin();
-    createUser(firstName, lastName, password, login);
-    validateUser(login);
-    disableUser(login);
-    logout();
+    createUserExec(login, firstName, lastName, password);
+    cy.ipa({
+      command: "user-disable",
+      name: login,
+    });
   }
 );

--- a/cypress/support/utils.ts
+++ b/cypress/support/utils.ts
@@ -4,3 +4,4 @@ import { promisify } from "util";
 export const exec = promisify(cpExec);
 
 export const IPA_PREFIX = "podman exec webui ipa";
+export const IPA_PREFIX_INTERACTIVE = "podman exec -i webui ipa";

--- a/developer/deploy-ipaserver.yml
+++ b/developer/deploy-ipaserver.yml
@@ -41,6 +41,12 @@
             RewriteRule ^ index.html [QSA,L]
           </Directory>
 
+    - name: Temporary fix for CryptographyDeprecationWarning
+      ansible.builtin.replace:
+        path: /usr/lib/python3.14/site-packages/ipalib/constants.py
+        regexp: '^(\s*)b"\\x00" \* 8\), modes\.CBC\(b"\\x00" \* 8\)\):'
+        replace: '\1b"\\x00" * 24), modes.CBC(b"\\x00" * 8)):'
+
     - name: Restart web server
       ansible.builtin.systemd_service:
         name: httpd.service

--- a/doc/designs/main-pages.md
+++ b/doc/designs/main-pages.md
@@ -12,7 +12,7 @@ Each file below covers a specific, self-contained topic (~100–200 lines). Load
 |------|----------|-------|
 | [01-overview.md](main-pages/01-overview.md) | What is a main page, required & optional inputs, example prompt, what gets generated | ~85 |
 | [02-structure-and-anatomy.md](main-pages/02-structure-and-anatomy.md) | Folder structure, page anatomy (10-step pattern), required & optional imports | ~105 |
-| [03-walkthrough-init-fetch.md](main-pages/03-walkthrough-init-fetch.md) | Route setup, API version, data fetching with `useMemo` pattern, `SearchDataResultType`, search handler | ~195 |
+| [03-walkthrough-init-fetch.md](main-pages/03-walkthrough-init-fetch.md) | Route setup, API version, data fetching with `useMemo` pattern, URL-backed search | ~180 |
 | [04-walkthrough-selection-toolbar.md](main-pages/04-walkthrough-selection-toolbar.md) | Selection management, button state, modal state, data wrappers, toolbar items | ~200 |
 | [05-walkthrough-render-table-features.md](main-pages/05-walkthrough-render-table-features.md) | JSX render, `MainTable` usage, optional features (kebab menu, enable/disable, contextual help panel) | ~280 |
 | [06-checklist-and-types.md](main-pages/06-checklist-and-types.md) | Files to create/modify checklist, `SearchDataResultType`, data type definition, selectability function | ~105 |

--- a/doc/designs/main-pages/01-overview.md
+++ b/doc/designs/main-pages/01-overview.md
@@ -31,8 +31,7 @@ The RPC service file (`src/services/rpc<Entity>.ts`) **must be created manually 
 Every main page imports hooks from its RPC service file (e.g. `useGetDnsZonesFullDataQuery` from `src/services/rpcDnsZones.ts`, `useGettingHbacRulesQuery` from `src/services/rpcHBACRules.ts`). The main page component cannot function without them.
 
 To create the RPC service file, follow the template in [09-rpc-service.md](09-rpc-service.md). At minimum, you need:
-- A **query** for listing entities (paginated, using the two-step `*_find` + `*_show` pattern)
-- A **search mutation** for explicit search submissions (or use the generic `useSearchEntriesMutation` from `rpc.ts`)
+- A **query** for listing entities (paginated, using the two-step `*_find` + `*_show` pattern). Pass URL `searchValue` into this query so search and pagination share one data path.
 - An **add mutation** and a **delete mutation** for the modals
 
 Existing RPC service files to use as reference:

--- a/doc/designs/main-pages/02-structure-and-anatomy.md
+++ b/doc/designs/main-pages/02-structure-and-anatomy.md
@@ -23,13 +23,12 @@ Every main page follows the same structural pattern, in this order:
 1. **Route & title setup** (`useUpdateRoute`)
 2. **URL-synced pagination/search state** (`useListPageSearchParams`)
 3. **API version retrieval** (Redux selector)
-4. **Data fetching** (RTK Query hook for initial load)
-5. **Search mutation** (RTK Query mutation for submit-only search)
-6. **Selection management** (selected items, bulk selector logic)
-7. **Button state management** (delete, enable, disable disabled states)
-8. **Data wrappers** (prop bundles for child components)
-9. **Toolbar items array** (search, buttons, pagination, kebab, help)
-10. **JSX render** (title, toolbar, table, bottom pagination, modals)
+4. **Data fetching** (RTK Query hook; includes `searchValue` from the URL)
+5. **Selection management** (selected items, bulk selector logic)
+6. **Button state management** (delete, enable, disable disabled states)
+7. **Data wrappers** (prop bundles for child components)
+8. **Toolbar items array** (search, buttons, pagination, kebab, help)
+9. **JSX render** (title, toolbar, table, bottom pagination, modals)
 
 ## Imports
 

--- a/doc/designs/main-pages/02-structure-and-anatomy.md
+++ b/doc/designs/main-pages/02-structure-and-anatomy.md
@@ -24,7 +24,7 @@ Every main page follows the same structural pattern, in this order:
 2. **URL-synced pagination/search state** (`useListPageSearchParams`)
 3. **API version retrieval** (Redux selector)
 4. **Data fetching** (RTK Query hook for initial load)
-5. **Search mutation** (RTK Query mutation for explicit search)
+5. **Search mutation** (RTK Query mutation for submit-only search)
 6. **Selection management** (selected items, bulk selector logic)
 7. **Button state management** (delete, enable, disable disabled states)
 8. **Data wrappers** (prop bundles for child components)

--- a/doc/designs/main-pages/03-walkthrough-init-fetch.md
+++ b/doc/designs/main-pages/03-walkthrough-init-fetch.md
@@ -31,7 +31,7 @@ The `pathname` must be registered in `AppRoutes.tsx` and `NavRoutes.ts`.
   const lastIdx = page * perPage;
 
   const dataResponse = useGettingMyEntitiesQuery({
-    searchValue: "",
+    searchValue: searchValue,
     sizeLimit: 0,
     apiVersion: apiVersion || API_VERSION_BACKUP,
     startIdx: firstIdx,
@@ -40,6 +40,11 @@ The `pathname` must be registered in `AppRoutes.tsx` and `NavRoutes.ts`.
 
   const { data: batchResponse, isLoading, isFetching, error } = dataResponse;
 ```
+
+> **Important:** Always pass `searchValue` (not `""`) to the query hook. RTK Query
+> auto-refetches whenever its parameters change (`searchValue`, `startIdx`, `stopIdx`),
+> so both pagination and filtering are handled automatically. Using a hardcoded `""`
+> causes a race condition where the unfiltered query response overwrites search results.
 
 ## Step 4: Derive State with useMemo (Recommended)
 
@@ -64,10 +69,14 @@ Use it to type the search data state:
 
   // Derive elementsList and totalCount
   const { elementsList, totalCount } = useMemo(() => {
+    // Search results are fetched with stopIdx: 100 (all matches at once),
+    // so paginate them client-side using page/perPage.
     if (isSearchActive && searchData) {
+      const start = (page - 1) * perPage;
+      const end = start + perPage;
       return {
-        elementsList: searchData.elementsList,
-        totalCount: searchData.totalCount,
+        elementsList: searchData.elementsList.slice(start, end),
+        totalCount: searchData.elementsList.length,
       };
     }
 
@@ -81,7 +90,7 @@ Use it to type the search data state:
     }
 
     return { elementsList: [], totalCount: 0 };
-  }, [batchResponse, isSearchActive, searchData]);
+  }, [batchResponse, isSearchActive, searchData, page, perPage]);
 
   // Derive showTableRows from loading states
   const showTableRows = useMemo(() => {
@@ -124,13 +133,29 @@ This pattern avoids eslint warnings about calling `setState` in `useEffect`.
 > **Note:** No manual `useEffect` for pagination is needed. RTK Query automatically
 > re-fetches when `startIdx`/`stopIdx` change (derived from `page`/`perPage`).
 
-## Step 7: Search Handler
+## Step 7: Search Value Update Handler
+
+The search input fires `updateSearchValue` on every keystroke. It must reset pagination
+to page 1 so the user always sees results from the first page:
+
+```tsx
+  const updateSearchValue = (value: string) => {
+    setPage(1);
+    setSearchValue(value);
+  };
+```
+
+## Step 8: Search Submit Handler
+
+The search input fires `submitSearchValue` when the user presses Enter or clicks the
+search button. This uses a mutation to fetch results independently of the query hook.
 
 ```tsx
   const [searchEntities, searchResult] = useSearchMyEntitiesEntriesMutation({});
   const [searchDisabled, setSearchIsDisabled] = useState(false);
 
   const submitSearchValue = () => {
+    setPage(1);
     setSearchIsDisabled(true);
     setIsSearchActive(true);
 
@@ -138,8 +163,8 @@ This pattern avoids eslint warnings about calling `setState` in `useEffect`.
       searchValue,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: firstIdx,
-      stopIdx: lastIdx,
+      startIdx: 0,
+      stopIdx: 100,
     }).then((result) => {
       if ("data" in result) {
         const searchError = result.data?.error;
@@ -169,6 +194,11 @@ This pattern avoids eslint warnings about calling `setState` in `useEffect`.
     });
   };
 ```
+
+> **Important — `stopIdx: 100`:** Use a fixed upper bound (100) instead of `perPage`.
+> The LDAP backend has a size limit close to this value, and using `perPage` (e.g. 10)
+> would miss entries beyond the first page of results when searching from a page other
+> than page 1.
 
 ## Legacy Pattern (Avoid)
 

--- a/doc/designs/main-pages/03-walkthrough-init-fetch.md
+++ b/doc/designs/main-pages/03-walkthrough-init-fetch.md
@@ -135,8 +135,13 @@ This pattern avoids eslint warnings about calling `setState` in `useEffect`.
 
 ## Step 7: Search Value Update Handler
 
-The search input fires `updateSearchValue` on every keystroke. It must reset pagination
-to page 1 so the user always sees results from the first page:
+`SearchInputLayout` buffers keystrokes locally — it does **not** call `updateSearchValue`
+on every keystroke. Instead, it calls `updateSearchValue(value)` and
+`submitSearchValue(value)` only when the user presses Enter or clicks the search button.
+This avoids firing an API request on every keystroke.
+
+`updateSearchValue` resets pagination to page 1 and updates the committed search value
+(which drives the RTK Query parameter and URL sync):
 
 ```tsx
   const updateSearchValue = (value: string) => {
@@ -145,22 +150,29 @@ to page 1 so the user always sees results from the first page:
   };
 ```
 
+> **Do not** add search-as-you-type behavior by calling `setSearchValue` inside
+> `SearchInputLayout`'s `onChange`. The component deliberately buffers input locally
+> and only propagates on submit or clear.
+
 ## Step 8: Search Submit Handler
 
-The search input fires `submitSearchValue` when the user presses Enter or clicks the
-search button. This uses a mutation to fetch results independently of the query hook.
+`submitSearchValue` is called by `SearchInputLayout` when the user presses Enter or
+clicks the search button. It receives the **current input value** as an argument to
+avoid stale closures (since `updateSearchValue` and `submitSearchValue` are called in
+the same event handler, the React state from `updateSearchValue` has not yet committed).
 
 ```tsx
   const [searchEntities, searchResult] = useSearchMyEntitiesEntriesMutation({});
   const [searchDisabled, setSearchIsDisabled] = useState(false);
 
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     setSearchIsDisabled(true);
     setIsSearchActive(true);
 
     searchEntities({
-      searchValue,
+      searchValue: search,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
       startIdx: 0,
@@ -194,6 +206,12 @@ search button. This uses a mutation to fetch results independently of the query 
     });
   };
 ```
+
+> **Important — `value` parameter:** Always use the `value` argument (falling back to
+> `searchValue` with `??`) instead of reading `searchValue` directly from the closure.
+> Both `updateSearchValue` and `submitSearchValue` are called in the same React event
+> handler, so the state set by `updateSearchValue` is not yet available when
+> `submitSearchValue` runs.
 
 > **Important — `stopIdx: 100`:** Use a fixed upper bound (100) instead of `perPage`.
 > The LDAP backend has a size limit close to this value, and using `perPage` (e.g. 10)

--- a/doc/designs/main-pages/03-walkthrough-init-fetch.md
+++ b/doc/designs/main-pages/03-walkthrough-init-fetch.md
@@ -20,9 +20,13 @@ The `pathname` must be registered in `AppRoutes.tsx` and `NavRoutes.ts`.
     (state) => state.global.environment.api_version
   ) as string;
 
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
-    useListPageSearchParams();
+  // page (`p`), perPage (`size`), and searchValue (`search`) are derived from the URL
+  const { page, perPage, searchValue } = useListPageSearchParams();
 ```
+
+`SearchInputLayout` and `PaginationLayout` update those URL params themselves. Pages
+normally only **read** `page` / `perPage` / `searchValue` for the query; they do not
+need local search submit handlers or pagination prop bundles for the list case.
 
 ## Step 3: Data Fetching Query
 
@@ -50,53 +54,27 @@ The `pathname` must be registered in `AppRoutes.tsx` and `NavRoutes.ts`.
 
 Use `useMemo` to derive `elementsList` and `totalCount` from the query response — **do not** use `useEffect` + `useState` to sync state.
 
-The `SearchDataResultType<T>` generic type (from `src/utils/datatypes/globalDataTypes.ts`) standardizes the search state structure:
-
 ```tsx
-export interface SearchDataResultType<T> {
-  elementsList: T[];
-  totalCount: number;
-}
-```
-
-Use it to type the search data state:
-
-```tsx
-  // Search state (for mutation-based search)
-  const [isSearchActive, setIsSearchActive] = useState(false);
-  const [searchData, setSearchData] =
-    useState<SearchDataResultType<MyEntity> | null>(null);
-
-  // Derive elementsList and totalCount
   const { elementsList, totalCount } = useMemo(() => {
-    // Search results are fetched with stopIdx: 100 (all matches at once),
-    // so paginate them client-side using page/perPage.
-    if (isSearchActive && searchData) {
-      const start = (page - 1) * perPage;
-      const end = start + perPage;
-      return {
-        elementsList: searchData.elementsList.slice(start, end),
-        totalCount: searchData.elementsList.length,
-      };
-    }
-
     if (batchResponse?.result) {
       const results = batchResponse.result.results;
       const entities: MyEntity[] = [];
       for (let i = 0; i < batchResponse.result.count; i++) {
         entities.push(results[i].result);
       }
-      return { elementsList: entities, totalCount: batchResponse.result.totalCount };
+      return {
+        elementsList: entities,
+        totalCount: batchResponse.result.totalCount,
+      };
     }
 
     return { elementsList: [], totalCount: 0 };
-  }, [batchResponse, isSearchActive, searchData, page, perPage]);
+  }, [batchResponse]);
 
   // Derive showTableRows from loading states
   const showTableRows = useMemo(() => {
-    if (isSearchActive) return !searchResult.isLoading;
     return !isFetching && !isLoading;
-  }, [isFetching, isLoading, isSearchActive, searchResult.isLoading]);
+  }, [isFetching, isLoading]);
 ```
 
 This pattern avoids eslint warnings about calling `setState` in `useEffect`.
@@ -123,100 +101,54 @@ This pattern avoids eslint warnings about calling `setState` in `useEffect`.
 
 ```tsx
   const refreshData = () => {
-    setIsSearchActive(false);
-    setSearchData(null);
     clearSelectedEntities();
     dataResponse.refetch();
   };
 ```
 
-> **Note:** No manual `useEffect` for pagination is needed. RTK Query automatically
-> re-fetches when `startIdx`/`stopIdx` change (derived from `page`/`perPage`).
+> **Note:** No manual `useEffect` for pagination or search is needed. RTK Query
+> automatically re-fetches when `startIdx`/`stopIdx`/`searchValue` change (derived
+> from URL params via `useListPageSearchParams`).
 
-## Step 7: Search Value Update Handler
+## Step 7: Search Behaviour (`SearchInputLayout`)
 
-`SearchInputLayout` buffers keystrokes locally — it does **not** call `updateSearchValue`
-on every keystroke. Instead, it calls `updateSearchValue(value)` and
-`submitSearchValue(value)` only when the user presses Enter or clicks the search button.
-This avoids firing an API request on every keystroke.
+`SearchInputLayout` buffers keystrokes locally. It commits a search only when the
+user presses Enter, clicks the search button, or clears the input — not on every
+keystroke.
 
-`updateSearchValue` resets pagination to page 1 and updates the committed search value
-(which drives the RTK Query parameter and URL sync):
+For list pages, omit `searchValueData`. The layout then:
 
-```tsx
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-```
-
-> **Do not** add search-as-you-type behavior by calling `setSearchValue` inside
-> `SearchInputLayout`'s `onChange`. The component deliberately buffers input locally
-> and only propagates on submit or clear.
-
-## Step 8: Search Submit Handler
-
-`submitSearchValue` is called by `SearchInputLayout` when the user presses Enter or
-clicks the search button. It receives the **current input value** as an argument to
-avoid stale closures (since `updateSearchValue` and `submitSearchValue` are called in
-the same event handler, the React state from `updateSearchValue` has not yet committed).
+1. Reads the committed value from the URL `search` param
+2. Writes the new value to `search` on submit/clear
+3. Deletes `p` so results start on page 1
 
 ```tsx
-  const [searchEntities, searchResult] = useSearchMyEntitiesEntriesMutation({});
-  const [searchDisabled, setSearchIsDisabled] = useState(false);
-
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    setSearchIsDisabled(true);
-    setIsSearchActive(true);
-
-    searchEntities({
-      searchValue: search,
-      sizeLimit: 0,
-      apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: 0,
-      stopIdx: 100,
-    }).then((result) => {
-      if ("data" in result) {
-        const searchError = result.data?.error;
-
-        if (searchError) {
-          dispatch(addAlert({
-            name: "submit-search-value-error",
-            title: searchError.message || "Error when searching",
-            variant: "danger",
-          }));
-          setIsSearchActive(false);
-          setSearchData(null);
-        } else {
-          const results = result.data?.result.results || [];
-          const searchTotalCount = result.data?.result.totalCount || 0;
-          const entities: MyEntity[] = [];
-          for (let i = 0; i < results.length; i++) {
-            entities.push(results[i].result);
-          }
-          setSearchData({
-            elementsList: entities,
-            totalCount: searchTotalCount,
-          });
-        }
-        setSearchIsDisabled(false);
-      }
-    });
-  };
+  <SearchInputLayout
+    dataCy="search"
+    name="search"
+    ariaLabel="Search my entities"
+    placeholder="Search"
+  />
 ```
 
-> **Important — `value` parameter:** Always use the `value` argument (falling back to
-> `searchValue` with `??`) instead of reading `searchValue` directly from the closure.
-> Both `updateSearchValue` and `submitSearchValue` are called in the same React event
-> handler, so the state set by `updateSearchValue` is not yet available when
-> `submitSearchValue` runs.
+Non-list UIs that need local search state (for example `DualListLayout`) can pass an
+optional override:
 
-> **Important — `stopIdx: 100`:** Use a fixed upper bound (100) instead of `perPage`.
-> The LDAP backend has a size limit close to this value, and using `perPage` (e.g. 10)
-> would miss entries beyond the first page of results when searching from a page other
-> than page 1.
+```tsx
+  <SearchInputLayout
+    dataCy="search"
+    searchValueData={{
+      searchValue,
+      onSubmit: (value) => {
+        /* update local state / run a custom search */
+      },
+    }}
+  />
+```
+
+> **Do not** add search-as-you-type behaviour by writing the URL (or parent state) on
+> every `onChange`. The component deliberately buffers input locally and only
+> propagates on submit or clear.
 
 ## Legacy Pattern (Avoid)
 

--- a/doc/designs/main-pages/03-walkthrough-init-fetch.md
+++ b/doc/designs/main-pages/03-walkthrough-init-fetch.md
@@ -70,14 +70,11 @@ Use `useMemo` to derive `elementsList` and `totalCount` from the query response 
 
     return { elementsList: [], totalCount: 0 };
   }, [batchResponse]);
-
-  // Derive showTableRows from loading states
-  const showTableRows = useMemo(() => {
-    return !isFetching && !isLoading;
-  }, [isFetching, isLoading]);
 ```
 
 This pattern avoids eslint warnings about calling `setState` in `useEffect`.
+
+> **Table visibility:** Pass `showTableRows={!isFetching}` (or `!isBatchFetching`) to the table and use `isFetching` / `isBatchFetching` directly to disable toolbar buttons. Do not keep a separate `showTableRows` local variable or sync it with `useEffect`/`useState`.
 
 ## Step 5: Error Handling
 
@@ -160,9 +157,8 @@ useEffect(() => {
   if (dataResponse.isSuccess && batchResponse) {
     setEntitiesList(/* ... */);  // Warning!
     setTotalCount(/* ... */);    // Warning!
-    setShowTableRows(true);      // Warning!
   }
 }, [dataResponse]);
 ```
 
-Use the `useMemo` pattern from Step 4 instead.
+Use the `useMemo` pattern from Step 4 instead. Drive table visibility from `isFetching` / `isBatchFetching` directly.

--- a/doc/designs/main-pages/04-walkthrough-selection-toolbar.md
+++ b/doc/designs/main-pages/04-walkthrough-selection-toolbar.md
@@ -98,12 +98,7 @@ are URL-backed via `SearchInputLayout` / `PaginationLayout`, so you do **not** n
 `searchValueData` or `paginationData` wrappers for the main list.
 
 ```tsx
-  const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
-
-  // Reset selected-per-page count when page or page size changes
-  React.useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
+  import { getSelectedPerPageData, ipaPrimaryKey } from "src/utils/selectedPerPage";
 
   const bulkSelectorData = {
     selected: selectedEntities,
@@ -112,10 +107,12 @@ are URL-backed via `SearchInputLayout` / `PaginationLayout`, so you do **not** n
     nameAttr: "pk",  // The primary key field name (e.g. "uid", "cn", "fqdn")
   };
 
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage: setSelectedPerPage,
-  };
+  // Derive how many of the current page rows are selected (do not keep a manual counter)
+  const selectedPerPageData = getSelectedPerPageData(
+    entitiesList,
+    selectedEntities.map((e) => ipaPrimaryKey(e.pk)),
+    (e) => ipaPrimaryKey(e.pk)
+  );
 ```
 
 ### 14. Toolbar Items

--- a/doc/designs/main-pages/04-walkthrough-selection-toolbar.md
+++ b/doc/designs/main-pages/04-walkthrough-selection-toolbar.md
@@ -110,7 +110,7 @@ These objects group related props for child components:
 
   const searchValueData = {
     searchValue,
-    updateSearchValue: setSearchValue,
+    updateSearchValue,
     submitSearchValue,
   };
 

--- a/doc/designs/main-pages/04-walkthrough-selection-toolbar.md
+++ b/doc/designs/main-pages/04-walkthrough-selection-toolbar.md
@@ -3,17 +3,12 @@
 > **Part of:** [Main Pages guide](../main-pages.md)
 > **See also:** [Steps 1–8: Init & Fetching](03-walkthrough-init-fetch.md) | [Step 15: Render, Table & Features](05-walkthrough-render-table-features.md)
 
-### 9. Show Table Rows
+### 9. Table Visibility (Fetching State)
 
-```tsx
-  const [showTableRows, setShowTableRows] = useState(!isBatchLoading);
+Use RTK Query `isFetching` or `isBatchFetching` directly. Do not introduce a local `showTableRows` alias.
 
-  useEffect(() => {
-    if (showTableRows !== !isBatchLoading) {
-      setShowTableRows(!isBatchLoading);
-    }
-  }, [isBatchLoading]);
-```
+- Toolbar buttons: `isDisabled={isBatchFetching}` (or `isFetching`)
+- Table prop: `showTableRows={!isBatchFetching}` (or `!isFetching`)
 
 ### 10. Selection Management
 
@@ -170,7 +165,7 @@ The toolbar is built as an array of `ToolbarItem` objects. The standard order is
         <SecondaryButton
           dataCy="my-entities-button-refresh"
           onClickHandler={refreshData}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
         >
           Refresh
         </SecondaryButton>
@@ -181,7 +176,7 @@ The toolbar is built as an array of `ToolbarItem` objects. The standard order is
       element: (
         <SecondaryButton
           dataCy="my-entities-button-delete"
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || isBatchFetching}
           onClickHandler={() => setShowDeleteModal(true)}
         >
           Delete
@@ -194,7 +189,7 @@ The toolbar is built as an array of `ToolbarItem` objects. The standard order is
         <SecondaryButton
           dataCy="my-entities-button-add"
           onClickHandler={() => setShowAddModal(true)}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
         >
           Add
         </SecondaryButton>

--- a/doc/designs/main-pages/04-walkthrough-selection-toolbar.md
+++ b/doc/designs/main-pages/04-walkthrough-selection-toolbar.md
@@ -93,26 +93,17 @@ Pages with enable/disable also need:
 
 ### 13. Data Wrappers (Prop Bundles)
 
-These objects group related props for child components:
+These objects group related props for child components. List search and pagination
+are URL-backed via `SearchInputLayout` / `PaginationLayout`, so you do **not** need
+`searchValueData` or `paginationData` wrappers for the main list.
 
 ```tsx
   const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
 
-  const paginationData = {
-    page,
-    perPage,
-    updatePage: setPage,
-    updatePerPage: setPerPage,
-    updateSelectedPerPage: setSelectedPerPage,
-    updateShownElementsList: setEntitiesList,
-    totalCount,
-  };
-
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
-  };
+  // Reset selected-per-page count when page or page size changes
+  React.useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
 
   const bulkSelectorData = {
     selected: selectedEntities,
@@ -167,8 +158,6 @@ The toolbar is built as an array of `ToolbarItem` objects. The standard order is
           name="search"
           ariaLabel="Search my entities"
           placeholder="Search"
-          searchValueData={searchValueData}
-          isDisabled={searchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,
@@ -229,7 +218,7 @@ The toolbar is built as an array of `ToolbarItem` objects. The standard order is
       element: (
         <PaginationLayout
           list={entitiesList}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -238,3 +227,7 @@ The toolbar is built as an array of `ToolbarItem` objects. The standard order is
     },
   ];
 ```
+
+`PaginationLayout` reads/writes URL `p` and `size` when `paginationData` is omitted.
+Pass `totalCount` as a top-level prop. Use the optional `paginationData` override only
+for non-list UIs (for example `SettingsTableLayout`) that keep local page state.

--- a/doc/designs/main-pages/05-walkthrough-render-table-features.md
+++ b/doc/designs/main-pages/05-walkthrough-render-table-features.md
@@ -85,7 +85,7 @@ New pages **must** use the `MainTable` component (`src/components/tables/MainTab
   columnNames={["Name", "Description"]}    // Column header labels
   hasCheckboxes={true}
   pathname="my-entities"                   // Route segment (no leading '/')
-  showTableRows={showTableRows}
+  showTableRows={!isBatchFetching}
   showLink={false}                         // Default to false for new pages (no settings page yet)
   elementsData={{
     isElementSelectable: isMyEntitySelectable,
@@ -138,8 +138,8 @@ For extra actions like "Rebuild auto membership". Used by ActiveUsers and Hosts.
         onKebabToggle={() => setKebabIsOpen(!kebabIsOpen)}
         idKebab="main-dropdown-kebab"
         isKebabOpen={kebabIsOpen}
-        dropdownItems={showTableRows ? dropdownItems : []}
-        isDisabled={!showTableRows}
+        dropdownItems={isBatchFetching ? [] : dropdownItems}
+        isDisabled={isBatchFetching}
       />
     ),
   },
@@ -156,7 +156,7 @@ For entities that support toggling status (Active Users, HBAC Rules, DNS Zones).
     element: (
       <SecondaryButton
         dataCy="my-entities-button-disable"
-        isDisabled={isDisableButtonDisabled || !showTableRows}
+        isDisabled={isDisableButtonDisabled || isBatchFetching}
         onClickHandler={() => onEnableDisableHandler(true)}
       >
         Disable
@@ -168,7 +168,7 @@ For entities that support toggling status (Active Users, HBAC Rules, DNS Zones).
     element: (
       <SecondaryButton
         dataCy="my-entities-button-enable"
-        isDisabled={isEnableButtonDisabled || !showTableRows}
+        isDisabled={isEnableButtonDisabled || isBatchFetching}
         onClickHandler={() => onEnableDisableHandler(false)}
       >
         Enable

--- a/doc/designs/main-pages/05-walkthrough-render-table-features.md
+++ b/doc/designs/main-pages/05-walkthrough-render-table-features.md
@@ -34,7 +34,7 @@
           <FlexItem style={{ flex: "0 0 auto", position: "sticky", bottom: 0 }}>
             <PaginationLayout
               list={entitiesList}
-              paginationData={paginationData}
+              totalCount={totalCount}
               variant={PaginationVariant.bottom}
               widgetId="pagination-options-menu-bottom"
             />

--- a/doc/designs/main-pages/05-walkthrough-render-table-features.md
+++ b/doc/designs/main-pages/05-walkthrough-render-table-features.md
@@ -103,10 +103,7 @@ New pages **must** use the `MainTable` component (`src/components/tables/MainTab
     updateIsDisableButtonDisabled: setIsDisableButtonDisabled,
     isDisableEnableOp: true,
   }}
-  paginationData={{
-    selectedPerPage,
-    updateSelectedPerPage: setSelectedPerPage,
-  }}
+  paginationData={selectedPerPageData}
   statusElementName="myStatusField"  // Optional: field name that determines row disabled styling
 />
 ```

--- a/doc/designs/main-pages/06-checklist-and-types.md
+++ b/doc/designs/main-pages/06-checklist-and-types.md
@@ -39,7 +39,10 @@ Add the entity interface to `src/utils/datatypes/globalDataTypes.ts`.
 
 ### SearchDataResultType (Generic)
 
-The `SearchDataResultType<T>` generic interface is used to standardize search state across main pages. It provides a consistent structure for storing search results:
+`SearchDataResultType<T>` still exists in `globalDataTypes.ts` for typing
+`{ elementsList, totalCount }` pairs, but **new main pages should not keep a
+separate mutation-based search state**. Prefer deriving both values from the list
+query response with `useMemo` (see [Walkthrough: Init & Data Fetching](03-walkthrough-init-fetch.md)).
 
 ```tsx
 export interface SearchDataResultType<T> {
@@ -47,17 +50,6 @@ export interface SearchDataResultType<T> {
   totalCount: number;
 }
 ```
-
-**Usage in main page components:**
-
-```tsx
-import { MyEntity, SearchDataResultType } from "src/utils/datatypes/globalDataTypes";
-
-const [searchData, setSearchData] =
-  useState<SearchDataResultType<MyEntity> | null>(null);
-```
-
-This type is used in conjunction with the `useMemo` pattern for deriving `elementsList` and `totalCount` from either the query response or search results. See [Walkthrough: Init & Data Fetching](03-walkthrough-init-fetch.md) for the full pattern.
 
 ### Entity Interface
 

--- a/doc/designs/main-pages/09-rpc-service.md
+++ b/doc/designs/main-pages/09-rpc-service.md
@@ -16,7 +16,7 @@ Create `src/services/rpcMyEntities.ts` with RTK Query endpoints. This file defin
 - Shared helper functions (`getCommand`, `getBatchCommand`)
 
 **Do NOT modify `rpc.ts`** when adding a new entity. Specifically:
-- Do NOT add new `entryType` values to `GenericPayload` or `useSearchEntriesMutation` — define a dedicated search mutation in the entity's `rpc<Entity>.ts` file instead
+- Do NOT add new `entryType` values to `GenericPayload` for entity list/search — put entity-specific list queries in `rpc<Entity>.ts` instead
 - Only add a cache tag to `tagTypes` if the entity-specific service file uses `providesTags` / `invalidatesTags`
 
 Entity-specific queries, mutations, and hooks are defined using `api.injectEndpoints()` in the entity's own file (e.g. `rpcRoles.ts`, `rpcTrusts.ts`, `rpcSelinuxUserMaps.ts`).
@@ -24,8 +24,10 @@ Entity-specific queries, mutations, and hooks are defined using `api.injectEndpo
 ## Minimum Endpoints for a Main Page
 
 A main page needs at least:
-1. A **query** for initial data loading — can use the generic `useGettingGenericQuery` wrapper from the entity's service file
-2. A **search mutation** for explicit search submissions — must be defined in `rpc<Entity>.ts` using the two-step find+show pattern
+1. A **query** for listing entities — paginated, and driven by URL `searchValue` / page indexes from `useListPageSearchParams`. Can use the generic `useGettingGenericQuery` wrapper from the entity's service file.
+2. **Add** and **delete** mutations for the modals
+
+A separate search mutation is **not** required for new main pages. `SearchInputLayout` commits the search string to the URL, and the list query refetches when `searchValue` changes.
 
 ## Template
 
@@ -111,16 +113,6 @@ const extendedApi = api.injectEndpoints({
         }
 
         return { data: response };
-      },
-    }),
-
-    /**
-     * Search entities (mutation variant for explicit search submit)
-     */
-    searchMyEntitiesEntries: build.mutation<BatchRPCResponse, MyEntitiesFullDataPayload>({
-      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
-        // Same two-step pattern as the query above
-        // ...
       },
     }),
 
@@ -215,8 +207,9 @@ Individual command docs: `https://freeipa.readthedocs.io/en/latest/api/<entity>_
 
 | Entity | Service file | Key hooks |
 |--------|-------------|-----------|
-| Roles | `src/services/rpcRoles.ts` | `useGettingRolesQuery`, `useSearchRolesEntriesMutation`, `useAddRoleMutation`, `useDeleteRolesMutation` |
-| Trusts | `src/services/rpcTrusts.ts` | `useGetTrustsFullDataQuery`, `useSearchTrustsEntriesMutation`, `useAddTrustMutation` |
-| DNS Zones | `src/services/rpcDnsZones.ts` | `useGetDnsZonesFullDataQuery`, `useSearchDnsZonesEntriesMutation` |
+| Privileges | `src/services/rpcPrivileges.ts` | `useGetPrivilegesFullDataQuery`, `useAddPrivilegeMutation`, `useRemovePrivilegesMutation` |
+| Roles | `src/services/rpcRoles.ts` | `useGettingRolesQuery`, `useAddRoleMutation`, `useDeleteRolesMutation` |
+| Trusts | `src/services/rpcTrusts.ts` | `useGetTrustsFullDataQuery`, `useAddTrustMutation` |
+| DNS Zones | `src/services/rpcDnsZones.ts` | `useGetDnsZonesFullDataQuery` |
 | Hosts | `src/services/rpcHosts.ts` | `useGettingHostQuery`, `useAutoMemberRebuildHostsMutation` |
 | HBAC Rules | `src/services/rpcHBACRules.ts` | `useGettingHbacRulesQuery` |

--- a/doc/designs/sub-pages/04a-settings-kebab-modals.md
+++ b/doc/designs/sub-pages/04a-settings-kebab-modals.md
@@ -26,7 +26,6 @@ interface EnableDisable<Entity>ModalProps {
   elementsList: string[];
   setElementsList?: (elementsList: <Entity>[]) => void;  // Optional for settings
   operation: "enable" | "disable";
-  setShowTableRows?: (value: boolean) => void;           // Optional for settings
   onRefresh: () => void;
   from?: "main-page" | "settings-page";                  // Context
 }

--- a/doc/designs/sub-pages/05-table-tab.md
+++ b/doc/designs/sub-pages/05-table-tab.md
@@ -79,18 +79,18 @@ const [showDeleteModal, setShowDeleteModal] = React.useState(false);
 
 ## Pagination and Search
 
-Use the `useListPageSearchParams` hook to manage pagination and search state in the URL:
+Use the `useListPageSearchParams` hook to **read** pagination and search state from the URL.
+`SearchInputLayout` and `PaginationLayout` write those params for you on list pages:
 
 ```tsx
-const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
-  useListPageSearchParams();
+const { page, perPage, searchValue } = useListPageSearchParams();
 
 // Calculate API query range
 const startIdx = (page - 1) * perPage;
 const stopIdx = startIdx + perPage;
 ```
 
-This keeps pagination state in the URL, so users can bookmark or share specific pages.
+This keeps pagination and search in the URL, so users can bookmark or share specific views.
 
 ## API Integration
 
@@ -140,14 +140,14 @@ Build the toolbar with all the action buttons:
 ```tsx
 const toolbarItems: ToolbarItem[] = [
   { key: 0, element: <BulkSelectorPrep bulkSelectorData={bulkSelectorData} /> },
-  { key: 1, element: <SearchInputLayout searchValueData={searchValueData} />, toolbarItemVariant: ToolbarItemVariant.label },
+  { key: 1, element: <SearchInputLayout dataCy="search" name="search" ariaLabel="Search" placeholder="Search" />, toolbarItemVariant: ToolbarItemVariant.label },
   { key: 2, toolbarItemVariant: ToolbarItemVariant.separator },
   { key: 3, element: <SecondaryButton onClickHandler={refreshData}>Refresh</SecondaryButton> },
   { key: 4, element: <SecondaryButton isDisabled={isDeleteButtonDisabled} onClickHandler={() => setShowDeleteModal(true)}>Delete</SecondaryButton> },
   { key: 5, element: <SecondaryButton onClickHandler={() => setShowAddModal(true)}>Add</SecondaryButton> },
   { key: 6, toolbarItemVariant: ToolbarItemVariant.separator },
   { key: 7, element: <HelpTextWithIconLayout textContent="Help" /> },
-  { key: 8, element: <PaginationLayout paginationData={paginationData} />, toolbarItemAlignment: { default: "alignEnd" } },
+  { key: 8, element: <PaginationLayout list={<childEntities>} totalCount={totalCount} />, toolbarItemAlignment: { default: "alignEnd" } },
 ];
 ```
 
@@ -181,7 +181,7 @@ return (
           </OuterScrollContainer>
         </FlexItem>
         <FlexItem style={{ position: "sticky", bottom: 0 }}>
-          <PaginationLayout list={<childEntities>} paginationData={paginationData} variant={PaginationVariant.bottom} />
+          <PaginationLayout list={<childEntities>} totalCount={totalCount} variant={PaginationVariant.bottom} />
         </FlexItem>
       </Flex>
     </PageSection>

--- a/doc/designs/sub-pages/05-table-tab.md
+++ b/doc/designs/sub-pages/05-table-tab.md
@@ -172,7 +172,7 @@ return (
                 columnNames={["Column 1", "Column 2", ...]}
                 hasCheckboxes={true}
                 pathname="<child-pathname>"
-                showTableRows={!isLoading}
+                showTableRows={!isFetching}
                 showLink={false}
                 elementsData={{...}}
                 buttonsData={{...}}

--- a/doc/designs/sub-pages/06a-membership-custom.md
+++ b/doc/designs/sub-pages/06a-membership-custom.md
@@ -135,6 +135,54 @@ return (
 - Modals should be **outside** `TabLayout` to avoid z-index issues
 - Inner `Tab` title can include a `Badge` showing member count
 
+## Search Behavior in Membership Tabs
+
+`SearchInputLayout` buffers keystrokes locally — the `searchValue` state is only updated
+when the user presses Enter, clicks the search button, or clears the input. This avoids
+unnecessary re-renders and API calls on every keystroke.
+
+### Wiring the MemberOfToolbar
+
+```tsx
+<MemberOfToolbar
+  searchText={searchValue}
+  onSearchTextChange={setSearchValue}
+  onSearch={() => {}}
+  searchPlaceholder="Search members"
+  searchAriaLabel="Search members"
+  // ... other props
+/>
+```
+
+- **`onSearchTextChange`** is called by `SearchInputLayout` only on submit or clear
+  (not on every keystroke). It updates `searchValue` which drives the client-side filter.
+- **`onSearch`** can remain `() => {}` — membership tabs use client-side filtering
+  via `searchValue`, so no mutation-based search is needed.
+
+### Client-Side Filtering Pattern
+
+Use `searchValue` to filter the membership list. Since `searchValue` only changes on
+submit, the filter is applied only when the user explicitly searches:
+
+```tsx
+const filteredMembers = React.useMemo(() => {
+  let toLoad = [...memberList].sort();
+  if (searchValue) {
+    const q = searchValue.toLowerCase();
+    toLoad = toLoad.filter((name) => name.toLowerCase().includes(q));
+  }
+  return toLoad;
+}, [memberList, searchValue]);
+
+const namesToLoad = React.useMemo(
+  () => paginate(filteredMembers, page, perPage),
+  [filteredMembers, page, perPage]
+);
+```
+
+> **Do not** wire `onSearchTextChange` to trigger API calls or heavy computations.
+> It is called once per search submit, not per keystroke.
+
 ## Handling API Array Responses
 
 The IPA API often returns single values as arrays:

--- a/doc/designs/sub-pages/06a-membership-custom.md
+++ b/doc/designs/sub-pages/06a-membership-custom.md
@@ -137,32 +137,42 @@ return (
 
 ## Search Behavior in Membership Tabs
 
-`SearchInputLayout` buffers keystrokes locally — the `searchValue` state is only updated
-when the user presses Enter, clicks the search button, or clears the input. This avoids
-unnecessary re-renders and API calls on every keystroke.
+`SearchInputLayout` (rendered inside `MemberOfToolbar`) buffers keystrokes locally and
+commits the value to the URL `search` param on Enter, search button, or clear.
+Membership tabs read that value via `useListPageSearchParams()` and filter client-side.
 
 ### Wiring the MemberOfToolbar
 
 ```tsx
+const { page, perPage, searchValue, membershipDirection, setMembershipDirection } =
+  useListPageSearchParams();
+
 <MemberOfToolbar
-  searchText={searchValue}
-  onSearchTextChange={setSearchValue}
-  onSearch={() => {}}
   searchPlaceholder="Search members"
   searchAriaLabel="Search members"
-  // ... other props
+  refreshButtonEnabled={isRefreshButtonEnabled}
+  onRefreshButtonClick={props.onRefresh}
+  deleteButtonEnabled={selected.length > 0}
+  onDeleteButtonClick={() => setShowDeleteModal(true)}
+  addButtonEnabled={isAddButtonEnabled}
+  onAddButtonClick={() => setShowAddModal(true)}
+  membershipDirectionEnabled={true}
+  membershipDirection={membershipDirection}
+  onMembershipDirectionChange={setMembershipDirection}
+  helpIconEnabled={true}
+  onHelpIconClick={() => dispatch(toggleHelpPanel())}
+  totalItems={filteredMembers.length}
 />
 ```
 
-- **`onSearchTextChange`** is called by `SearchInputLayout` only on submit or clear
-  (not on every keystroke). It updates `searchValue` which drives the client-side filter.
-- **`onSearch`** can remain `() => {}` — membership tabs use client-side filtering
-  via `searchValue`, so no mutation-based search is needed.
+`MemberOfToolbar` does not take search text props — search and pagination are
+URL-backed by `SearchInputLayout` / `PaginationLayout` inside the toolbar.
 
 ### Client-Side Filtering Pattern
 
-Use `searchValue` to filter the membership list. Since `searchValue` only changes on
-submit, the filter is applied only when the user explicitly searches:
+Use `searchValue` from `useListPageSearchParams` to filter the membership list.
+Since the URL `search` param only changes on submit, the filter is applied only when
+the user explicitly searches:
 
 ```tsx
 const filteredMembers = React.useMemo(() => {
@@ -179,9 +189,6 @@ const namesToLoad = React.useMemo(
   [filteredMembers, page, perPage]
 );
 ```
-
-> **Do not** wire `onSearchTextChange` to trigger API calls or heavy computations.
-> It is called once per search submit, not per keystroke.
 
 ## Handling API Array Responses
 

--- a/doc/designs/sub-pages/06c-membership-creating-new.md
+++ b/doc/designs/sub-pages/06c-membership-creating-new.md
@@ -183,7 +183,7 @@ After gathering information, the component MUST include:
 
 | Required Feature | Description |
 |------------------|-------------|
-| **Toolbar** | `MemberOfToolbar` with search, pagination, Add/Delete buttons |
+| **Toolbar** | `MemberOfToolbar` with search (submit-only, not per-keystroke), pagination, Add/Delete buttons |
 | **Table** | `MemberTable` displaying the member list |
 | **Pagination** | Bottom pagination component |
 | **Add button** | Enabled, opens add modal |

--- a/doc/designs/sub-pages/08a-common-issues.md
+++ b/doc/designs/sub-pages/08a-common-issues.md
@@ -9,13 +9,20 @@
 
 ```tsx
 <MemberOfToolbar
-  searchText={searchValue}
-  onSearchTextChange={setSearchValue}
-  onSearch={() => {}}              // Required!
-  searchPlaceholder="Search users" // Required!
-  searchAriaLabel="Search users"   // Required!
+  searchPlaceholder="Search users" // Required
+  searchAriaLabel="Search users"   // Required
+  refreshButtonEnabled={isRefreshButtonEnabled}
+  onRefreshButtonClick={onRefresh}
+  deleteButtonEnabled={selected.length > 0}
+  onDeleteButtonClick={() => setShowDeleteModal(true)}
+  addButtonEnabled={isAddButtonEnabled}
+  onAddButtonClick={() => setShowAddModal(true)}
+  totalItems={filteredMembers.length} // Required — drives top pagination
 />
 ```
+
+Search and pagination are URL-backed inside the toolbar; do **not** pass
+`searchText` / `onSearchTextChange` / `onSearch` (those props no longer exist).
 
 ### Wrong Table Component Import
 

--- a/src/components/AutomemberSections/InclusiveExclusiveSection.tsx
+++ b/src/components/AutomemberSections/InclusiveExclusiveSection.tsx
@@ -200,30 +200,12 @@ const InclusiveExclusiveSection = (props: PropsToInclusiveExclusiveSection) => {
     });
   };
 
-  // Pagination prep
-  const updateSelectedPerPage = () => {
-    // Nothing to do since we are not using bulk selector comp
-    return;
-  };
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
-  };
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
-  };
-  // Entries displayed on the first page
-  const updateShownElementsList = (newShownEntriesList: Condition[]) => {
-    setShownElements(newShownEntriesList);
-  };
-
   // Pagination data required by the Table Layout
   const paginationData = {
     page,
     perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList,
+    onUpdatePage: setPage,
+    onUpdatePerPage: setPerPage,
     totalCount: tableEntryList.length,
   };
 

--- a/src/components/Form/IpaCertificateMappingData/IpaCertificateMappingData.test.tsx
+++ b/src/components/Form/IpaCertificateMappingData/IpaCertificateMappingData.test.tsx
@@ -6,7 +6,7 @@ import IpaCertificateMappingData, {
   PropsToIpaCertificateMappingData,
 } from "./IpaCertificateMappingData";
 // Redux
-import { renderWithAlerts } from "src/utils/testAlertsUtils";
+import { renderWithAlerts } from "src/utils/testUtils";
 
 interface MockReturn {
   data:

--- a/src/components/Form/IpaCertificates/IpaCertificates.test.tsx
+++ b/src/components/Form/IpaCertificates/IpaCertificates.test.tsx
@@ -10,7 +10,7 @@ import {
 } from "src/utils/datatypes/globalDataTypes";
 import { parseDn } from "src/utils/utils";
 // Redux
-import { renderWithAlerts } from "src/utils/testAlertsUtils";
+import { renderWithAlerts } from "src/utils/testUtils";
 
 interface MockReturn {
   data: { result: boolean } | { error: { message: string } };

--- a/src/components/Form/IpaSshPublicKeys/IpaSshPublicKeys.test.tsx
+++ b/src/components/Form/IpaSshPublicKeys/IpaSshPublicKeys.test.tsx
@@ -6,7 +6,7 @@ import IpaSshPublicKeys, {
   PropsToSshPublicKeysModal,
 } from "./IpaSshPublicKeys";
 // Redux
-import { renderWithAlerts } from "src/utils/testAlertsUtils";
+import { renderWithAlerts } from "src/utils/testUtils";
 
 /**
  * Checks whether payload argument for updateSSHKey contains string *fail create*

--- a/src/components/Form/PrincipalAliasMultiTextBox/PrincipalAliasMultiTextBox.test.tsx
+++ b/src/components/Form/PrincipalAliasMultiTextBox/PrincipalAliasMultiTextBox.test.tsx
@@ -5,7 +5,7 @@ import { Mock, vi, describe, afterEach, it, expect } from "vitest";
 import PrincipalAliasMultiTextBox, {
   PrincipalAliasMultiTextBoxProps,
 } from "./PrincipalAliasMultiTextBox";
-import { renderWithAlerts } from "src/utils/testAlertsUtils";
+import { renderWithAlerts } from "src/utils/testUtils";
 
 interface MockReturn {
   data: { result: boolean } | { error: { message: string } };

--- a/src/components/ManagedBy/ManagedByHosts.tsx
+++ b/src/components/ManagedBy/ManagedByHosts.tsx
@@ -135,9 +135,9 @@ const ManagedByHosts = (props: ManagedByHostsProps) => {
 
   // Load available Hosts
   const hostsQuery = useGettingHostQuery({
-    search: adderSearchValue,
+    searchValue: adderSearchValue,
     apiVersion: API_VERSION_BACKUP,
-    sizelimit: 100,
+    sizeLimit: 100,
     startIdx: 0,
     stopIdx: 100,
   });

--- a/src/components/ManagedBy/ManagedByHosts.tsx
+++ b/src/components/ManagedBy/ManagedByHosts.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 // PatternFly
-import { Pagination, PaginationVariant } from "@patternfly/react-core";
+import { PaginationVariant } from "@patternfly/react-core";
 // Data types
 import { Host, Service } from "src/utils/datatypes/globalDataTypes";
 // Components
 import MemberOfToolbar from "../MemberOf/MemberOfToolbar";
 import MemberOfHostsTable from "./ManagedByTableHosts";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
 import MemberOfAddModal, { AvailableItems } from "../MemberOf/MemberOfAddModal";
 import MemberOfDeleteModal from "../MemberOf/MemberOfDeleteModal";
 
@@ -46,8 +47,7 @@ const ManagedByHosts = (props: ManagedByHostsProps) => {
   const dispatch = useAppDispatch();
 
   // Get parameters from URL
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
 
   // Other states
   const [hostsSelected, setHostsSelected] = React.useState<string[]>([]);
@@ -314,10 +314,6 @@ const ManagedByHosts = (props: ManagedByHostsProps) => {
         helpIconEnabled={true}
         onHelpIconClick={() => dispatch(toggleHelpPanel())}
         totalItems={managedby_host.length}
-        perPage={perPage}
-        page={page}
-        onPerPageChange={setPerPage}
-        onPageChange={setPage}
       />
       <MemberOfHostsTable
         hosts={hosts}
@@ -325,15 +321,12 @@ const ManagedByHosts = (props: ManagedByHostsProps) => {
         onCheckItemsChange={setHostsSelected}
         showTableRows={showTableRows}
       />
-      <Pagination
-        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
-        itemCount={managedby_host.length}
-        widgetId="pagination-options-menu-bottom"
-        perPage={perPage}
-        page={page}
+      <PaginationLayout
+        list={[]}
+        totalCount={managedby_host.length}
         variant={PaginationVariant.bottom}
-        onSetPage={(_e, page) => setPage(page)}
-        onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+        widgetId="pagination-options-menu-bottom"
+        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
       />
       {showAddModal && (
         <MemberOfAddModal

--- a/src/components/ManagedBy/ManagedByHosts.tsx
+++ b/src/components/ManagedBy/ManagedByHosts.tsx
@@ -46,7 +46,7 @@ const ManagedByHosts = (props: ManagedByHostsProps) => {
   const dispatch = useAppDispatch();
 
   // Get parameters from URL
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   // Other states
@@ -303,9 +303,6 @@ const ManagedByHosts = (props: ManagedByHostsProps) => {
   return (
     <>
       <MemberOfToolbar
-        searchText={searchValue}
-        onSearchTextChange={setSearchValue}
-        onSearch={() => {}}
         searchPlaceholder="Search hosts"
         searchAriaLabel="Search hosts"
         refreshButtonEnabled={isRefreshButtonEnabled}

--- a/src/components/ManagedBy/ManagedByUsers.tsx
+++ b/src/components/ManagedBy/ManagedByUsers.tsx
@@ -102,9 +102,9 @@ const ManagedByUsers = (props: ManagedByUsersProps) => {
 
   // Load available Users
   const usersQuery = useGettingActiveUserQuery({
-    search: adderSearchValue,
+    searchValue: adderSearchValue,
     apiVersion: API_VERSION_BACKUP,
-    sizelimit: 100,
+    sizeLimit: 100,
     startIdx: 0,
     stopIdx: 100,
   });

--- a/src/components/ManagedBy/ManagedByUsers.tsx
+++ b/src/components/ManagedBy/ManagedByUsers.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 // PatternFly
-import { Pagination, PaginationVariant } from "@patternfly/react-core";
+import { PaginationVariant } from "@patternfly/react-core";
 // Components
 import MemberOfToolbar from "../MemberOf/MemberOfToolbar";
 import MemberOfAddModal, { AvailableItems } from "../MemberOf/MemberOfAddModal";
@@ -30,6 +30,7 @@ import {
 } from "src/services/rpcOtpTokens";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import { SerializedError } from "@reduxjs/toolkit";
+import PaginationLayout from "../layouts/PaginationLayout";
 
 interface ManagedByUsersProps {
   entity: Partial<OtpToken>;
@@ -43,8 +44,7 @@ const ManagedByUsers = (props: ManagedByUsersProps) => {
   const dispatch = useAppDispatch();
 
   // Get parameters from URL
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
-    useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
 
   // Other states
   const [usersSelected, setUsersSelected] = React.useState<string[]>([]);
@@ -76,15 +76,6 @@ const ManagedByUsers = (props: ManagedByUsersProps) => {
     () => fullUsersQuery.data ?? [],
     [fullUsersQuery.data]
   );
-
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
-  const submitSearchValue = () => {
-    setPage(1);
-  };
 
   // Computed "states"
   const someItemSelected = usersSelected.length > 0;
@@ -255,9 +246,6 @@ const ManagedByUsers = (props: ManagedByUsersProps) => {
   return (
     <>
       <MemberOfToolbar
-        searchText={searchValue}
-        onSearchTextChange={updateSearchValue}
-        onSearch={submitSearchValue}
         searchPlaceholder="Search users"
         searchAriaLabel="Search users"
         refreshButtonEnabled={isRefreshButtonEnabled}
@@ -269,10 +257,6 @@ const ManagedByUsers = (props: ManagedByUsersProps) => {
         helpIconEnabled={true}
         onHelpIconClick={() => dispatch(toggleHelpPanel())}
         totalItems={filteredUsers.length}
-        perPage={perPage}
-        page={page}
-        onPerPageChange={setPerPage}
-        onPageChange={setPage}
       />
       <MemberTable
         entityList={users}
@@ -284,15 +268,12 @@ const ManagedByUsers = (props: ManagedByUsersProps) => {
         onCheckItemsChange={setUsersSelected}
         showTableRows={showTableRows}
       />
-      <Pagination
-        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
-        itemCount={filteredUsers.length}
-        widgetId="pagination-options-menu-bottom"
-        perPage={perPage}
-        page={page}
+      <PaginationLayout
+        list={[]}
+        totalCount={filteredUsers.length}
         variant={PaginationVariant.bottom}
-        onSetPage={(_e, page) => setPage(page)}
-        onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+        widgetId="pagination-options-menu-bottom"
+        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
       />
       {showAddModal && (
         <MemberOfAddModal

--- a/src/components/MemberManagers/ManagersUserGroups.tsx
+++ b/src/components/MemberManagers/ManagersUserGroups.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 // PatternFly
-import { Pagination, PaginationVariant } from "@patternfly/react-core";
+import { PaginationVariant } from "@patternfly/react-core";
 // Components
 import MemberOfToolbar from "../MemberOf/MemberOfToolbar";
 import MemberOfAddModal, { AvailableItems } from "../MemberOf/MemberOfAddModal";
 import MemberOfDeleteModal from "../MemberOf/MemberOfDeleteModal";
 import MemberTable from "src/components/tables/MembershipTable";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
 // Data types
 import { UserGroup } from "src/utils/datatypes/globalDataTypes";
 // Redux
@@ -42,8 +43,7 @@ const ManagersUserGroups = (props: PropsToManagersUsergroups) => {
   const dispatch = useAppDispatch();
 
   // Get parameters from URL
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, setPage, perPage, searchValue } = useListPageSearchParams();
 
   // Other states
   const [userGroupsSelected, setUserGroupsSelected] = React.useState<string[]>(
@@ -293,10 +293,6 @@ const ManagersUserGroups = (props: PropsToManagersUsergroups) => {
         membershipDirectionEnabled={false}
         helpIconEnabled={true}
         totalItems={props.manager_groups.length}
-        perPage={perPage}
-        page={page}
-        onPerPageChange={setPerPage}
-        onPageChange={setPage}
       />
       <MemberTable
         entityList={managers}
@@ -308,15 +304,12 @@ const ManagersUserGroups = (props: PropsToManagersUsergroups) => {
         onCheckItemsChange={setUserGroupsSelected}
         showTableRows={showTableRows}
       />
-      <Pagination
-        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
-        itemCount={managers.length}
-        widgetId="pagination-options-menu-bottom"
-        perPage={perPage}
-        page={page}
+      <PaginationLayout
+        list={[]}
+        totalCount={managers.length}
         variant={PaginationVariant.bottom}
-        onSetPage={(_e, page) => setPage(page)}
-        onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+        widgetId="pagination-options-menu-bottom"
+        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
       />
       {showAddModal && (
         <MemberOfAddModal

--- a/src/components/MemberManagers/ManagersUserGroups.tsx
+++ b/src/components/MemberManagers/ManagersUserGroups.tsx
@@ -42,7 +42,7 @@ const ManagersUserGroups = (props: PropsToManagersUsergroups) => {
   const dispatch = useAppDispatch();
 
   // Get parameters from URL
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   // Other states
@@ -282,9 +282,6 @@ const ManagersUserGroups = (props: PropsToManagersUsergroups) => {
   return (
     <>
       <MemberOfToolbar
-        searchText={searchValue}
-        onSearchTextChange={setSearchValue}
-        onSearch={() => {}}
         searchPlaceholder="Search user groups"
         searchAriaLabel="Search user groups"
         refreshButtonEnabled={isRefreshButtonEnabled}

--- a/src/components/MemberManagers/ManagersUserGroups.tsx
+++ b/src/components/MemberManagers/ManagersUserGroups.tsx
@@ -150,9 +150,9 @@ const ManagersUserGroups = (props: PropsToManagersUsergroups) => {
 
   // Load available user groups, delay the search for opening the modal
   const userGroupsQuery = useGettingGroupsQuery({
-    search: adderSearchValue,
+    searchValue: adderSearchValue,
     apiVersion: API_VERSION_BACKUP,
-    sizelimit: 100,
+    sizeLimit: 100,
     startIdx: 0,
     stopIdx: 100,
   });

--- a/src/components/MemberManagers/ManagersUsers.tsx
+++ b/src/components/MemberManagers/ManagersUsers.tsx
@@ -44,7 +44,7 @@ const ManagersUsers = (props: PropsToManagersUsers) => {
   const dispatch = useAppDispatch();
 
   // Get parameters from URL
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   // Other states
@@ -278,9 +278,6 @@ const ManagersUsers = (props: PropsToManagersUsers) => {
   return (
     <>
       <MemberOfToolbar
-        searchText={searchValue}
-        onSearchTextChange={setSearchValue}
-        onSearch={() => {}}
         searchPlaceholder="Search users"
         searchAriaLabel="Search users"
         refreshButtonEnabled={isRefreshButtonEnabled}

--- a/src/components/MemberManagers/ManagersUsers.tsx
+++ b/src/components/MemberManagers/ManagersUsers.tsx
@@ -146,9 +146,9 @@ const ManagersUsers = (props: PropsToManagersUsers) => {
 
   // Load available user, delay the search for opening the modal
   const usersQuery = useGettingActiveUserQuery({
-    search: adderSearchValue,
+    searchValue: adderSearchValue,
     apiVersion: API_VERSION_BACKUP,
-    sizelimit: 100,
+    sizeLimit: 100,
     startIdx: 0,
     stopIdx: 100,
   });

--- a/src/components/MemberManagers/ManagersUsers.tsx
+++ b/src/components/MemberManagers/ManagersUsers.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 // PatternFly
-import { Pagination, PaginationVariant } from "@patternfly/react-core";
+import { PaginationVariant } from "@patternfly/react-core";
 // Components
 import MemberOfToolbar from "../MemberOf/MemberOfToolbar";
 import MemberOfAddModal, { AvailableItems } from "../MemberOf/MemberOfAddModal";
 import MemberOfDeleteModal from "../MemberOf/MemberOfDeleteModal";
 import MemberTable from "src/components/tables/MembershipTable";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
 // Data types
 import { User } from "src/utils/datatypes/globalDataTypes";
 // Redux
@@ -44,8 +45,7 @@ const ManagersUsers = (props: PropsToManagersUsers) => {
   const dispatch = useAppDispatch();
 
   // Get parameters from URL
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, setPage, perPage, searchValue } = useListPageSearchParams();
 
   // Other states
   const [usersSelected, setUsersSelected] = React.useState<string[]>([]);
@@ -289,10 +289,6 @@ const ManagersUsers = (props: PropsToManagersUsers) => {
         membershipDirectionEnabled={false}
         helpIconEnabled={true}
         totalItems={props.manager_users.length}
-        perPage={perPage}
-        page={page}
-        onPerPageChange={setPerPage}
-        onPageChange={setPage}
       />
       <MemberTable
         entityList={managers}
@@ -304,15 +300,12 @@ const ManagersUsers = (props: PropsToManagersUsers) => {
         onCheckItemsChange={setUsersSelected}
         showTableRows={showTableRows}
       />
-      <Pagination
-        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
-        itemCount={managers.length}
-        widgetId="pagination-options-menu-bottom"
-        perPage={perPage}
-        page={page}
+      <PaginationLayout
+        list={[]}
+        totalCount={managers.length}
         variant={PaginationVariant.bottom}
-        onSetPage={(_e, page) => setPage(page)}
-        onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+        widgetId="pagination-options-menu-bottom"
+        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
       />
       {showAddModal && (
         <MemberOfAddModal

--- a/src/components/MemberOf/MemberOfHbacRules.tsx
+++ b/src/components/MemberOf/MemberOfHbacRules.tsx
@@ -175,9 +175,9 @@ const MemberOfHbacRules = (props: MemberOfHbacRulesProps) => {
 
   // Load available HBAC rules, delay the search for opening the modal
   const hbacRulesQuery = useGettingHbacRulesQuery({
-    search: adderSearchValue,
+    searchValue: adderSearchValue,
     apiVersion: API_VERSION_BACKUP,
-    sizelimit: 100,
+    sizeLimit: 100,
     startIdx: 0,
     stopIdx: 100,
   });

--- a/src/components/MemberOf/MemberOfHbacRules.tsx
+++ b/src/components/MemberOf/MemberOfHbacRules.tsx
@@ -118,10 +118,6 @@ const MemberOfHbacRules = (props: MemberOfHbacRulesProps) => {
     }
   }, [hbacRulesNamesToLoad]);
 
-  React.useEffect(() => {
-    setMembershipDirection(props.direction);
-  }, [props.entity]);
-
   // Update HBAC rules
   React.useEffect(() => {
     if (fullHbacRulesQuery.data && !fullHbacRulesQuery.isFetching) {

--- a/src/components/MemberOf/MemberOfHbacRules.tsx
+++ b/src/components/MemberOf/MemberOfHbacRules.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 // PatternFly
-import { Pagination, PaginationVariant } from "@patternfly/react-core";
+import { PaginationVariant } from "@patternfly/react-core";
 // Data types
 import {
   User,
@@ -11,6 +11,7 @@ import {
 // Components
 import MemberOfToolbar from "./MemberOfToolbar";
 import MemberTable from "src/components/tables/MembershipTable";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
 import MemberOfAddModal, { AvailableItems } from "./MemberOfAddModal";
 import MemberOfDeleteModal from "./MemberOfDeleteModal";
 import { MembershipDirection } from "src/components/MemberOf/MemberOfToolbar";
@@ -49,7 +50,6 @@ const MemberOfHbacRules = (props: MemberOfHbacRulesProps) => {
     page,
     setPage,
     perPage,
-    setPerPage,
     searchValue,
     membershipDirection,
     setMembershipDirection,
@@ -325,10 +325,6 @@ const MemberOfHbacRules = (props: MemberOfHbacRulesProps) => {
         helpIconEnabled={true}
         onHelpIconClick={() => dispatch(toggleHelpPanel())}
         totalItems={hbacRuleNames.length}
-        perPage={perPage}
-        page={page}
-        onPerPageChange={setPerPage}
-        onPageChange={setPage}
       />
       <MemberTable
         entityList={hbacRules}
@@ -349,15 +345,12 @@ const MemberOfHbacRules = (props: MemberOfHbacRulesProps) => {
         showTableRows={showTableRows}
       />
       {hbacRuleNames.length > 0 && (
-        <Pagination
-          className="pf-v6-u-pb-0 pf-v6-u-pr-md"
-          itemCount={hbacRuleNames.length}
-          widgetId="pagination-options-menu-bottom"
-          perPage={perPage}
-          page={page}
+        <PaginationLayout
+          list={[]}
+          totalCount={hbacRuleNames.length}
           variant={PaginationVariant.bottom}
-          onSetPage={(_e, page) => setPage(page)}
-          onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+          widgetId="pagination-options-menu-bottom"
+          className="pf-v6-u-pb-0 pf-v6-u-pr-md"
         />
       )}
       <MemberOfAddModal

--- a/src/components/MemberOf/MemberOfHbacRules.tsx
+++ b/src/components/MemberOf/MemberOfHbacRules.tsx
@@ -51,7 +51,6 @@ const MemberOfHbacRules = (props: MemberOfHbacRulesProps) => {
     perPage,
     setPerPage,
     searchValue,
-    setSearchValue,
     membershipDirection,
     setMembershipDirection,
   } = useListPageSearchParams();
@@ -308,9 +307,6 @@ const MemberOfHbacRules = (props: MemberOfHbacRulesProps) => {
   return (
     <>
       <MemberOfToolbar
-        searchText={searchValue}
-        onSearchTextChange={setSearchValue}
-        onSearch={() => {}}
         searchPlaceholder="Search HBAC rules"
         searchAriaLabel="Search HBAC rules"
         refreshButtonEnabled={isRefreshButtonEnabled}

--- a/src/components/MemberOf/MemberOfHbacServiceGroups.tsx
+++ b/src/components/MemberOf/MemberOfHbacServiceGroups.tsx
@@ -125,9 +125,9 @@ const MemberOfHbacServices = (props: MemberOfHbacServicesProps) => {
 
   // Load available HBAC services, delay the search for opening the modal
   const hbacGroupsQuery = useGettingHbacServiceGroupQuery({
-    search: adderSearchValue,
+    searchValue: adderSearchValue,
     apiVersion: API_VERSION_BACKUP,
-    sizelimit: 100,
+    sizeLimit: 100,
     startIdx: 0,
     stopIdx: 100,
   });

--- a/src/components/MemberOf/MemberOfHbacServiceGroups.tsx
+++ b/src/components/MemberOf/MemberOfHbacServiceGroups.tsx
@@ -40,7 +40,7 @@ interface MemberOfHbacServicesProps {
 const MemberOfHbacServices = (props: MemberOfHbacServicesProps) => {
   const dispatch = useAppDispatch();
 
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   const [hbacGroupsSelected, setHbacGroupsSelected] = React.useState<string[]>(
@@ -257,9 +257,6 @@ const MemberOfHbacServices = (props: MemberOfHbacServicesProps) => {
   return (
     <>
       <MemberOfToolbar
-        searchText={searchValue}
-        onSearchTextChange={setSearchValue}
-        onSearch={() => {}}
         searchPlaceholder="Search HBAC service groups"
         searchAriaLabel="Search HBAC service groups"
         refreshButtonEnabled={isRefreshButtonEnabled}

--- a/src/components/MemberOf/MemberOfHbacServiceGroups.tsx
+++ b/src/components/MemberOf/MemberOfHbacServiceGroups.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 // PatternFly
-import { Pagination, PaginationVariant } from "@patternfly/react-core";
+import { PaginationVariant } from "@patternfly/react-core";
 // Data types
 import {
   HBACService,
@@ -9,6 +9,7 @@ import {
 // Components
 import MemberOfToolbar from "./MemberOfToolbar";
 import MemberTable from "src/components/tables/MembershipTable";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
 import MemberOfAddModal, { AvailableItems } from "./MemberOfAddModal";
 import MemberOfDeleteModal from "./MemberOfDeleteModal";
 
@@ -40,8 +41,7 @@ interface MemberOfHbacServicesProps {
 const MemberOfHbacServices = (props: MemberOfHbacServicesProps) => {
   const dispatch = useAppDispatch();
 
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, setPage, perPage, searchValue } = useListPageSearchParams();
 
   const [hbacGroupsSelected, setHbacGroupsSelected] = React.useState<string[]>(
     []
@@ -268,10 +268,6 @@ const MemberOfHbacServices = (props: MemberOfHbacServicesProps) => {
         helpIconEnabled={true}
         onHelpIconClick={() => dispatch(toggleHelpPanel())}
         totalItems={memberof_hbacsvcgroup.length}
-        perPage={perPage}
-        page={page}
-        onPerPageChange={setPerPage}
-        onPageChange={setPage}
       />
       <MemberTable
         entityList={hbacGroups}
@@ -284,15 +280,12 @@ const MemberOfHbacServices = (props: MemberOfHbacServicesProps) => {
         showTableRows={showTableRows}
       />
       {memberof_hbacsvcgroup.length > 0 && (
-        <Pagination
-          className="pf-v6-u-pb-0 pf-v6-u-pr-md"
-          itemCount={memberof_hbacsvcgroup.length}
-          widgetId="pagination-options-menu-bottom"
-          perPage={perPage}
-          page={page}
+        <PaginationLayout
+          list={[]}
+          totalCount={memberof_hbacsvcgroup.length}
           variant={PaginationVariant.bottom}
-          onSetPage={(_e, page) => setPage(page)}
-          onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+          widgetId="pagination-options-menu-bottom"
+          className="pf-v6-u-pb-0 pf-v6-u-pr-md"
         />
       )}
       <MemberOfAddModal

--- a/src/components/MemberOf/MemberOfHostGroups.tsx
+++ b/src/components/MemberOf/MemberOfHostGroups.tsx
@@ -114,10 +114,6 @@ const MemberOfHostGroups = (props: MemberOfHostGroupsProps) => {
     }
   }, [hostGroupNamesToLoad]);
 
-  React.useEffect(() => {
-    setMembershipDirection(props.direction);
-  }, [props.entity]);
-
   // Update host groups
   React.useEffect(() => {
     if (fullHostGroupsQuery.data && !fullHostGroupsQuery.isFetching) {

--- a/src/components/MemberOf/MemberOfHostGroups.tsx
+++ b/src/components/MemberOf/MemberOfHostGroups.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 // PatternFly
-import { Pagination, PaginationVariant } from "@patternfly/react-core";
+import { PaginationVariant } from "@patternfly/react-core";
 // Data types
 import { Host, HostGroup } from "src/utils/datatypes/globalDataTypes";
 // Components
 import MemberOfToolbar from "./MemberOfToolbar";
 import MemberTable from "src/components/tables/MembershipTable";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
 import MemberOfAddModal, { AvailableItems } from "./MemberOfAddModal";
 import MemberOfDeleteModal from "./MemberOfDeleteModal";
 import { MembershipDirection } from "src/components/MemberOf/MemberOfToolbar";
@@ -44,7 +45,6 @@ const MemberOfHostGroups = (props: MemberOfHostGroupsProps) => {
     page,
     setPage,
     perPage,
-    setPerPage,
     searchValue,
     membershipDirection,
     setMembershipDirection,
@@ -311,10 +311,6 @@ const MemberOfHostGroups = (props: MemberOfHostGroupsProps) => {
         helpIconEnabled={true}
         onHelpIconClick={() => dispatch(toggleHelpPanel())}
         totalItems={hostGroupNames.length}
-        perPage={perPage}
-        page={page}
-        onPerPageChange={setPerPage}
-        onPageChange={setPage}
       />
       <MemberTable
         entityList={hostGroups}
@@ -335,15 +331,12 @@ const MemberOfHostGroups = (props: MemberOfHostGroupsProps) => {
         showTableRows={showTableRows}
       />
       {hostGroupNames.length > 0 && (
-        <Pagination
-          className="pf-v6-u-pb-0 pf-v6-u-pr-md"
-          itemCount={hostGroupNames.length}
-          widgetId="pagination-options-menu-bottom"
-          perPage={perPage}
-          page={page}
+        <PaginationLayout
+          list={[]}
+          totalCount={hostGroupNames.length}
           variant={PaginationVariant.bottom}
-          onSetPage={(_e, page) => setPage(page)}
-          onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+          widgetId="pagination-options-menu-bottom"
+          className="pf-v6-u-pb-0 pf-v6-u-pr-md"
         />
       )}
       <MemberOfAddModal

--- a/src/components/MemberOf/MemberOfHostGroups.tsx
+++ b/src/components/MemberOf/MemberOfHostGroups.tsx
@@ -46,7 +46,6 @@ const MemberOfHostGroups = (props: MemberOfHostGroupsProps) => {
     perPage,
     setPerPage,
     searchValue,
-    setSearchValue,
     membershipDirection,
     setMembershipDirection,
   } = useListPageSearchParams();
@@ -294,9 +293,6 @@ const MemberOfHostGroups = (props: MemberOfHostGroupsProps) => {
   return (
     <>
       <MemberOfToolbar
-        searchText={searchValue}
-        onSearchTextChange={setSearchValue}
-        onSearch={() => {}}
         searchPlaceholder="Search host groups"
         searchAriaLabel="Search host groups"
         refreshButtonEnabled={isRefreshButtonEnabled}

--- a/src/components/MemberOf/MemberOfHostGroups.tsx
+++ b/src/components/MemberOf/MemberOfHostGroups.tsx
@@ -166,9 +166,9 @@ const MemberOfHostGroups = (props: MemberOfHostGroupsProps) => {
 
   // Load available Host groups
   const hostGroupsQuery = useGettingHostGroupsQuery({
-    search: adderSearchValue,
+    searchValue: adderSearchValue,
     apiVersion: API_VERSION_BACKUP,
-    sizelimit: 100,
+    sizeLimit: 100,
     startIdx: 0,
     stopIdx: 100,
   });

--- a/src/components/MemberOf/MemberOfNetgroups.tsx
+++ b/src/components/MemberOf/MemberOfNetgroups.tsx
@@ -56,7 +56,6 @@ const memberOfNetgroups = (props: MemberOfNetgroupsProps) => {
     perPage,
     setPerPage,
     searchValue,
-    setSearchValue,
     membershipDirection,
     setMembershipDirection,
   } = useListPageSearchParams();
@@ -313,9 +312,6 @@ const memberOfNetgroups = (props: MemberOfNetgroupsProps) => {
     <>
       {membershipDisabled ? (
         <MemberOfToolbar
-          searchText={searchValue}
-          onSearchTextChange={setSearchValue}
-          onSearch={() => {}}
           searchPlaceholder="Search netgroups"
           searchAriaLabel="Search netgroups"
           refreshButtonEnabled={isRefreshButtonEnabled}
@@ -341,9 +337,6 @@ const memberOfNetgroups = (props: MemberOfNetgroupsProps) => {
         />
       ) : (
         <MemberOfToolbar
-          searchText={searchValue}
-          onSearchTextChange={setSearchValue}
-          onSearch={() => {}}
           searchPlaceholder="Search netgroups"
           searchAriaLabel="Search netgroups"
           refreshButtonEnabled={isRefreshButtonEnabled}

--- a/src/components/MemberOf/MemberOfNetgroups.tsx
+++ b/src/components/MemberOf/MemberOfNetgroups.tsx
@@ -188,9 +188,9 @@ const memberOfNetgroups = (props: MemberOfNetgroupsProps) => {
 
   // Load available netgroups, delay the search for opening the modal
   const netgroupsQuery = useGettingNetgroupsQuery({
-    search: adderSearchValue,
+    searchValue: adderSearchValue,
     apiVersion: API_VERSION_BACKUP,
-    sizelimit: 100,
+    sizeLimit: 100,
     startIdx: 0,
     stopIdx: 100,
   });

--- a/src/components/MemberOf/MemberOfNetgroups.tsx
+++ b/src/components/MemberOf/MemberOfNetgroups.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 // PatternFly
-import { Pagination, PaginationVariant } from "@patternfly/react-core";
+import { PaginationVariant } from "@patternfly/react-core";
 // Data types
 import {
   User,
@@ -11,6 +11,7 @@ import {
 // Components
 import MemberOfToolbar from "./MemberOfToolbar";
 import MemberTable from "src/components/tables/MembershipTable";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
 import { MembershipDirection } from "src/components/MemberOf/MemberOfToolbar";
 // Redux
 import { useAppDispatch } from "src/store/hooks";
@@ -54,7 +55,6 @@ const memberOfNetgroups = (props: MemberOfNetgroupsProps) => {
     page,
     setPage,
     perPage,
-    setPerPage,
     searchValue,
     membershipDirection,
     setMembershipDirection,
@@ -330,10 +330,6 @@ const memberOfNetgroups = (props: MemberOfNetgroupsProps) => {
           helpIconEnabled={true}
           onHelpIconClick={() => dispatch(toggleHelpPanel())}
           totalItems={netgroupNames.length}
-          perPage={perPage}
-          page={page}
-          onPerPageChange={setPerPage}
-          onPageChange={setPage}
         />
       ) : (
         <MemberOfToolbar
@@ -352,10 +348,6 @@ const memberOfNetgroups = (props: MemberOfNetgroupsProps) => {
           helpIconEnabled={true}
           onHelpIconClick={() => dispatch(toggleHelpPanel())}
           totalItems={netgroupNames.length}
-          perPage={perPage}
-          page={page}
-          onPerPageChange={setPerPage}
-          onPageChange={setPage}
         />
       )}
       <MemberTable
@@ -377,15 +369,12 @@ const memberOfNetgroups = (props: MemberOfNetgroupsProps) => {
         showTableRows={showTableRows}
       />
       {netgroupNames.length > 0 && (
-        <Pagination
-          className="pf-v6-u-pb-0 pf-v6-u-pr-md"
-          itemCount={netgroupNames.length}
-          widgetId="pagination-options-menu-bottom"
-          perPage={perPage}
-          page={page}
+        <PaginationLayout
+          list={[]}
+          totalCount={netgroupNames.length}
           variant={PaginationVariant.bottom}
-          onSetPage={(_e, page) => setPage(page)}
-          onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+          widgetId="pagination-options-menu-bottom"
+          className="pf-v6-u-pb-0 pf-v6-u-pr-md"
         />
       )}
       <MemberOfAddModal

--- a/src/components/MemberOf/MemberOfNetgroups.tsx
+++ b/src/components/MemberOf/MemberOfNetgroups.tsx
@@ -128,12 +128,6 @@ const memberOfNetgroups = (props: MemberOfNetgroupsProps) => {
     }
   }, [netgroupNamesToLoad]);
 
-  React.useEffect(() => {
-    if (props.direction) {
-      setMembershipDirection(props.direction);
-    }
-  }, [props.entity]);
-
   // Update netgroups
   React.useEffect(() => {
     if (fullNetgroupsQuery.data && !fullNetgroupsQuery.isFetching) {

--- a/src/components/MemberOf/MemberOfRoles.tsx
+++ b/src/components/MemberOf/MemberOfRoles.tsx
@@ -50,7 +50,6 @@ const MemberOfRoles = (props: MemberOfRolesProps) => {
     perPage,
     setPerPage,
     searchValue,
-    setSearchValue,
     membershipDirection,
     setMembershipDirection,
   } = useListPageSearchParams();
@@ -293,9 +292,6 @@ const MemberOfRoles = (props: MemberOfRolesProps) => {
     <>
       {membershipDisabled ? (
         <MemberOfToolbar
-          searchText={searchValue}
-          onSearchTextChange={setSearchValue}
-          onSearch={() => {}}
           searchPlaceholder="Search roles"
           searchAriaLabel="Search roles"
           refreshButtonEnabled={isRefreshButtonEnabled}
@@ -318,9 +314,6 @@ const MemberOfRoles = (props: MemberOfRolesProps) => {
         />
       ) : (
         <MemberOfToolbar
-          searchText={searchValue}
-          onSearchTextChange={setSearchValue}
-          onSearch={() => {}}
           searchPlaceholder="Search roles"
           searchAriaLabel="Search roles"
           refreshButtonEnabled={isRefreshButtonEnabled}

--- a/src/components/MemberOf/MemberOfRoles.tsx
+++ b/src/components/MemberOf/MemberOfRoles.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect } from "react";
 // PatternFly
-import { Pagination, PaginationVariant } from "@patternfly/react-core";
+import { PaginationVariant } from "@patternfly/react-core";
 // Data types
 import { User, Role, Host, Service } from "src/utils/datatypes/globalDataTypes";
 // Components
 import MemberOfToolbar from "./MemberOfToolbar";
 import MemberTable from "src/components/tables/MembershipTable";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
 import MemberOfAddModal, { AvailableItems } from "./MemberOfAddModal";
 import MemberOfDeleteModal from "./MemberOfDeleteModal";
 import { MembershipDirection } from "src/components/MemberOf/MemberOfToolbar";
@@ -48,7 +49,6 @@ const MemberOfRoles = (props: MemberOfRolesProps) => {
     page,
     setPage,
     perPage,
-    setPerPage,
     searchValue,
     membershipDirection,
     setMembershipDirection,
@@ -307,10 +307,6 @@ const MemberOfRoles = (props: MemberOfRolesProps) => {
           helpIconEnabled={true}
           onHelpIconClick={() => dispatch(toggleHelpPanel())}
           totalItems={roleNames.length}
-          perPage={perPage}
-          page={page}
-          onPerPageChange={setPerPage}
-          onPageChange={setPage}
         />
       ) : (
         <MemberOfToolbar
@@ -332,10 +328,6 @@ const MemberOfRoles = (props: MemberOfRolesProps) => {
           helpIconEnabled={true}
           onHelpIconClick={() => dispatch(toggleHelpPanel())}
           totalItems={roleNames.length}
-          perPage={perPage}
-          page={page}
-          onPerPageChange={setPerPage}
-          onPageChange={setPage}
         />
       )}
       <MemberTable
@@ -357,15 +349,12 @@ const MemberOfRoles = (props: MemberOfRolesProps) => {
         showTableRows={showTableRows}
       />
       {roleNames.length > 0 && (
-        <Pagination
-          className="pf-v6-u-pb-0 pf-v6-u-pr-md"
-          itemCount={roleNames.length}
-          widgetId="pagination-options-menu-bottom"
-          perPage={perPage}
-          page={page}
+        <PaginationLayout
+          list={[]}
+          totalCount={roleNames.length}
           variant={PaginationVariant.bottom}
-          onSetPage={(_e, page) => setPage(page)}
-          onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+          widgetId="pagination-options-menu-bottom"
+          className="pf-v6-u-pb-0 pf-v6-u-pr-md"
         />
       )}
       <MemberOfAddModal

--- a/src/components/MemberOf/MemberOfRoles.tsx
+++ b/src/components/MemberOf/MemberOfRoles.tsx
@@ -111,10 +111,6 @@ const MemberOfRoles = (props: MemberOfRolesProps) => {
   }, [props.entity, membershipDirection, searchValue, page, perPage]);
 
   React.useEffect(() => {
-    setMembershipDirection(props.direction);
-  }, [props.entity]);
-
-  React.useEffect(() => {
     if (roleNamesToLoad.length > 0) {
       fullRolesQuery.refetch();
     }

--- a/src/components/MemberOf/MemberOfRoles.tsx
+++ b/src/components/MemberOf/MemberOfRoles.tsx
@@ -171,9 +171,9 @@ const MemberOfRoles = (props: MemberOfRolesProps) => {
   // Load available roles, delay the search for opening the modal
   const rolesQuery = useGettingRolesQuery(
     {
-      search: adderSearchValue,
+      searchValue: adderSearchValue,
       apiVersion: API_VERSION_BACKUP,
-      sizelimit: 100,
+      sizeLimit: 100,
       startIdx: 0,
       stopIdx: 100,
     },

--- a/src/components/MemberOf/MemberOfSubIdToolbar.tsx
+++ b/src/components/MemberOf/MemberOfSubIdToolbar.tsx
@@ -2,7 +2,6 @@ import React from "react";
 // PatternFly
 import {
   Button,
-  Pagination,
   Content,
   ContentVariants,
   Toolbar,
@@ -12,6 +11,8 @@ import {
 } from "@patternfly/react-core";
 // Icons
 import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
+// Components
+import PaginationLayout from "../layouts/PaginationLayout";
 
 interface MemberOfSubIdToolbarProps {
   // buttons
@@ -24,12 +25,8 @@ interface MemberOfSubIdToolbarProps {
   helpIconEnabled?: boolean;
   onHelpIconClick?: () => void;
 
-  // paging
+  // paging — page/perPage come from URL via PaginationLayout
   totalItems: number;
-  perPage: number;
-  page: number;
-  onPageChange?: (page: number) => void;
-  onPerPageChange?: (pageSize: number) => void;
 }
 
 const MemberOfSubIdToolbar = (props: MemberOfSubIdToolbarProps) => {
@@ -76,17 +73,10 @@ const MemberOfSubIdToolbar = (props: MemberOfSubIdToolbarProps) => {
         </ToolbarItem>
         {props.totalItems > 0 && (
           <ToolbarItem id="pagination" align={{ default: "alignEnd" }}>
-            <Pagination
-              itemCount={props.totalItems}
-              perPage={props.perPage}
-              page={props.page}
-              onSetPage={(_e, page) =>
-                props.onPageChange ? props.onPageChange(page) : null
-              }
+            <PaginationLayout
+              list={[]}
+              totalCount={props.totalItems}
               widgetId="pagination-options-menu-top"
-              onPerPageSelect={(_e, perPage) =>
-                props.onPerPageChange ? props.onPerPageChange(perPage) : null
-              }
               isCompact
             />
           </ToolbarItem>

--- a/src/components/MemberOf/MemberOfSubIds.tsx
+++ b/src/components/MemberOf/MemberOfSubIds.tsx
@@ -1,15 +1,17 @@
 import React from "react";
 // PatternFly
-import { Pagination, PaginationVariant } from "@patternfly/react-core";
+import { PaginationVariant } from "@patternfly/react-core";
 // Data types
 import { SubId, User } from "src/utils/datatypes/globalDataTypes";
 // Components
 import MemberOfTableSubIds from "./MemberOfTableSubIds";
 import MemberOfSubIdToolbar from "./MemberOfSubIdToolbar";
+import PaginationLayout from "../layouts/PaginationLayout";
 // Redux
 import { useAppDispatch } from "src/store/hooks";
 // Hooks
 import { addAlert } from "src/store/Global/alerts-slice";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 // RPC
 import {
   useAssignSubIdsMutation,
@@ -17,8 +19,6 @@ import {
 } from "src/services/rpcSubIds";
 // Utils
 import { API_VERSION_BACKUP, paginate } from "src/utils/utils";
-// React Router DOM
-import { useSearchParams } from "react-router";
 
 interface MemberOfSubIdsProps {
   user: Partial<User>;
@@ -29,16 +29,10 @@ interface MemberOfSubIdsProps {
 const MemberOfSubIds = (props: MemberOfSubIdsProps) => {
   const dispatch = useAppDispatch();
 
-  const [searchParams, setSearchParams] = useSearchParams();
+  const { page, perPage } = useListPageSearchParams();
 
   // API calls
   const [assignSubIds] = useAssignSubIdsMutation();
-
-  // Page indexes
-  const [page, setPage] = React.useState(
-    parseInt(searchParams.get("p") || "1")
-  );
-  const [perPage, setPerPage] = React.useState(10);
 
   // Other states
   const [subIdsSelected, setSubIdsSelected] = React.useState<string[]>([]);
@@ -66,20 +60,6 @@ const MemberOfSubIds = (props: MemberOfSubIdsProps) => {
     subIdsList: subIdsNamesToLoad,
     version: API_VERSION_BACKUP,
   });
-
-  // Handle URLs with pagination and search values
-  React.useEffect(() => {
-    let searchParamsNew = {};
-
-    if (page > 1) {
-      searchParamsNew = {
-        ...searchParamsNew,
-        p: page.toString(),
-      };
-    }
-
-    setSearchParams(searchParamsNew, { replace: true });
-  }, [page]);
 
   // Refresh Subordinate IDs
   React.useEffect(() => {
@@ -149,10 +129,6 @@ const MemberOfSubIds = (props: MemberOfSubIdsProps) => {
         autoAssignButtonEnabled={isEnabledAutoAssign}
         onAutoAssignSubIdsClick={onAssignSubIds}
         totalItems={memberof_subid.length}
-        perPage={perPage}
-        page={page}
-        onPerPageChange={setPerPage}
-        onPageChange={setPage}
       />
       <MemberOfTableSubIds
         subIds={subIds}
@@ -162,15 +138,12 @@ const MemberOfSubIds = (props: MemberOfSubIdsProps) => {
         showCheckboxColumn={false}
       />
       {memberof_subid.length > 0 && (
-        <Pagination
-          className="pf-v6-u-pb-0 pf-v6-u-pr-md"
-          itemCount={memberof_subid.length}
-          widgetId="pagination-options-menu-bottom"
-          perPage={perPage}
-          page={page}
+        <PaginationLayout
+          list={subIds}
+          totalCount={memberof_subid.length}
           variant={PaginationVariant.bottom}
-          onSetPage={(_e, page) => setPage(page)}
-          onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+          widgetId="pagination-options-menu-bottom"
+          className="pf-v6-u-pb-0 pf-v6-u-pr-md"
         />
       )}
     </>

--- a/src/components/MemberOf/MemberOfSudoCmdGroups.tsx
+++ b/src/components/MemberOf/MemberOfSudoCmdGroups.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 // PatternFly
-import { Pagination, PaginationVariant } from "@patternfly/react-core";
+import { PaginationVariant } from "@patternfly/react-core";
 // Data types
 import { SudoCmd, SudoCmdGroup } from "src/utils/datatypes/globalDataTypes";
 // Components
 import MemberOfToolbar from "./MemberOfToolbar";
 import MemberTable from "src/components/tables/MembershipTable";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
 import MemberOfAddModal, { AvailableItems } from "./MemberOfAddModal";
 import MemberOfDeleteModal from "./MemberOfDeleteModal";
 
@@ -37,8 +38,7 @@ interface MemberOfSudoCmdGroupsProps {
 const MemberOfSudoCmdGroups = (props: MemberOfSudoCmdGroupsProps) => {
   const dispatch = useAppDispatch();
 
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, setPage, perPage, searchValue } = useListPageSearchParams();
 
   const [sudoGroupsSelected, setSudoGroupsSelected] = React.useState<string[]>(
     []
@@ -264,10 +264,6 @@ const MemberOfSudoCmdGroups = (props: MemberOfSudoCmdGroupsProps) => {
         helpIconEnabled={true}
         onHelpIconClick={() => dispatch(toggleHelpPanel())}
         totalItems={memberof_sudocmdgroup.length}
-        perPage={perPage}
-        page={page}
-        onPerPageChange={setPerPage}
-        onPageChange={setPage}
       />
       <MemberTable
         entityList={sudoGroups}
@@ -280,15 +276,12 @@ const MemberOfSudoCmdGroups = (props: MemberOfSudoCmdGroupsProps) => {
         showTableRows={showTableRows}
       />
       {memberof_sudocmdgroup.length > 0 && (
-        <Pagination
-          className="pf-v6-u-pb-0 pf-v6-u-pr-md"
-          itemCount={memberof_sudocmdgroup.length}
-          widgetId="pagination-options-menu-bottom"
-          perPage={perPage}
-          page={page}
+        <PaginationLayout
+          list={[]}
+          totalCount={memberof_sudocmdgroup.length}
           variant={PaginationVariant.bottom}
-          onSetPage={(_e, page) => setPage(page)}
-          onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+          widgetId="pagination-options-menu-bottom"
+          className="pf-v6-u-pb-0 pf-v6-u-pr-md"
         />
       )}
       <MemberOfAddModal

--- a/src/components/MemberOf/MemberOfSudoCmdGroups.tsx
+++ b/src/components/MemberOf/MemberOfSudoCmdGroups.tsx
@@ -121,9 +121,9 @@ const MemberOfSudoCmdGroups = (props: MemberOfSudoCmdGroupsProps) => {
 
   // Load available Sudo groups
   const sudoGroupsQuery = useGettingSudoCmdGroupsQuery({
-    search: adderSearchValue,
+    searchValue: adderSearchValue,
     apiVersion: API_VERSION_BACKUP,
-    sizelimit: 100,
+    sizeLimit: 100,
     startIdx: 0,
     stopIdx: 100,
   });

--- a/src/components/MemberOf/MemberOfSudoCmdGroups.tsx
+++ b/src/components/MemberOf/MemberOfSudoCmdGroups.tsx
@@ -37,7 +37,7 @@ interface MemberOfSudoCmdGroupsProps {
 const MemberOfSudoCmdGroups = (props: MemberOfSudoCmdGroupsProps) => {
   const dispatch = useAppDispatch();
 
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   const [sudoGroupsSelected, setSudoGroupsSelected] = React.useState<string[]>(
@@ -253,9 +253,6 @@ const MemberOfSudoCmdGroups = (props: MemberOfSudoCmdGroupsProps) => {
   return (
     <>
       <MemberOfToolbar
-        searchText={searchValue}
-        onSearchTextChange={setSearchValue}
-        onSearch={() => {}}
         searchPlaceholder="Search sudo command groups"
         searchAriaLabel="Search sudo command groups"
         refreshButtonEnabled={isRefreshButtonEnabled}

--- a/src/components/MemberOf/MemberOfSudoRules.tsx
+++ b/src/components/MemberOf/MemberOfSudoRules.tsx
@@ -114,10 +114,6 @@ const MemberOfSudoRules = (props: MemberOfSudoRulesProps) => {
     }
   }, [sudoRulesNamesToLoad]);
 
-  React.useEffect(() => {
-    setMembershipDirection(props.direction);
-  }, [props.entity]);
-
   // Update Sudo rules
   React.useEffect(() => {
     if (fullSudoRulesQuery.data && !fullSudoRulesQuery.isFetching) {

--- a/src/components/MemberOf/MemberOfSudoRules.tsx
+++ b/src/components/MemberOf/MemberOfSudoRules.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 // PatternFly
-import { Pagination, PaginationVariant } from "@patternfly/react-core";
+import { PaginationVariant } from "@patternfly/react-core";
 // Data types
 import { User, SudoRule, Host } from "src/utils/datatypes/globalDataTypes";
 // Components
 import MemberOfToolbar from "./MemberOfToolbar";
 import MemberTable from "src/components/tables/MembershipTable";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
 import MemberOfAddModal, { AvailableItems } from "./MemberOfAddModal";
 import MemberOfDeleteModal from "./MemberOfDeleteModal";
 import { MembershipDirection } from "src/components/MemberOf/MemberOfToolbar";
@@ -45,7 +46,6 @@ const MemberOfSudoRules = (props: MemberOfSudoRulesProps) => {
     page,
     setPage,
     perPage,
-    setPerPage,
     searchValue,
     membershipDirection,
     setMembershipDirection,
@@ -318,10 +318,6 @@ const MemberOfSudoRules = (props: MemberOfSudoRulesProps) => {
         helpIconEnabled={true}
         onHelpIconClick={() => dispatch(toggleHelpPanel())}
         totalItems={sudoRuleNames.length}
-        perPage={perPage}
-        page={page}
-        onPerPageChange={setPerPage}
-        onPageChange={setPage}
       />
       <MemberTable
         entityList={sudoRules}
@@ -342,15 +338,12 @@ const MemberOfSudoRules = (props: MemberOfSudoRulesProps) => {
         showTableRows={showTableRows}
       />
       {sudoRuleNames.length > 0 && (
-        <Pagination
-          className="pf-v6-u-pb-0 pf-v6-u-pr-md"
-          itemCount={sudoRuleNames.length}
-          widgetId="pagination-options-menu-bottom"
-          perPage={perPage}
-          page={page}
+        <PaginationLayout
+          list={[]}
+          totalCount={sudoRuleNames.length}
           variant={PaginationVariant.bottom}
-          onSetPage={(_e, page) => setPage(page)}
-          onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+          widgetId="pagination-options-menu-bottom"
+          className="pf-v6-u-pb-0 pf-v6-u-pr-md"
         />
       )}
       <MemberOfAddModal

--- a/src/components/MemberOf/MemberOfSudoRules.tsx
+++ b/src/components/MemberOf/MemberOfSudoRules.tsx
@@ -47,7 +47,6 @@ const MemberOfSudoRules = (props: MemberOfSudoRulesProps) => {
     perPage,
     setPerPage,
     searchValue,
-    setSearchValue,
     membershipDirection,
     setMembershipDirection,
   } = useListPageSearchParams();
@@ -301,9 +300,6 @@ const MemberOfSudoRules = (props: MemberOfSudoRulesProps) => {
   return (
     <>
       <MemberOfToolbar
-        searchText={searchValue}
-        onSearchTextChange={setSearchValue}
-        onSearch={() => {}}
         searchPlaceholder="Search sudo rules"
         searchAriaLabel="Search sudo rules"
         refreshButtonEnabled={isRefreshButtonEnabled}

--- a/src/components/MemberOf/MemberOfSudoRules.tsx
+++ b/src/components/MemberOf/MemberOfSudoRules.tsx
@@ -171,9 +171,9 @@ const MemberOfSudoRules = (props: MemberOfSudoRulesProps) => {
 
   // Load available Sudo rules, delay the search for opening the modal
   const sudoRulesQuery = useGettingSudoRulesQuery({
-    search: adderSearchValue,
+    searchValue: adderSearchValue,
     apiVersion: API_VERSION_BACKUP,
-    sizelimit: 100,
+    sizeLimit: 100,
     startIdx: 0,
     stopIdx: 100,
   });

--- a/src/components/MemberOf/MemberOfToolbar.tsx
+++ b/src/components/MemberOf/MemberOfToolbar.tsx
@@ -20,9 +20,6 @@ export type MembershipDirection = "direct" | "indirect";
 
 interface MemberOfToolbarProps {
   // search
-  searchText: string;
-  onSearchTextChange: (value: string) => void;
-  onSearch: (value?: string) => void;
   searchPlaceholder: string;
   searchAriaLabel: string;
 
@@ -69,11 +66,6 @@ const MemberOfToolbar = (props: MemberOfToolbarProps) => {
             name="search"
             ariaLabel={props.searchAriaLabel}
             placeholder={props.searchPlaceholder}
-            searchValueData={{
-              searchValue: props.searchText,
-              updateSearchValue: props.onSearchTextChange,
-              submitSearchValue: props.onSearch,
-            }}
           />
         </ToolbarItem>
         <ToolbarItem

--- a/src/components/MemberOf/MemberOfToolbar.tsx
+++ b/src/components/MemberOf/MemberOfToolbar.tsx
@@ -22,7 +22,7 @@ interface MemberOfToolbarProps {
   // search
   searchText: string;
   onSearchTextChange: (value: string) => void;
-  onSearch: () => void;
+  onSearch: (value?: string) => void;
   searchPlaceholder: string;
   searchAriaLabel: string;
 

--- a/src/components/MemberOf/MemberOfToolbar.tsx
+++ b/src/components/MemberOf/MemberOfToolbar.tsx
@@ -4,7 +4,6 @@ import {
   Button,
   Form,
   FormGroup,
-  Pagination,
   ToggleGroup,
   ToggleGroupItem,
   Toolbar,
@@ -15,6 +14,7 @@ import {
 // Components
 import SearchInputLayout from "../layouts/SearchInputLayout";
 import HelpTextWithIconLayout from "../layouts/HelpTextWithIconLayout";
+import PaginationLayout from "../layouts/PaginationLayout";
 
 export type MembershipDirection = "direct" | "indirect";
 
@@ -39,12 +39,8 @@ interface MemberOfToolbarProps {
   helpIconEnabled?: boolean;
   onHelpIconClick?: () => void;
 
-  // paging
+  // paging — page/perPage come from URL via PaginationLayout
   totalItems: number;
-  perPage: number;
-  page: number;
-  onPageChange?: (page: number) => void;
-  onPerPageChange?: (pageSize: number) => void;
 }
 
 const MemberOfToolbar = (props: MemberOfToolbarProps) => {
@@ -167,17 +163,10 @@ const MemberOfToolbar = (props: MemberOfToolbarProps) => {
         </ToolbarItem>
         {props.totalItems > 0 && (
           <ToolbarItem id="pagination" align={{ default: "alignEnd" }}>
-            <Pagination
-              itemCount={props.totalItems}
-              perPage={props.perPage}
-              page={props.page}
-              onSetPage={(_e, page) =>
-                props.onPageChange ? props.onPageChange(page) : null
-              }
+            <PaginationLayout
+              list={[]}
+              totalCount={props.totalItems}
               widgetId="pagination-options-menu-top"
-              onPerPageSelect={(_e, perPage) =>
-                props.onPerPageChange ? props.onPerPageChange(perPage) : null
-              }
               isCompact
             />
           </ToolbarItem>

--- a/src/components/MemberOf/MemberOfUserGroups.tsx
+++ b/src/components/MemberOf/MemberOfUserGroups.tsx
@@ -50,7 +50,6 @@ const MemberOfUserGroups = (props: MemberOfUserGroupsProps) => {
     perPage,
     setPerPage,
     searchValue,
-    setSearchValue,
     membershipDirection,
     setMembershipDirection,
   } = useListPageSearchParams();
@@ -286,9 +285,6 @@ const MemberOfUserGroups = (props: MemberOfUserGroupsProps) => {
     <>
       <Flex direction={{ default: "column" }}>
         <MemberOfToolbar
-          searchText={searchValue}
-          onSearchTextChange={setSearchValue}
-          onSearch={() => {}}
           searchPlaceholder="Search user groups"
           searchAriaLabel="Search user groups"
           refreshButtonEnabled={isRefreshButtonEnabled}

--- a/src/components/MemberOf/MemberOfUserGroups.tsx
+++ b/src/components/MemberOf/MemberOfUserGroups.tsx
@@ -156,9 +156,9 @@ const MemberOfUserGroups = (props: MemberOfUserGroupsProps) => {
 
   // Load available User groups
   const userGroupsQuery = useGettingGroupsQuery({
-    search: adderSearchValue,
+    searchValue: adderSearchValue,
     apiVersion: API_VERSION_BACKUP,
-    sizelimit: 100,
+    sizeLimit: 100,
     startIdx: 0,
     stopIdx: 100,
   });

--- a/src/components/MemberOf/MemberOfUserGroups.tsx
+++ b/src/components/MemberOf/MemberOfUserGroups.tsx
@@ -1,16 +1,12 @@
 import React from "react";
 // PatternFly
-import {
-  FlexItem,
-  Flex,
-  Pagination,
-  PaginationVariant,
-} from "@patternfly/react-core";
+import { FlexItem, Flex, PaginationVariant } from "@patternfly/react-core";
 // Data types
 import { User, UserGroup } from "src/utils/datatypes/globalDataTypes";
 // Components
 import MemberOfToolbar from "./MemberOfToolbar";
 import MemberTable from "src/components/tables/MembershipTable";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
 import MemberOfAddModal, { AvailableItems } from "./MemberOfAddModal";
 import MemberOfDeleteModal from "./MemberOfDeleteModal";
 // Redux
@@ -48,7 +44,6 @@ const MemberOfUserGroups = (props: MemberOfUserGroupsProps) => {
     page,
     setPage,
     perPage,
-    setPerPage,
     searchValue,
     membershipDirection,
     setMembershipDirection,
@@ -303,10 +298,6 @@ const MemberOfUserGroups = (props: MemberOfUserGroupsProps) => {
           helpIconEnabled={true}
           onHelpIconClick={() => dispatch(toggleHelpPanel())}
           totalItems={userGroupNames.length}
-          perPage={perPage}
-          page={page}
-          onPerPageChange={setPerPage}
-          onPageChange={setPage}
         />
         <MemberTable
           entityList={userGroups}
@@ -328,15 +319,11 @@ const MemberOfUserGroups = (props: MemberOfUserGroupsProps) => {
         />
         {userGroupNames.length > 0 && (
           <FlexItem style={{ flex: "0 0 auto", position: "sticky", bottom: 0 }}>
-            <Pagination
-              // className="pf-v6-u-pb-0 pf-v6-u-pr-md"
-              itemCount={userGroupNames.length}
-              widgetId="pagination-options-menu-bottom"
-              perPage={perPage}
-              page={page}
+            <PaginationLayout
+              list={[]}
+              totalCount={userGroupNames.length}
               variant={PaginationVariant.bottom}
-              onSetPage={(_e, page) => setPage(page)}
-              onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+              widgetId="pagination-options-menu-bottom"
             />
           </FlexItem>
         )}

--- a/src/components/Members/MembersExternal.tsx
+++ b/src/components/Members/MembersExternal.tsx
@@ -42,7 +42,7 @@ const MembersExternal = (props: PropsToMembersExternal) => {
   const dispatch = useAppDispatch();
 
   // Get parameters from URL
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   // Other states
@@ -228,9 +228,6 @@ const MembersExternal = (props: PropsToMembersExternal) => {
   return (
     <>
       <MemberOfToolbar
-        searchText={searchValue}
-        onSearchTextChange={setSearchValue}
-        onSearch={() => {}}
         searchPlaceholder="Search external members"
         searchAriaLabel="Search external members"
         refreshButtonEnabled={isRefreshButtonEnabled}

--- a/src/components/Members/MembersExternal.tsx
+++ b/src/components/Members/MembersExternal.tsx
@@ -1,16 +1,12 @@
 import React from "react";
 // PatternFly
-import {
-  Button,
-  Pagination,
-  PaginationVariant,
-  TextInput,
-} from "@patternfly/react-core";
+import { Button, PaginationVariant, TextInput } from "@patternfly/react-core";
 // Components
 import MemberOfToolbar from "../MemberOf/MemberOfToolbar";
 import { AvailableItems } from "../MemberOf/MemberOfAddModal";
 import MemberOfDeleteModal from "../MemberOf/MemberOfDeleteModal";
 import MemberTable from "src/components/tables/MembershipTable";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
 
 // Data types
 import { UserGroup } from "src/utils/datatypes/globalDataTypes";
@@ -42,8 +38,7 @@ const MembersExternal = (props: PropsToMembersExternal) => {
   const dispatch = useAppDispatch();
 
   // Get parameters from URL
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { setPage } = useListPageSearchParams();
 
   // Other states
   const [externalsSelected, setExternalsSelected] = React.useState<string[]>(
@@ -239,10 +234,6 @@ const MembersExternal = (props: PropsToMembersExternal) => {
         helpIconEnabled={true}
         onHelpIconClick={() => dispatch(toggleHelpPanel())}
         totalItems={props.member_external.length}
-        perPage={perPage}
-        page={page}
-        onPerPageChange={setPerPage}
-        onPageChange={setPage}
       />
       <MemberTable
         entityList={props.member_external}
@@ -254,15 +245,12 @@ const MembersExternal = (props: PropsToMembersExternal) => {
         onCheckItemsChange={setExternalsSelected}
         showTableRows={showTableRows}
       />
-      <Pagination
-        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
-        itemCount={props.member_external.length}
-        widgetId="pagination-options-menu-bottom"
-        perPage={perPage}
-        page={page}
+      <PaginationLayout
+        list={[]}
+        totalCount={props.member_external.length}
         variant={PaginationVariant.bottom}
-        onSetPage={(_e, page) => setPage(page)}
-        onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+        widgetId="pagination-options-menu-bottom"
+        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
       />
       {showAddModal && (
         <ModalWithFormLayout

--- a/src/components/Members/MembersHbacServices.tsx
+++ b/src/components/Members/MembersHbacServices.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 // PatternFly
-import { Pagination, PaginationVariant } from "@patternfly/react-core";
+import { PaginationVariant } from "@patternfly/react-core";
 // Components
 import MemberOfToolbar from "../MemberOf/MemberOfToolbar";
 import MemberOfAddModal, { AvailableItems } from "../MemberOf/MemberOfAddModal";
 import MemberOfDeleteModal from "../MemberOf/MemberOfDeleteModal";
 import MemberTable from "src/components/tables/MembershipTable";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
 
 // Data types
 import {
@@ -45,8 +46,7 @@ const MembersHBACServices = (props: PropsToMembersHBACServices) => {
   const dispatch = useAppDispatch();
 
   // Get parameters from URL
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, setPage, perPage, searchValue } = useListPageSearchParams();
 
   // Other states
   const [membersSelected, setMembersSelected] = React.useState<string[]>([]);
@@ -272,10 +272,6 @@ const MembersHBACServices = (props: PropsToMembersHBACServices) => {
         helpIconEnabled={true}
         onHelpIconClick={() => dispatch(toggleHelpPanel())}
         totalItems={props.member_hbacsvc.length}
-        perPage={perPage}
-        page={page}
-        onPerPageChange={setPerPage}
-        onPageChange={setPage}
       />
       <MemberTable
         entityList={members}
@@ -287,15 +283,12 @@ const MembersHBACServices = (props: PropsToMembersHBACServices) => {
         onCheckItemsChange={setMembersSelected}
         showTableRows={showTableRows}
       />
-      <Pagination
-        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
-        itemCount={props.member_hbacsvc.length}
-        widgetId="pagination-options-menu-bottom"
-        perPage={perPage}
-        page={page}
+      <PaginationLayout
+        list={[]}
+        totalCount={props.member_hbacsvc.length}
         variant={PaginationVariant.bottom}
-        onSetPage={(_e, page) => setPage(page)}
-        onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+        widgetId="pagination-options-menu-bottom"
+        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
       />
       <MemberOfAddModal
         showModal={showAddModal}

--- a/src/components/Members/MembersHbacServices.tsx
+++ b/src/components/Members/MembersHbacServices.tsx
@@ -45,7 +45,7 @@ const MembersHBACServices = (props: PropsToMembersHBACServices) => {
   const dispatch = useAppDispatch();
 
   // Get parameters from URL
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   // Other states
@@ -261,9 +261,6 @@ const MembersHBACServices = (props: PropsToMembersHBACServices) => {
   return (
     <>
       <MemberOfToolbar
-        searchText={searchValue}
-        onSearchTextChange={setSearchValue}
-        onSearch={() => {}}
         searchPlaceholder="Search HBAC services"
         searchAriaLabel="Search HBAC services"
         refreshButtonEnabled={isRefreshButtonEnabled}

--- a/src/components/Members/MembersHbacServices.tsx
+++ b/src/components/Members/MembersHbacServices.tsx
@@ -129,9 +129,9 @@ const MembersHBACServices = (props: PropsToMembersHBACServices) => {
 
   // Load available services, delay the search for opening the modal
   const servicesQuery = useGettingHbacServicesQuery({
-    search: adderSearchValue,
+    searchValue: adderSearchValue,
     apiVersion: API_VERSION_BACKUP,
-    sizelimit: 100,
+    sizeLimit: 100,
     startIdx: 0,
     stopIdx: 100,
   });

--- a/src/components/Members/MembersHostGroups.tsx
+++ b/src/components/Members/MembersHostGroups.tsx
@@ -62,7 +62,6 @@ const MembersHostGroups = (props: PropsToMembersHostGroups) => {
     perPage,
     setPerPage,
     searchValue,
-    setSearchValue,
     membershipDirection,
     setMembershipDirection,
   } = useListPageSearchParams();
@@ -346,9 +345,6 @@ const MembersHostGroups = (props: PropsToMembersHostGroups) => {
     <>
       {membershipDisabled ? (
         <MemberOfToolbar
-          searchText={searchValue}
-          onSearchTextChange={setSearchValue}
-          onSearch={() => {}}
           searchPlaceholder="Search host groups"
           searchAriaLabel="Search host groups"
           refreshButtonEnabled={isRefreshButtonEnabled}
@@ -371,9 +367,6 @@ const MembersHostGroups = (props: PropsToMembersHostGroups) => {
         />
       ) : (
         <MemberOfToolbar
-          searchText={searchValue}
-          onSearchTextChange={setSearchValue}
-          onSearch={() => {}}
           searchPlaceholder="Search host groups"
           searchAriaLabel="Search host groups"
           refreshButtonEnabled={isRefreshButtonEnabled}

--- a/src/components/Members/MembersHostGroups.tsx
+++ b/src/components/Members/MembersHostGroups.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 // PatternFly
-import { Pagination, PaginationVariant } from "@patternfly/react-core";
+import { PaginationVariant } from "@patternfly/react-core";
 // Components
 import MemberOfToolbar from "../MemberOf/MemberOfToolbar";
 import MemberOfAddModal, { AvailableItems } from "../MemberOf/MemberOfAddModal";
 import MemberOfDeleteModal from "../MemberOf/MemberOfDeleteModal";
 import MemberTable from "src/components/tables/MembershipTable";
 import { MembershipDirection } from "src/components/MemberOf/MemberOfToolbar";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
 
 // Data types
 import { HostGroup } from "src/utils/datatypes/globalDataTypes";
@@ -60,7 +61,6 @@ const MembersHostGroups = (props: PropsToMembersHostGroups) => {
     page,
     setPage,
     perPage,
-    setPerPage,
     searchValue,
     membershipDirection,
     setMembershipDirection,
@@ -360,10 +360,6 @@ const MembersHostGroups = (props: PropsToMembersHostGroups) => {
           helpIconEnabled={true}
           onHelpIconClick={() => dispatch(toggleHelpPanel())}
           totalItems={hostGroupNames.length}
-          perPage={perPage}
-          page={page}
-          onPerPageChange={setPerPage}
-          onPageChange={setPage}
         />
       ) : (
         <MemberOfToolbar
@@ -385,10 +381,6 @@ const MembersHostGroups = (props: PropsToMembersHostGroups) => {
           helpIconEnabled={true}
           onHelpIconClick={() => dispatch(toggleHelpPanel())}
           totalItems={hostGroupNames.length}
-          perPage={perPage}
-          page={page}
-          onPerPageChange={setPerPage}
-          onPageChange={setPage}
         />
       )}
       <MemberTable
@@ -409,15 +401,12 @@ const MembersHostGroups = (props: PropsToMembersHostGroups) => {
         }
         showTableRows={showTableRows}
       />
-      <Pagination
-        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
-        itemCount={hostGroupNames.length}
-        widgetId="pagination-options-menu-bottom"
-        perPage={perPage}
-        page={page}
+      <PaginationLayout
+        list={[]}
+        totalCount={hostGroupNames.length}
         variant={PaginationVariant.bottom}
-        onSetPage={(_e, page) => setPage(page)}
-        onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+        widgetId="pagination-options-menu-bottom"
+        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
       />
       {showAddModal && (
         <MemberOfAddModal

--- a/src/components/Members/MembersHostGroups.tsx
+++ b/src/components/Members/MembersHostGroups.tsx
@@ -121,10 +121,6 @@ const MembersHostGroups = (props: PropsToMembersHostGroups) => {
   }, [props.entity, membershipDirection, searchValue, page, perPage]);
 
   React.useEffect(() => {
-    setMembershipDirection(props.direction);
-  }, [props.entity]);
-
-  React.useEffect(() => {
     if (hostGroupNamesToLoad.length > 0) {
       fullHostGroupsQuery.refetch();
     }

--- a/src/components/Members/MembersHostGroups.tsx
+++ b/src/components/Members/MembersHostGroups.tsx
@@ -196,9 +196,9 @@ const MembersHostGroups = (props: PropsToMembersHostGroups) => {
 
   // Load available host groups, delay the search for opening the modal
   const hostGroupsQuery = useGettingHostGroupsQuery({
-    search: adderSearchValue,
+    searchValue: adderSearchValue,
     apiVersion: API_VERSION_BACKUP,
-    sizelimit: 100,
+    sizeLimit: 100,
     startIdx: 0,
     stopIdx: 100,
   });

--- a/src/components/Members/MembersHosts.tsx
+++ b/src/components/Members/MembersHosts.tsx
@@ -191,9 +191,9 @@ const MembersHosts = (props: PropsToMembersHosts) => {
 
   // Load available hosts, delay the search for opening the modal
   const hostsQuery = useGettingHostQuery({
-    search: adderSearchValue,
+    searchValue: adderSearchValue,
     apiVersion: API_VERSION_BACKUP,
-    sizelimit: 100,
+    sizeLimit: 100,
     startIdx: 0,
     stopIdx: 100,
   });

--- a/src/components/Members/MembersHosts.tsx
+++ b/src/components/Members/MembersHosts.tsx
@@ -64,7 +64,6 @@ const MembersHosts = (props: PropsToMembersHosts) => {
     perPage,
     setPerPage,
     searchValue,
-    setSearchValue,
     membershipDirection,
     setMembershipDirection,
   } = useListPageSearchParams();
@@ -332,9 +331,6 @@ const MembersHosts = (props: PropsToMembersHosts) => {
     <>
       {membershipDisabled ? (
         <MemberOfToolbar
-          searchText={searchValue}
-          onSearchTextChange={setSearchValue}
-          onSearch={() => {}}
           searchPlaceholder="Search hosts"
           searchAriaLabel="Search hosts"
           refreshButtonEnabled={isRefreshButtonEnabled}
@@ -357,9 +353,6 @@ const MembersHosts = (props: PropsToMembersHosts) => {
         />
       ) : (
         <MemberOfToolbar
-          searchText={searchValue}
-          onSearchTextChange={setSearchValue}
-          onSearch={() => {}}
           searchPlaceholder="Search hosts"
           searchAriaLabel="Search hosts"
           refreshButtonEnabled={isRefreshButtonEnabled}

--- a/src/components/Members/MembersHosts.tsx
+++ b/src/components/Members/MembersHosts.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 // PatternFly
-import { Pagination, PaginationVariant } from "@patternfly/react-core";
+import { PaginationVariant } from "@patternfly/react-core";
 // Components
 import MemberOfToolbar from "../MemberOf/MemberOfToolbar";
 import MemberOfAddModal, { AvailableItems } from "../MemberOf/MemberOfAddModal";
 import MemberOfDeleteModal from "../MemberOf/MemberOfDeleteModal";
 import MemberTable from "src/components/tables/MembershipTable";
 import { MembershipDirection } from "src/components/MemberOf/MemberOfToolbar";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
 
 // Data types
 import { Host, HostGroup } from "src/utils/datatypes/globalDataTypes";
@@ -62,7 +63,6 @@ const MembersHosts = (props: PropsToMembersHosts) => {
     page,
     setPage,
     perPage,
-    setPerPage,
     searchValue,
     membershipDirection,
     setMembershipDirection,
@@ -346,10 +346,6 @@ const MembersHosts = (props: PropsToMembersHosts) => {
           helpIconEnabled={true}
           onHelpIconClick={() => dispatch(toggleHelpPanel())}
           totalItems={hostNames.length}
-          perPage={perPage}
-          page={page}
-          onPerPageChange={setPerPage}
-          onPageChange={setPage}
         />
       ) : (
         <MemberOfToolbar
@@ -371,10 +367,6 @@ const MembersHosts = (props: PropsToMembersHosts) => {
           helpIconEnabled={true}
           onHelpIconClick={() => dispatch(toggleHelpPanel())}
           totalItems={hostNames.length}
-          perPage={perPage}
-          page={page}
-          onPerPageChange={setPerPage}
-          onPageChange={setPage}
         />
       )}
       <MemberTable
@@ -395,15 +387,12 @@ const MembersHosts = (props: PropsToMembersHosts) => {
         }
         showTableRows={showTableRows}
       />
-      <Pagination
-        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
-        itemCount={hostNames.length}
-        widgetId="pagination-options-menu-bottom"
-        perPage={perPage}
-        page={page}
+      <PaginationLayout
+        list={[]}
+        totalCount={hostNames.length}
         variant={PaginationVariant.bottom}
-        onSetPage={(_e, page) => setPage(page)}
-        onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+        widgetId="pagination-options-menu-bottom"
+        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
       />
       {showAddModal && (
         <MemberOfAddModal

--- a/src/components/Members/MembersHosts.tsx
+++ b/src/components/Members/MembersHosts.tsx
@@ -119,10 +119,6 @@ const MembersHosts = (props: PropsToMembersHosts) => {
   }, [props.entity, membershipDirection, searchValue, page, perPage]);
 
   React.useEffect(() => {
-    setMembershipDirection(props.direction);
-  }, [props.entity]);
-
-  React.useEffect(() => {
     if (hostNamesToLoad.length > 0) {
       fullHostsQuery.refetch();
     }

--- a/src/components/Members/MembersNetgroups.tsx
+++ b/src/components/Members/MembersNetgroups.tsx
@@ -109,10 +109,6 @@ const MembersNetgroups = (props: PropsToMembersNetgroups) => {
   }, [props.entity, membershipDirection, searchValue, page, perPage]);
 
   React.useEffect(() => {
-    setMembershipDirection(props.direction);
-  }, [props.entity]);
-
-  React.useEffect(() => {
     if (netgroupNamesToLoad.length > 0) {
       fullNetgroupsQuery.refetch();
     }

--- a/src/components/Members/MembersNetgroups.tsx
+++ b/src/components/Members/MembersNetgroups.tsx
@@ -50,7 +50,6 @@ const MembersNetgroups = (props: PropsToMembersNetgroups) => {
     perPage,
     setPerPage,
     searchValue,
-    setSearchValue,
     membershipDirection,
     setMembershipDirection,
   } = useListPageSearchParams();
@@ -293,9 +292,6 @@ const MembersNetgroups = (props: PropsToMembersNetgroups) => {
   return (
     <>
       <MemberOfToolbar
-        searchText={searchValue}
-        onSearchTextChange={setSearchValue}
-        onSearch={() => {}}
         searchPlaceholder="Search netgroups"
         searchAriaLabel="Search netgroups"
         refreshButtonEnabled={isRefreshButtonEnabled}

--- a/src/components/Members/MembersNetgroups.tsx
+++ b/src/components/Members/MembersNetgroups.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 // PatternFly
-import { Pagination, PaginationVariant } from "@patternfly/react-core";
+import { PaginationVariant } from "@patternfly/react-core";
 // Components
 import MemberOfToolbar from "../MemberOf/MemberOfToolbar";
 import MemberOfAddModal, { AvailableItems } from "../MemberOf/MemberOfAddModal";
 import MemberOfDeleteModal from "../MemberOf/MemberOfDeleteModal";
 import MemberTable from "src/components/tables/MembershipTable";
 import { MembershipDirection } from "src/components/MemberOf/MemberOfToolbar";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
 
 // Data types
 import { Netgroup } from "src/utils/datatypes/globalDataTypes";
@@ -48,7 +49,6 @@ const MembersNetgroups = (props: PropsToMembersNetgroups) => {
     page,
     setPage,
     perPage,
-    setPerPage,
     searchValue,
     membershipDirection,
     setMembershipDirection,
@@ -310,10 +310,6 @@ const MembersNetgroups = (props: PropsToMembersNetgroups) => {
         helpIconEnabled={true}
         onHelpIconClick={() => dispatch(toggleHelpPanel())}
         totalItems={netgroupNames.length}
-        perPage={perPage}
-        page={page}
-        onPerPageChange={setPerPage}
-        onPageChange={setPage}
       />
       <MemberTable
         entityList={netgroups}
@@ -333,15 +329,12 @@ const MembersNetgroups = (props: PropsToMembersNetgroups) => {
         }
         showTableRows={showTableRows}
       />
-      <Pagination
-        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
-        itemCount={netgroupNames.length}
-        widgetId="pagination-options-menu-bottom"
-        perPage={perPage}
-        page={page}
+      <PaginationLayout
+        list={[]}
+        totalCount={netgroupNames.length}
         variant={PaginationVariant.bottom}
-        onSetPage={(_e, page) => setPage(page)}
-        onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+        widgetId="pagination-options-menu-bottom"
+        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
       />
       <MemberOfAddModal
         showModal={showAddModal}

--- a/src/components/Members/MembersNetgroups.tsx
+++ b/src/components/Members/MembersNetgroups.tsx
@@ -154,9 +154,9 @@ const MembersNetgroups = (props: PropsToMembersNetgroups) => {
 
   // Load available netgroups, delay the search for opening the modal
   const netgroupsQuery = useGettingNetgroupsQuery({
-    search: adderSearchValue,
+    searchValue: adderSearchValue,
     apiVersion: API_VERSION_BACKUP,
-    sizelimit: 100,
+    sizeLimit: 100,
     startIdx: 0,
     stopIdx: 100,
   });

--- a/src/components/Members/MembersServices.tsx
+++ b/src/components/Members/MembersServices.tsx
@@ -111,10 +111,6 @@ const MembersServices = (props: PropsToMembersServices) => {
   }, [props.entity, membershipDirection, searchValue, page, perPage]);
 
   React.useEffect(() => {
-    setMembershipDirection(props.direction);
-  }, [props.entity]);
-
-  React.useEffect(() => {
     if (serviceNamesToLoad.length > 0) {
       fullServicesQuery.refetch();
     }

--- a/src/components/Members/MembersServices.tsx
+++ b/src/components/Members/MembersServices.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 // PatternFly
-import { Pagination, PaginationVariant } from "@patternfly/react-core";
+import { PaginationVariant } from "@patternfly/react-core";
 // Components
 import MemberOfToolbar from "../MemberOf/MemberOfToolbar";
 import MemberOfAddModal, { AvailableItems } from "../MemberOf/MemberOfAddModal";
 import MemberOfDeleteModal from "../MemberOf/MemberOfDeleteModal";
 import MemberTable from "src/components/tables/MembershipTable";
 import { MembershipDirection } from "src/components/MemberOf/MemberOfToolbar";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
 
 // Data types
 import { Service, UserGroup } from "src/utils/datatypes/globalDataTypes";
@@ -58,7 +59,6 @@ const MembersServices = (props: PropsToMembersServices) => {
     page,
     setPage,
     perPage,
-    setPerPage,
     searchValue,
     membershipDirection,
     setMembershipDirection,
@@ -319,10 +319,6 @@ const MembersServices = (props: PropsToMembersServices) => {
           helpIconEnabled={true}
           onHelpIconClick={() => dispatch(toggleHelpPanel())}
           totalItems={serviceNames.length}
-          perPage={perPage}
-          page={page}
-          onPerPageChange={setPerPage}
-          onPageChange={setPage}
         />
       ) : (
         <MemberOfToolbar
@@ -344,10 +340,6 @@ const MembersServices = (props: PropsToMembersServices) => {
           helpIconEnabled={true}
           onHelpIconClick={() => dispatch(toggleHelpPanel())}
           totalItems={serviceNames.length}
-          perPage={perPage}
-          page={page}
-          onPerPageChange={setPerPage}
-          onPageChange={setPage}
         />
       )}
       <MemberTable
@@ -368,15 +360,12 @@ const MembersServices = (props: PropsToMembersServices) => {
         }
         showTableRows={showTableRows}
       />
-      <Pagination
-        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
-        itemCount={serviceNames.length}
-        widgetId="pagination-options-menu-bottom"
-        perPage={perPage}
-        page={page}
+      <PaginationLayout
+        list={[]}
+        totalCount={serviceNames.length}
         variant={PaginationVariant.bottom}
-        onSetPage={(_e, page) => setPage(page)}
-        onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+        widgetId="pagination-options-menu-bottom"
+        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
       />
       {showAddModal && (
         <MemberOfAddModal

--- a/src/components/Members/MembersServices.tsx
+++ b/src/components/Members/MembersServices.tsx
@@ -60,7 +60,6 @@ const MembersServices = (props: PropsToMembersServices) => {
     perPage,
     setPerPage,
     searchValue,
-    setSearchValue,
     membershipDirection,
     setMembershipDirection,
   } = useListPageSearchParams();
@@ -309,9 +308,6 @@ const MembersServices = (props: PropsToMembersServices) => {
     <>
       {membershipDisabled ? (
         <MemberOfToolbar
-          searchText={searchValue}
-          onSearchTextChange={setSearchValue}
-          onSearch={() => {}}
           searchPlaceholder="Search services"
           searchAriaLabel="Search services"
           refreshButtonEnabled={isRefreshButtonEnabled}
@@ -330,9 +326,6 @@ const MembersServices = (props: PropsToMembersServices) => {
         />
       ) : (
         <MemberOfToolbar
-          searchText={searchValue}
-          onSearchTextChange={setSearchValue}
-          onSearch={() => {}}
           searchPlaceholder="Search services"
           searchAriaLabel="Search services"
           refreshButtonEnabled={isRefreshButtonEnabled}

--- a/src/components/Members/MembersServices.tsx
+++ b/src/components/Members/MembersServices.tsx
@@ -169,9 +169,9 @@ const MembersServices = (props: PropsToMembersServices) => {
 
   // Load available services, delay the search for opening the modal
   const servicesQuery = useGettingServicesQuery({
-    search: adderSearchValue,
+    searchValue: adderSearchValue,
     apiVersion: API_VERSION_BACKUP,
-    sizelimit: 100,
+    sizeLimit: 100,
     startIdx: 0,
     stopIdx: 100,
   });

--- a/src/components/Members/MembersSudoCommands.tsx
+++ b/src/components/Members/MembersSudoCommands.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 // PatternFly
-import { Pagination, PaginationVariant } from "@patternfly/react-core";
+import { PaginationVariant } from "@patternfly/react-core";
 // Components
 import MemberOfToolbar from "../MemberOf/MemberOfToolbar";
 import MemberOfAddModal, { AvailableItems } from "../MemberOf/MemberOfAddModal";
 import MemberOfDeleteModal from "../MemberOf/MemberOfDeleteModal";
 import MemberTable from "src/components/tables/MembershipTable";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
 
 // Data types
 import { SudoCmd, SudoCmdGroup } from "src/utils/datatypes/globalDataTypes";
@@ -41,8 +42,7 @@ const MembersSudoCommands = (props: PropsToMembersSudoGroups) => {
   const dispatch = useAppDispatch();
 
   // Get parameters from URL
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, setPage, perPage, searchValue } = useListPageSearchParams();
 
   // Other states
   const [membersSelected, setMembersSelected] = React.useState<string[]>([]);
@@ -250,10 +250,6 @@ const MembersSudoCommands = (props: PropsToMembersSudoGroups) => {
         helpIconEnabled={true}
         onHelpIconClick={() => dispatch(toggleHelpPanel())}
         totalItems={props.entity?.member_sudocmd?.length || 0}
-        perPage={perPage}
-        page={page}
-        onPerPageChange={setPerPage}
-        onPageChange={setPage}
       />
       <MemberTable
         entityList={members}
@@ -265,15 +261,12 @@ const MembersSudoCommands = (props: PropsToMembersSudoGroups) => {
         onCheckItemsChange={setMembersSelected}
         showTableRows={showTableRows}
       />
-      <Pagination
-        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
-        itemCount={props.entity?.member_sudocmd?.length || 0}
-        widgetId="pagination-options-menu-bottom"
-        perPage={perPage}
-        page={page}
+      <PaginationLayout
+        list={[]}
+        totalCount={props.entity?.member_sudocmd?.length || 0}
         variant={PaginationVariant.bottom}
-        onSetPage={(_e, page) => setPage(page)}
-        onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+        widgetId="pagination-options-menu-bottom"
+        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
       />
       <MemberOfAddModal
         showModal={showAddModal}

--- a/src/components/Members/MembersSudoCommands.tsx
+++ b/src/components/Members/MembersSudoCommands.tsx
@@ -41,7 +41,7 @@ const MembersSudoCommands = (props: PropsToMembersSudoGroups) => {
   const dispatch = useAppDispatch();
 
   // Get parameters from URL
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   // Other states
@@ -239,9 +239,6 @@ const MembersSudoCommands = (props: PropsToMembersSudoGroups) => {
   return (
     <>
       <MemberOfToolbar
-        searchText={searchValue}
-        onSearchTextChange={setSearchValue}
-        onSearch={() => {}}
         searchPlaceholder="Search sudo commands"
         searchAriaLabel="Search sudo commands"
         refreshButtonEnabled={isRefreshButtonEnabled}

--- a/src/components/Members/MembersSudoCommands.tsx
+++ b/src/components/Members/MembersSudoCommands.tsx
@@ -107,9 +107,9 @@ const MembersSudoCommands = (props: PropsToMembersSudoGroups) => {
 
   // Load available services, delay the search for opening the modal
   const cmdsQuery = useGettingSudoCmdsQuery({
-    search: adderSearchValue,
+    searchValue: adderSearchValue,
     apiVersion: API_VERSION_BACKUP,
-    sizelimit: 100,
+    sizeLimit: 100,
     startIdx: 0,
     stopIdx: 100,
   });

--- a/src/components/Members/MembersSystemAccount.tsx
+++ b/src/components/Members/MembersSystemAccount.tsx
@@ -1,11 +1,12 @@
 import React, { useMemo } from "react";
 // PatternFly
-import { Pagination, PaginationVariant } from "@patternfly/react-core";
+import { PaginationVariant } from "@patternfly/react-core";
 // Components
 import MemberOfToolbar from "../MemberOf/MemberOfToolbar";
 import MemberOfAddModal, { AvailableItems } from "../MemberOf/MemberOfAddModal";
 import MemberOfDeleteModal from "../MemberOf/MemberOfDeleteModal";
 import MemberTable from "src/components/tables/MembershipTable";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
 // Data types
 import { Role } from "src/utils/datatypes/globalDataTypes";
 // Redux
@@ -36,8 +37,7 @@ interface PropsToMembersSystemAccount {
 const MembersSystemAccount = (props: PropsToMembersSystemAccount) => {
   const dispatch = useAppDispatch();
 
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, setPage, perPage, searchValue } = useListPageSearchParams();
 
   const [selectedItems, setSelectedItems] = React.useState<string[]>([]);
 
@@ -195,10 +195,6 @@ const MembersSystemAccount = (props: PropsToMembersSystemAccount) => {
         onAddButtonClick={() => setShowAddModal(true)}
         helpIconEnabled={true}
         totalItems={member_sysaccount.length}
-        perPage={perPage}
-        page={page}
-        onPerPageChange={setPerPage}
-        onPageChange={setPage}
       />
       <MemberTable
         entityList={itemsToShow}
@@ -210,15 +206,12 @@ const MembersSystemAccount = (props: PropsToMembersSystemAccount) => {
         onCheckItemsChange={setSelectedItems}
         showTableRows={showTableRows}
       />
-      <Pagination
-        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
-        itemCount={member_sysaccount.length}
-        widgetId="pagination-options-menu-bottom"
-        perPage={perPage}
-        page={page}
+      <PaginationLayout
+        list={[]}
+        totalCount={member_sysaccount.length}
         variant={PaginationVariant.bottom}
-        onSetPage={(_e, page) => setPage(page)}
-        onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+        widgetId="pagination-options-menu-bottom"
+        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
       />
       {showAddModal && (
         <MemberOfAddModal

--- a/src/components/Members/MembersSystemAccount.tsx
+++ b/src/components/Members/MembersSystemAccount.tsx
@@ -36,7 +36,7 @@ interface PropsToMembersSystemAccount {
 const MembersSystemAccount = (props: PropsToMembersSystemAccount) => {
   const dispatch = useAppDispatch();
 
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   const [selectedItems, setSelectedItems] = React.useState<string[]>([]);
@@ -185,9 +185,6 @@ const MembersSystemAccount = (props: PropsToMembersSystemAccount) => {
   return (
     <>
       <MemberOfToolbar
-        searchText={searchValue}
-        onSearchTextChange={setSearchValue}
-        onSearch={() => {}}
         searchPlaceholder="Search system accounts"
         searchAriaLabel="Search system accounts"
         refreshButtonEnabled={isRefreshButtonEnabled}

--- a/src/components/Members/MembersUserGroups.tsx
+++ b/src/components/Members/MembersUserGroups.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 // PatternFly
-import { Pagination, PaginationVariant } from "@patternfly/react-core";
+import { PaginationVariant } from "@patternfly/react-core";
 // Components
 import MemberOfToolbar from "../MemberOf/MemberOfToolbar";
 import MemberOfAddModal, { AvailableItems } from "../MemberOf/MemberOfAddModal";
 import MemberOfDeleteModal from "../MemberOf/MemberOfDeleteModal";
 import MemberTable from "src/components/tables/MembershipTable";
 import { MembershipDirection } from "src/components/MemberOf/MemberOfToolbar";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
 
 // Data types
 import { UserGroup } from "src/utils/datatypes/globalDataTypes";
@@ -59,7 +60,6 @@ const MembersUserGroups = (props: PropsToMembersUsergroups) => {
     page,
     setPage,
     perPage,
-    setPerPage,
     searchValue,
     membershipDirection,
     setMembershipDirection,
@@ -357,10 +357,6 @@ const MembersUserGroups = (props: PropsToMembersUsergroups) => {
           helpIconEnabled={true}
           onHelpIconClick={() => dispatch(toggleHelpPanel())}
           totalItems={userGroupNames.length}
-          perPage={perPage}
-          page={page}
-          onPerPageChange={setPerPage}
-          onPageChange={setPage}
         />
       ) : (
         <MemberOfToolbar
@@ -382,10 +378,6 @@ const MembersUserGroups = (props: PropsToMembersUsergroups) => {
           helpIconEnabled={true}
           onHelpIconClick={() => dispatch(toggleHelpPanel())}
           totalItems={userGroupNames.length}
-          perPage={perPage}
-          page={page}
-          onPerPageChange={setPerPage}
-          onPageChange={setPage}
         />
       )}
       <MemberTable
@@ -406,15 +398,12 @@ const MembersUserGroups = (props: PropsToMembersUsergroups) => {
         }
         showTableRows={showTableRows}
       />
-      <Pagination
-        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
-        itemCount={userGroupNames.length}
-        widgetId="pagination-options-menu-bottom"
-        perPage={perPage}
-        page={page}
+      <PaginationLayout
+        list={[]}
+        totalCount={userGroupNames.length}
         variant={PaginationVariant.bottom}
-        onSetPage={(_e, page) => setPage(page)}
-        onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+        widgetId="pagination-options-menu-bottom"
+        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
       />
       {showAddModal && (
         <MemberOfAddModal

--- a/src/components/Members/MembersUserGroups.tsx
+++ b/src/components/Members/MembersUserGroups.tsx
@@ -118,10 +118,6 @@ const MembersUserGroups = (props: PropsToMembersUsergroups) => {
   }, [props.entity, membershipDirection, searchValue, page, perPage]);
 
   React.useEffect(() => {
-    setMembershipDirection(props.direction);
-  }, [props.entity]);
-
-  React.useEffect(() => {
     if (userGroupNamesToLoad.length > 0) {
       fullUserGroupsQuery.refetch();
     }

--- a/src/components/Members/MembersUserGroups.tsx
+++ b/src/components/Members/MembersUserGroups.tsx
@@ -193,9 +193,9 @@ const MembersUserGroups = (props: PropsToMembersUsergroups) => {
 
   // Load available user groups, delay the search for opening the modal
   const userGroupsQuery = useGettingGroupsQuery({
-    search: adderSearchValue,
+    searchValue: adderSearchValue,
     apiVersion: API_VERSION_BACKUP,
-    sizelimit: 100,
+    sizeLimit: 100,
     startIdx: 0,
     stopIdx: 100,
   });

--- a/src/components/Members/MembersUserGroups.tsx
+++ b/src/components/Members/MembersUserGroups.tsx
@@ -61,7 +61,6 @@ const MembersUserGroups = (props: PropsToMembersUsergroups) => {
     perPage,
     setPerPage,
     searchValue,
-    setSearchValue,
     membershipDirection,
     setMembershipDirection,
   } = useListPageSearchParams();
@@ -343,9 +342,6 @@ const MembersUserGroups = (props: PropsToMembersUsergroups) => {
     <>
       {membershipDisabled ? (
         <MemberOfToolbar
-          searchText={searchValue}
-          onSearchTextChange={setSearchValue}
-          onSearch={() => {}}
           searchPlaceholder="Search user groups"
           searchAriaLabel="Search user groups"
           refreshButtonEnabled={isRefreshButtonEnabled}
@@ -368,9 +364,6 @@ const MembersUserGroups = (props: PropsToMembersUsergroups) => {
         />
       ) : (
         <MemberOfToolbar
-          searchText={searchValue}
-          onSearchTextChange={setSearchValue}
-          onSearch={() => {}}
           searchPlaceholder="Search user groups"
           searchAriaLabel="Search user groups"
           refreshButtonEnabled={isRefreshButtonEnabled}

--- a/src/components/Members/MembersUserIdOverride.tsx
+++ b/src/components/Members/MembersUserIdOverride.tsx
@@ -1,11 +1,12 @@
 import React, { useMemo } from "react";
 // PatternFly
-import { Pagination, PaginationVariant } from "@patternfly/react-core";
+import { PaginationVariant } from "@patternfly/react-core";
 // Components
 import MemberOfToolbar from "../MemberOf/MemberOfToolbar";
 import MemberOfAddModal, { AvailableItems } from "../MemberOf/MemberOfAddModal";
 import MemberOfDeleteModal from "../MemberOf/MemberOfDeleteModal";
 import MemberTable from "src/components/tables/MembershipTable";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
 // Data types
 import { Role } from "src/utils/datatypes/globalDataTypes";
 // Redux
@@ -38,8 +39,7 @@ interface PropsToMembersUserIdOverride {
 const MembersUserIdOverride = (props: PropsToMembersUserIdOverride) => {
   const dispatch = useAppDispatch();
 
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, setPage, perPage, searchValue } = useListPageSearchParams();
 
   const [selectedItems, setSelectedItems] = React.useState<string[]>([]);
 
@@ -206,10 +206,6 @@ const MembersUserIdOverride = (props: PropsToMembersUserIdOverride) => {
         onAddButtonClick={() => setShowAddModal(true)}
         helpIconEnabled={true}
         totalItems={member_idoverrideuser.length}
-        perPage={perPage}
-        page={page}
-        onPerPageChange={setPerPage}
-        onPageChange={setPage}
       />
       <MemberTable
         entityList={itemsToShow}
@@ -221,15 +217,12 @@ const MembersUserIdOverride = (props: PropsToMembersUserIdOverride) => {
         onCheckItemsChange={setSelectedItems}
         showTableRows={showTableRows}
       />
-      <Pagination
-        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
-        itemCount={member_idoverrideuser.length}
-        widgetId="pagination-options-menu-bottom"
-        perPage={perPage}
-        page={page}
+      <PaginationLayout
+        list={[]}
+        totalCount={member_idoverrideuser.length}
         variant={PaginationVariant.bottom}
-        onSetPage={(_e, page) => setPage(page)}
-        onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+        widgetId="pagination-options-menu-bottom"
+        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
       />
       {showAddModal && (
         <MemberOfAddModal

--- a/src/components/Members/MembersUserIdOverride.tsx
+++ b/src/components/Members/MembersUserIdOverride.tsx
@@ -38,7 +38,7 @@ interface PropsToMembersUserIdOverride {
 const MembersUserIdOverride = (props: PropsToMembersUserIdOverride) => {
   const dispatch = useAppDispatch();
 
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   const [selectedItems, setSelectedItems] = React.useState<string[]>([]);
@@ -196,9 +196,6 @@ const MembersUserIdOverride = (props: PropsToMembersUserIdOverride) => {
   return (
     <>
       <MemberOfToolbar
-        searchText={searchValue}
-        onSearchTextChange={setSearchValue}
-        onSearch={() => {}}
         searchPlaceholder="Search user ID overrides"
         searchAriaLabel="Search user ID overrides"
         refreshButtonEnabled={isRefreshButtonEnabled}

--- a/src/components/Members/MembersUsers.tsx
+++ b/src/components/Members/MembersUsers.tsx
@@ -63,7 +63,6 @@ const MembersUsers = (props: PropsToMembersUsers) => {
     perPage,
     setPerPage,
     searchValue,
-    setSearchValue,
     membershipDirection,
     setMembershipDirection,
   } = useListPageSearchParams();
@@ -336,9 +335,6 @@ const MembersUsers = (props: PropsToMembersUsers) => {
     <>
       {membershipDisabled ? (
         <MemberOfToolbar
-          searchText={searchValue}
-          onSearchTextChange={setSearchValue}
-          onSearch={() => {}}
           searchPlaceholder="Search users"
           searchAriaLabel="Search users"
           refreshButtonEnabled={isRefreshButtonEnabled}
@@ -361,9 +357,6 @@ const MembersUsers = (props: PropsToMembersUsers) => {
         />
       ) : (
         <MemberOfToolbar
-          searchText={searchValue}
-          onSearchTextChange={setSearchValue}
-          onSearch={() => {}}
           searchPlaceholder="Search users"
           searchAriaLabel="Search users"
           refreshButtonEnabled={isRefreshButtonEnabled}

--- a/src/components/Members/MembersUsers.tsx
+++ b/src/components/Members/MembersUsers.tsx
@@ -134,10 +134,6 @@ const MembersUsers = (props: PropsToMembersUsers) => {
   }, [props.entity, membershipDirection, searchValue, page, perPage]);
 
   React.useEffect(() => {
-    setMembershipDirection(props.direction);
-  }, [props.entity]);
-
-  React.useEffect(() => {
     if (userNamesToLoad.length > 0) {
       fullUsersQuery.refetch();
     }

--- a/src/components/Members/MembersUsers.tsx
+++ b/src/components/Members/MembersUsers.tsx
@@ -195,9 +195,9 @@ const MembersUsers = (props: PropsToMembersUsers) => {
 
   // Load available users, delay the search for opening the modal
   const usersQuery = useGettingActiveUserQuery({
-    search: adderSearchValue,
+    searchValue: adderSearchValue,
     apiVersion: API_VERSION_BACKUP,
-    sizelimit: 100,
+    sizeLimit: 100,
     startIdx: 0,
     stopIdx: 100,
   });

--- a/src/components/Members/MembersUsers.tsx
+++ b/src/components/Members/MembersUsers.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 // PatternFly
-import { Pagination, PaginationVariant } from "@patternfly/react-core";
+import { PaginationVariant } from "@patternfly/react-core";
 // Components
 import MemberOfToolbar from "../MemberOf/MemberOfToolbar";
 import MemberOfAddModal, { AvailableItems } from "../MemberOf/MemberOfAddModal";
 import MemberOfDeleteModal from "../MemberOf/MemberOfDeleteModal";
 import MemberTable from "src/components/tables/MembershipTable";
 import { MembershipDirection } from "src/components/MemberOf/MemberOfToolbar";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
 
 // Data types
 import { User, UserGroup } from "src/utils/datatypes/globalDataTypes";
@@ -61,7 +62,6 @@ const MembersUsers = (props: PropsToMembersUsers) => {
     page,
     setPage,
     perPage,
-    setPerPage,
     searchValue,
     membershipDirection,
     setMembershipDirection,
@@ -350,10 +350,6 @@ const MembersUsers = (props: PropsToMembersUsers) => {
           helpIconEnabled={true}
           onHelpIconClick={() => dispatch(toggleHelpPanel())}
           totalItems={userNames.length}
-          perPage={perPage}
-          page={page}
-          onPerPageChange={setPerPage}
-          onPageChange={setPage}
         />
       ) : (
         <MemberOfToolbar
@@ -375,10 +371,6 @@ const MembersUsers = (props: PropsToMembersUsers) => {
           helpIconEnabled={true}
           onHelpIconClick={() => dispatch(toggleHelpPanel())}
           totalItems={userNames.length}
-          perPage={perPage}
-          page={page}
-          onPerPageChange={setPerPage}
-          onPageChange={setPage}
         />
       )}
       <MemberTable
@@ -399,15 +391,12 @@ const MembersUsers = (props: PropsToMembersUsers) => {
         }
         showTableRows={showTableRows}
       />
-      <Pagination
-        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
-        itemCount={userNames.length}
-        widgetId="pagination-options-menu-bottom"
-        perPage={perPage}
-        page={page}
+      <PaginationLayout
+        list={[]}
+        totalCount={userNames.length}
         variant={PaginationVariant.bottom}
-        onSetPage={(_e, page) => setPage(page)}
-        onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+        widgetId="pagination-options-menu-bottom"
+        className="pf-v6-u-pb-0 pf-v6-u-pr-md"
       />
       {showAddModal && (
         <MemberOfAddModal

--- a/src/components/SudoRuleSections/SudoRuleOptions.tsx
+++ b/src/components/SudoRuleSections/SudoRuleOptions.tsx
@@ -197,29 +197,13 @@ const SudoRuleOptions = (props: PropsToSudoRuleOptions) => {
   // Pagination prep
   const [page, setPage] = React.useState<number>(1);
   const [perPage, setPerPage] = React.useState<number>(5);
-  const updateSelectedPerPage = () => {
-    // Nothing to do since we are not using bulk selector comp
-    return;
-  };
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
-  };
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
-  };
-  // Entries displayed on the first page
-  const updateShownElementsList = (newShownEntriesList: string[]) => {
-    setTableEntryList(newShownEntriesList);
-  };
 
   // Pagination data required by the Table Layout
   const paginationData = {
     page,
     perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList,
+    onUpdatePage: setPage,
+    onUpdatePerPage: setPerPage,
     totalCount: tableEntryList.length,
   };
 

--- a/src/components/layouts/DualListLayout/DualListLayout.test.tsx
+++ b/src/components/layouts/DualListLayout/DualListLayout.test.tsx
@@ -2,13 +2,13 @@ import React from "react";
 import {
   cleanup,
   fireEvent,
-  render,
   screen,
   waitForElementToBeRemoved,
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, Mock, vi } from "vitest";
 // Component
 import DualListLayout, { DualListProps } from "./DualListLayout";
+import { renderWithRouter } from "src/utils/testUtils";
 
 interface MockReturn {
   data: { list: string[] } | { error: { message: string } };
@@ -28,6 +28,10 @@ const retrieveIDs: Mock<() => Promise<MockReturn>> = vi.fn(async () => {
 });
 
 vi.mock("src/services/rpc", () => ({
+  api: {
+    reducer: () => ({}),
+    middleware: () => (next) => next,
+  },
   useGetIDListMutation: () => [retrieveIDs],
 }));
 
@@ -53,7 +57,7 @@ describe("DualListLayout Component", () => {
   });
 
   it("renders the DualListLayout component", async () => {
-    render(<DualListLayout {...initialProps} />);
+    renderWithRouter(<DualListLayout {...initialProps} />);
 
     // Search exists
     const searchEntry = screen.getByRole("textbox", {
@@ -81,7 +85,7 @@ describe("DualListLayout Component", () => {
   });
 
   it("renders the DualListLayout component without items", async () => {
-    render(<DualListLayout {...initialProps} />);
+    renderWithRouter(<DualListLayout {...initialProps} />);
 
     // Mock no entries
     retrieveIDs.mockReturnValueOnce(
@@ -114,7 +118,7 @@ describe("DualListLayout Component", () => {
   });
 
   it("renders the DualListLayout component with items", async () => {
-    render(<DualListLayout {...initialProps} />);
+    renderWithRouter(<DualListLayout {...initialProps} />);
 
     // Fetch new entries
     const clickButton = screen.getByRole("option", {
@@ -138,7 +142,7 @@ describe("DualListLayout Component", () => {
   });
 
   it("renders the DualListLayout component using search", async () => {
-    render(<DualListLayout {...initialProps} />);
+    renderWithRouter(<DualListLayout {...initialProps} />);
 
     // Use search bar
     const searchEntry = screen.getByRole("textbox", {
@@ -163,7 +167,7 @@ describe("DualListLayout Component", () => {
   });
 
   it("renders the DualListLayout with moved items", async () => {
-    render(<DualListLayout {...initialProps} />);
+    renderWithRouter(<DualListLayout {...initialProps} />);
 
     // Fetch new entries
     const clickButton = screen.getByRole("option", {
@@ -200,7 +204,9 @@ describe("DualListLayout Component", () => {
   });
 
   it("renders the DualListLayout with externals correctly", async () => {
-    render(<DualListLayout {...initialProps} addExternalsOption={true} />);
+    renderWithRouter(
+      <DualListLayout {...initialProps} addExternalsOption={true} />
+    );
 
     const TEST_EXTERNAL = "test";
 

--- a/src/components/layouts/DualListLayout/DualListLayout.tsx
+++ b/src/components/layouts/DualListLayout/DualListLayout.tsx
@@ -190,15 +190,15 @@ const DualListTableLayoutInner = (props: DualListProps) => {
     }
   };
 
-  function doSearch(value?: string) {
+  function doSearch(value: string) {
+    setSearchValue(value);
     setStatus("searching");
     submitSearchValue(value);
   }
 
   const searchValueData = {
     searchValue: searchValue,
-    updateSearchValue: setSearchValue,
-    submitSearchValue: doSearch,
+    onSubmit: doSearch,
   };
 
   const onButtonClick = () => {
@@ -296,7 +296,7 @@ const DualListTableLayoutInner = (props: DualListProps) => {
   const getListItems = (status: Status): ReactNode[] => {
     switch (status) {
       case "toSearch":
-        return [searchItem(doSearch)];
+        return [searchItem(() => doSearch(searchValue))];
       case "searching":
         return [searchingItem()];
       case "empty":

--- a/src/components/layouts/DualListLayout/DualListLayout.tsx
+++ b/src/components/layouts/DualListLayout/DualListLayout.tsx
@@ -162,11 +162,12 @@ const DualListTableLayoutInner = (props: DualListProps) => {
 
   // Issue a search using a specific search value
   const [retrieveIDs] = useGetIDListMutation({});
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setSearchIsDisabled(true);
     if (props.availableOptions === undefined) {
       retrieveIDs({
-        searchValue: props.availableOptions || searchValue,
+        searchValue: props.availableOptions || search,
         sizeLimit: 200,
         startIdx: 0,
         stopIdx: 200,
@@ -189,9 +190,9 @@ const DualListTableLayoutInner = (props: DualListProps) => {
     }
   };
 
-  function doSearch() {
+  function doSearch(value?: string) {
     setStatus("searching");
-    submitSearchValue();
+    submitSearchValue(value);
   }
 
   const searchValueData = {

--- a/src/components/layouts/PaginationLayout.test.tsx
+++ b/src/components/layouts/PaginationLayout.test.tsx
@@ -1,0 +1,130 @@
+import React from "react";
+import { MemoryRouter, useSearchParams } from "react-router";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+// Component
+import PaginationLayout from "./PaginationLayout";
+
+const SearchParamsProbe = ({
+  onParams,
+}: {
+  onParams: (params: URLSearchParams) => void;
+}) => {
+  const [params] = useSearchParams();
+  onParams(params);
+  return null;
+};
+
+const renderWithRouter = (ui: React.ReactElement, initialEntry = "/") => {
+  let latestParams = new URLSearchParams();
+  const result = render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      {ui}
+      <SearchParamsProbe
+        onParams={(params) => {
+          latestParams = params;
+        }}
+      />
+    </MemoryRouter>
+  );
+  return {
+    ...result,
+    getParams: () => latestParams,
+  };
+};
+
+const list = Array.from({ length: 50 }, (_, i) => `item-${i + 1}`);
+
+describe("PaginationLayout Component", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    cleanup();
+  });
+
+  it("reads page and perPage from URL search params", () => {
+    renderWithRouter(
+      <PaginationLayout list={list} totalCount={50} />,
+      "/?p=3&size=20"
+    );
+
+    expect(
+      screen.getByRole("spinbutton", { name: /Current page/i })
+    ).toHaveValue(3);
+    // Page 3 with size 20 → items 41-50 (shown in total items + menu toggle)
+    expect(
+      screen.getAllByText((_, el) => el?.textContent === "41 - 50").length
+    ).toBeGreaterThan(0);
+  });
+
+  it("writes page to URL when navigating", () => {
+    const { getParams } = renderWithRouter(
+      <PaginationLayout list={list} totalCount={50} />,
+      "/?size=10"
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Go to next page/i }));
+
+    expect(getParams().get("p")).toBe("2");
+    expect(getParams().get("size")).toBe("10");
+  });
+
+  it("omits p from URL when returning to page 1", () => {
+    const { getParams } = renderWithRouter(
+      <PaginationLayout list={list} totalCount={50} />,
+      "/?p=2&size=10"
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Go to previous page/i })
+    );
+
+    expect(getParams().get("p")).toBeNull();
+    expect(getParams().get("size")).toBe("10");
+  });
+
+  it("writes size and recalculated page to URL on per-page change", () => {
+    const { getParams } = renderWithRouter(
+      <PaginationLayout
+        list={list}
+        totalCount={50}
+        widgetId="test-pagination"
+      />,
+      "/?size=10"
+    );
+
+    fireEvent.click(document.getElementById("test-pagination-top-toggle")!);
+    fireEvent.click(screen.getByRole("menuitem", { name: /20 per page/i }));
+
+    expect(getParams().get("size")).toBe("20");
+    expect(getParams().get("p")).toBeNull();
+  });
+
+  it("uses local paginationData override instead of URL", () => {
+    const onUpdatePage = vi.fn();
+    const onUpdatePerPage = vi.fn();
+
+    const { getParams } = renderWithRouter(
+      <PaginationLayout
+        list={list}
+        totalCount={50}
+        paginationData={{
+          page: 2,
+          perPage: 10,
+          onUpdatePage,
+          onUpdatePerPage,
+        }}
+      />,
+      "/?p=5&size=50"
+    );
+
+    expect(
+      screen.getByRole("spinbutton", { name: /Current page/i })
+    ).toHaveValue(2);
+
+    fireEvent.click(screen.getByRole("button", { name: /Go to next page/i }));
+
+    expect(onUpdatePage).toHaveBeenCalledWith(3);
+    expect(getParams().get("p")).toBe("5");
+    expect(getParams().get("size")).toBe("50");
+  });
+});

--- a/src/components/layouts/PaginationLayout.test.tsx
+++ b/src/components/layouts/PaginationLayout.test.tsx
@@ -1,37 +1,9 @@
 import React from "react";
-import { MemoryRouter, useSearchParams } from "react-router";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 // Component
 import PaginationLayout from "./PaginationLayout";
-
-const SearchParamsProbe = ({
-  onParams,
-}: {
-  onParams: (params: URLSearchParams) => void;
-}) => {
-  const [params] = useSearchParams();
-  onParams(params);
-  return null;
-};
-
-const renderWithRouter = (ui: React.ReactElement, initialEntry = "/") => {
-  let latestParams = new URLSearchParams();
-  const result = render(
-    <MemoryRouter initialEntries={[initialEntry]}>
-      {ui}
-      <SearchParamsProbe
-        onParams={(params) => {
-          latestParams = params;
-        }}
-      />
-    </MemoryRouter>
-  );
-  return {
-    ...result,
-    getParams: () => latestParams,
-  };
-};
+import { renderWithRouter } from "src/utils/testUtils";
 
 const list = Array.from({ length: 50 }, (_, i) => `item-${i + 1}`);
 

--- a/src/components/layouts/PaginationLayout.tsx
+++ b/src/components/layouts/PaginationLayout.tsx
@@ -100,7 +100,6 @@ const PaginationLayout = <T,>(props: PropsToPaginationPrep<T>) => {
   };
 
   // Ensure page is always at least 1 to prevent negative display values
-  const safePage = Math.max(1, page);
   const itemCount = props.totalCount > 0 ? props.totalCount : props.list.length;
 
   return (
@@ -109,7 +108,7 @@ const PaginationLayout = <T,>(props: PropsToPaginationPrep<T>) => {
       itemCount={itemCount}
       widgetId={props.widgetId}
       perPage={perPage}
-      page={safePage}
+      page={page}
       variant={props.variant}
       onSetPage={handleSetPage}
       onPerPageSelect={handlePerPageSelect}

--- a/src/components/layouts/PaginationLayout.tsx
+++ b/src/components/layouts/PaginationLayout.tsx
@@ -1,104 +1,124 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import React from "react";
 import { Pagination } from "@patternfly/react-core";
+import { useSearchParams } from "react-router";
+import { parsePage, parsePerPage } from "src/hooks/useListPageSearchParams";
 
-interface PaginationData {
+/** Local override for non-list UIs (e.g. SettingsTableLayout). When omitted, uses URL `p`/`size`. */
+export interface PaginationData {
   page: number;
   perPage: number;
-  updatePage: (newPage: number) => void;
-  updatePerPage: (newSetPerPage: number) => void;
-  updateSelectedPerPage?: (selected: number) => void;
-  updateShownElementsList?: (newShownElementsList: any[]) => void;
-  totalCount: number;
+  onUpdatePage: (newPage: number) => void;
+  onUpdatePerPage: (newPerPage: number) => void;
 }
 
-interface PropsToPaginationPrep {
-  list: any[];
-  paginationData: PaginationData;
+interface PropsToPaginationPrep<T> {
+  list: T[];
+  totalCount: number;
+  paginationData?: PaginationData;
   variant?: "top" | "bottom";
-  widgetId?: string | undefined;
+  widgetId?: string;
   className?: string;
   isCompact?: boolean;
-  perPageSize?: "sm" | "default";
+  perPageSize?: "sm";
 }
 
-const PaginationLayout = (props: PropsToPaginationPrep) => {
-  let perPageOptions = [
-    { title: "10", value: 10 },
-    { title: "20", value: 20 },
-    { title: "50", value: 50 },
-    { title: "100", value: 100 },
-  ];
+const DEFAULT_PER_PAGE_OPTIONS = [
+  { title: "10", value: 10 },
+  { title: "20", value: 20 },
+  { title: "50", value: 50 },
+  { title: "100", value: 100 },
+];
+
+const SMALL_PER_PAGE_OPTIONS = [
+  { title: "5", value: 5 },
+  { title: "10", value: 10 },
+  { title: "20", value: 20 },
+  { title: "50", value: 50 },
+];
+
+const PaginationLayout = <T,>(props: PropsToPaginationPrep<T>) => {
+  const [params, setParams] = useSearchParams();
+  const page = props.paginationData?.page ?? parsePage(params.get("p"));
+  const perPage =
+    props.paginationData?.perPage ?? parsePerPage(params.get("size"));
+
+  const updatePage = (newPage: number) => {
+    if (props.paginationData !== undefined) {
+      props.paginationData.onUpdatePage(newPage);
+      return;
+    }
+
+    const nextPage = Math.max(1, newPage);
+    setParams(
+      (currentParams) => {
+        if (nextPage > 1) {
+          currentParams.set("p", nextPage.toString());
+        } else {
+          currentParams.delete("p");
+        }
+        return currentParams;
+      },
+      { replace: true }
+    );
+  };
+
+  const updatePageAndPerPage = (newPage: number, newPerPage: number) => {
+    if (props.paginationData !== undefined) {
+      props.paginationData.onUpdatePerPage(newPerPage);
+      props.paginationData.onUpdatePage(newPage);
+      return;
+    }
+    const nextPage = Math.max(1, newPage);
+    const nextPerPage = Math.max(1, newPerPage);
+    setParams(
+      (currentParams) => {
+        currentParams.set("size", nextPerPage.toString());
+        if (nextPage > 1) {
+          currentParams.set("p", nextPage.toString());
+        } else {
+          currentParams.delete("p");
+        }
+        return currentParams;
+      },
+      { replace: true }
+    );
+  };
 
   const handleSetPage = (
     _event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
-    newPage: number,
-    perPage: number | undefined,
-    startIdx: number | undefined,
-    endIdx: number | undefined
+    newPage: number
   ) => {
-    props.paginationData.updatePage(newPage);
-    if (props.paginationData.updateShownElementsList) {
-      props.paginationData.updateShownElementsList(
-        props.list.slice(startIdx, endIdx)
-      );
-    }
-    // Reset 'selectedPerPage'
-    if (props.paginationData.updateSelectedPerPage) {
-      props.paginationData.updateSelectedPerPage(0);
-    }
+    updatePage(newPage);
   };
 
-  // Handle content on 'perPageSelect'
   const handlePerPageSelect = (
     _event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
     newPerPage: number,
-    newPage: number,
-    startIdx: number | undefined,
-    endIdx: number | undefined
+    newPage: number
   ) => {
-    props.paginationData.updatePerPage(newPerPage);
-    props.paginationData.updatePage(newPage);
-    if (props.paginationData.updateShownElementsList) {
-      props.paginationData.updateShownElementsList(
-        props.list.slice(startIdx, endIdx)
-      );
-    }
-    // Reset 'selectedPerPage'
-    if (props.paginationData.updateSelectedPerPage) {
-      props.paginationData.updateSelectedPerPage(0);
-    }
+    updatePageAndPerPage(newPage, newPerPage);
   };
 
-  if (props.perPageSize !== undefined && props.perPageSize === "sm") {
-    perPageOptions = [
-      { title: "5", value: 5 },
-      { title: "10", value: 10 },
-      { title: "20", value: 20 },
-      { title: "50", value: 50 },
-    ];
-  }
-
   // Ensure page is always at least 1 to prevent negative display values
-  const safePage = Math.max(1, props.paginationData.page);
-
-  const itemCount =
-    props.paginationData.totalCount > 0
-      ? props.paginationData.totalCount
-      : props.list.length;
+  const safePage = Math.max(1, page);
+  const itemCount = props.totalCount > 0 ? props.totalCount : props.list.length;
 
   return (
     <Pagination
       className={props.className}
       itemCount={itemCount}
       widgetId={props.widgetId}
-      perPage={props.paginationData.perPage}
+      perPage={perPage}
       page={safePage}
       variant={props.variant}
       onSetPage={handleSetPage}
       onPerPageSelect={handlePerPageSelect}
       isCompact={props.isCompact}
-      perPageOptions={perPageOptions}
+      perPageOptions={
+        props.perPageSize === "sm"
+          ? SMALL_PER_PAGE_OPTIONS
+          : DEFAULT_PER_PAGE_OPTIONS
+      }
     />
   );
 };

--- a/src/components/layouts/SearchInputLayout/SearchInputLayout.test.tsx
+++ b/src/components/layouts/SearchInputLayout/SearchInputLayout.test.tsx
@@ -61,7 +61,7 @@ describe("SearchInputLayout Component", () => {
     expect(searchInput).toHaveValue("current search value");
   });
 
-  it("calls updateSearchValue when input changes", () => {
+  it("does not call updateSearchValue on keystroke (buffers locally)", () => {
     render(
       <SearchInputLayout
         dataCy="search-input"
@@ -72,7 +72,8 @@ describe("SearchInputLayout Component", () => {
     const searchInput = screen.getByRole("textbox");
     fireEvent.change(searchInput, { target: { value: "new search value" } });
 
-    expect(mockUpdateSearchValue).toHaveBeenCalledWith("new search value");
+    expect(mockUpdateSearchValue).not.toHaveBeenCalled();
+    expect(searchInput).toHaveValue("new search value");
   });
 
   it("calls updateSearchValue with empty string when reset button is clicked", () => {
@@ -94,7 +95,7 @@ describe("SearchInputLayout Component", () => {
     expect(mockUpdateSearchValue).toHaveBeenCalledWith("");
   });
 
-  it("calls submitSearchValue when search button is clicked", () => {
+  it("calls updateSearchValue and submitSearchValue with input value on search submit", () => {
     render(
       <SearchInputLayout
         dataCy="search-input"
@@ -102,9 +103,13 @@ describe("SearchInputLayout Component", () => {
       />
     );
 
+    const searchInput = screen.getByRole("textbox");
+    fireEvent.change(searchInput, { target: { value: "typed value" } });
+
     const searchButton = screen.getByRole("button", { name: /search/i });
     fireEvent.click(searchButton);
 
-    expect(mockSubmitSearchValue).toHaveBeenCalled();
+    expect(mockUpdateSearchValue).toHaveBeenCalledWith("typed value");
+    expect(mockSubmitSearchValue).toHaveBeenCalledWith("typed value");
   });
 });

--- a/src/components/layouts/SearchInputLayout/SearchInputLayout.test.tsx
+++ b/src/components/layouts/SearchInputLayout/SearchInputLayout.test.tsx
@@ -1,16 +1,36 @@
 import React from "react";
+import { MemoryRouter, useSearchParams } from "react-router";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 // Component
 import SearchInputLayout from "./SearchInputLayout";
 
-const mockUpdateSearchValue = vi.fn();
-const mockSubmitSearchValue = vi.fn();
+const SearchParamsProbe = ({
+  onParams,
+}: {
+  onParams: (params: URLSearchParams) => void;
+}) => {
+  const [params] = useSearchParams();
+  onParams(params);
+  return null;
+};
 
-const defaultSearchValueData = {
-  searchValue: "",
-  updateSearchValue: mockUpdateSearchValue,
-  submitSearchValue: mockSubmitSearchValue,
+const renderWithRouter = (ui: React.ReactElement, initialEntry = "/") => {
+  let latestParams = new URLSearchParams();
+  const result = render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      {ui}
+      <SearchParamsProbe
+        onParams={(params) => {
+          latestParams = params;
+        }}
+      />
+    </MemoryRouter>
+  );
+  return {
+    ...result,
+    getParams: () => latestParams,
+  };
 };
 
 describe("SearchInputLayout Component", () => {
@@ -20,20 +40,15 @@ describe("SearchInputLayout Component", () => {
   });
 
   it("renders correctly with all optional props", () => {
-    const searchValueData = {
-      ...defaultSearchValueData,
-      searchValue: "test search",
-    };
-
-    render(
+    renderWithRouter(
       <SearchInputLayout
         name="search-field"
         dataCy="search-input"
         ariaLabel="Search users"
         placeholder="Enter search term"
-        searchValueData={searchValueData}
         isDisabled={false}
-      />
+      />,
+      "/?search=test%20search"
     );
 
     const searchInput = screen.getByRole("textbox");
@@ -44,63 +59,45 @@ describe("SearchInputLayout Component", () => {
     expect(searchInput).not.toBeDisabled();
   });
 
-  it("displays the current search value", () => {
-    const searchValueData = {
-      ...defaultSearchValueData,
-      searchValue: "current search value",
-    };
-
-    render(
-      <SearchInputLayout
-        dataCy="search-input"
-        searchValueData={searchValueData}
-      />
+  it("displays the current URL search value", () => {
+    renderWithRouter(
+      <SearchInputLayout dataCy="search-input" />,
+      "/?search=current%20search%20value"
     );
 
     const searchInput = screen.getByRole("textbox");
     expect(searchInput).toHaveValue("current search value");
   });
 
-  it("does not call updateSearchValue on keystroke (buffers locally)", () => {
-    render(
-      <SearchInputLayout
-        dataCy="search-input"
-        searchValueData={defaultSearchValueData}
-      />
+  it("does not update URL on keystroke (buffers locally)", () => {
+    const { getParams } = renderWithRouter(
+      <SearchInputLayout dataCy="search-input" />
     );
 
     const searchInput = screen.getByRole("textbox");
     fireEvent.change(searchInput, { target: { value: "new search value" } });
 
-    expect(mockUpdateSearchValue).not.toHaveBeenCalled();
+    expect(getParams().get("search")).toBeNull();
     expect(searchInput).toHaveValue("new search value");
   });
 
-  it("calls updateSearchValue with empty string when reset button is clicked", () => {
-    const searchValueData = {
-      ...defaultSearchValueData,
-      searchValue: "search to clear",
-    };
-
-    render(
-      <SearchInputLayout
-        dataCy="search-input"
-        searchValueData={searchValueData}
-      />
+  it("commits empty string to URL when reset button is clicked", () => {
+    const { getParams } = renderWithRouter(
+      <SearchInputLayout dataCy="search-input" />,
+      "/?search=search%20to%20clear&p=3"
     );
 
     const clearButton = screen.getByRole("button", { name: /Reset/i });
     fireEvent.click(clearButton);
 
-    expect(mockUpdateSearchValue).toHaveBeenCalledWith("");
+    expect(getParams().get("search")).toBeNull();
+    expect(getParams().get("p")).toBeNull();
   });
 
-  it("calls updateSearchValue and submitSearchValue with input value on search submit", () => {
-    render(
-      <SearchInputLayout
-        dataCy="search-input"
-        searchValueData={defaultSearchValueData}
-      />
+  it("commits input value to URL on search submit and resets page", () => {
+    const { getParams } = renderWithRouter(
+      <SearchInputLayout dataCy="search-input" />,
+      "/?p=3"
     );
 
     const searchInput = screen.getByRole("textbox");
@@ -109,7 +106,32 @@ describe("SearchInputLayout Component", () => {
     const searchButton = screen.getByRole("button", { name: /search/i });
     fireEvent.click(searchButton);
 
-    expect(mockUpdateSearchValue).toHaveBeenCalledWith("typed value");
-    expect(mockSubmitSearchValue).toHaveBeenCalledWith("typed value");
+    expect(getParams().get("search")).toBe("typed value");
+    expect(getParams().get("p")).toBeNull();
+  });
+
+  it("uses local searchValueData override instead of URL", () => {
+    const mockOnSubmit = vi.fn();
+
+    const { getParams } = renderWithRouter(
+      <SearchInputLayout
+        dataCy="search-input"
+        searchValueData={{
+          searchValue: "local value",
+          onSubmit: mockOnSubmit,
+        }}
+      />,
+      "/?search=url%20value"
+    );
+
+    const searchInput = screen.getByRole("textbox");
+    expect(searchInput).toHaveValue("local value");
+
+    fireEvent.change(searchInput, { target: { value: "typed local" } });
+    const searchButton = screen.getByRole("button", { name: /search/i });
+    fireEvent.click(searchButton);
+
+    expect(mockOnSubmit).toHaveBeenCalledWith("typed local");
+    expect(getParams().get("search")).toBe("url value");
   });
 });

--- a/src/components/layouts/SearchInputLayout/SearchInputLayout.tsx
+++ b/src/components/layouts/SearchInputLayout/SearchInputLayout.tsx
@@ -1,12 +1,11 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import React, { FormEvent, SyntheticEvent } from "react";
+import React from "react";
 // PatternFly
 import { SearchInput } from "@patternfly/react-core";
 
 interface SearchValueData {
   searchValue: string;
   updateSearchValue: (value: string) => void;
-  submitSearchValue?: () => void;
+  submitSearchValue?: (value?: string) => void;
 }
 
 interface PropsToSearchInput {
@@ -19,15 +18,19 @@ interface PropsToSearchInput {
 }
 
 const SearchInputLayout = (props: PropsToSearchInput) => {
-  const onSearchChange = (
-    _event: FormEvent<HTMLInputElement>,
-    value: string
-  ) => {
-    props.searchValueData.updateSearchValue(value);
-  };
+  const [inputValue, setInputValue] = React.useState(
+    props.searchValueData.searchValue
+  );
 
-  const onSearchClear = (_event: SyntheticEvent<HTMLButtonElement, Event>) => {
-    props.searchValueData.updateSearchValue("");
+  const prevSearchValue = React.useRef(props.searchValueData.searchValue);
+  if (prevSearchValue.current !== props.searchValueData.searchValue) {
+    prevSearchValue.current = props.searchValueData.searchValue;
+    setInputValue(props.searchValueData.searchValue);
+  }
+
+  const onSearchSubmit = () => {
+    props.searchValueData.updateSearchValue(inputValue);
+    props.searchValueData.submitSearchValue?.(inputValue);
   };
 
   return (
@@ -36,14 +39,13 @@ const SearchInputLayout = (props: PropsToSearchInput) => {
       name={props.name}
       aria-label={props.ariaLabel}
       placeholder={props.placeholder}
-      value={props.searchValueData.searchValue}
-      onSearch={
-        props.searchValueData.submitSearchValue
-          ? props.searchValueData.submitSearchValue
-          : () => void undefined
-      }
-      onChange={onSearchChange}
-      onClear={onSearchClear}
+      value={inputValue}
+      onSearch={onSearchSubmit}
+      onChange={(_event, value: string) => setInputValue(value)}
+      onClear={() => {
+        setInputValue("");
+        props.searchValueData.updateSearchValue("");
+      }}
       isDisabled={props.isDisabled}
     />
   );

--- a/src/components/layouts/SearchInputLayout/SearchInputLayout.tsx
+++ b/src/components/layouts/SearchInputLayout/SearchInputLayout.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 // PatternFly
 import { SearchInput } from "@patternfly/react-core";
+// Router
+import { useSearchParams } from "react-router";
 
 interface SearchValueData {
   searchValue: string;
-  updateSearchValue: (value: string) => void;
-  submitSearchValue?: (value?: string) => void;
+  onSubmit: (value: string) => void;
 }
 
 interface PropsToSearchInput {
@@ -13,24 +14,42 @@ interface PropsToSearchInput {
   dataCy: string;
   ariaLabel?: string;
   placeholder?: string;
-  searchValueData: SearchValueData;
+  /** Local override for non-list UIs (e.g. DualListLayout). When omitted, uses URL search params. */
+  searchValueData?: SearchValueData;
   isDisabled?: boolean;
 }
 
 const SearchInputLayout = (props: PropsToSearchInput) => {
-  const [inputValue, setInputValue] = React.useState(
-    props.searchValueData.searchValue
-  );
-
-  const prevSearchValue = React.useRef(props.searchValueData.searchValue);
-  if (prevSearchValue.current !== props.searchValueData.searchValue) {
-    prevSearchValue.current = props.searchValueData.searchValue;
-    setInputValue(props.searchValueData.searchValue);
+  const [params, setParams] = useSearchParams();
+  const committedSearchValue =
+    props.searchValueData !== undefined
+      ? props.searchValueData.searchValue
+      : params.get("search") || "";
+  const [inputValue, setInputValue] = React.useState(committedSearchValue);
+  const prevSearchValue = React.useRef(committedSearchValue);
+  if (prevSearchValue.current !== committedSearchValue) {
+    prevSearchValue.current = committedSearchValue;
+    setInputValue(committedSearchValue);
   }
 
-  const onSearchSubmit = () => {
-    props.searchValueData.updateSearchValue(inputValue);
-    props.searchValueData.submitSearchValue?.(inputValue);
+  const commitSearch = (value: string) => {
+    if (props.searchValueData !== undefined) {
+      props.searchValueData.onSubmit(value);
+      return;
+    }
+    setParams(
+      (currentParams) => {
+        if (value !== "") {
+          currentParams.set("search", value);
+        } else {
+          currentParams.delete("search");
+        }
+        // Reset to first page when search changes
+        currentParams.delete("p");
+        return currentParams;
+      },
+      { replace: true }
+    );
   };
 
   return (
@@ -40,11 +59,11 @@ const SearchInputLayout = (props: PropsToSearchInput) => {
       aria-label={props.ariaLabel}
       placeholder={props.placeholder}
       value={inputValue}
-      onSearch={onSearchSubmit}
+      onSearch={(_, value: string) => commitSearch(value)}
       onChange={(_event, value: string) => setInputValue(value)}
       onClear={() => {
         setInputValue("");
-        props.searchValueData.updateSearchValue("");
+        commitSearch("");
       }}
       isDisabled={props.isDisabled}
     />

--- a/src/components/layouts/SettingsTableLayout/SettingsTableLayout.test.tsx
+++ b/src/components/layouts/SettingsTableLayout/SettingsTableLayout.test.tsx
@@ -1,24 +1,26 @@
 import React from "react";
+import { MemoryRouter } from "react-router";
 import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import { expect, it, describe, vi, afterEach } from "vitest";
 import { Tr, Th, Td } from "@patternfly/react-table";
 // Component
 import SettingsTableLayout from "./SettingsTableLayout";
 
+const renderWithRouter = (ui: React.ReactElement) =>
+  render(<MemoryRouter>{ui}</MemoryRouter>);
+
 describe("SettingsTableLayout Component", () => {
   const mockOnAddModal = vi.fn();
   const mockOnDeleteModal = vi.fn();
-  const mockUpdatePage = vi.fn();
-  const mockUpdatePerPage = vi.fn();
+  const mockOnUpdatePage = vi.fn();
+  const mockOnUpdatePerPage = vi.fn();
   const mockOnSearchChange = vi.fn();
 
   const paginationData = {
     page: 1,
     perPage: 10,
-    updatePage: mockUpdatePage,
-    updatePerPage: mockUpdatePerPage,
-    updateSelectedPerPage: vi.fn(),
-    updateShownElementsList: vi.fn(),
+    onUpdatePage: mockOnUpdatePage,
+    onUpdatePerPage: mockOnUpdatePerPage,
     totalCount: 25,
   };
 
@@ -59,7 +61,7 @@ describe("SettingsTableLayout Component", () => {
   });
 
   it("should render SettingsTableLayout with table when length of list > 0", () => {
-    render(<SettingsTableLayout {...defaultProps} />);
+    renderWithRouter(<SettingsTableLayout {...defaultProps} />);
 
     // Check table is rendered
     expect(screen.getByLabelText("Settings Table")).toBeInTheDocument();
@@ -87,7 +89,7 @@ describe("SettingsTableLayout Component", () => {
       paginationData: { ...paginationData, totalCount: 0 },
     };
 
-    render(<SettingsTableLayout {...emptyProps} />);
+    renderWithRouter(<SettingsTableLayout {...emptyProps} />);
 
     // Check EmptyState is rendered
     expect(screen.getByText("No users")).toBeInTheDocument();
@@ -104,14 +106,14 @@ describe("SettingsTableLayout Component", () => {
       paginationData: { ...paginationData, totalCount: 0 },
     };
 
-    render(<SettingsTableLayout {...emptyProps} />);
+    renderWithRouter(<SettingsTableLayout {...emptyProps} />);
 
     const addButton = screen.getByRole("button", { name: /Add users/i });
     expect(addButton).toBeDisabled();
   });
 
   it("should call onAddModal when Add button is clicked", () => {
-    render(<SettingsTableLayout {...defaultProps} />);
+    renderWithRouter(<SettingsTableLayout {...defaultProps} />);
 
     const addButton = screen.getByRole("button", { name: /add/i });
     fireEvent.click(addButton);
@@ -119,7 +121,7 @@ describe("SettingsTableLayout Component", () => {
   });
 
   it("should call onDeleteModal when Delete button is clicked", () => {
-    render(<SettingsTableLayout {...defaultProps} />);
+    renderWithRouter(<SettingsTableLayout {...defaultProps} />);
 
     const deleteButton = screen.getByRole("button", { name: /delete/i });
     fireEvent.click(deleteButton);
@@ -127,7 +129,7 @@ describe("SettingsTableLayout Component", () => {
   });
 
   it("should search for an item in the list", () => {
-    render(<SettingsTableLayout {...defaultProps} />);
+    renderWithRouter(<SettingsTableLayout {...defaultProps} />);
 
     const searchInput = screen.getByPlaceholderText(/Filter by .../i);
     fireEvent.change(searchInput, { target: { value: "item1" } });
@@ -135,7 +137,7 @@ describe("SettingsTableLayout Component", () => {
   });
 
   it("should clear the search input when clear button is clicked", () => {
-    render(<SettingsTableLayout {...defaultProps} />);
+    renderWithRouter(<SettingsTableLayout {...defaultProps} />);
 
     const searchInput = screen.getByPlaceholderText(/Filter by .../i);
     fireEvent.change(searchInput, { target: { value: "item1" } });
@@ -150,7 +152,7 @@ describe("SettingsTableLayout Component", () => {
       entryType: "User",
     };
 
-    render(<SettingsTableLayout {...propsWithExtraId} />);
+    renderWithRouter(<SettingsTableLayout {...propsWithExtraId} />);
 
     // Check that the Add button has the correct ID with extraID
     const addButton = screen.getByRole("button", { name: /add/i });
@@ -164,7 +166,7 @@ describe("SettingsTableLayout Component", () => {
       entryType: "Host Group",
     };
 
-    render(<SettingsTableLayout {...propsWithSpaces} />);
+    renderWithRouter(<SettingsTableLayout {...propsWithSpaces} />);
 
     const addButton = screen.getByRole("button", { name: /add/i });
     expect(addButton).toHaveAttribute("id", "add-host-group-host-group");

--- a/src/components/layouts/SettingsTableLayout/SettingsTableLayout.tsx
+++ b/src/components/layouts/SettingsTableLayout/SettingsTableLayout.tsx
@@ -16,7 +16,7 @@ import TableLayout from "../TableLayout";
 import PaginationLayout, { PaginationData } from "../PaginationLayout";
 
 /** Local pagination for settings tables; includes totalCount for empty-state gating. */
-export interface SettingsPaginationData extends PaginationData {
+interface SettingsPaginationData extends PaginationData {
   totalCount: number;
 }
 

--- a/src/components/layouts/SettingsTableLayout/SettingsTableLayout.tsx
+++ b/src/components/layouts/SettingsTableLayout/SettingsTableLayout.tsx
@@ -13,7 +13,12 @@ import { TableVariant } from "@patternfly/react-table";
 // Layout
 import SecondaryButton from "../SecondaryButton";
 import TableLayout from "../TableLayout";
-import PaginationLayout from "../PaginationLayout";
+import PaginationLayout, { PaginationData } from "../PaginationLayout";
+
+/** Local pagination for settings tables; includes totalCount for empty-state gating. */
+export interface SettingsPaginationData extends PaginationData {
+  totalCount: number;
+}
 
 interface PropsToSettingsTableLayout {
   // Table
@@ -33,23 +38,12 @@ interface PropsToSettingsTableLayout {
   onSearchChange?: (value: string) => void;
   searchValue?: string;
   // pagination
-  paginationData: PaginationData;
+  paginationData: SettingsPaginationData;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   list: any[];
   entryCount?: number;
   entryType: string;
   extraID?: string;
-}
-
-interface PaginationData {
-  page: number;
-  perPage: number;
-  updatePage: (newPage: number) => void;
-  updatePerPage: (newSetPerPage: number) => void;
-  updateSelectedPerPage: (selected: number) => void;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  updateShownElementsList: (newShownElementsList: any[]) => void;
-  totalCount: number;
 }
 
 // The settings table is meant to be used in the "settings" page for users,
@@ -64,6 +58,8 @@ const SettingsTableLayout = (props: PropsToSettingsTableLayout) => {
   const addButtonId = extraId
     ? "add-" + extraId + "-" + props.entryType.toLowerCase().replace(" ", "-")
     : "add-" + props.entryType.toLowerCase().replace(" ", "-");
+
+  const { totalCount, ...paginationOverride } = props.paginationData;
 
   return (
     <>
@@ -81,7 +77,7 @@ const SettingsTableLayout = (props: PropsToSettingsTableLayout) => {
             />
           )}
         </FlexItem>
-        {props.paginationData.totalCount > 0 && (
+        {totalCount > 0 && (
           <>
             <FlexItem>
               <SecondaryButton
@@ -105,7 +101,8 @@ const SettingsTableLayout = (props: PropsToSettingsTableLayout) => {
             <FlexItem align={{ default: "alignRight" }}>
               <PaginationLayout
                 list={props.list}
-                paginationData={props.paginationData}
+                totalCount={totalCount}
+                paginationData={paginationOverride}
                 widgetId="pagination-options-menu-bottom"
                 className="pf-v6-u-pb-0 pf-v6-u-pr-md"
                 perPageSize="sm"
@@ -114,7 +111,7 @@ const SettingsTableLayout = (props: PropsToSettingsTableLayout) => {
           </>
         )}
       </Flex>
-      {props.paginationData.totalCount > 0 ? (
+      {totalCount > 0 ? (
         <>
           <TableLayout
             ariaLabel={props.ariaLabel}

--- a/src/components/modals/CertificateMapping/EnableDisableMultipleRules.tsx
+++ b/src/components/modals/CertificateMapping/EnableDisableMultipleRules.tsx
@@ -18,7 +18,6 @@ interface EnableDisableMultipleRulesModalProps {
   elementsList: string[];
   setElementsList: (elementsList: string[]) => void;
   operation: "enable" | "disable";
-  setShowTableRows: (value: boolean) => void;
   onRefresh: () => void;
 }
 
@@ -35,7 +34,6 @@ const EnableDisableMultipleRulesModal = (
   const onEnableDisable = () => {
     const operation = props.operation === "enable" ? enableRule : disableRule;
 
-    props.setShowTableRows(false);
     operation(props.elementsList).then((response) => {
       if ("data" in response) {
         const { data } = response;
@@ -58,19 +56,16 @@ const EnableDisableMultipleRulesModal = (
           props.onRefresh();
           onClose();
         }
-        props.setShowTableRows(true);
       }
     });
   };
 
   const onClose = () => {
-    props.setShowTableRows(true);
     props.setElementsList([]);
     props.onClose();
   };
 
   const onCloseWithoutClearingElements = () => {
-    props.setShowTableRows(true);
     props.onClose();
   };
 

--- a/src/components/modals/DnsZones/EnableDisableDnsForwardZonesModal.tsx
+++ b/src/components/modals/DnsZones/EnableDisableDnsForwardZonesModal.tsx
@@ -21,7 +21,6 @@ interface EnableDisableDnsForwardZonesModalProps {
   elementsList: string[];
   setElementsList: (elementsList: string[]) => void;
   operation: "enable" | "disable";
-  setShowTableRows: (value: boolean) => void;
   onRefresh: () => void;
 }
 
@@ -38,7 +37,6 @@ const EnableDisableDnsForwardZonesModal = (
   const onEnableDisable = () => {
     const operation = props.operation === "enable" ? enableRule : disableRule;
 
-    props.setShowTableRows(false);
     operation(props.elementsList).then((response) => {
       if ("data" in response) {
         const { data } = response;
@@ -61,19 +59,16 @@ const EnableDisableDnsForwardZonesModal = (
           props.onRefresh();
           onClose();
         }
-        props.setShowTableRows(true);
       }
     });
   };
 
   const onClose = () => {
-    props.setShowTableRows(true);
     props.setElementsList([]);
     props.onClose();
   };
 
   const onCloseWithoutClearingElements = () => {
-    props.setShowTableRows(true);
     props.onClose();
   };
 

--- a/src/components/modals/DnsZones/EnableDisableDnsZonesModal.tsx
+++ b/src/components/modals/DnsZones/EnableDisableDnsZonesModal.tsx
@@ -23,7 +23,6 @@ interface EnableDisableDnsZonesModalProps {
   elementsList: string[];
   setElementsList: (elementsList: DNSZone[]) => void;
   operation: "enable" | "disable";
-  setShowTableRows: (value: boolean) => void;
   onRefresh: () => void;
 }
 

--- a/src/components/modals/UserModals/AddUser.tsx
+++ b/src/components/modals/UserModals/AddUser.tsx
@@ -44,7 +44,6 @@ interface GroupId {
 interface PropsToAddUser {
   show: boolean;
   from: "active-users" | "stage-users" | "preserved-users";
-  setShowTableRows?: (value: boolean) => void;
   handleModalToggle: () => void;
   onOpenAddModal?: () => void;
   onCloseAddModal?: () => void;

--- a/src/components/tables/KeytabTable.tsx
+++ b/src/components/tables/KeytabTable.tsx
@@ -82,23 +82,6 @@ const KeytabTable = (props: PropsToTable) => {
   const [page, setPage] = useState<number>(1);
   const [perPage, setPerPage] = useState<number>(5);
   const [totalCount, setEntriesTotalCount] = useState<number>(0);
-  const updateSelectedPerPage = () => {
-    // Nothing to do since we are not using bulk selector comp
-    return;
-  };
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
-  };
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
-  };
-
-  // Entries displayed on the first page
-  const updateShownEntriesList = (
-    newShownEntriesList: User[] | UserGroup[] | Host[] | HostGroup[]
-  ) => {
-    setFullEntriesFiltered(newShownEntriesList);
-  };
 
   const resetEntries = () => {
     const firstIdx = (page - 1) * perPage;
@@ -478,10 +461,8 @@ const KeytabTable = (props: PropsToTable) => {
   const paginationData = {
     page,
     perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList: updateShownEntriesList,
+    onUpdatePage: setPage,
+    onUpdatePerPage: setPerPage,
     totalCount,
   };
 

--- a/src/components/tables/KeytabTableWithFilter.tsx
+++ b/src/components/tables/KeytabTableWithFilter.tsx
@@ -96,7 +96,6 @@ const KeytabTableWithFilter = (props: PropsToKeytabTable) => {
     setLastIdx,
     totalCount,
     setTotalCount,
-    updateSelectedPerPage,
   } = usePagination(tableEntryList, 5);
 
   const resetEntries = () => {
@@ -135,11 +134,6 @@ const KeytabTableWithFilter = (props: PropsToKeytabTable) => {
   const isDeleteDisabled = selectedEntries.length === 0;
   const isAddDisabled = props.checkboxesDisabled;
 
-  // Entries displayed on the first page
-  const updateShownEntriesList = (newShownEntriesList: TableEntry[]) => {
-    setTableEntriesFilteredList(newShownEntriesList);
-  };
-
   // on Search change
   const onSearchChange = (value: string) => {
     const entryList: TableEntry[] = [];
@@ -169,10 +163,8 @@ const KeytabTableWithFilter = (props: PropsToKeytabTable) => {
   const paginationData = {
     page,
     perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList: updateShownEntriesList,
+    onUpdatePage: updatePage,
+    onUpdatePerPage: updatePerPage,
     totalCount,
   };
 

--- a/src/hooks/useHostGroupRules.tsx
+++ b/src/hooks/useHostGroupRules.tsx
@@ -3,7 +3,9 @@ import React from "react";
 import {
   useDefaultGroupShowQuery,
   useAutomemberFindBasicInfoQuery,
+  useSearchHostGroupRulesEntriesQuery,
 } from "src/services/rpcAutomember";
+import { GenericPayload } from "src/services/rpc";
 // Error types
 import { SerializedError } from "@reduxjs/toolkit";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
@@ -14,36 +16,53 @@ import {
 } from "src/utils/datatypes/globalDataTypes";
 import { useGettingHostGroupsQuery } from "src/services/rpcHostGroups";
 import { API_VERSION_BACKUP } from "src/utils/utils";
+import { useAppSelector } from "src/store/hooks";
+
+type HostGroupsRulesDataArgs = {
+  searchValue: string;
+  startIdx: number;
+  stopIdx: number;
+};
 
 type HostGroupsRulesData = {
   isLoading: boolean;
   isFetching: boolean;
   automembersIds: AutomemberEntry[];
+  shownAutomembers: AutomemberEntry[];
+  totalCount: number;
   hostGroups: string[];
   defaultGroup: string;
   refetch: () => void;
   errors?: Array<FetchBaseQueryError | SerializedError>;
 };
 
-const useHostGroupsRulesData = (): HostGroupsRulesData => {
-  // States
+const useHostGroupsRulesData = ({
+  searchValue,
+  startIdx,
+  stopIdx,
+}: HostGroupsRulesDataArgs): HostGroupsRulesData => {
+  const apiVersion = useAppSelector(
+    (state) => state.global.environment.api_version
+  ) as string;
+
   const [hostGroups, setHostGroups] = React.useState<string[]>([]);
   const [automemberIdsList, setAutomemberIdsList] = React.useState<
     AutomemberEntry[]
   >([]);
-  const [defaultHostGroup, setDefaultHostGroup] = React.useState<string>("");
-  const [hostGroupsGeneralData, setHostGroupsGeneralData] = React.useState<
-    groupType[]
+  const [shownAutomembers, setShownAutomembers] = React.useState<
+    AutomemberEntry[]
   >([]);
+  const [totalCount, setTotalCount] = React.useState<number>(0);
+  const [defaultHostGroup, setDefaultHostGroup] = React.useState<string>("");
   const [error, setError] = React.useState<
     Array<FetchBaseQueryError | SerializedError>
   >([]);
 
-  // API call: Get all host groups
+  // API call: Get all host groups (needed for default selector and add modal)
   const hostGroupsQuery = useGettingHostGroupsQuery({
-    search: "",
+    searchValue: "",
     sizeLimit: 0,
-    apiVersion: API_VERSION_BACKUP,
+    apiVersion: apiVersion || API_VERSION_BACKUP,
     startIdx: 0,
     stopIdx: 100,
   });
@@ -63,21 +82,17 @@ const useHostGroupsRulesData = (): HostGroupsRulesData => {
           dn: results[i].result.dn,
         });
       }
-      setHostGroupsGeneralData(hostGroupsList);
       setHostGroups(hostGroupsList.map((group) => group.cn.toString()));
     }
   }, [hostGroupsData, hostGroupsQuery.isFetching]);
 
   React.useEffect(() => {
     if (hostGroupsError) {
-      const errorsUpdated = [...error];
-      errorsUpdated.push(hostGroupsError);
-      setError(errorsUpdated);
+      setError((prev) => [...prev, hostGroupsError]);
     }
   }, [hostGroupsError]);
 
-  // API call: Get all automembers
-  // const automembersQuery = useAutomemberFindQuery("hostgroup");
+  // Full automember list for availableToAdd (unfiltered)
   const automembersQuery = useAutomemberFindBasicInfoQuery("hostgroup");
   const automembersError = automembersQuery.error;
   const automembersListData = automembersQuery.data;
@@ -87,15 +102,38 @@ const useHostGroupsRulesData = (): HostGroupsRulesData => {
     if (automembersListData && !automembersQuery.isFetching) {
       setAutomemberIdsList(automembersListData);
     }
-  }, [automembersListData, automembersQuery.isFetching, hostGroupsGeneralData]);
+  }, [automembersListData, automembersQuery.isFetching]);
 
   React.useEffect(() => {
     if (automembersError) {
-      const errorsUpdated = [...error];
-      errorsUpdated.push(automembersError);
-      setError(errorsUpdated);
+      setError((prev) => [...prev, automembersError]);
     }
   }, [automembersError]);
+
+  // Paginated / filtered table data
+  const searchQuery = useSearchHostGroupRulesEntriesQuery({
+    searchValue,
+    sizeLimit: 0,
+    apiVersion: apiVersion || API_VERSION_BACKUP,
+    startIdx,
+    stopIdx,
+  } as GenericPayload);
+  const searchError = searchQuery.error;
+  const searchData = searchQuery.data;
+  const searchLoading = searchQuery.isLoading;
+
+  React.useEffect(() => {
+    if (searchData && !searchQuery.isFetching) {
+      setShownAutomembers(searchData.automemberRules);
+      setTotalCount(searchData.totalCount);
+    }
+  }, [searchData, searchQuery.isFetching]);
+
+  React.useEffect(() => {
+    if (searchError) {
+      setError((prev) => [...prev, searchError]);
+    }
+  }, [searchError]);
 
   // API call: Get default group for automember
   const defaultGroupQuery = useDefaultGroupShowQuery("hostgroup");
@@ -117,23 +155,30 @@ const useHostGroupsRulesData = (): HostGroupsRulesData => {
 
   React.useEffect(() => {
     if (defaultGroupError) {
-      const errorsUpdated = [...error];
-      errorsUpdated.push(defaultGroupError);
-      setError(errorsUpdated);
+      setError((prev) => [...prev, defaultGroupError]);
     }
   }, [defaultGroupError]);
 
-  // Return object with all data
   const hostGroupRulesData: HostGroupsRulesData = {
-    isLoading: hostGroupsLoading || automembersLoading || defaultGroupLoading,
-    isFetching: hostGroupsQuery.isFetching,
+    isLoading:
+      hostGroupsLoading ||
+      automembersLoading ||
+      defaultGroupLoading ||
+      searchLoading,
+    isFetching:
+      hostGroupsQuery.isFetching ||
+      automembersQuery.isFetching ||
+      searchQuery.isFetching,
     automembersIds: automemberIdsList,
+    shownAutomembers,
+    totalCount,
     hostGroups: hostGroups,
     defaultGroup: defaultHostGroup,
     refetch: () => {
       hostGroupsQuery.refetch();
       automembersQuery.refetch();
       defaultGroupQuery.refetch();
+      searchQuery.refetch();
     },
     errors: error.length > 0 ? error : undefined,
   };

--- a/src/hooks/useListPageSearchParams.tsx
+++ b/src/hooks/useListPageSearchParams.tsx
@@ -1,93 +1,88 @@
-import React from "react";
 import { useSearchParams } from "react-router";
 import { MembershipDirection } from "src/components/MemberOf/MemberOfToolbar";
+
+export const parsePage = (value: string | null): number => {
+  if (value && (parseInt(value) < 1 || isNaN(parseInt(value)))) {
+    return 1;
+  }
+  return Math.max(1, parseInt(value || "1"));
+};
+
+export const parsePerPage = (value: string | null): number => {
+  if (value && (parseInt(value) < 1 || isNaN(parseInt(value)))) {
+    return 10;
+  }
+  return Math.max(10, parseInt(value || "10"));
+};
+
+export const parseMembership = (value: string | null): MembershipDirection => {
+  if (value === "direct" || value === "indirect") {
+    return value;
+  }
+  return "direct";
+};
 
 const useListPageSearchParams = () => {
   const [params, setParams] = useSearchParams();
 
-  // States
-  // Page indexes
-  // - Ensure that the page index is always a positive integer
-  const getPageParam = () => {
-    const pageParam = params.get("p");
-    if (pageParam && (parseInt(pageParam) < 1 || isNaN(parseInt(pageParam)))) {
-      return 1;
-    } else {
-      return Math.max(1, parseInt(pageParam || "1"));
-    }
-  };
+  const page = parsePage(params.get("p"));
+  const perPage = parsePerPage(params.get("size"));
+  const searchValue = params.get("search") || "";
+  const membershipDirection = parseMembership(params.get("membership"));
 
-  const getPerPageParam = () => {
-    const pageParam = params.get("size");
-    if (pageParam && (parseInt(pageParam) < 1 || isNaN(parseInt(pageParam)))) {
-      return 10;
-    } else {
-      return Math.max(10, parseInt(pageParam || "10"));
-    }
-  };
-
-  const [page, _setPage] = React.useState(getPageParam());
-  const [perPage, _setPerPage] = React.useState(getPerPageParam());
-
-  // Ensure 'page' is always >= 1
   const setPage = (newPage: number) => {
-    _setPage(Math.max(1, newPage));
-  };
-
-  // Ensure 'perPage' is always >= 1
-  const setPerPage = (newPerPage: number) => {
-    _setPerPage(Math.max(1, newPerPage));
-  };
-
-  // Search value
-  const [searchValue, setSearchValue] = React.useState(
-    params.get("search") || ""
-  );
-
-  // Membership direction
-  // - Ensure that the teo possible options are "direct" and "indirect"
-  const getMembershipParam = () => {
-    if (
-      params.get("membership") !== "indirect" ||
-      params.get("membership") !== "direct"
-    ) {
-      return "direct";
-    } else {
-      return params.get("membership") as MembershipDirection;
-    }
-  };
-
-  const [membershipDirection, setMembershipDirection] =
-    React.useState<MembershipDirection>(getMembershipParam());
-
-  // Handle URLs with navigation parameters
-  React.useEffect(() => {
+    const nextPage = Math.max(1, newPage);
     setParams(
-      (params) => {
-        if (page > 1) {
-          params.set("p", page.toString());
+      (currentParams) => {
+        if (nextPage > 1) {
+          currentParams.set("p", nextPage.toString());
         } else {
-          params.delete("p");
+          currentParams.delete("p");
         }
-
-        if (searchValue !== "") {
-          params.set("search", searchValue);
-        } else {
-          params.delete("search");
-        }
-
-        if (membershipDirection !== "direct") {
-          params.set("membership", membershipDirection);
-        } else {
-          params.delete("membership");
-        }
-
-        params.set("size", perPage.toString());
-        return params;
+        return currentParams;
       },
       { replace: true }
     );
-  }, [page, searchValue, membershipDirection, perPage]);
+  };
+
+  const setPerPage = (newPerPage: number) => {
+    const nextPerPage = Math.max(1, newPerPage);
+    setParams(
+      (currentParams) => {
+        currentParams.set("size", nextPerPage.toString());
+        return currentParams;
+      },
+      { replace: true }
+    );
+  };
+
+  const setSearchValue = (value: string) => {
+    setParams(
+      (currentParams) => {
+        if (value !== "") {
+          currentParams.set("search", value);
+        } else {
+          currentParams.delete("search");
+        }
+        return currentParams;
+      },
+      { replace: true }
+    );
+  };
+
+  const setMembershipDirection = (direction: MembershipDirection) => {
+    setParams(
+      (currentParams) => {
+        if (direction !== "direct") {
+          currentParams.set("membership", direction);
+        } else {
+          currentParams.delete("membership");
+        }
+        return currentParams;
+      },
+      { replace: true }
+    );
+  };
 
   return {
     page,

--- a/src/hooks/useListPageSearchParams.tsx
+++ b/src/hooks/useListPageSearchParams.tsx
@@ -12,7 +12,7 @@ export const parsePerPage = (value: string | null): number => {
   if (value && (parseInt(value) < 1 || isNaN(parseInt(value)))) {
     return 10;
   }
-  return Math.max(10, parseInt(value || "10"));
+  return parseInt(value || "10");
 };
 
 export const parseMembership = (value: string | null): MembershipDirection => {

--- a/src/hooks/useListPageSearchParams.tsx
+++ b/src/hooks/useListPageSearchParams.tsx
@@ -15,7 +15,7 @@ export const parsePerPage = (value: string | null): number => {
   return parseInt(value || "10");
 };
 
-export const parseMembership = (value: string | null): MembershipDirection => {
+const parseMembership = (value: string | null): MembershipDirection => {
   if (value === "direct" || value === "indirect") {
     return value;
   }

--- a/src/hooks/useListPageSearchParams.tsx
+++ b/src/hooks/useListPageSearchParams.tsx
@@ -2,25 +2,17 @@ import { useSearchParams } from "react-router";
 import { MembershipDirection } from "src/components/MemberOf/MemberOfToolbar";
 
 export const parsePage = (value: string | null): number => {
-  if (value && (parseInt(value) < 1 || isNaN(parseInt(value)))) {
-    return 1;
-  }
-  return Math.max(1, parseInt(value || "1"));
+  const parsedValue = parseInt(value || "1", 10);
+  return isNaN(parsedValue) ? 1 : parsedValue;
 };
 
 export const parsePerPage = (value: string | null): number => {
-  if (value && (parseInt(value) < 1 || isNaN(parseInt(value)))) {
-    return 10;
-  }
-  return parseInt(value || "10");
+  const parsedValue = parseInt(value || "10", 10);
+  return isNaN(parsedValue) ? 1 : parsedValue;
 };
 
-const parseMembership = (value: string | null): MembershipDirection => {
-  if (value === "direct" || value === "indirect") {
-    return value;
-  }
-  return "direct";
-};
+const parseMembership = (value: string | null): MembershipDirection =>
+  value === "indirect" ? value : "direct";
 
 const useListPageSearchParams = () => {
   const [params, setParams] = useSearchParams();
@@ -31,11 +23,11 @@ const useListPageSearchParams = () => {
   const membershipDirection = parseMembership(params.get("membership"));
 
   const setPage = (newPage: number) => {
-    const nextPage = Math.max(1, newPage);
+    const nextPage = isNaN(newPage) ? 1 : Math.max(1, newPage);
     setParams(
       (currentParams) => {
         if (nextPage > 1) {
-          currentParams.set("p", nextPage.toString());
+          currentParams.set("p", nextPage.toString(10));
         } else {
           currentParams.delete("p");
         }
@@ -46,10 +38,14 @@ const useListPageSearchParams = () => {
   };
 
   const setPerPage = (newPerPage: number) => {
-    const nextPerPage = Math.max(1, newPerPage);
+    const nextPerPage = isNaN(newPerPage) ? 10 : Math.max(10, newPerPage);
     setParams(
       (currentParams) => {
-        currentParams.set("size", nextPerPage.toString());
+        if (nextPerPage !== 10) {
+          currentParams.set("size", nextPerPage.toString(10));
+        } else {
+          currentParams.delete("size");
+        }
         return currentParams;
       },
       { replace: true }

--- a/src/hooks/useUserGroupsRules.tsx
+++ b/src/hooks/useUserGroupsRules.tsx
@@ -1,9 +1,10 @@
 import React from "react";
-import { useGetGenericListQuery } from "src/services/rpc";
+import { useGetGenericListQuery, GenericPayload } from "src/services/rpc";
 // RPC
 import {
   useDefaultGroupShowQuery,
   useAutomemberFindBasicInfoQuery,
+  useSearchUserGroupRulesEntriesQuery,
 } from "src/services/rpcAutomember";
 // Error types
 import { SerializedError } from "@reduxjs/toolkit";
@@ -13,27 +14,45 @@ import {
   AutomemberEntry,
   groupType,
 } from "src/utils/datatypes/globalDataTypes";
+import { API_VERSION_BACKUP } from "src/utils/utils";
+import { useAppSelector } from "src/store/hooks";
+
+type UserGroupsRulesDataArgs = {
+  searchValue: string;
+  startIdx: number;
+  stopIdx: number;
+};
 
 type UserGroupsRulesData = {
   isLoading: boolean;
   isFetching: boolean;
   automembersIds: AutomemberEntry[];
+  shownAutomembers: AutomemberEntry[];
+  totalCount: number;
   userGroups: string[];
   defaultGroup: string;
   refetch: () => void;
   errors?: Array<FetchBaseQueryError | SerializedError>;
 };
 
-const useUserGroupsRulesData = (): UserGroupsRulesData => {
-  // States
+const useUserGroupsRulesData = ({
+  searchValue,
+  startIdx,
+  stopIdx,
+}: UserGroupsRulesDataArgs): UserGroupsRulesData => {
+  const apiVersion = useAppSelector(
+    (state) => state.global.environment.api_version
+  ) as string;
+
   const [userGroups, setUserGroups] = React.useState<string[]>([]);
   const [automemberIdsList, setAutomemberIdsList] = React.useState<
     AutomemberEntry[]
   >([]);
-  const [defaultUserGroup, setDefaultUserGroup] = React.useState<string>("");
-  const [userGroupsGeneralData, setUserGroupsGeneralData] = React.useState<
-    groupType[]
+  const [shownAutomembers, setShownAutomembers] = React.useState<
+    AutomemberEntry[]
   >([]);
+  const [totalCount, setTotalCount] = React.useState<number>(0);
+  const [defaultUserGroup, setDefaultUserGroup] = React.useState<string>("");
   const [error, setError] = React.useState<
     Array<FetchBaseQueryError | SerializedError>
   >([]);
@@ -47,24 +66,21 @@ const useUserGroupsRulesData = (): UserGroupsRulesData => {
 
   React.useEffect(() => {
     if (userGroupsData && !userGroupsQuery.isFetching) {
-      setUserGroupsGeneralData(userGroupsData);
-      const userGroups: string[] = [];
+      const groups: string[] = [];
       userGroupsData.map((group) => {
-        userGroups.push(group.cn.toString());
+        groups.push(group.cn.toString());
       });
-      setUserGroups(userGroups);
+      setUserGroups(groups);
     }
   }, [userGroupsData, userGroupsQuery.isFetching]);
 
   React.useEffect(() => {
     if (userGroupsError) {
-      const errorsUpdated = [...error];
-      errorsUpdated.push(userGroupsError);
-      setError(errorsUpdated);
+      setError((prev) => [...prev, userGroupsError]);
     }
   }, [userGroupsError]);
 
-  // API call: Get all automembers
+  // Full automember list for availableToAdd (unfiltered)
   const automembersQuery = useAutomemberFindBasicInfoQuery("group");
   const automembersError = automembersQuery.error;
   const automembersList = automembersQuery.data || [];
@@ -74,15 +90,38 @@ const useUserGroupsRulesData = (): UserGroupsRulesData => {
     if (automembersList && !automembersQuery.isFetching) {
       setAutomemberIdsList(automembersList);
     }
-  }, [automembersList, automembersQuery.isFetching, userGroupsGeneralData]);
+  }, [automembersList, automembersQuery.isFetching]);
 
   React.useEffect(() => {
     if (automembersError) {
-      const errorsUpdated = [...error];
-      errorsUpdated.push(automembersError);
-      setError(errorsUpdated);
+      setError((prev) => [...prev, automembersError]);
     }
   }, [automembersError]);
+
+  // Paginated / filtered table data
+  const searchQuery = useSearchUserGroupRulesEntriesQuery({
+    searchValue,
+    sizeLimit: 0,
+    apiVersion: apiVersion || API_VERSION_BACKUP,
+    startIdx,
+    stopIdx,
+  } as GenericPayload);
+  const searchError = searchQuery.error;
+  const searchData = searchQuery.data;
+  const searchLoading = searchQuery.isLoading;
+
+  React.useEffect(() => {
+    if (searchData && !searchQuery.isFetching) {
+      setShownAutomembers(searchData.automemberRules);
+      setTotalCount(searchData.totalCount);
+    }
+  }, [searchData, searchQuery.isFetching]);
+
+  React.useEffect(() => {
+    if (searchError) {
+      setError((prev) => [...prev, searchError]);
+    }
+  }, [searchError]);
 
   // API call: Get default group for automember
   const defaultGroupQuery = useDefaultGroupShowQuery("group");
@@ -104,23 +143,30 @@ const useUserGroupsRulesData = (): UserGroupsRulesData => {
 
   React.useEffect(() => {
     if (defaultGroupError) {
-      const errorsUpdated = [...error];
-      errorsUpdated.push(defaultGroupError);
-      setError(errorsUpdated);
+      setError((prev) => [...prev, defaultGroupError]);
     }
   }, [defaultGroupError]);
 
-  // Return object with all data
   const userGroupRulesData: UserGroupsRulesData = {
-    isLoading: userGroupsLoading || automembersLoading || defaultGroupLoading,
-    isFetching: userGroupsQuery.isFetching,
+    isLoading:
+      userGroupsLoading ||
+      automembersLoading ||
+      defaultGroupLoading ||
+      searchLoading,
+    isFetching:
+      userGroupsQuery.isFetching ||
+      automembersQuery.isFetching ||
+      searchQuery.isFetching,
     automembersIds: automemberIdsList,
+    shownAutomembers,
+    totalCount,
     userGroups: userGroups,
     defaultGroup: defaultUserGroup,
     refetch: () => {
       userGroupsQuery.refetch();
       automembersQuery.refetch();
       defaultGroupQuery.refetch();
+      searchQuery.refetch();
     },
     errors: error.length > 0 ? error : undefined,
   };

--- a/src/pages/ActiveUsers/ActiveUsers.tsx
+++ b/src/pages/ActiveUsers/ActiveUsers.tsx
@@ -516,6 +516,7 @@ const ActiveUsers = () => {
           name="search"
           ariaLabel="Search users"
           placeholder="Search users"
+          isDisabled={!showTableRows}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/ActiveUsers/ActiveUsers.tsx
+++ b/src/pages/ActiveUsers/ActiveUsers.tsx
@@ -106,14 +106,13 @@ const ActiveUsers = () => {
 
   const {
     data: batchResponse,
-    isLoading: isBatchLoading,
+    isFetching: isBatchFetching,
     error: batchError,
   } = userDataResponse;
 
   // Handle data when the API call is finished
   useEffect(() => {
     if (userDataResponse.isFetching) {
-      setShowTableRows(false);
       // Reset selected users on refresh
       setUsersTotalCount(0);
       globalErrors.clear();
@@ -138,8 +137,6 @@ const ActiveUsers = () => {
       setUsersTotalCount(totalCount);
       // Update the list of users
       setActiveUsersList(usersList);
-      // Show table elements
-      setShowTableRows(true);
     }
 
     // API response: Error
@@ -156,9 +153,6 @@ const ActiveUsers = () => {
 
   // Refresh button handling
   const refreshUsersData = () => {
-    // Hide table
-    setShowTableRows(false);
-
     // Reset selected users on refresh
     setUsersTotalCount(0);
     clearSelectedUsers();
@@ -210,16 +204,6 @@ const ActiveUsers = () => {
     const emptyList: User[] = [];
     setSelectedUsers(emptyList);
   };
-
-  // Show table rows
-  const [showTableRows, setShowTableRows] = useState(!isBatchLoading);
-
-  // Show table rows only when data is fully retrieved
-  useEffect(() => {
-    if (showTableRows !== !isBatchLoading) {
-      setShowTableRows(!isBatchLoading);
-    }
-  }, [isBatchLoading]);
 
   // [API call] 'Rebuild auto membership'
   const onRebuildAutoMembership = () => {
@@ -516,7 +500,7 @@ const ActiveUsers = () => {
           name="search"
           ariaLabel="Search users"
           placeholder="Search users"
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,
@@ -532,7 +516,7 @@ const ActiveUsers = () => {
         <SecondaryButton
           dataCy="active-users-button-refresh"
           onClickHandler={refreshUsersData}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
         >
           Refresh
         </SecondaryButton>
@@ -543,7 +527,7 @@ const ActiveUsers = () => {
       element: (
         <SecondaryButton
           dataCy="active-users-button-delete"
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || isBatchFetching}
           onClickHandler={onDeleteHandler}
         >
           Delete
@@ -556,7 +540,7 @@ const ActiveUsers = () => {
         <SecondaryButton
           dataCy="active-users-button-add"
           onClickHandler={onAddClickHandler}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
         >
           Add
         </SecondaryButton>
@@ -567,7 +551,7 @@ const ActiveUsers = () => {
       element: (
         <SecondaryButton
           dataCy="active-users-button-disable"
-          isDisabled={isDisableButtonDisabled || !showTableRows}
+          isDisabled={isDisableButtonDisabled || isBatchFetching}
           onClickHandler={() => onEnableDisableHandler(true)}
         >
           Disable
@@ -579,7 +563,7 @@ const ActiveUsers = () => {
       element: (
         <SecondaryButton
           dataCy="active-users-button-enable"
-          isDisabled={isEnableButtonDisabled || !showTableRows}
+          isDisabled={isEnableButtonDisabled || isBatchFetching}
           onClickHandler={() => onEnableDisableHandler(false)}
         >
           Enable
@@ -595,8 +579,8 @@ const ActiveUsers = () => {
           onKebabToggle={onKebabToggle}
           idKebab="main-dropdown-kebab"
           isKebabOpen={kebabIsOpen}
-          dropdownItems={showTableRows ? dropdownItems : []}
-          isDisabled={!showTableRows}
+          dropdownItems={isBatchFetching ? [] : dropdownItems}
+          isDisabled={isBatchFetching}
         />
       ),
     },
@@ -651,7 +635,7 @@ const ActiveUsers = () => {
                   <UsersTable
                     shownElementsList={activeUsersList}
                     from="active-users"
-                    showTableRows={showTableRows}
+                    showTableRows={!isBatchFetching}
                     usersData={usersTableData}
                     buttonsData={usersTableButtonsData}
                     paginationData={selectedPerPageData}

--- a/src/pages/ActiveUsers/ActiveUsers.tsx
+++ b/src/pages/ActiveUsers/ActiveUsers.tsx
@@ -246,7 +246,8 @@ const ActiveUsers = () => {
   const [retrieveUser] = useSearchEntriesMutation({});
 
   // Issue a search using a specific search value
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     setShowTableRows(false);
     setSearchIsDisabled(true);
@@ -254,7 +255,7 @@ const ActiveUsers = () => {
 
     // Make search via API call
     retrieveUser({
-      searchValue: searchValue,
+      searchValue: search,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
       startIdx: 0,

--- a/src/pages/ActiveUsers/ActiveUsers.tsx
+++ b/src/pages/ActiveUsers/ActiveUsers.tsx
@@ -46,7 +46,7 @@ import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Utils
 import { API_VERSION_BACKUP, isUserSelectable } from "src/utils/utils";
 // RPC client
-import { GenericPayload, useSearchEntriesMutation } from "src/services/rpc";
+import { GenericPayload } from "src/services/rpc";
 import {
   useGettingActiveUserQuery,
   useAutoMemberRebuildUsersMutation,
@@ -77,7 +77,7 @@ const ActiveUsers = () => {
   const [executeAutoMemberRebuild] = useAutoMemberRebuildUsersMutation();
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   // Handle API calls errors
@@ -86,7 +86,6 @@ const ActiveUsers = () => {
 
   // Main states - what user can define / what we could use in page URL
   const [totalCount, setUsersTotalCount] = useState<number>(0);
-  const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
   // Page indexes
   // - Ensure 'firstUserIdx' is always >= 0
@@ -230,78 +229,11 @@ const ActiveUsers = () => {
     setActiveUsersList(newShownUsersList);
   };
 
-  // Update search input valie
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
   const [selectedUsers, setSelectedUsers] = useState<User[]>([]);
 
   const clearSelectedUsers = () => {
     const emptyList: User[] = [];
     setSelectedUsers(emptyList);
-  };
-
-  const [retrieveUser] = useSearchEntriesMutation({});
-
-  // Issue a search using a specific search value
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    setShowTableRows(false);
-    setSearchIsDisabled(true);
-    setUsersTotalCount(0);
-
-    // Make search via API call
-    retrieveUser({
-      searchValue: search,
-      sizeLimit: 0,
-      apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: 0,
-      stopIdx: 100,
-      entryType: "user",
-    } as GenericPayload).then((result) => {
-      // Manage new response here
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for users",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success
-          const usersListResult = result.data?.result.results || [];
-          const usersListSize = result.data?.result.count || 0;
-          const totalCount = result.data?.result.totalCount || 0;
-          const usersList: User[] = [];
-
-          for (let i = 0; i < usersListSize; i++) {
-            usersList.push(usersListResult[i].result);
-          }
-
-          setUsersTotalCount(totalCount);
-          setActiveUsersList(usersList.slice(0, perPage));
-          // Show table elements
-          setShowTableRows(true);
-        }
-        setSearchIsDisabled(false);
-      }
-    });
   };
 
   // Show table rows
@@ -597,13 +529,6 @@ const ActiveUsers = () => {
     updateIsDisableEnableOp,
   };
 
-  // SearchInputLayout
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
-  };
-
   // List of Toolbar items
   const toolbarItems: ToolbarItem[] = [
     {
@@ -626,8 +551,6 @@ const ActiveUsers = () => {
           name="search"
           ariaLabel="Search users"
           placeholder="Search users"
-          searchValueData={searchValueData}
-          isDisabled={searchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/ActiveUsers/ActiveUsers.tsx
+++ b/src/pages/ActiveUsers/ActiveUsers.tsx
@@ -232,6 +232,7 @@ const ActiveUsers = () => {
 
   // Update search input valie
   const updateSearchValue = (value: string) => {
+    setPage(1);
     setSearchValue(value);
   };
 
@@ -246,6 +247,7 @@ const ActiveUsers = () => {
 
   // Issue a search using a specific search value
   const submitSearchValue = () => {
+    setPage(1);
     setShowTableRows(false);
     setSearchIsDisabled(true);
     setUsersTotalCount(0);
@@ -255,8 +257,8 @@ const ActiveUsers = () => {
       searchValue: searchValue,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: firstUserIdx,
-      stopIdx: lastUserIdx,
+      startIdx: 0,
+      stopIdx: 100,
       entryType: "user",
     } as GenericPayload).then((result) => {
       // Manage new response here
@@ -292,7 +294,7 @@ const ActiveUsers = () => {
           }
 
           setUsersTotalCount(totalCount);
-          setActiveUsersList(usersList);
+          setActiveUsersList(usersList.slice(0, perPage));
           // Show table elements
           setShowTableRows(true);
         }

--- a/src/pages/ActiveUsers/ActiveUsers.tsx
+++ b/src/pages/ActiveUsers/ActiveUsers.tsx
@@ -77,8 +77,7 @@ const ActiveUsers = () => {
   const [executeAutoMemberRebuild] = useAutoMemberRebuildUsersMutation();
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
 
   // Handle API calls errors
   const globalErrors = useApiError([]);
@@ -163,12 +162,6 @@ const ActiveUsers = () => {
     userDataResponse.refetch();
   };
 
-  // Always refetch data when the component is loaded.
-  // This ensures the data is always up-to-date.
-  React.useEffect(() => {
-    userDataResponse.refetch();
-  }, []);
-
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
     useState<boolean>(true);
@@ -215,19 +208,10 @@ const ActiveUsers = () => {
     setSelectedPerPage(selected);
   };
 
-  // Pagination
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
-  };
-
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
-  };
-
-  // Users displayed on the first page
-  const updateShownUsersList = (newShownUsersList: User[]) => {
-    setActiveUsersList(newShownUsersList);
-  };
+  // Reset selected-per-page count whenever the page or page size changes
+  useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
 
   const [selectedUsers, setSelectedUsers] = useState<User[]>([]);
 
@@ -461,17 +445,6 @@ const ActiveUsers = () => {
 
   // Data wrappers
   // TODO: Better separation of concerts
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList: updateShownUsersList,
-    totalCount,
-  };
-
   // - 'BulkSelectorUsersPrep'
   const usersBulkSelectorData = {
     selected: selectedUsers,
@@ -652,7 +625,7 @@ const ActiveUsers = () => {
       element: (
         <PaginationLayout
           list={activeUsersList}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -698,7 +671,7 @@ const ActiveUsers = () => {
           <FlexItem style={{ flex: "0 0 auto", position: "sticky", bottom: 0 }}>
             <PaginationLayout
               list={activeUsersList}
-              paginationData={paginationData}
+              totalCount={totalCount}
               variant={PaginationVariant.bottom}
               widgetId="pagination-options-menu-bottom"
             />

--- a/src/pages/ActiveUsers/ActiveUsers.tsx
+++ b/src/pages/ActiveUsers/ActiveUsers.tsx
@@ -45,6 +45,10 @@ import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Utils
 import { API_VERSION_BACKUP, isUserSelectable } from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 // RPC client
 import { GenericPayload } from "src/services/rpc";
 import {
@@ -199,19 +203,6 @@ const ActiveUsers = () => {
   const updateIsDisableEnableOp = (value: boolean) => {
     setIsDisableEnableOp(value);
   };
-
-  // Elements selected (per page)
-  //  - This will help to calculate the remaining elements on a specific page (bulk selector)
-  const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
-
-  const updateSelectedPerPage = (selected: number) => {
-    setSelectedPerPage(selected);
-  };
-
-  // Reset selected-per-page count whenever the page or page size changes
-  useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
 
   const [selectedUsers, setSelectedUsers] = useState<User[]>([]);
 
@@ -460,10 +451,11 @@ const ActiveUsers = () => {
     updateIsDisableEnableOp,
   };
 
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage,
-  };
+  const selectedPerPageData = getSelectedPerPageData(
+    activeUsersList,
+    selectedUsers.map((item) => ipaPrimaryKey(item.uid)),
+    (item) => ipaPrimaryKey(item.uid)
+  );
 
   // 'DeleteUsers'
   const deleteUsersButtonsData = {

--- a/src/pages/AutoMemHostRules/AutoMemHostRules.tsx
+++ b/src/pages/AutoMemHostRules/AutoMemHostRules.tsx
@@ -104,7 +104,11 @@ const AutoMemHostRules = () => {
   const lastIdx = page * perPage;
 
   // API calls via custom hook
-  const hostGroupRulesData = useHostGroupsRulesData();
+  const hostGroupRulesData = useHostGroupsRulesData({
+    searchValue,
+    startIdx: firstIdx,
+    stopIdx: lastIdx,
+  });
   const [changeDefaultGroup] = useChangeDefaultGroupMutation();
 
   // Show table rows
@@ -127,18 +131,9 @@ const AutoMemHostRules = () => {
       if (hostGroupRulesData.errors && hostGroupRulesData.errors.length > 0) {
         setErrors(hostGroupRulesData.errors || []);
       } else {
-        const fullAutomemberIds: AutomemberEntry[] =
-          hostGroupRulesData.automembersIds;
-        const totalAutomembersCount = fullAutomemberIds.length;
-        // Paginate data based on first and last indexes
-        const shownPaginatedRulesList: AutomemberEntry[] = [];
-        if (hostGroupRulesData.automembersIds.length > 0) {
-          const pagAutomemberIds = fullAutomemberIds.slice(firstIdx, lastIdx);
-          shownPaginatedRulesList.push(...pagAutomemberIds);
-        }
         // Update lists
         setHostGroups(hostGroupRulesData.hostGroups);
-        setAutomemberRules(shownPaginatedRulesList);
+        setAutomemberRules(hostGroupRulesData.shownAutomembers);
         // If no default group is set, set it as 'No selection'
         if (hostGroupRulesData.defaultGroup === "") {
           setDefaultGroup(NO_SELECTION);
@@ -148,8 +143,8 @@ const AutoMemHostRules = () => {
           setPreviousDefaultGroup(hostGroupRulesData.defaultGroup);
         }
 
-        // Set available host groups to add
-        const allAutomemberIds = fullAutomemberIds.map(
+        // Set available host groups to add (use full unfiltered rule list)
+        const allAutomemberIds = hostGroupRulesData.automembersIds.map(
           (item) => item.automemberRule
         );
         const availableItems = hostGroupRulesData.hostGroups.filter(
@@ -157,8 +152,8 @@ const AutoMemHostRules = () => {
         );
         setGroupsAvailableToAdd(availableItems);
 
-        // Set table count
-        setTotalCount(totalAutomembersCount);
+        // Set table count from search match total
+        setTotalCount(hostGroupRulesData.totalCount);
         // Show table elements
         setShowTableRows(true);
       }
@@ -166,6 +161,8 @@ const AutoMemHostRules = () => {
   }, [
     hostGroupRulesData.hostGroups,
     hostGroupRulesData.automembersIds,
+    hostGroupRulesData.shownAutomembers,
+    hostGroupRulesData.totalCount,
     hostGroupRulesData.defaultGroup,
   ]);
 

--- a/src/pages/AutoMemHostRules/AutoMemHostRules.tsx
+++ b/src/pages/AutoMemHostRules/AutoMemHostRules.tsx
@@ -49,6 +49,7 @@ import useContextualHelpTopic from "src/hooks/useContextualHelpTopic";
 import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Utils
 import { isAutomemberUserGroupSelectable } from "src/utils/utils";
+import { getSelectedPerPageData } from "src/utils/selectedPerPage";
 // Errors
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import { SerializedError } from "@reduxjs/toolkit";
@@ -228,19 +229,6 @@ const AutoMemHostRules = () => {
     setIsDisableEnableOp(value);
   };
 
-  // Elements selected (per page)
-  //  - This will help to calculate the remaining elements on a specific page (bulk selector)
-  const [selectedPerPage, setSelectedPerPage] = React.useState<number>(0);
-
-  const updateSelectedPerPage = (selected: number) => {
-    setSelectedPerPage(selected);
-  };
-
-  // Reset selected-per-page count whenever the page or page size changes
-  React.useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
-
   const [selectedAutomembers, setSelectedAutomembers] = React.useState<
     AutomemberEntry[]
   >([]);
@@ -351,10 +339,11 @@ const AutoMemHostRules = () => {
     updateIsDisableEnableOp,
   };
 
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage,
-  };
+  const selectedPerPageData = getSelectedPerPageData(
+    automemberRules,
+    selectedAutomembers.map((rule) => rule.automemberRule),
+    (rule) => rule.automemberRule
+  );
 
   // 'Table'
   const automembersTableData = {

--- a/src/pages/AutoMemHostRules/AutoMemHostRules.tsx
+++ b/src/pages/AutoMemHostRules/AutoMemHostRules.tsx
@@ -292,13 +292,14 @@ const AutoMemHostRules = () => {
   const [retrieveAutomembers] = useSearchHostGroupRulesEntriesMutation({});
 
   // Issue a search using a specific search value
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     setShowTableRows(false);
     setSearchIsDisabled(true);
     setTotalCount(0);
     retrieveAutomembers({
-      searchValue: searchValue,
+      searchValue: search,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
       startIdx: 0,

--- a/src/pages/AutoMemHostRules/AutoMemHostRules.tsx
+++ b/src/pages/AutoMemHostRules/AutoMemHostRules.tsx
@@ -101,8 +101,7 @@ const AutoMemHostRules = () => {
   const globalErrors = useApiError([]);
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
 
   const [totalCount, setTotalCount] = React.useState<number>(0);
 
@@ -244,21 +243,10 @@ const AutoMemHostRules = () => {
     setSelectedPerPage(selected);
   };
 
-  // Pagination
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
-  };
-
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
-  };
-
-  // Automembers displayed on the first page
-  const updateShownAutomembersList = (
-    newShownAutomembersList: AutomemberEntry[]
-  ) => {
-    setAutomemberRules(newShownAutomembersList);
-  };
+  // Reset selected-per-page count whenever the page or page size changes
+  React.useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
 
   const [selectedAutomembers, setSelectedAutomembers] = React.useState<
     AutomemberEntry[]
@@ -357,17 +345,6 @@ const AutoMemHostRules = () => {
 
   // Data wrappers
   // TODO: Better separation of concerts
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList: updateShownAutomembersList,
-    totalCount,
-  };
-
   // - 'BulkSelectorPrep'
   const automembersBulkSelectorData = {
     selected: selectedAutomembers,
@@ -556,7 +533,7 @@ const AutoMemHostRules = () => {
       element: (
         <PaginationLayout
           list={automemberRules}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -606,7 +583,7 @@ const AutoMemHostRules = () => {
             >
               <PaginationLayout
                 list={automemberRules}
-                paginationData={paginationData}
+                totalCount={totalCount}
                 variant={PaginationVariant.bottom}
                 widgetId="pagination-options-menu-bottom"
               />

--- a/src/pages/AutoMemHostRules/AutoMemHostRules.tsx
+++ b/src/pages/AutoMemHostRules/AutoMemHostRules.tsx
@@ -36,9 +36,7 @@ import TypeAheadSelect from "src/components/TypeAheadSelect";
 import useApiError from "src/hooks/useApiError";
 import GlobalErrors from "src/components/errors/GlobalErrors";
 // RPC
-import { GenericPayload } from "src/services/rpc";
 import {
-  useSearchHostGroupRulesEntriesMutation,
   ChangeDefaultPayload,
   useChangeDefaultGroupMutation,
 } from "src/services/rpcAutomember";
@@ -52,10 +50,7 @@ import { useHostGroupsRulesData } from "src/hooks/useHostGroupRules";
 import useContextualHelpTopic from "src/hooks/useContextualHelpTopic";
 import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Utils
-import {
-  API_VERSION_BACKUP,
-  isAutomemberUserGroupSelectable,
-} from "src/utils/utils";
+import { isAutomemberUserGroupSelectable } from "src/utils/utils";
 // Errors
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import { SerializedError } from "@reduxjs/toolkit";
@@ -106,11 +101,10 @@ const AutoMemHostRules = () => {
   const globalErrors = useApiError([]);
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   const [totalCount, setTotalCount] = React.useState<number>(0);
-  const [searchDisabled, setSearchIsDisabled] = React.useState<boolean>(false);
 
   // Page indexes
   const firstIdx = (page - 1) * perPage;
@@ -266,12 +260,6 @@ const AutoMemHostRules = () => {
     setAutomemberRules(newShownAutomembersList);
   };
 
-  // Update search input valie
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
   const [selectedAutomembers, setSelectedAutomembers] = React.useState<
     AutomemberEntry[]
   >([]);
@@ -287,33 +275,6 @@ const AutoMemHostRules = () => {
     setTotalCount(0);
     clearSelectedRules();
     hostGroupRulesData.refetch();
-  };
-
-  const [retrieveAutomembers] = useSearchHostGroupRulesEntriesMutation({});
-
-  // Issue a search using a specific search value
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    setShowTableRows(false);
-    setSearchIsDisabled(true);
-    setTotalCount(0);
-    retrieveAutomembers({
-      searchValue: search,
-      sizeLimit: 0,
-      apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: 0,
-      stopIdx: 100,
-    } as GenericPayload).then((result) => {
-      if ("data" in result) {
-        const automembersListResult = result.data;
-        setTotalCount(result.data?.length ?? 0);
-        setAutomemberRules((automembersListResult || []).slice(0, perPage));
-        // Show table elements
-        setShowTableRows(true);
-        setSearchIsDisabled(false);
-      }
-    });
   };
 
   // Always refetch data when the component is loaded.
@@ -425,13 +386,6 @@ const AutoMemHostRules = () => {
     updateSelectedPerPage,
   };
 
-  // SearchInputLayout
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
-  };
-
   // 'Table'
   const automembersTableData = {
     isElementSelectable: isAutomemberUserGroupSelectable,
@@ -526,8 +480,6 @@ const AutoMemHostRules = () => {
           name="search"
           ariaLabel="Search host rules"
           placeholder="Search host rules"
-          searchValueData={searchValueData}
-          isDisabled={searchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/AutoMemHostRules/AutoMemHostRules.tsx
+++ b/src/pages/AutoMemHostRules/AutoMemHostRules.tsx
@@ -268,6 +268,7 @@ const AutoMemHostRules = () => {
 
   // Update search input valie
   const updateSearchValue = (value: string) => {
+    setPage(1);
     setSearchValue(value);
   };
 
@@ -292,6 +293,7 @@ const AutoMemHostRules = () => {
 
   // Issue a search using a specific search value
   const submitSearchValue = () => {
+    setPage(1);
     setShowTableRows(false);
     setSearchIsDisabled(true);
     setTotalCount(0);
@@ -299,13 +301,13 @@ const AutoMemHostRules = () => {
       searchValue: searchValue,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: firstIdx,
-      stopIdx: lastIdx,
+      startIdx: 0,
+      stopIdx: 100,
     } as GenericPayload).then((result) => {
       if ("data" in result) {
         const automembersListResult = result.data;
         setTotalCount(result.data?.length ?? 0);
-        setAutomemberRules(automembersListResult || []);
+        setAutomemberRules((automembersListResult || []).slice(0, perPage));
         // Show table elements
         setShowTableRows(true);
         setSearchIsDisabled(false);

--- a/src/pages/AutoMemHostRules/AutoMemHostRules.tsx
+++ b/src/pages/AutoMemHostRules/AutoMemHostRules.tsx
@@ -72,11 +72,12 @@ const AutoMemHostRules = () => {
 
   const NO_SELECTION = "No default group selected";
 
-  const [hostGroups, setHostGroups] = React.useState<string[]>([]);
   const [automemberRules, setAutomemberRules] = React.useState<
     AutomemberEntry[]
   >([]);
   const [defaultGroup, setDefaultGroup] = React.useState<string>(NO_SELECTION);
+  const [previousDefaultGroup, setPreviousDefaultGroup] =
+    React.useState<string>(NO_SELECTION);
   const [errors, setErrors] = React.useState<
     Array<FetchBaseQueryError | SerializedError>
   >([]);
@@ -88,8 +89,6 @@ const AutoMemHostRules = () => {
   const [groupsAvailableToAdd, setGroupsAvailableToAdd] = React.useState<
     string[]
   >([]);
-  const [previousDefaultGroup, setPreviousDefaultGroup] =
-    React.useState<string>(NO_SELECTION);
 
   // Handle API calls errors
   const globalErrors = useApiError([]);
@@ -111,28 +110,35 @@ const AutoMemHostRules = () => {
   });
   const [changeDefaultGroup] = useChangeDefaultGroupMutation();
 
-  // Show table rows
-  const [showTableRows, setShowTableRows] = React.useState(
-    !hostGroupRulesData.isLoading
-  );
-
-  // Update table rows when the data is loaded
-  React.useEffect(() => {
-    if (showTableRows !== !hostGroupRulesData.isLoading) {
-      setShowTableRows(!hostGroupRulesData.isLoading);
-    }
-  }, [hostGroupRulesData.isLoading]);
-
   // Main API call
   React.useEffect(() => {
-    if (hostGroupRulesData.isFetching) {
-      setShowTableRows(false);
-    } else {
+    if (!hostGroupRulesData.isFetching) {
       if (hostGroupRulesData.errors && hostGroupRulesData.errors.length > 0) {
         setErrors(hostGroupRulesData.errors || []);
       } else {
         // Update lists
-        setHostGroups(hostGroupRulesData.hostGroups);
+        if (hostGroupRulesData.hostGroups.length > 0) {
+          // Add empty entry as an option
+          const groupsToSelector = [
+            {
+              "data-cy": "typeahead-select-no-selection",
+              value: NO_SELECTION,
+              children: NO_SELECTION,
+            },
+          ];
+
+          // Add the rest of the data from hostgroups
+          const tempGroupsToSelector = hostGroupRulesData.hostGroups.map(
+            (group) => ({
+              "data-cy": "typeahead-select-" + group,
+              value: group,
+              children: group,
+            })
+          );
+          groupsToSelector.push(...tempGroupsToSelector);
+          setHostGroupsOptions(groupsToSelector);
+        }
+
         setAutomemberRules(hostGroupRulesData.shownAutomembers);
         // If no default group is set, set it as 'No selection'
         if (hostGroupRulesData.defaultGroup === "") {
@@ -154,8 +160,6 @@ const AutoMemHostRules = () => {
 
         // Set table count from search match total
         setTotalCount(hostGroupRulesData.totalCount);
-        // Show table elements
-        setShowTableRows(true);
       }
     }
   }, [
@@ -165,29 +169,6 @@ const AutoMemHostRules = () => {
     hostGroupRulesData.totalCount,
     hostGroupRulesData.defaultGroup,
   ]);
-
-  // Parse host groups to be shown in the default host group selector
-  React.useEffect(() => {
-    if (hostGroups.length > 0) {
-      // Add empty entry as an option
-      const groupsToSelector = [
-        {
-          "data-cy": "typeahead-select-no-selection",
-          value: NO_SELECTION,
-          children: NO_SELECTION,
-        },
-      ];
-
-      // Add the rest of the data from hostgroups
-      const tempGroupsToSelector = hostGroups.map((group) => ({
-        "data-cy": "typeahead-select-" + group,
-        value: group,
-        children: group,
-      }));
-      groupsToSelector.push(...tempGroupsToSelector);
-      setHostGroupsOptions(groupsToSelector);
-    }
-  }, [hostGroups]);
 
   // On select default group
   const onSelectDefaultGroup = (group: string) => {
@@ -237,17 +218,10 @@ const AutoMemHostRules = () => {
 
   // Refresh button handling
   const refreshData = () => {
-    setShowTableRows(false);
     setTotalCount(0);
     clearSelectedRules();
     hostGroupRulesData.refetch();
   };
-
-  // Always refetch data when the component is loaded.
-  // This ensures the data is always up-to-date.
-  React.useEffect(() => {
-    hostGroupRulesData.refetch();
-  }, [page, perPage]);
 
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
@@ -342,7 +316,7 @@ const AutoMemHostRules = () => {
     (rule) => rule.automemberRule
   );
 
-  // 'Table'
+  // Data wrappers
   const automembersTableData = {
     isElementSelectable: isAutomemberUserGroupSelectable,
     selectedElements: selectedAutomembers,
@@ -464,7 +438,7 @@ const AutoMemHostRules = () => {
         <SecondaryButton
           dataCy="auto-member-host-rules-button-refresh"
           onClickHandler={refreshData}
-          isDisabled={!showTableRows}
+          isDisabled={hostGroupRulesData.isFetching}
         >
           Refresh
         </SecondaryButton>
@@ -475,7 +449,7 @@ const AutoMemHostRules = () => {
       element: (
         <SecondaryButton
           dataCy="auto-member-host-rules-button-delete"
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || hostGroupRulesData.isFetching}
           onClickHandler={onOpenDeleteModal}
         >
           Delete
@@ -487,7 +461,7 @@ const AutoMemHostRules = () => {
       element: (
         <SecondaryButton
           dataCy="auto-member-host-rules-button-add"
-          isDisabled={!showTableRows}
+          isDisabled={hostGroupRulesData.isFetching}
           onClickHandler={onOpenAddModal}
         >
           Add
@@ -522,99 +496,95 @@ const AutoMemHostRules = () => {
   ];
 
   return (
-    <>
-      <div>
-        <PageSection hasBodyWrapper={false}>
-          <TitleLayout
-            id="Automember host groups title"
-            headingLevel="h1"
-            text="Host group rules"
-          />
-        </PageSection>
-        <PageSection hasBodyWrapper={false} isFilled={false}>
-          <Flex direction={{ default: "column" }}>
-            <FlexItem>
-              <ToolbarLayout toolbarItems={toolbarItems} />
-            </FlexItem>
-            <FlexItem style={{ flex: "0 0 auto" }}>
-              <OuterScrollContainer>
-                <InnerScrollContainer
-                  style={{ height: "55vh", overflow: "auto" }}
-                >
-                  {errors !== undefined && errors.length > 0 ? (
-                    <GlobalErrors errors={globalErrors.getAll()} />
-                  ) : (
-                    <MainTable
-                      shownElementsList={automemberRules}
-                      showTableRows={showTableRows}
-                      elementsData={automembersTableData}
-                      buttonsData={automembersTableButtonsData}
-                      paginationData={selectedPerPageData}
-                      searchValue={searchValue}
-                      automemberType="host-group"
-                    />
-                  )}
-                </InnerScrollContainer>
-              </OuterScrollContainer>
-            </FlexItem>
-            <FlexItem
-              style={{ flex: "0 0 auto", position: "sticky", bottom: 0 }}
-            >
-              <PaginationLayout
-                list={automemberRules}
-                totalCount={totalCount}
-                variant={PaginationVariant.bottom}
-                widgetId="pagination-options-menu-bottom"
-              />
-            </FlexItem>
-          </Flex>
-        </PageSection>
-        <AddRule
-          show={showAddModal}
-          handleModalToggle={onAddModalToggle}
-          onOpenAddModal={onOpenAddModal}
-          onCloseAddModal={onCloseAddModal}
-          onRefresh={refreshData}
-          groupsAvailableToAdd={groupsAvailableToAdd}
-          ruleType="hostgroup"
+    <div>
+      <PageSection hasBodyWrapper={false}>
+        <TitleLayout
+          id="Automember host groups title"
+          headingLevel="h1"
+          text="Host group rules"
         />
-        <DeleteRule
-          show={showDeleteModal}
-          handleModalToggle={onToggleDeleteModal}
-          onRefresh={refreshData}
-          buttonsData={deleteButtonsData}
-          selectedData={selectedData}
-          ruleType="hostgroup"
-        />
-        <ConfirmationModal
-          dataCy="auto-member-default-host-rules-modal"
-          title="Default hostgroup"
-          isOpen={showChangeConfirmationModal}
-          onClose={onCloseConfirmationModal}
-          actions={[
-            <Button
-              data-cy="modal-button-ok"
-              variant="primary"
-              key="change-default"
-              onClick={() => {
-                onSelectDefaultGroup(defaultGroup);
-              }}
-            >
-              OK
-            </Button>,
-            <SecondaryButton
-              key="cancel"
-              onClickHandler={onCancelDefaultGroup}
-              dataCy="modal-button-cancel"
-            >
-              Cancel
-            </SecondaryButton>,
-          ]}
-          messageText="Are you sure you want to change default group?"
-          messageObj={defaultGroup}
-        />
-      </div>
-    </>
+      </PageSection>
+      <PageSection hasBodyWrapper={false} isFilled={false}>
+        <Flex direction={{ default: "column" }}>
+          <FlexItem>
+            <ToolbarLayout toolbarItems={toolbarItems} />
+          </FlexItem>
+          <FlexItem style={{ flex: "0 0 auto" }}>
+            <OuterScrollContainer>
+              <InnerScrollContainer
+                style={{ height: "55vh", overflow: "auto" }}
+              >
+                {errors !== undefined && errors.length > 0 ? (
+                  <GlobalErrors errors={globalErrors.getAll()} />
+                ) : (
+                  <MainTable
+                    shownElementsList={automemberRules}
+                    showTableRows={!hostGroupRulesData.isFetching}
+                    elementsData={automembersTableData}
+                    buttonsData={automembersTableButtonsData}
+                    paginationData={selectedPerPageData}
+                    searchValue={searchValue}
+                    automemberType="host-group"
+                  />
+                )}
+              </InnerScrollContainer>
+            </OuterScrollContainer>
+          </FlexItem>
+          <FlexItem style={{ flex: "0 0 auto", position: "sticky", bottom: 0 }}>
+            <PaginationLayout
+              list={automemberRules}
+              totalCount={totalCount}
+              variant={PaginationVariant.bottom}
+              widgetId="pagination-options-menu-bottom"
+            />
+          </FlexItem>
+        </Flex>
+      </PageSection>
+      <AddRule
+        show={showAddModal}
+        handleModalToggle={onAddModalToggle}
+        onOpenAddModal={onOpenAddModal}
+        onCloseAddModal={onCloseAddModal}
+        onRefresh={refreshData}
+        groupsAvailableToAdd={groupsAvailableToAdd}
+        ruleType="hostgroup"
+      />
+      <DeleteRule
+        show={showDeleteModal}
+        handleModalToggle={onToggleDeleteModal}
+        onRefresh={refreshData}
+        buttonsData={deleteButtonsData}
+        selectedData={selectedData}
+        ruleType="hostgroup"
+      />
+      <ConfirmationModal
+        dataCy="auto-member-default-host-rules-modal"
+        title="Default hostgroup"
+        isOpen={showChangeConfirmationModal}
+        onClose={onCloseConfirmationModal}
+        actions={[
+          <Button
+            data-cy="modal-button-ok"
+            variant="primary"
+            key="change-default"
+            onClick={() => {
+              onSelectDefaultGroup(defaultGroup);
+            }}
+          >
+            OK
+          </Button>,
+          <SecondaryButton
+            key="cancel"
+            onClickHandler={onCancelDefaultGroup}
+            dataCy="modal-button-cancel"
+          >
+            Cancel
+          </SecondaryButton>,
+        ]}
+        messageText="Are you sure you want to change default group?"
+        messageObj={defaultGroup}
+      />
+    </div>
   );
 };
 

--- a/src/pages/AutoMemHostRules/AutoMemHostRules.tsx
+++ b/src/pages/AutoMemHostRules/AutoMemHostRules.tsx
@@ -16,8 +16,6 @@ import {
 } from "@patternfly/react-table";
 // Data types
 import { AutomemberEntry } from "src/utils/datatypes/globalDataTypes";
-// Redux
-import { useAppSelector } from "src/store/hooks";
 // Layouts
 import TitleLayout from "src/components/layouts/TitleLayout";
 import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
@@ -70,11 +68,6 @@ const AutoMemHostRules = () => {
   useUpdateRoute({
     pathname: "host-group-rules",
   });
-
-  // Retrieve API version from environment data
-  const apiVersion = useAppSelector(
-    (state) => state.global.environment.api_version
-  ) as string;
 
   const NO_SELECTION = "No default group selected";
 

--- a/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
+++ b/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
@@ -17,7 +17,7 @@ import {
 // Data types
 import { AutomemberEntry } from "src/utils/datatypes/globalDataTypes";
 // Redux
-import { useAppDispatch, useAppSelector } from "src/store/hooks";
+import { useAppDispatch } from "src/store/hooks";
 // Layouts
 import TitleLayout from "src/components/layouts/TitleLayout";
 import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
@@ -68,11 +68,6 @@ const AutoMemUserRules = () => {
   useUpdateRoute({
     pathname: "user-group-rules",
   });
-
-  // Retrieve API version from environment data
-  const apiVersion = useAppSelector(
-    (state) => state.global.environment.api_version
-  ) as string;
 
   const NO_SELECTION = "No default group selected";
 

--- a/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
+++ b/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
@@ -36,9 +36,7 @@ import TypeAheadSelect from "src/components/TypeAheadSelect";
 import useApiError from "src/hooks/useApiError";
 import GlobalErrors from "src/components/errors/GlobalErrors";
 // RPC
-import { GenericPayload } from "src/services/rpc";
 import {
-  useSearchUserGroupRulesEntriesMutation,
   ChangeDefaultPayload,
   useChangeDefaultGroupMutation,
 } from "src/services/rpcAutomember";
@@ -50,10 +48,7 @@ import { useUserGroupsRulesData } from "src/hooks/useUserGroupsRules";
 import useContextualHelpTopic from "src/hooks/useContextualHelpTopic";
 import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Utils
-import {
-  API_VERSION_BACKUP,
-  isAutomemberUserGroupSelectable,
-} from "src/utils/utils";
+import { isAutomemberUserGroupSelectable } from "src/utils/utils";
 // Errors
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import { SerializedError } from "@reduxjs/toolkit";
@@ -104,11 +99,10 @@ const AutoMemUserRules = () => {
   const globalErrors = useApiError([]);
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   const [totalCount, setTotalCount] = React.useState<number>(0);
-  const [searchDisabled, setSearchIsDisabled] = React.useState<boolean>(false);
 
   // Page indexes
   const firstIdx = (page - 1) * perPage;
@@ -264,12 +258,6 @@ const AutoMemUserRules = () => {
     setAutomemberRules(newShownAutomembersList);
   };
 
-  // Update search input valie
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
   const [selectedAutomembers, setSelectedAutomembers] = React.useState<
     AutomemberEntry[]
   >([]);
@@ -285,33 +273,6 @@ const AutoMemUserRules = () => {
     setTotalCount(0);
     clearSelectedRules();
     userGroupRulesData.refetch();
-  };
-
-  const [retrieveAutomembers] = useSearchUserGroupRulesEntriesMutation({});
-
-  // Issue a search using a specific search value
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    setShowTableRows(false);
-    setSearchIsDisabled(true);
-    setTotalCount(0);
-    retrieveAutomembers({
-      searchValue: search,
-      sizeLimit: 0,
-      apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: 0,
-      stopIdx: 100,
-    } as GenericPayload).then((result) => {
-      if ("data" in result) {
-        const automembersListResult = result.data;
-        setTotalCount((result.data ?? []).length);
-        setAutomemberRules((automembersListResult ?? []).slice(0, perPage));
-        // Show table elements
-        setShowTableRows(true);
-        setSearchIsDisabled(false);
-      }
-    });
   };
 
   // Always refetch data when the component is loaded.
@@ -423,13 +384,6 @@ const AutoMemUserRules = () => {
     updateSelectedPerPage,
   };
 
-  // SearchInputLayout
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
-  };
-
   // 'Table'
   const automembersTableData = {
     isElementSelectable: isAutomemberUserGroupSelectable,
@@ -524,8 +478,6 @@ const AutoMemUserRules = () => {
           name="search"
           ariaLabel="Search user rules"
           placeholder="Search user rules"
-          searchValueData={searchValueData}
-          isDisabled={searchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
+++ b/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
@@ -266,6 +266,7 @@ const AutoMemUserRules = () => {
 
   // Update search input valie
   const updateSearchValue = (value: string) => {
+    setPage(1);
     setSearchValue(value);
   };
 
@@ -290,6 +291,7 @@ const AutoMemUserRules = () => {
 
   // Issue a search using a specific search value
   const submitSearchValue = () => {
+    setPage(1);
     setShowTableRows(false);
     setSearchIsDisabled(true);
     setTotalCount(0);
@@ -297,13 +299,13 @@ const AutoMemUserRules = () => {
       searchValue: searchValue,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: firstIdx,
-      stopIdx: lastIdx,
+      startIdx: 0,
+      stopIdx: 100,
     } as GenericPayload).then((result) => {
       if ("data" in result) {
         const automembersListResult = result.data;
         setTotalCount((result.data ?? []).length);
-        setAutomemberRules(automembersListResult ?? []);
+        setAutomemberRules((automembersListResult ?? []).slice(0, perPage));
         // Show table elements
         setShowTableRows(true);
         setSearchIsDisabled(false);

--- a/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
+++ b/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
@@ -290,13 +290,14 @@ const AutoMemUserRules = () => {
   const [retrieveAutomembers] = useSearchUserGroupRulesEntriesMutation({});
 
   // Issue a search using a specific search value
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     setShowTableRows(false);
     setSearchIsDisabled(true);
     setTotalCount(0);
     retrieveAutomembers({
-      searchValue: searchValue,
+      searchValue: search,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
       startIdx: 0,

--- a/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
+++ b/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
@@ -72,7 +72,6 @@ const AutoMemUserRules = () => {
 
   const NO_SELECTION = "No default group selected";
 
-  const [userGroups, setUserGroups] = React.useState<string[]>([]);
   const [automemberRules, setAutomemberRules] = React.useState<
     AutomemberEntry[]
   >([]);
@@ -111,23 +110,9 @@ const AutoMemUserRules = () => {
   });
   const [changeDefaultGroup] = useChangeDefaultGroupMutation();
 
-  // Show table rows
-  const [showTableRows, setShowTableRows] = React.useState(
-    !userGroupRulesData.isLoading
-  );
-
-  // Update table rows when the data is loaded
-  React.useEffect(() => {
-    if (showTableRows !== !userGroupRulesData.isLoading) {
-      setShowTableRows(!userGroupRulesData.isLoading);
-    }
-  }, [userGroupRulesData.isLoading]);
-
   // Main API call
   React.useEffect(() => {
-    if (userGroupRulesData.isFetching) {
-      setShowTableRows(false);
-    } else {
+    if (!userGroupRulesData.isFetching) {
       if (userGroupRulesData.errors && userGroupRulesData.errors.length > 0) {
         setErrors(userGroupRulesData.errors || []);
       } else {
@@ -154,8 +139,6 @@ const AutoMemUserRules = () => {
 
         // Set table count from search match total
         setTotalCount(userGroupRulesData.totalCount);
-        // Show table elements
-        setShowTableRows(true);
       }
     }
   }, [
@@ -167,7 +150,7 @@ const AutoMemUserRules = () => {
   ]);
 
   // Parse user groups to be shown in the default user group selector
-  React.useEffect(() => {
+  const setUserGroups = (userGroups: string[]) => {
     if (userGroups.length > 0) {
       // Add empty entry as an option
       const groupsToSelector = [
@@ -187,7 +170,7 @@ const AutoMemUserRules = () => {
       groupsToSelector.push(...tempGroupsToSelector);
       setUserGroupsOptions(groupsToSelector);
     }
-  }, [userGroups]);
+  };
 
   // On select default group
   const onSelectDefaultGroup = (group: string) => {
@@ -237,7 +220,6 @@ const AutoMemUserRules = () => {
 
   // Refresh button handling
   const refreshData = () => {
-    setShowTableRows(false);
     setTotalCount(0);
     clearSelectedRules();
     userGroupRulesData.refetch();
@@ -464,7 +446,7 @@ const AutoMemUserRules = () => {
         <SecondaryButton
           dataCy={"auto-member-user-rules-button-refresh"}
           onClickHandler={refreshData}
-          isDisabled={!showTableRows}
+          isDisabled={userGroupRulesData.isFetching}
         >
           Refresh
         </SecondaryButton>
@@ -475,7 +457,7 @@ const AutoMemUserRules = () => {
       element: (
         <SecondaryButton
           dataCy={"auto-member-user-rules-button-delete"}
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || userGroupRulesData.isFetching}
           onClickHandler={onOpenDeleteModal}
         >
           Delete
@@ -487,7 +469,7 @@ const AutoMemUserRules = () => {
       element: (
         <SecondaryButton
           dataCy={"auto-member-user-rules-button-add"}
-          isDisabled={!showTableRows}
+          isDisabled={userGroupRulesData.isFetching}
           onClickHandler={onOpenAddModal}
         >
           Add
@@ -545,7 +527,7 @@ const AutoMemUserRules = () => {
                 ) : (
                   <MainTable
                     shownElementsList={automemberRules}
-                    showTableRows={showTableRows}
+                    showTableRows={!userGroupRulesData.isFetching}
                     elementsData={automembersTableData}
                     buttonsData={automembersTableButtonsData}
                     paginationData={selectedPerPageData}

--- a/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
+++ b/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
@@ -104,7 +104,11 @@ const AutoMemUserRules = () => {
   const lastIdx = page * perPage;
 
   // API calls via custom hook
-  const userGroupRulesData = useUserGroupsRulesData();
+  const userGroupRulesData = useUserGroupsRulesData({
+    searchValue,
+    startIdx: firstIdx,
+    stopIdx: lastIdx,
+  });
   const [changeDefaultGroup] = useChangeDefaultGroupMutation();
 
   // Show table rows
@@ -127,18 +131,9 @@ const AutoMemUserRules = () => {
       if (userGroupRulesData.errors && userGroupRulesData.errors.length > 0) {
         setErrors(userGroupRulesData.errors || []);
       } else {
-        const fullAutomemberIds: AutomemberEntry[] =
-          userGroupRulesData.automembersIds;
-        const totalAutomembersCount = fullAutomemberIds.length;
-        // Paginate data based on first and last indexes
-        const shownPaginatedRulesList: AutomemberEntry[] = [];
-        if (userGroupRulesData.automembersIds.length > 0) {
-          const pagAutomemberIds = fullAutomemberIds.slice(firstIdx, lastIdx);
-          shownPaginatedRulesList.push(...pagAutomemberIds);
-        }
         // Update lists
         setUserGroups(userGroupRulesData.userGroups);
-        setAutomemberRules(shownPaginatedRulesList);
+        setAutomemberRules(userGroupRulesData.shownAutomembers);
         // If no default group is set, set it as 'No selection'
         if (userGroupRulesData.defaultGroup === "") {
           setDefaultGroup(NO_SELECTION);
@@ -148,8 +143,8 @@ const AutoMemUserRules = () => {
           setPreviousDefaultGroup(userGroupRulesData.defaultGroup);
         }
 
-        // Set available user groups to add (userGroupRulesData.userGroups and fullAutomemberIds)
-        const allAutomemberIds = fullAutomemberIds.map(
+        // Set available user groups to add (use full unfiltered rule list)
+        const allAutomemberIds = userGroupRulesData.automembersIds.map(
           (item) => item.automemberRule
         );
         const availableItems = userGroupRulesData.userGroups.filter(
@@ -157,8 +152,8 @@ const AutoMemUserRules = () => {
         );
         setGroupsAvailableToAdd(availableItems);
 
-        // Set table count
-        setTotalCount(totalAutomembersCount);
+        // Set table count from search match total
+        setTotalCount(userGroupRulesData.totalCount);
         // Show table elements
         setShowTableRows(true);
       }
@@ -166,6 +161,8 @@ const AutoMemUserRules = () => {
   }, [
     userGroupRulesData.userGroups,
     userGroupRulesData.automembersIds,
+    userGroupRulesData.shownAutomembers,
+    userGroupRulesData.totalCount,
     userGroupRulesData.defaultGroup,
   ]);
 

--- a/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
+++ b/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
@@ -49,6 +49,7 @@ import useContextualHelpTopic from "src/hooks/useContextualHelpTopic";
 import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Utils
 import { isAutomemberUserGroupSelectable } from "src/utils/utils";
+import { getSelectedPerPageData } from "src/utils/selectedPerPage";
 // Errors
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import { SerializedError } from "@reduxjs/toolkit";
@@ -228,19 +229,6 @@ const AutoMemUserRules = () => {
     setIsDisableEnableOp(value);
   };
 
-  // Elements selected (per page)
-  //  - This will help to calculate the remaining elements on a specific page (bulk selector)
-  const [selectedPerPage, setSelectedPerPage] = React.useState<number>(0);
-
-  const updateSelectedPerPage = (selected: number) => {
-    setSelectedPerPage(selected);
-  };
-
-  // Reset selected-per-page count whenever the page or page size changes
-  React.useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
-
   const [selectedAutomembers, setSelectedAutomembers] = React.useState<
     AutomemberEntry[]
   >([]);
@@ -351,12 +339,13 @@ const AutoMemUserRules = () => {
     updateIsDisableEnableOp,
   };
 
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage,
-  };
+  const selectedPerPageData = getSelectedPerPageData(
+    automemberRules,
+    selectedAutomembers.map((rule) => rule.automemberRule),
+    (rule) => rule.automemberRule
+  );
 
-  // 'Table'
+  // Data wrappers
   const automembersTableData = {
     isElementSelectable: isAutomemberUserGroupSelectable,
     selectedElements: selectedAutomembers,

--- a/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
+++ b/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
@@ -99,8 +99,7 @@ const AutoMemUserRules = () => {
   const globalErrors = useApiError([]);
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
 
   const [totalCount, setTotalCount] = React.useState<number>(0);
 
@@ -242,21 +241,10 @@ const AutoMemUserRules = () => {
     setSelectedPerPage(selected);
   };
 
-  // Pagination
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
-  };
-
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
-  };
-
-  // Automembers displayed on the first page
-  const updateShownAutomembersList = (
-    newShownAutomembersList: AutomemberEntry[]
-  ) => {
-    setAutomemberRules(newShownAutomembersList);
-  };
+  // Reset selected-per-page count whenever the page or page size changes
+  React.useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
 
   const [selectedAutomembers, setSelectedAutomembers] = React.useState<
     AutomemberEntry[]
@@ -355,17 +343,6 @@ const AutoMemUserRules = () => {
 
   // Data wrappers
   // TODO: Better separation of concerts
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList: updateShownAutomembersList,
-    totalCount,
-  };
-
   // - 'BulkSelectorPrep'
   const automembersBulkSelectorData = {
     selected: selectedAutomembers,
@@ -554,7 +531,7 @@ const AutoMemUserRules = () => {
       element: (
         <PaginationLayout
           list={automemberRules}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -601,7 +578,7 @@ const AutoMemUserRules = () => {
           <FlexItem style={{ flex: "0 0 auto", position: "sticky", bottom: 0 }}>
             <PaginationLayout
               list={automemberRules}
-              paginationData={paginationData}
+              totalCount={totalCount}
               variant={PaginationVariant.bottom}
               widgetId="pagination-options-menu-bottom"
             />

--- a/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
+++ b/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
@@ -225,12 +225,6 @@ const AutoMemUserRules = () => {
     userGroupRulesData.refetch();
   };
 
-  // Always refetch data when the component is loaded.
-  // This ensures the data is always up-to-date.
-  React.useEffect(() => {
-    userGroupRulesData.refetch();
-  }, [page, perPage]);
-
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
     React.useState<boolean>(true);

--- a/src/pages/AutomountLocations/AutomountLocations.tsx
+++ b/src/pages/AutomountLocations/AutomountLocations.tsx
@@ -58,7 +58,7 @@ const AutomountLocations = () => {
   ) as string;
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   // Handle API calls errors
@@ -195,16 +195,6 @@ const AutomountLocations = () => {
     totalCount,
   };
 
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-  };
-
   const bulkSelectorData = {
     selected: selectedElements,
     updateSelected: updateSelectedLocations,
@@ -243,7 +233,6 @@ const AutomountLocations = () => {
           name="search"
           ariaLabel="Search automount locations"
           placeholder="Search automount locations"
-          searchValueData={searchValueData}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/AutomountLocations/AutomountLocations.tsx
+++ b/src/pages/AutomountLocations/AutomountLocations.tsx
@@ -58,8 +58,7 @@ const AutomountLocations = () => {
   ) as string;
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
 
   // Handle API calls errors
   const globalErrors = useApiError([]);
@@ -185,15 +184,10 @@ const AutomountLocations = () => {
     }
   };
 
-  // Data wrappers
-  const paginationData = {
-    page,
-    perPage,
-    updatePage: setPage,
-    updatePerPage: setPerPage,
-    updateSelectedPerPage: setSelectedPerPage,
-    totalCount,
-  };
+  // Reset the selected per-page count when the page or page size changes
+  React.useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
 
   const bulkSelectorData = {
     selected: selectedElements,
@@ -296,7 +290,7 @@ const AutomountLocations = () => {
       element: (
         <PaginationLayout
           list={locations}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -363,7 +357,7 @@ const AutomountLocations = () => {
           <FlexItem style={{ flex: "0 0 auto", position: "sticky", bottom: 0 }}>
             <PaginationLayout
               list={locations}
-              paginationData={paginationData}
+              totalCount={totalCount}
               variant={PaginationVariant.bottom}
               widgetId="pagination-options-menu-bottom"
             />

--- a/src/pages/AutomountLocations/AutomountLocations.tsx
+++ b/src/pages/AutomountLocations/AutomountLocations.tsx
@@ -83,7 +83,7 @@ const AutomountLocations = () => {
     { refetchOnMountOrArgChange: true }
   );
 
-  const { data, isLoading, error } = locationsResponse;
+  const { data, isFetching, error } = locationsResponse;
 
   // Handle auth errors
   React.useEffect(() => {
@@ -118,8 +118,6 @@ const AutomountLocations = () => {
 
   const totalCount =
     locationsResponse.isSuccess && data ? data.result.totalCount : 0;
-
-  const showTableRows = !locationsResponse.isFetching && !isLoading;
 
   // Selected elements
   const [selectedElements, setSelectedElements] = React.useState<
@@ -243,7 +241,7 @@ const AutomountLocations = () => {
         <SecondaryButton
           dataCy="automount-locations-button-refresh"
           onClickHandler={refreshData}
-          isDisabled={!showTableRows}
+          isDisabled={isFetching}
         >
           Refresh
         </SecondaryButton>
@@ -253,7 +251,7 @@ const AutomountLocations = () => {
       key: 4,
       element: (
         <SecondaryButton
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || isFetching}
           dataCy="automount-locations-button-delete"
           onClickHandler={() => setShowDeleteModal(true)}
         >
@@ -265,7 +263,7 @@ const AutomountLocations = () => {
       key: 5,
       element: (
         <SecondaryButton
-          isDisabled={!showTableRows}
+          isDisabled={isFetching}
           dataCy="automount-locations-button-add"
           onClickHandler={() => setShowAddModal(true)}
         >
@@ -330,7 +328,7 @@ const AutomountLocations = () => {
                     columnNames={["Location name"]}
                     hasCheckboxes={true}
                     pathname="automount-locations"
-                    showTableRows={showTableRows}
+                    showTableRows={!isFetching}
                     showLink={false}
                     elementsData={{
                       isElementSelectable: isAutomountLocationSelectable,

--- a/src/pages/AutomountLocations/AutomountLocations.tsx
+++ b/src/pages/AutomountLocations/AutomountLocations.tsx
@@ -195,9 +195,14 @@ const AutomountLocations = () => {
     totalCount,
   };
 
+  const updateSearchValue = (value: string) => {
+    setPage(1);
+    setSearchValue(value);
+  };
+
   const searchValueData = {
     searchValue,
-    updateSearchValue: setSearchValue,
+    updateSearchValue,
   };
 
   const bulkSelectorData = {

--- a/src/pages/AutomountLocations/AutomountLocations.tsx
+++ b/src/pages/AutomountLocations/AutomountLocations.tsx
@@ -26,6 +26,10 @@ import { useGetAutomountLocationsFullDataQuery } from "src/services/rpcAutomount
 // Utils
 import { apiToAutomountLocation } from "src/utils/automountLocationUtils";
 import { isAutomountLocationSelectable } from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 // React router
 import { useNavigate } from "react-router";
 // Components
@@ -121,7 +125,6 @@ const AutomountLocations = () => {
   const [selectedElements, setSelectedElements] = React.useState<
     AutomountLocation[]
   >([]);
-  const [selectedPerPage, setSelectedPerPage] = React.useState<number>(0);
 
   // Refresh button handling
   const refreshData = () => {
@@ -184,10 +187,11 @@ const AutomountLocations = () => {
     }
   };
 
-  // Reset the selected per-page count when the page or page size changes
-  React.useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
+  const selectedPerPageData = getSelectedPerPageData(
+    locations,
+    selectedElements.map((item) => ipaPrimaryKey(item.cn)),
+    (item) => ipaPrimaryKey(item.cn)
+  );
 
   const bulkSelectorData = {
     selected: selectedElements,
@@ -212,10 +216,7 @@ const AutomountLocations = () => {
           buttonsData={{
             updateIsDeleteButtonDisabled: setIsDeleteButtonDisabled,
           }}
-          selectedPerPageData={{
-            selectedPerPage,
-            updateSelectedPerPage: setSelectedPerPage,
-          }}
+          selectedPerPageData={selectedPerPageData}
         />
       ),
     },
@@ -345,10 +346,7 @@ const AutomountLocations = () => {
                       updateIsDeletion: (value) => setIsDeletion(value),
                       isDisableEnableOp: false,
                     }}
-                    paginationData={{
-                      selectedPerPage,
-                      updateSelectedPerPage: setSelectedPerPage,
-                    }}
+                    paginationData={selectedPerPageData}
                   />
                 )}
               </InnerScrollContainer>

--- a/src/pages/CertificateMapping/CertificateMapping.tsx
+++ b/src/pages/CertificateMapping/CertificateMapping.tsx
@@ -25,6 +25,10 @@ import { useAppDispatch, useAppSelector } from "src/store/hooks";
 import { useGetCertMapRuleEntriesQuery } from "src/services/rpcCertMapping";
 // Utils
 import { isCertMapSelectable } from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 import { apiToCertificateMapping } from "src/utils/certMappingUtils";
 // React router
 import { useNavigate } from "react-router";
@@ -138,12 +142,6 @@ const CertificateMappingPage = () => {
   const [selectedElements, setSelectedElements] = React.useState<
     CertificateMapping[]
   >([]);
-  const [selectedPerPage, setSelectedPerPage] = React.useState<number>(0);
-
-  // Reset selected-per-page count whenever the page or page size changes
-  React.useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
 
   // Refresh button handling
   const refreshData = () => {
@@ -226,6 +224,12 @@ const CertificateMappingPage = () => {
     }
   };
 
+  const selectedPerPageData = getSelectedPerPageData(
+    certMapRules,
+    selectedElements.map((item) => ipaPrimaryKey(item.cn)),
+    (item) => ipaPrimaryKey(item.cn)
+  );
+
   // Always refetch data when the component is loaded.
   // This ensures the data is always up-to-date.
   React.useEffect(() => {
@@ -250,11 +254,6 @@ const CertificateMappingPage = () => {
     updateSelected: updateSelectedCertMapRules,
     selectableTable: selectableCertMapRulesTable,
     nameAttr: "cn",
-  };
-
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage: setSelectedPerPage,
   };
 
   // Modals functionality
@@ -448,10 +447,7 @@ const CertificateMappingPage = () => {
                         setIsDisableButtonDisabled(value),
                       isDisableEnableOp: true,
                     }}
-                    paginationData={{
-                      selectedPerPage,
-                      updateSelectedPerPage: setSelectedPerPage,
-                    }}
+                    paginationData={selectedPerPageData}
                     statusElementName="ipaenabledflag"
                   />
                 )}

--- a/src/pages/CertificateMapping/CertificateMapping.tsx
+++ b/src/pages/CertificateMapping/CertificateMapping.tsx
@@ -222,12 +222,6 @@ const CertificateMappingPage = () => {
     (item) => ipaPrimaryKey(item.cn)
   );
 
-  // Always refetch data when the component is loaded.
-  // This ensures the data is always up-to-date.
-  React.useEffect(() => {
-    certMapsResponse.refetch();
-  }, []);
-
   // Show table rows
   // Data wrappers
   // TODO: Better separation of concerts

--- a/src/pages/CertificateMapping/CertificateMapping.tsx
+++ b/src/pages/CertificateMapping/CertificateMapping.tsx
@@ -248,10 +248,11 @@ const CertificateMappingPage = () => {
   // Search API call
   const [searchEntry] = useSearchCertMapRuleEntriesMutation();
 
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     searchEntry({
-      searchValue: searchValue,
+      searchValue: search,
       apiVersion,
       sizelimit: 100,
       startIdx: 0,

--- a/src/pages/CertificateMapping/CertificateMapping.tsx
+++ b/src/pages/CertificateMapping/CertificateMapping.tsx
@@ -64,8 +64,7 @@ const CertificateMappingPage = () => {
   ) as string;
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
 
   // Handle API calls errors
   const globalErrors = useApiError([]);
@@ -140,6 +139,11 @@ const CertificateMappingPage = () => {
     CertificateMapping[]
   >([]);
   const [selectedPerPage, setSelectedPerPage] = React.useState<number>(0);
+
+  // Reset selected-per-page count whenever the page or page size changes
+  React.useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
 
   // Refresh button handling
   const refreshData = () => {
@@ -240,17 +244,6 @@ const CertificateMappingPage = () => {
 
   // Data wrappers
   // TODO: Better separation of concerts
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage: setPage,
-    updatePerPage: setPerPage,
-    updateSelectedPerPage: setSelectedPerPage,
-    updateShownElementsList: setCertMapRules,
-    totalCount,
-  };
-
   // - 'BulkSelectorrep'
   const bulkSelectorData = {
     selected: selectedElements,
@@ -395,7 +388,7 @@ const CertificateMappingPage = () => {
       element: (
         <PaginationLayout
           list={certMapRules}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -468,7 +461,7 @@ const CertificateMappingPage = () => {
           <FlexItem style={{ flex: "0 0 auto", position: "sticky", bottom: 0 }}>
             <PaginationLayout
               list={certMapRules}
-              paginationData={paginationData}
+              totalCount={totalCount}
               variant={PaginationVariant.bottom}
               widgetId="pagination-options-menu-bottom"
             />

--- a/src/pages/CertificateMapping/CertificateMapping.tsx
+++ b/src/pages/CertificateMapping/CertificateMapping.tsx
@@ -249,6 +249,7 @@ const CertificateMappingPage = () => {
   const [searchEntry] = useSearchCertMapRuleEntriesMutation();
 
   const submitSearchValue = () => {
+    setPage(1);
     searchEntry({
       searchValue: searchValue,
       apiVersion,
@@ -288,7 +289,7 @@ const CertificateMappingPage = () => {
           }
 
           setTotalCount(totalCount);
-          setCertMapRules(elementsList);
+          setCertMapRules(elementsList.slice(0, perPage));
           setShowTableRows(true);
         }
         setIsSearchDisabled(false);
@@ -309,10 +310,15 @@ const CertificateMappingPage = () => {
     totalCount,
   };
 
+  const updateSearchValue = (value: string) => {
+    setPage(1);
+    setSearchValue(value);
+  };
+
   // SearchInputLayout
   const searchValueData = {
     searchValue,
-    updateSearchValue: setSearchValue,
+    updateSearchValue,
     submitSearchValue,
   };
 

--- a/src/pages/CertificateMapping/CertificateMapping.tsx
+++ b/src/pages/CertificateMapping/CertificateMapping.tsx
@@ -92,12 +92,11 @@ const CertificateMappingPage = () => {
     stopIdx: lastUserIdx,
   });
 
-  const { data, isLoading, error } = certMapsResponse;
+  const { data, isFetching, error } = certMapsResponse;
 
   // Handle data when the API call is finished
   React.useEffect(() => {
     if (certMapsResponse.isFetching) {
-      setShowTableRows(false);
       // Reset selected elements on refresh
       setTotalCount(0);
       globalErrors.clear();
@@ -121,8 +120,6 @@ const CertificateMappingPage = () => {
       setTotalCount(certMapsResponse.data.result.totalCount);
       // Update the list of elements
       setCertMapRules(elementsList);
-      // Show table elements
-      setShowTableRows(true);
     }
 
     // API response: Error
@@ -145,15 +142,10 @@ const CertificateMappingPage = () => {
 
   // Refresh button handling
   const refreshData = () => {
-    // Hide table
-    setShowTableRows(false);
-
     // Reset selected elements on refresh
     setTotalCount(0);
 
-    certMapsResponse.refetch().then(() => {
-      setShowTableRows(true);
-    });
+    certMapsResponse.refetch();
   };
 
   // 'Delete' button state
@@ -237,15 +229,6 @@ const CertificateMappingPage = () => {
   }, []);
 
   // Show table rows
-  const [showTableRows, setShowTableRows] = React.useState(!isLoading);
-
-  // Show table rows only when data is fully retrieved
-  React.useEffect(() => {
-    if (showTableRows !== !isLoading) {
-      setShowTableRows(!isLoading);
-    }
-  }, [isLoading]);
-
   // Data wrappers
   // TODO: Better separation of concerts
   // - 'BulkSelectorrep'
@@ -315,7 +298,7 @@ const CertificateMappingPage = () => {
         <SecondaryButton
           dataCy="certificate-mapping-button-refresh"
           onClickHandler={refreshData}
-          isDisabled={!showTableRows}
+          isDisabled={isFetching}
         >
           Refresh
         </SecondaryButton>
@@ -326,7 +309,7 @@ const CertificateMappingPage = () => {
       element: (
         <SecondaryButton
           dataCy="certificate-mapping-button-delete"
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || isFetching}
           onClickHandler={() => setShowDeleteModal(true)}
         >
           Delete
@@ -338,7 +321,7 @@ const CertificateMappingPage = () => {
       element: (
         <SecondaryButton
           dataCy="certificate-mapping-button-add"
-          isDisabled={!showTableRows}
+          isDisabled={isFetching}
           onClickHandler={() => setShowAddModal(true)}
         >
           Add
@@ -350,7 +333,7 @@ const CertificateMappingPage = () => {
       element: (
         <SecondaryButton
           dataCy="certificate-mapping-button-disable"
-          isDisabled={isDisableButtonDisabled || !showTableRows}
+          isDisabled={isDisableButtonDisabled || isFetching}
           onClickHandler={onDisableOperation}
         >
           Disable
@@ -362,7 +345,7 @@ const CertificateMappingPage = () => {
       element: (
         <SecondaryButton
           dataCy="certificate-mapping-button-enable"
-          isDisabled={isEnableButtonDisabled || !showTableRows}
+          isDisabled={isEnableButtonDisabled || isFetching}
           onClickHandler={onEnableOperation}
         >
           Enable
@@ -427,7 +410,7 @@ const CertificateMappingPage = () => {
                     columnNames={["Rule name", "Status", "Description"]}
                     hasCheckboxes={true}
                     pathname="cert-id-mapping-rules"
-                    showTableRows={showTableRows}
+                    showTableRows={!isFetching}
                     showLink={true}
                     elementsData={{
                       isElementSelectable: isCertMapSelectable,
@@ -489,7 +472,6 @@ const CertificateMappingPage = () => {
           setSelectedElements(value.map((cn) => ({ cn }) as CertificateMapping))
         }
         operation={operation}
-        setShowTableRows={setShowTableRows}
         onRefresh={refreshData}
       />
     </div>

--- a/src/pages/CertificateMapping/CertificateMapping.tsx
+++ b/src/pages/CertificateMapping/CertificateMapping.tsx
@@ -14,7 +14,6 @@ import {
 // Data types
 import { CertificateMapping } from "src/utils/datatypes/globalDataTypes";
 // Hooks
-import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import useApiError from "src/hooks/useApiError";
@@ -23,18 +22,13 @@ import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Redux
 import { useAppDispatch, useAppSelector } from "src/store/hooks";
 // RPC
-import {
-  useGetCertMapRuleEntriesQuery,
-  useSearchCertMapRuleEntriesMutation,
-} from "src/services/rpcCertMapping";
+import { useGetCertMapRuleEntriesQuery } from "src/services/rpcCertMapping";
 // Utils
 import { isCertMapSelectable } from "src/utils/utils";
 import { apiToCertificateMapping } from "src/utils/certMappingUtils";
 // React router
 import { useNavigate } from "react-router";
 // Components
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 import ToolbarLayout, {
   ToolbarItem,
 } from "src/components/layouts/ToolbarLayout";
@@ -70,7 +64,7 @@ const CertificateMappingPage = () => {
   ) as string;
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   // Handle API calls errors
@@ -84,7 +78,6 @@ const CertificateMappingPage = () => {
   const [certMapRules, setCertMapRules] = React.useState<CertificateMapping[]>(
     []
   );
-  const [isSearchDisabled, setIsSearchDisabled] = React.useState(false);
   const [totalCount, setTotalCount] = React.useState(0);
 
   // API calls
@@ -245,59 +238,6 @@ const CertificateMappingPage = () => {
     }
   }, [isLoading]);
 
-  // Search API call
-  const [searchEntry] = useSearchCertMapRuleEntriesMutation();
-
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    searchEntry({
-      searchValue: search,
-      apiVersion,
-      sizelimit: 100,
-      startIdx: 0,
-      stopIdx: 200, // Search will consider a max. of elements
-    }).then((result) => {
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for IdPs",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success
-          const listResult = result.data?.result.results || [];
-          const listSize = result.data?.result.count || 0;
-          const totalCount = result.data?.result.totalCount || 0;
-          const elementsList: CertificateMapping[] = [];
-
-          for (let i = 0; i < listSize; i++) {
-            elementsList.push(apiToCertificateMapping(listResult[i].result));
-          }
-
-          setTotalCount(totalCount);
-          setCertMapRules(elementsList.slice(0, perPage));
-          setShowTableRows(true);
-        }
-        setIsSearchDisabled(false);
-      }
-    });
-  };
-
   // Data wrappers
   // TODO: Better separation of concerts
   // - 'PaginationLayout'
@@ -309,18 +249,6 @@ const CertificateMappingPage = () => {
     updateSelectedPerPage: setSelectedPerPage,
     updateShownElementsList: setCertMapRules,
     totalCount,
-  };
-
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
-  // SearchInputLayout
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
   };
 
   // - 'BulkSelectorrep'
@@ -380,8 +308,6 @@ const CertificateMappingPage = () => {
           name="search"
           ariaLabel="Search certificate mapping rules"
           placeholder="Search certificate mapping rules"
-          searchValueData={searchValueData}
-          isDisabled={isSearchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/DNSZones/DnsForwardZones.tsx
+++ b/src/pages/DNSZones/DnsForwardZones.tsx
@@ -197,10 +197,11 @@ const DnsForwardZones = () => {
   // Search API call
   const [searchEntry] = useSearchDnsForwardZonesEntriesMutation();
 
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     searchEntry({
-      searchValue: searchValue,
+      searchValue: search,
       apiVersion,
       startIdx: 0,
       stopIdx: 200, // Search will consider a max. of elements

--- a/src/pages/DNSZones/DnsForwardZones.tsx
+++ b/src/pages/DNSZones/DnsForwardZones.tsx
@@ -60,8 +60,7 @@ const DnsForwardZones = () => {
   ) as string;
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
 
   // Handle API calls errors
   const globalErrors = useApiError([]);
@@ -188,19 +187,12 @@ const DnsForwardZones = () => {
   // Show table rows
   const [showTableRows, setShowTableRows] = React.useState(!isLoading);
 
-  // Data wrappers
-  // TODO: Better separation of concerns
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage: setPage,
-    updatePerPage: setPerPage,
-    updateSelectedPerPage: setSelectedPerPage,
-    updateShownElementsList: setDnsForwardZones,
-    totalCount,
-  };
+  // Reset the selected per-page count when the page or page size changes
+  React.useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
 
+  // Data wrappers
   // - 'BulkSelectorPrep'
   const bulkSelectorData = {
     selected: selectedElements,
@@ -342,7 +334,7 @@ const DnsForwardZones = () => {
       element: (
         <PaginationLayout
           list={dnsForwardZones}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -428,7 +420,7 @@ const DnsForwardZones = () => {
             >
               <PaginationLayout
                 list={dnsForwardZones}
-                paginationData={paginationData}
+                totalCount={totalCount}
                 variant={PaginationVariant.bottom}
                 widgetId="pagination-options-menu-bottom"
               />

--- a/src/pages/DNSZones/DnsForwardZones.tsx
+++ b/src/pages/DNSZones/DnsForwardZones.tsx
@@ -25,6 +25,10 @@ import { useAppDispatch, useAppSelector } from "src/store/hooks";
 import { useGetDnsForwardZonesFullDataQuery } from "src/services/rpcDnsForwardZones";
 // Utils
 import { isDnsForwardZoneSelectable } from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 // Components
 import ToolbarLayout, {
   ToolbarItem,
@@ -120,7 +124,6 @@ const DnsForwardZones = () => {
   const [selectedElements, setSelectedElements] = React.useState<
     DNSForwardZone[]
   >([]);
-  const [selectedPerPage, setSelectedPerPage] = React.useState<number>(0);
 
   // Refresh button handling
   const refreshData = () => {
@@ -187,10 +190,11 @@ const DnsForwardZones = () => {
   // Show table rows
   const [showTableRows, setShowTableRows] = React.useState(!isLoading);
 
-  // Reset the selected per-page count when the page or page size changes
-  React.useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
+  const selectedPerPageData = getSelectedPerPageData(
+    dnsForwardZones,
+    selectedElements.map((dnsZone) => ipaPrimaryKey(dnsZone.idnsname)),
+    (dnsZone) => ipaPrimaryKey(dnsZone.idnsname)
+  );
 
   // Data wrappers
   // - 'BulkSelectorPrep'
@@ -199,11 +203,6 @@ const DnsForwardZones = () => {
     updateSelected: updateSelectedDnsZones,
     selectableTable: selectableDnsZonesTable,
     nameAttr: "idnsname",
-  };
-
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage: setSelectedPerPage,
   };
 
   const [showEnableDisableModal, setShowEnableDisableModal] =
@@ -405,10 +404,7 @@ const DnsForwardZones = () => {
                           setIsDisableButtonDisabled(value),
                         isDisableEnableOp: true,
                       }}
-                      paginationData={{
-                        selectedPerPage,
-                        updateSelectedPerPage: setSelectedPerPage,
-                      }}
+                      paginationData={selectedPerPageData}
                       statusElementName="idnszoneactive"
                     />
                   )}

--- a/src/pages/DNSZones/DnsForwardZones.tsx
+++ b/src/pages/DNSZones/DnsForwardZones.tsx
@@ -198,6 +198,7 @@ const DnsForwardZones = () => {
   const [searchEntry] = useSearchDnsForwardZonesEntriesMutation();
 
   const submitSearchValue = () => {
+    setPage(1);
     searchEntry({
       searchValue: searchValue,
       apiVersion,
@@ -224,7 +225,7 @@ const DnsForwardZones = () => {
         const dnsForwardZones = result.data?.result || [];
 
         setTotalCount(dnsForwardZones.length);
-        setDnsForwardZones(dnsForwardZones);
+        setDnsForwardZones(dnsForwardZones.slice(0, perPage));
         setShowTableRows(true);
       }
       setIsSearchDisabled(false);
@@ -244,10 +245,15 @@ const DnsForwardZones = () => {
     totalCount,
   };
 
+  const updateSearchValue = (value: string) => {
+    setPage(1);
+    setSearchValue(value);
+  };
+
   // SearchInputLayout
   const searchValueData = {
     searchValue,
-    updateSearchValue: setSearchValue,
+    updateSearchValue,
     submitSearchValue,
   };
 

--- a/src/pages/DNSZones/DnsForwardZones.tsx
+++ b/src/pages/DNSZones/DnsForwardZones.tsx
@@ -87,12 +87,11 @@ const DnsForwardZones = () => {
     stopIdx: lastUserIdx,
   });
 
-  const { data, isLoading, error } = forwardDnsZonesResponse;
+  const { data, isFetching, error } = forwardDnsZonesResponse;
 
   // Handle data when the API call is finished
   React.useEffect(() => {
     if (forwardDnsZonesResponse.isFetching) {
-      setShowTableRows(false);
       // Reset selected elements on refresh
       setTotalCount(0);
       globalErrors.clear();
@@ -115,8 +114,6 @@ const DnsForwardZones = () => {
       setTotalCount(forwardDnsZonesResponse.data.result.totalCount);
       // Update the list of elements
       setDnsForwardZones(elementsList);
-      // Show table elements
-      setShowTableRows(true);
     }
   }, [forwardDnsZonesResponse]);
 
@@ -127,16 +124,11 @@ const DnsForwardZones = () => {
 
   // Refresh button handling
   const refreshData = () => {
-    // Hide table
-    setShowTableRows(false);
-
     // Reset selected elements on refresh
     setTotalCount(0);
     setSelectedElements([]);
 
-    forwardDnsZonesResponse.refetch().then(() => {
-      setShowTableRows(true);
-    });
+    forwardDnsZonesResponse.refetch();
   };
 
   // 'Delete' button state
@@ -188,8 +180,6 @@ const DnsForwardZones = () => {
   }, []);
 
   // Show table rows
-  const [showTableRows, setShowTableRows] = React.useState(!isLoading);
-
   const selectedPerPageData = getSelectedPerPageData(
     dnsForwardZones,
     selectedElements.map((dnsZone) => ipaPrimaryKey(dnsZone.idnsname)),
@@ -260,7 +250,7 @@ const DnsForwardZones = () => {
       element: (
         <SecondaryButton
           onClickHandler={refreshData}
-          isDisabled={!showTableRows}
+          isDisabled={isFetching}
           dataCy={"dns-forward-zones-refresh"}
         >
           Refresh
@@ -271,7 +261,7 @@ const DnsForwardZones = () => {
       key: 4,
       element: (
         <SecondaryButton
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || isFetching}
           dataCy={"dns-forward-zones-button-delete"}
           onClickHandler={() => setShowDeleteForwardZonesModal(true)}
         >
@@ -283,7 +273,7 @@ const DnsForwardZones = () => {
       key: 5,
       element: (
         <SecondaryButton
-          isDisabled={!showTableRows}
+          isDisabled={isFetching}
           dataCy={"dns-forward-zones-add"}
           onClickHandler={() => setShowAddForwardZoneModal(true)}
         >
@@ -296,7 +286,7 @@ const DnsForwardZones = () => {
       element: (
         <SecondaryButton
           onClickHandler={() => onEnableDisableHandler("disable")}
-          isDisabled={isDisableButtonDisabled || !showTableRows}
+          isDisabled={isDisableButtonDisabled || isFetching}
           dataCy={"dns-forward-zones-disable"}
         >
           Disable
@@ -308,7 +298,7 @@ const DnsForwardZones = () => {
       element: (
         <SecondaryButton
           onClickHandler={() => onEnableDisableHandler("enable")}
-          isDisabled={isEnableButtonDisabled || !showTableRows}
+          isDisabled={isEnableButtonDisabled || isFetching}
           dataCy={"dns-forward-zones-enable"}
         >
           Enable
@@ -384,7 +374,7 @@ const DnsForwardZones = () => {
                       ]}
                       hasCheckboxes={true}
                       pathname="dns-forward-zones"
-                      showTableRows={showTableRows}
+                      showTableRows={!isFetching}
                       showLink={true}
                       elementsData={{
                         isElementSelectable: isDnsForwardZoneSelectable,
@@ -446,7 +436,6 @@ const DnsForwardZones = () => {
           elementsList={selectedElements.map((dnszone) => dnszone.idnsname)}
           setElementsList={() => {}}
           operation={operation}
-          setShowTableRows={setShowTableRows}
           onRefresh={refreshData}
         />
       </div>

--- a/src/pages/DNSZones/DnsForwardZones.tsx
+++ b/src/pages/DNSZones/DnsForwardZones.tsx
@@ -173,12 +173,6 @@ const DnsForwardZones = () => {
     }
   };
 
-  // Always refetch data when the component is loaded.
-  // This ensures the data is always up-to-date.
-  React.useEffect(() => {
-    forwardDnsZonesResponse.refetch();
-  }, []);
-
   // Show table rows
   const selectedPerPageData = getSelectedPerPageData(
     dnsForwardZones,

--- a/src/pages/DNSZones/DnsForwardZones.tsx
+++ b/src/pages/DNSZones/DnsForwardZones.tsx
@@ -14,7 +14,6 @@ import {
 // Data types
 import { DNSForwardZone } from "src/utils/datatypes/globalDataTypes";
 // Hooks
-import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import useApiError from "src/hooks/useApiError";
@@ -23,10 +22,7 @@ import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Redux
 import { useAppDispatch, useAppSelector } from "src/store/hooks";
 // RPC
-import {
-  useGetDnsForwardZonesFullDataQuery,
-  useSearchDnsForwardZonesEntriesMutation,
-} from "src/services/rpcDnsForwardZones";
+import { useGetDnsForwardZonesFullDataQuery } from "src/services/rpcDnsForwardZones";
 // Utils
 import { isDnsForwardZoneSelectable } from "src/utils/utils";
 // Components
@@ -64,7 +60,7 @@ const DnsForwardZones = () => {
   ) as string;
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   // Handle API calls errors
@@ -78,8 +74,6 @@ const DnsForwardZones = () => {
   const [dnsForwardZones, setDnsForwardZones] = React.useState<
     DNSForwardZone[]
   >([]);
-  const [isSearchDisabled, setIsSearchDisabled] =
-    React.useState<boolean>(false);
   const [totalCount, setTotalCount] = React.useState<number>(0);
 
   // API calls
@@ -194,45 +188,6 @@ const DnsForwardZones = () => {
   // Show table rows
   const [showTableRows, setShowTableRows] = React.useState(!isLoading);
 
-  // Search API call
-  const [searchEntry] = useSearchDnsForwardZonesEntriesMutation();
-
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    searchEntry({
-      searchValue: search,
-      apiVersion,
-      startIdx: 0,
-      stopIdx: 200, // Search will consider a max. of elements
-    }).then((result) => {
-      if ("error" in result && !("data" in result)) {
-        const searchError = result.error;
-        let error: string | undefined = "";
-        if ("error" in searchError) {
-          error = searchError.error;
-        } else if ("message" in searchError) {
-          error = searchError.message;
-        }
-        dispatch(
-          addAlert({
-            name: "submit-search-value-error",
-            title: error || "Error when searching for elements",
-            variant: "danger",
-          })
-        );
-      } else {
-        // Success
-        const dnsForwardZones = result.data?.result || [];
-
-        setTotalCount(dnsForwardZones.length);
-        setDnsForwardZones(dnsForwardZones.slice(0, perPage));
-        setShowTableRows(true);
-      }
-      setIsSearchDisabled(false);
-    });
-  };
-
   // Data wrappers
   // TODO: Better separation of concerns
   // - 'PaginationLayout'
@@ -244,18 +199,6 @@ const DnsForwardZones = () => {
     updateSelectedPerPage: setSelectedPerPage,
     updateShownElementsList: setDnsForwardZones,
     totalCount,
-  };
-
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
-  // SearchInputLayout
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
   };
 
   // - 'BulkSelectorPrep'
@@ -311,8 +254,6 @@ const DnsForwardZones = () => {
           name="search"
           ariaLabel="Search DNS forward zones"
           placeholder="Search DNS forward zones"
-          searchValueData={searchValueData}
-          isDisabled={isSearchDisabled}
           dataCy={"search"}
         />
       ),

--- a/src/pages/DNSZones/DnsResourceRecords.tsx
+++ b/src/pages/DNSZones/DnsResourceRecords.tsx
@@ -222,12 +222,13 @@ const DnsResourceRecords = (props: DnsResourceRecordsProps) => {
   const [searchDnsRecords] = useSearchDnsRecordsEntriesMutation();
 
   const submitSearchValue = () => {
+    setPage(1);
     const payload: FindDnsRecordPayload = {
       dnsZoneId: props.dnsZoneId,
       recordName: searchValue,
-      sizeLimit: perPage,
+      sizeLimit: 100,
       startIdx: 0, // Reset to first page for search
-      stopIdx: perPage,
+      stopIdx: 100,
     };
 
     setIsSearchDisabled(true);
@@ -256,11 +257,9 @@ const DnsResourceRecords = (props: DnsResourceRecordsProps) => {
         } else {
           // Success
           const records = result.data?.result || [];
-          setDnsRecords(records);
+          setDnsRecords(records.slice(0, perPage));
           setTotalCount(records.length);
           setShowTableRows(true);
-          // Reset to first page
-          setPage(1);
         }
         setIsSearchDisabled(false);
       }
@@ -280,10 +279,15 @@ const DnsResourceRecords = (props: DnsResourceRecordsProps) => {
     totalCount,
   };
 
+  const updateSearchValue = (value: string) => {
+    setPage(1);
+    setSearchValue(value);
+  };
+
   // SearchInputLayout
   const searchValueData = {
     searchValue,
-    updateSearchValue: setSearchValue,
+    updateSearchValue,
     submitSearchValue,
   };
 

--- a/src/pages/DNSZones/DnsResourceRecords.tsx
+++ b/src/pages/DNSZones/DnsResourceRecords.tsx
@@ -186,12 +186,6 @@ const DnsResourceRecords = (props: DnsResourceRecordsProps) => {
   };
 
   // Show table rows
-  // Always refetch data when the component is loaded.
-  // This ensures the data is always up-to-date.
-  React.useEffect(() => {
-    dnsRecordsResponse.refetch();
-  }, []);
-
   // Show table rows only when data is fully retrieved
   const selectedPerPageData = getSelectedPerPageData(
     dnsRecords,

--- a/src/pages/DNSZones/DnsResourceRecords.tsx
+++ b/src/pages/DNSZones/DnsResourceRecords.tsx
@@ -83,12 +83,11 @@ const DnsResourceRecords = (props: DnsResourceRecordsProps) => {
     stopIdx: stopIdx,
   });
 
-  const { data, isLoading, error } = dnsRecordsResponse;
+  const { data, isFetching, error } = dnsRecordsResponse;
 
   // Handle data when the API call is finished
   React.useEffect(() => {
     if (dnsRecordsResponse.isFetching) {
-      setShowTableRows(false);
       // Reset selected elements on refresh
       setTotalCount(0);
       globalErrors.clear();
@@ -103,8 +102,6 @@ const DnsResourceRecords = (props: DnsResourceRecordsProps) => {
     ) {
       setDnsRecords(data.result);
       setTotalCount(data.count);
-      // Show table elements
-      setShowTableRows(true);
     }
   }, [dnsRecordsResponse]);
 
@@ -115,28 +112,19 @@ const DnsResourceRecords = (props: DnsResourceRecordsProps) => {
 
   // Refresh button handling
   const refreshData = () => {
-    // Hide table
-    setShowTableRows(false);
-
     // Reset selected elements on refresh
     setTotalCount(0);
     setSelectedElements([]);
 
-    dnsRecordsResponse
-      .refetch()
-      .then(() => {
-        setShowTableRows(true);
-      })
-      .catch(() => {
-        dispatch(
-          addAlert({
-            name: "refresh-dns-records-error",
-            title: "Error refreshing DNS records",
-            variant: "danger",
-          })
-        );
-        setShowTableRows(true); // Show table even if there's an error
-      });
+    dnsRecordsResponse.refetch().catch(() => {
+      dispatch(
+        addAlert({
+          name: "refresh-dns-records-error",
+          title: "Error refreshing DNS records",
+          variant: "danger",
+        })
+      );
+    });
   };
 
   // 'Delete' button state
@@ -197,22 +185,14 @@ const DnsResourceRecords = (props: DnsResourceRecordsProps) => {
     }
   };
 
+  // Show table rows
   // Always refetch data when the component is loaded.
   // This ensures the data is always up-to-date.
   React.useEffect(() => {
     dnsRecordsResponse.refetch();
   }, []);
 
-  // Show table rows
-  const [showTableRows, setShowTableRows] = React.useState<boolean>(!isLoading);
-
   // Show table rows only when data is fully retrieved
-  React.useEffect(() => {
-    if (showTableRows !== !isLoading) {
-      setShowTableRows(!isLoading);
-    }
-  }, [isLoading]);
-
   const selectedPerPageData = getSelectedPerPageData(
     dnsRecords,
     selectedElements.map((dnsRecord) => ipaPrimaryKey(dnsRecord.idnsname)),
@@ -270,7 +250,7 @@ const DnsResourceRecords = (props: DnsResourceRecordsProps) => {
       element: (
         <SecondaryButton
           onClickHandler={refreshData}
-          isDisabled={!showTableRows}
+          isDisabled={isFetching}
           dataCy="refresh-dns-records"
         >
           Refresh
@@ -281,7 +261,7 @@ const DnsResourceRecords = (props: DnsResourceRecordsProps) => {
       key: 4,
       element: (
         <SecondaryButton
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || isFetching}
           onClickHandler={() => setShowDeleteModal(true)}
           dataCy="delete-dns-records"
         >
@@ -293,7 +273,7 @@ const DnsResourceRecords = (props: DnsResourceRecordsProps) => {
       key: 5,
       element: (
         <SecondaryButton
-          isDisabled={!showTableRows}
+          isDisabled={isFetching}
           onClickHandler={() => setShowAddModal(true)}
           dataCy="add-dns-records"
         >
@@ -360,7 +340,7 @@ const DnsResourceRecords = (props: DnsResourceRecordsProps) => {
                     <GlobalErrors errors={globalErrors.getAll()} />
                   ) : (
                     <>
-                      {isLoading || !showTableRows ? (
+                      {isFetching ? (
                         spinner
                       ) : (
                         <MainTable
@@ -375,7 +355,7 @@ const DnsResourceRecords = (props: DnsResourceRecordsProps) => {
                           columnNames={["Record name", "Record type", "Data"]}
                           hasCheckboxes={true}
                           pathname="dns-records"
-                          showTableRows={showTableRows}
+                          showTableRows={!isFetching}
                           showLink={false}
                           elementsData={{
                             isElementSelectable: isDnsRecordSelectable,

--- a/src/pages/DNSZones/DnsResourceRecords.tsx
+++ b/src/pages/DNSZones/DnsResourceRecords.tsx
@@ -19,6 +19,10 @@ import { DNSRecord } from "src/utils/datatypes/globalDataTypes";
 import { useDnsRecordFindQuery } from "src/services/rpcDnsZones";
 // Utils
 import { isDnsRecordSelectable } from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 // Redux
 import { useAppDispatch } from "src/store/hooks";
 // Hooks
@@ -108,7 +112,6 @@ const DnsResourceRecords = (props: DnsResourceRecordsProps) => {
   const [selectedElements, setSelectedElements] = React.useState<DNSRecord[]>(
     []
   );
-  const [selectedPerPage, setSelectedPerPage] = React.useState<number>(0);
 
   // Refresh button handling
   const refreshData = () => {
@@ -210,10 +213,11 @@ const DnsResourceRecords = (props: DnsResourceRecordsProps) => {
     }
   }, [isLoading]);
 
-  // Reset the selected per-page count when the page or page size changes
-  React.useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
+  const selectedPerPageData = getSelectedPerPageData(
+    dnsRecords,
+    selectedElements.map((dnsRecord) => ipaPrimaryKey(dnsRecord.idnsname)),
+    (dnsRecord) => ipaPrimaryKey(dnsRecord.idnsname)
+  );
 
   // Data wrappers
   // - 'BulkSelectorPrep'
@@ -222,11 +226,6 @@ const DnsResourceRecords = (props: DnsResourceRecordsProps) => {
     updateSelected: updateSelectedDnsRecords,
     selectableTable: selectableDnsRecordsTable,
     nameAttr: "idnsname",
-  };
-
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage: setSelectedPerPage,
   };
 
   // Modals functionality
@@ -393,10 +392,7 @@ const DnsResourceRecords = (props: DnsResourceRecordsProps) => {
                             updateIsDeletion: (value) => setIsDeletion(value),
                             isDisableEnableOp: true,
                           }}
-                          paginationData={{
-                            selectedPerPage,
-                            updateSelectedPerPage: setSelectedPerPage,
-                          }}
+                          paginationData={selectedPerPageData}
                         />
                       )}
                     </>

--- a/src/pages/DNSZones/DnsResourceRecords.tsx
+++ b/src/pages/DNSZones/DnsResourceRecords.tsx
@@ -57,8 +57,7 @@ const DnsResourceRecords = (props: DnsResourceRecordsProps) => {
   useUpdateRoute({ pathname: "dns-records" });
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
 
   // Handle API calls errors
   const globalErrors = useApiError([]);
@@ -211,19 +210,12 @@ const DnsResourceRecords = (props: DnsResourceRecordsProps) => {
     }
   }, [isLoading]);
 
-  // Data wrappers
-  // TODO: Better separation of concerns
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage: setPage,
-    updatePerPage: setPerPage,
-    updateSelectedPerPage: setSelectedPerPage,
-    updateShownElementsList: setDnsRecords,
-    totalCount,
-  };
+  // Reset the selected per-page count when the page or page size changes
+  React.useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
 
+  // Data wrappers
   // - 'BulkSelectorPrep'
   const bulkSelectorData = {
     selected: selectedElements,
@@ -328,7 +320,7 @@ const DnsResourceRecords = (props: DnsResourceRecordsProps) => {
       element: (
         <PaginationLayout
           list={dnsRecords}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -417,7 +409,7 @@ const DnsResourceRecords = (props: DnsResourceRecordsProps) => {
             >
               <PaginationLayout
                 list={dnsRecords}
-                paginationData={paginationData}
+                totalCount={totalCount}
                 variant={PaginationVariant.bottom}
                 widgetId="pagination-options-menu-bottom"
                 className="pf-v6-u-pb-0 pf-v6-u-pr-md"

--- a/src/pages/DNSZones/DnsResourceRecords.tsx
+++ b/src/pages/DNSZones/DnsResourceRecords.tsx
@@ -16,11 +16,7 @@ import {
 // Data types
 import { DNSRecord } from "src/utils/datatypes/globalDataTypes";
 // RPC
-import {
-  FindDnsRecordPayload,
-  useDnsRecordFindQuery,
-  useSearchDnsRecordsEntriesMutation,
-} from "src/services/rpcDnsZones";
+import { useDnsRecordFindQuery } from "src/services/rpcDnsZones";
 // Utils
 import { isDnsRecordSelectable } from "src/utils/utils";
 // Redux
@@ -37,8 +33,6 @@ import ToolbarLayout, {
   ToolbarItem,
 } from "src/components/layouts/ToolbarLayout";
 import GlobalErrors from "src/components/errors/GlobalErrors";
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 import SecondaryButton from "src/components/layouts/SecondaryButton";
 import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
 
@@ -63,7 +57,7 @@ const DnsResourceRecords = (props: DnsResourceRecordsProps) => {
   useUpdateRoute({ pathname: "dns-records" });
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   // Handle API calls errors
@@ -71,7 +65,6 @@ const DnsResourceRecords = (props: DnsResourceRecordsProps) => {
 
   // States
   const [dnsRecords, setDnsRecords] = React.useState<DNSRecord[]>([]);
-  const [isSearchDisabled, setIsSearchDisabled] = React.useState(false);
   const [totalCount, setTotalCount] = React.useState(0);
 
   // Calculate pagination parameters for server-side pagination
@@ -218,55 +211,6 @@ const DnsResourceRecords = (props: DnsResourceRecordsProps) => {
     }
   }, [isLoading]);
 
-  // Search DNS records
-  const [searchDnsRecords] = useSearchDnsRecordsEntriesMutation();
-
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    const payload: FindDnsRecordPayload = {
-      dnsZoneId: props.dnsZoneId,
-      recordName: search,
-      sizeLimit: 100,
-      startIdx: 0, // Reset to first page for search
-      stopIdx: 100,
-    };
-
-    setIsSearchDisabled(true);
-
-    searchDnsRecords(payload).then((result) => {
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for elements",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success
-          const records = result.data?.result || [];
-          setDnsRecords(records.slice(0, perPage));
-          setTotalCount(records.length);
-          setShowTableRows(true);
-        }
-        setIsSearchDisabled(false);
-      }
-    });
-  };
-
   // Data wrappers
   // TODO: Better separation of concerns
   // - 'PaginationLayout'
@@ -278,18 +222,6 @@ const DnsResourceRecords = (props: DnsResourceRecordsProps) => {
     updateSelectedPerPage: setSelectedPerPage,
     updateShownElementsList: setDnsRecords,
     totalCount,
-  };
-
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
-  // SearchInputLayout
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
   };
 
   // - 'BulkSelectorPrep'
@@ -332,8 +264,6 @@ const DnsResourceRecords = (props: DnsResourceRecordsProps) => {
           name="search"
           ariaLabel="Search DNS records"
           placeholder="Search DNS records"
-          searchValueData={searchValueData}
-          isDisabled={isSearchDisabled}
           dataCy="search"
         />
       ),

--- a/src/pages/DNSZones/DnsResourceRecords.tsx
+++ b/src/pages/DNSZones/DnsResourceRecords.tsx
@@ -221,11 +221,12 @@ const DnsResourceRecords = (props: DnsResourceRecordsProps) => {
   // Search DNS records
   const [searchDnsRecords] = useSearchDnsRecordsEntriesMutation();
 
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     const payload: FindDnsRecordPayload = {
       dnsZoneId: props.dnsZoneId,
-      recordName: searchValue,
+      recordName: search,
       sizeLimit: 100,
       startIdx: 0, // Reset to first page for search
       stopIdx: 100,

--- a/src/pages/DNSZones/DnsServers.tsx
+++ b/src/pages/DNSZones/DnsServers.tsx
@@ -57,8 +57,7 @@ const DnsServers = () => {
   ) as string;
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
 
   // Handle API calls errors
   const globalErrors = useApiError([]);
@@ -128,19 +127,6 @@ const DnsServers = () => {
     }
   }, [dnsServersResponse.isSuccess, dnsServersResponse.data]);
 
-  // Data wrappers
-  // TODO: Better separation of concerts
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage: setPage,
-    updatePerPage: setPerPage,
-    updateSelectedPerPage: () => {},
-    updateShownElementsList: setDnsServersId,
-    totalCount,
-  };
-
   // List of Toolbar items
   const toolbarItems: ToolbarItem[] = [
     {
@@ -190,7 +176,7 @@ const DnsServers = () => {
       element: (
         <PaginationLayout
           list={dnsServersId}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -271,7 +257,7 @@ const DnsServers = () => {
             >
               <PaginationLayout
                 list={dnsServersId}
-                paginationData={paginationData}
+                totalCount={totalCount}
                 variant={PaginationVariant.bottom}
                 widgetId="pagination-options-menu-bottom"
               />

--- a/src/pages/DNSZones/DnsServers.tsx
+++ b/src/pages/DNSZones/DnsServers.tsx
@@ -140,6 +140,7 @@ const DnsServers = () => {
   const [searchEntry] = useSearchDnsServersEntriesMutation();
 
   const submitSearchValue = () => {
+    setPage(1);
     searchEntry({
       searchValue: searchValue,
       pkeyOnly: true,
@@ -169,9 +170,7 @@ const DnsServers = () => {
           const dnsServers = result.data || [];
 
           setTotalCount(totalCount);
-          setDnsServersId(
-            dnsServers.data.slice(firstUserIdx, lastUserIdx) || []
-          );
+          setDnsServersId(dnsServers.data.slice(0, perPage) || []);
           setShowTableRows(true);
         }
         setIsSearchDisabled(false);
@@ -192,10 +191,15 @@ const DnsServers = () => {
     totalCount,
   };
 
+  const updateSearchValue = (value: string) => {
+    setPage(1);
+    setSearchValue(value);
+  };
+
   // SearchInputLayout
   const searchValueData = {
     searchValue,
-    updateSearchValue: setSearchValue,
+    updateSearchValue,
     submitSearchValue,
   };
 

--- a/src/pages/DNSZones/DnsServers.tsx
+++ b/src/pages/DNSZones/DnsServers.tsx
@@ -15,7 +15,6 @@ import {
   Tr,
 } from "@patternfly/react-table";
 // Hooks
-import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import useApiError from "src/hooks/useApiError";
@@ -24,15 +23,10 @@ import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Redux
 import { useAppDispatch, useAppSelector } from "src/store/hooks";
 // RPC
-import {
-  useDnsServersFindQuery,
-  useSearchDnsServersEntriesMutation,
-} from "src/services/rpcDnsServers";
+import { useDnsServersFindQuery } from "src/services/rpcDnsServers";
 // React router
 import { Link } from "react-router";
 // Components
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 import ToolbarLayout, {
   ToolbarItem,
 } from "src/components/layouts/ToolbarLayout";
@@ -63,7 +57,7 @@ const DnsServers = () => {
   ) as string;
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   // Handle API calls errors
@@ -75,8 +69,6 @@ const DnsServers = () => {
 
   // States
   const [dnsServersId, setDnsServersId] = React.useState<string[]>([]);
-  const [isSearchDisabled, setIsSearchDisabled] =
-    React.useState<boolean>(false);
   const [totalCount, setTotalCount] = React.useState<number>(0);
 
   // API calls
@@ -136,49 +128,6 @@ const DnsServers = () => {
     }
   }, [dnsServersResponse.isSuccess, dnsServersResponse.data]);
 
-  // Search API call
-  const [searchEntry] = useSearchDnsServersEntriesMutation();
-
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    searchEntry({
-      searchValue: search,
-      pkeyOnly: true,
-      sizeLimit: 100,
-      version: apiVersion,
-    }).then((result) => {
-      if ("data" in result && result.data !== undefined) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for elements",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success
-          const dnsServers = result.data || [];
-
-          setTotalCount(totalCount);
-          setDnsServersId(dnsServers.data.slice(0, perPage) || []);
-          setShowTableRows(true);
-        }
-        setIsSearchDisabled(false);
-      }
-    });
-  };
-
   // Data wrappers
   // TODO: Better separation of concerts
   // - 'PaginationLayout'
@@ -192,18 +141,6 @@ const DnsServers = () => {
     totalCount,
   };
 
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
-  // SearchInputLayout
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
-  };
-
   // List of Toolbar items
   const toolbarItems: ToolbarItem[] = [
     {
@@ -214,8 +151,6 @@ const DnsServers = () => {
           name="search"
           ariaLabel="Search DNS servers"
           placeholder="Search DNS servers"
-          searchValueData={searchValueData}
-          isDisabled={isSearchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/DNSZones/DnsServers.tsx
+++ b/src/pages/DNSZones/DnsServers.tsx
@@ -78,12 +78,11 @@ const DnsServers = () => {
     version: apiVersion,
   });
 
-  const { data, isLoading, error } = dnsServersResponse;
+  const { data, isFetching, error } = dnsServersResponse;
 
   // Handle data when the API call is finished
   React.useEffect(() => {
     if (dnsServersResponse.isFetching) {
-      setShowTableRows(false);
       setTotalCount(0);
       globalErrors.clear();
       return;
@@ -97,18 +96,14 @@ const DnsServers = () => {
     ) {
       setTotalCount(data.data.length || 0);
       setDnsServersId(data.data.slice(firstUserIdx, lastUserIdx) || []);
-      setShowTableRows(true);
     }
   }, [dnsServersResponse]);
 
   // Refresh button handling
   const refreshData = () => {
-    setShowTableRows(false);
     setTotalCount(0);
 
-    dnsServersResponse.refetch().then(() => {
-      setShowTableRows(true);
-    });
+    dnsServersResponse.refetch();
   };
 
   // Always refetch data when the component is loaded.
@@ -116,16 +111,6 @@ const DnsServers = () => {
   React.useEffect(() => {
     dnsServersResponse.refetch();
   }, []);
-
-  // Show table rows
-  const [showTableRows, setShowTableRows] = React.useState<boolean>(!isLoading);
-
-  // Show table rows only when data is fully retrieved
-  React.useEffect(() => {
-    if (dnsServersResponse.isSuccess && dnsServersResponse.data) {
-      setShowTableRows(true);
-    }
-  }, [dnsServersResponse.isSuccess, dnsServersResponse.data]);
 
   // List of Toolbar items
   const toolbarItems: ToolbarItem[] = [
@@ -152,7 +137,7 @@ const DnsServers = () => {
         <SecondaryButton
           dataCy="dns-servers-button-refresh"
           onClickHandler={refreshData}
-          isDisabled={!showTableRows}
+          isDisabled={isFetching}
         >
           Refresh
         </SecondaryButton>
@@ -246,7 +231,7 @@ const DnsServers = () => {
                       tableId={"dns-servers-table"}
                       isStickyHeader={true}
                       tableHeader={header}
-                      tableBody={!showTableRows ? skeleton : body}
+                      tableBody={isFetching ? skeleton : body}
                     />
                   )}
                 </InnerScrollContainer>

--- a/src/pages/DNSZones/DnsServers.tsx
+++ b/src/pages/DNSZones/DnsServers.tsx
@@ -139,10 +139,11 @@ const DnsServers = () => {
   // Search API call
   const [searchEntry] = useSearchDnsServersEntriesMutation();
 
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     searchEntry({
-      searchValue: searchValue,
+      searchValue: search,
       pkeyOnly: true,
       sizeLimit: 100,
       version: apiVersion,

--- a/src/pages/DNSZones/DnsServers.tsx
+++ b/src/pages/DNSZones/DnsServers.tsx
@@ -106,12 +106,6 @@ const DnsServers = () => {
     dnsServersResponse.refetch();
   };
 
-  // Always refetch data when the component is loaded.
-  // This ensures the data is always up-to-date.
-  React.useEffect(() => {
-    dnsServersResponse.refetch();
-  }, []);
-
   // List of Toolbar items
   const toolbarItems: ToolbarItem[] = [
     {

--- a/src/pages/DNSZones/DnsZones.tsx
+++ b/src/pages/DNSZones/DnsZones.tsx
@@ -86,12 +86,11 @@ const DnsZones = () => {
     stopIdx: lastUserIdx,
   });
 
-  const { data, isLoading, error } = dnsZonesResponse;
+  const { data, isFetching, error } = dnsZonesResponse;
 
   // Handle data when the API call is finished
   React.useEffect(() => {
     if (dnsZonesResponse.isFetching) {
-      setShowTableRows(false);
       // Reset selected elements on refresh
       setTotalCount(0);
       globalErrors.clear();
@@ -115,8 +114,6 @@ const DnsZones = () => {
       setTotalCount(dnsZonesResponse.data.result.totalCount);
       // Update the list of elements
       setDnsZones(elementsList);
-      // Show table elements
-      setShowTableRows(true);
     }
   }, [dnsZonesResponse]);
 
@@ -125,15 +122,10 @@ const DnsZones = () => {
 
   // Refresh button handling
   const refreshData = () => {
-    // Hide table
-    setShowTableRows(false);
-
     // Reset selected elements on refresh
     setTotalCount(0);
 
-    dnsZonesResponse.refetch().then(() => {
-      setShowTableRows(true);
-    });
+    dnsZonesResponse.refetch();
   };
 
   // 'Delete' button state
@@ -204,16 +196,6 @@ const DnsZones = () => {
   React.useEffect(() => {
     dnsZonesResponse.refetch();
   }, []);
-
-  // Show table rows
-  const [showTableRows, setShowTableRows] = React.useState<boolean>(!isLoading);
-
-  // Show table rows only when data is fully retrieved
-  React.useEffect(() => {
-    if (showTableRows !== !isLoading) {
-      setShowTableRows(!isLoading);
-    }
-  }, [isLoading]);
 
   const selectedPerPageData = getSelectedPerPageData(
     dnsZones,
@@ -289,7 +271,7 @@ const DnsZones = () => {
         <SecondaryButton
           dataCy="dns-zones-button-refresh"
           onClickHandler={refreshData}
-          isDisabled={!showTableRows}
+          isDisabled={isFetching}
         >
           Refresh
         </SecondaryButton>
@@ -299,7 +281,7 @@ const DnsZones = () => {
       key: 4,
       element: (
         <SecondaryButton
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || isFetching}
           onClickHandler={() => setShowDeleteModal(true)}
           dataCy="dns-zones-button-delete"
         >
@@ -311,7 +293,7 @@ const DnsZones = () => {
       key: 5,
       element: (
         <SecondaryButton
-          isDisabled={!showTableRows}
+          isDisabled={isFetching}
           onClickHandler={() => setShowAddModal(true)}
           dataCy="dns-zones-button-add"
         >
@@ -323,7 +305,7 @@ const DnsZones = () => {
       key: 6,
       element: (
         <SecondaryButton
-          isDisabled={isDisableButtonDisabled || !showTableRows}
+          isDisabled={isDisableButtonDisabled || isFetching}
           onClickHandler={onDisableOperation}
           dataCy="dns-zones-button-disable"
         >
@@ -335,7 +317,7 @@ const DnsZones = () => {
       key: 7,
       element: (
         <SecondaryButton
-          isDisabled={isEnableButtonDisabled || !showTableRows}
+          isDisabled={isEnableButtonDisabled || isFetching}
           onClickHandler={onEnableOperation}
           dataCy="dns-zones-button-enable"
         >
@@ -398,7 +380,7 @@ const DnsZones = () => {
                       columnNames={["Zone name", "Status"]}
                       hasCheckboxes={true}
                       pathname="dns-zones"
-                      showTableRows={showTableRows}
+                      showTableRows={!isFetching}
                       showLink={true}
                       elementsData={{
                         isElementSelectable: isDnsZoneSelectable,
@@ -462,7 +444,6 @@ const DnsZones = () => {
             setSelectedElements(newElementsList)
           }
           operation={operation}
-          setShowTableRows={setShowTableRows}
           onRefresh={refreshData}
         />
       </div>

--- a/src/pages/DNSZones/DnsZones.tsx
+++ b/src/pages/DNSZones/DnsZones.tsx
@@ -14,7 +14,6 @@ import {
 // Data types
 import { DNSZone } from "src/utils/datatypes/globalDataTypes";
 // Hooks
-import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import useApiError from "src/hooks/useApiError";
@@ -23,16 +22,11 @@ import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Redux
 import { useAppDispatch, useAppSelector } from "src/store/hooks";
 // RPC
-import {
-  useGetDnsZonesFullDataQuery,
-  useSearchDnsZonesEntriesMutation,
-} from "src/services/rpcDnsZones";
+import { useGetDnsZonesFullDataQuery } from "src/services/rpcDnsZones";
 // Utils
 import { isDnsZoneSelectable } from "src/utils/utils";
 import { apiToDnsZone } from "src/utils/dnsZonesUtils";
 // Components
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 import ToolbarLayout, {
   ToolbarItem,
 } from "src/components/layouts/ToolbarLayout";
@@ -66,7 +60,7 @@ const DnsZones = () => {
   ) as string;
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   // Handle API calls errors
@@ -78,8 +72,6 @@ const DnsZones = () => {
 
   // States
   const [dnsZones, setDnsZones] = React.useState<DNSZone[]>([]);
-  const [isSearchDisabled, setIsSearchDisabled] =
-    React.useState<boolean>(false);
   const [totalCount, setTotalCount] = React.useState<number>(0);
 
   // API calls
@@ -221,52 +213,6 @@ const DnsZones = () => {
     }
   }, [isLoading]);
 
-  // Search API call
-  const [searchEntry] = useSearchDnsZonesEntriesMutation();
-
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    searchEntry({
-      searchValue: search,
-      apiVersion,
-      sizelimit: 100,
-      startIdx: 0,
-      stopIdx: 200, // Search will consider a max. of elements
-    }).then((result) => {
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for elements",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success
-          const dnsZones = result.data?.result || [];
-
-          setTotalCount(totalCount);
-          setDnsZones(dnsZones.slice(0, perPage));
-          setShowTableRows(true);
-        }
-        setIsSearchDisabled(false);
-      }
-    });
-  };
-
   // Data wrappers
   // TODO: Better separation of concerts
   // - 'PaginationLayout'
@@ -278,18 +224,6 @@ const DnsZones = () => {
     updateSelectedPerPage: setSelectedPerPage,
     updateShownElementsList: setDnsZones,
     totalCount,
-  };
-
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
-  // SearchInputLayout
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
   };
 
   // - 'BulkSelectorrep'
@@ -349,8 +283,6 @@ const DnsZones = () => {
           name="search"
           ariaLabel="Search DNS zones"
           placeholder="Search DNS zones"
-          searchValueData={searchValueData}
-          isDisabled={isSearchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/DNSZones/DnsZones.tsx
+++ b/src/pages/DNSZones/DnsZones.tsx
@@ -25,6 +25,10 @@ import { useAppDispatch, useAppSelector } from "src/store/hooks";
 import { useGetDnsZonesFullDataQuery } from "src/services/rpcDnsZones";
 // Utils
 import { isDnsZoneSelectable } from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 import { apiToDnsZone } from "src/utils/dnsZonesUtils";
 // Components
 import ToolbarLayout, {
@@ -118,7 +122,6 @@ const DnsZones = () => {
 
   // Selected elements
   const [selectedElements, setSelectedElements] = React.useState<DNSZone[]>([]);
-  const [selectedPerPage, setSelectedPerPage] = React.useState<number>(0);
 
   // Refresh button handling
   const refreshData = () => {
@@ -212,10 +215,11 @@ const DnsZones = () => {
     }
   }, [isLoading]);
 
-  // Reset the selected per-page count when the page or page size changes
-  React.useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
+  const selectedPerPageData = getSelectedPerPageData(
+    dnsZones,
+    selectedElements.map((dnsZone) => ipaPrimaryKey(dnsZone.idnsname)),
+    (dnsZone) => ipaPrimaryKey(dnsZone.idnsname)
+  );
 
   // Data wrappers
   // - 'BulkSelectorrep'
@@ -224,11 +228,6 @@ const DnsZones = () => {
     updateSelected: updateSelectedDnsZones,
     selectableTable: selectableDnsZonesTable,
     nameAttr: "idnsname",
-  };
-
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage: setSelectedPerPage,
   };
 
   // Modals functionality
@@ -419,10 +418,7 @@ const DnsZones = () => {
                           setIsDisableButtonDisabled(value),
                         isDisableEnableOp: true,
                       }}
-                      paginationData={{
-                        selectedPerPage,
-                        updateSelectedPerPage: setSelectedPerPage,
-                      }}
+                      paginationData={selectedPerPageData}
                       statusElementName="idnszoneactive"
                     />
                   )}

--- a/src/pages/DNSZones/DnsZones.tsx
+++ b/src/pages/DNSZones/DnsZones.tsx
@@ -224,10 +224,11 @@ const DnsZones = () => {
   // Search API call
   const [searchEntry] = useSearchDnsZonesEntriesMutation();
 
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     searchEntry({
-      searchValue: searchValue,
+      searchValue: search,
       apiVersion,
       sizelimit: 100,
       startIdx: 0,

--- a/src/pages/DNSZones/DnsZones.tsx
+++ b/src/pages/DNSZones/DnsZones.tsx
@@ -225,6 +225,7 @@ const DnsZones = () => {
   const [searchEntry] = useSearchDnsZonesEntriesMutation();
 
   const submitSearchValue = () => {
+    setPage(1);
     searchEntry({
       searchValue: searchValue,
       apiVersion,
@@ -257,7 +258,7 @@ const DnsZones = () => {
           const dnsZones = result.data?.result || [];
 
           setTotalCount(totalCount);
-          setDnsZones(dnsZones);
+          setDnsZones(dnsZones.slice(0, perPage));
           setShowTableRows(true);
         }
         setIsSearchDisabled(false);
@@ -278,10 +279,15 @@ const DnsZones = () => {
     totalCount,
   };
 
+  const updateSearchValue = (value: string) => {
+    setPage(1);
+    setSearchValue(value);
+  };
+
   // SearchInputLayout
   const searchValueData = {
     searchValue,
-    updateSearchValue: setSearchValue,
+    updateSearchValue,
     submitSearchValue,
   };
 

--- a/src/pages/DNSZones/DnsZones.tsx
+++ b/src/pages/DNSZones/DnsZones.tsx
@@ -191,12 +191,6 @@ const DnsZones = () => {
     }
   };
 
-  // Always refetch data when the component is loaded.
-  // This ensures the data is always up-to-date.
-  React.useEffect(() => {
-    dnsZonesResponse.refetch();
-  }, []);
-
   const selectedPerPageData = getSelectedPerPageData(
     dnsZones,
     selectedElements.map((dnsZone) => ipaPrimaryKey(dnsZone.idnsname)),

--- a/src/pages/DNSZones/DnsZones.tsx
+++ b/src/pages/DNSZones/DnsZones.tsx
@@ -60,8 +60,7 @@ const DnsZones = () => {
   ) as string;
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
 
   // Handle API calls errors
   const globalErrors = useApiError([]);
@@ -213,19 +212,12 @@ const DnsZones = () => {
     }
   }, [isLoading]);
 
-  // Data wrappers
-  // TODO: Better separation of concerts
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage: setPage,
-    updatePerPage: setPerPage,
-    updateSelectedPerPage: setSelectedPerPage,
-    updateShownElementsList: setDnsZones,
-    totalCount,
-  };
+  // Reset the selected per-page count when the page or page size changes
+  React.useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
 
+  // Data wrappers
   // - 'BulkSelectorrep'
   const bulkSelectorData = {
     selected: selectedElements,
@@ -370,7 +362,7 @@ const DnsZones = () => {
       element: (
         <PaginationLayout
           list={dnsZones}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -442,7 +434,7 @@ const DnsZones = () => {
             >
               <PaginationLayout
                 list={dnsZones}
-                paginationData={paginationData}
+                totalCount={totalCount}
                 variant={PaginationVariant.bottom}
                 widgetId="pagination-options-menu-bottom"
               />

--- a/src/pages/DNSZones/DnsZonesSettings.tsx
+++ b/src/pages/DNSZones/DnsZonesSettings.tsx
@@ -627,7 +627,6 @@ const DnsZonesSettings = (props: DnsZonesSettingsProps) => {
         elementsList={[props.dnsZone.idnsname || ""]}
         setElementsList={() => {}} // No need to unselect elements in this case
         operation={isDnsZoneEnabled ? "disable" : "enable"}
-        setShowTableRows={setIsDataLoading}
         onRefresh={props.onRefresh}
       />
       <DeleteDnsZonesModal

--- a/src/pages/HBACRules/HBACRules.tsx
+++ b/src/pages/HBACRules/HBACRules.tsx
@@ -93,14 +93,13 @@ const HBACRules = () => {
 
   const {
     data: batchResponse,
-    isLoading: isBatchLoading,
+    isFetching: isBatchFetching,
     error: batchError,
   } = rulesDataResponse;
 
   // Handle data when the API call is finished
   useEffect(() => {
     if (rulesDataResponse.isFetching) {
-      setShowTableRows(false);
       // Reset selected users on refresh
       setRulesTotalCount(0);
       globalErrors.clear();
@@ -125,8 +124,6 @@ const HBACRules = () => {
       setRulesTotalCount(totalCount);
       // Update the list of users
       setRulesList(rulesList);
-      // Show table elements
-      setShowTableRows(true);
     }
 
     // API response: Error
@@ -143,9 +140,6 @@ const HBACRules = () => {
 
   // Refresh button handling
   const refreshRulesData = () => {
-    // Hide table
-    setShowTableRows(false);
-
     // Reset selected users on refresh
     setRulesTotalCount(0);
     clearSelectedRules();
@@ -203,16 +197,6 @@ const HBACRules = () => {
     const emptyList: HBACRule[] = [];
     setSelectedRules(emptyList);
   };
-
-  // Show table rows
-  const [showTableRows, setShowTableRows] = useState(!isBatchLoading);
-
-  // Show table rows only when data is fully retrieved
-  useEffect(() => {
-    if (showTableRows !== !isBatchLoading) {
-      setShowTableRows(!isBatchLoading);
-    }
-  }, [isBatchLoading]);
 
   // Modals functionality
   const [showAddModal, setShowAddModal] = useState(false);
@@ -397,7 +381,7 @@ const HBACRules = () => {
       element: (
         <SecondaryButton
           onClickHandler={refreshRulesData}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
           dataCy="hbac-rules-button-refresh"
         >
           Refresh
@@ -408,7 +392,7 @@ const HBACRules = () => {
       key: 4,
       element: (
         <SecondaryButton
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || isBatchFetching}
           onClickHandler={onDeleteHandler}
           dataCy="hbac-rules-button-delete"
         >
@@ -421,7 +405,7 @@ const HBACRules = () => {
       element: (
         <SecondaryButton
           onClickHandler={onAddClickHandler}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
           dataCy="hbac-rules-button-add"
         >
           Add
@@ -432,7 +416,7 @@ const HBACRules = () => {
       key: 6,
       element: (
         <SecondaryButton
-          isDisabled={isDisableButtonDisabled || !showTableRows}
+          isDisabled={isDisableButtonDisabled || isBatchFetching}
           onClickHandler={() => onEnableDisableHandler(true)}
           dataCy="hbac-rules-button-disable"
         >
@@ -444,7 +428,7 @@ const HBACRules = () => {
       key: 7,
       element: (
         <SecondaryButton
-          isDisabled={isEnableButtonDisabled || !showTableRows}
+          isDisabled={isEnableButtonDisabled || isBatchFetching}
           onClickHandler={() => onEnableDisableHandler(false)}
           dataCy="hbac-rules-button-enable"
         >
@@ -505,7 +489,7 @@ const HBACRules = () => {
                   ) : (
                     <HBACRulesTable
                       shownElementsList={rulesList}
-                      showTableRows={showTableRows}
+                      showTableRows={!isBatchFetching}
                       rulesData={rulesTableData}
                       buttonsData={rulesTableButtonsData}
                       paginationData={selectedPerPageData}

--- a/src/pages/HBACRules/HBACRules.tsx
+++ b/src/pages/HBACRules/HBACRules.tsx
@@ -147,12 +147,6 @@ const HBACRules = () => {
     rulesDataResponse.refetch();
   };
 
-  // Always refetch data when the component is loaded.
-  // This ensures the data is always up-to-date.
-  React.useEffect(() => {
-    rulesDataResponse.refetch();
-  }, []);
-
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
     useState<boolean>(true);

--- a/src/pages/HBACRules/HBACRules.tsx
+++ b/src/pages/HBACRules/HBACRules.tsx
@@ -234,13 +234,14 @@ const HBACRules = () => {
   const [retrieveRules] = useSearchEntriesMutation({});
 
   // Issue a search using a specific search value
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     setShowTableRows(false);
     setSearchIsDisabled(true);
     setRulesTotalCount(0);
     retrieveRules({
-      searchValue: searchValue,
+      searchValue: search,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
       startIdx: 0,

--- a/src/pages/HBACRules/HBACRules.tsx
+++ b/src/pages/HBACRules/HBACRules.tsx
@@ -39,6 +39,10 @@ import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Utils
 import { API_VERSION_BACKUP, isHbacRuleSelectable } from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 // RPC client
 import { GenericPayload } from "src/services/rpc";
 import { useGettingHbacRulesQuery } from "src/services/rpcHBACRules";
@@ -193,19 +197,6 @@ const HBACRules = () => {
     setIsDisableEnableOp(value);
   };
 
-  // Elements selected (per page)
-  //  - This will help to calculate the remaining elements on a specific page (bulk selector)
-  const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
-
-  const updateSelectedPerPage = (selected: number) => {
-    setSelectedPerPage(selected);
-  };
-
-  // Reset selected-per-page count whenever the page or page size changes
-  useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
-
   const [selectedRules, setSelectedRules] = useState<HBACRule[]>([]);
 
   const clearSelectedRules = () => {
@@ -327,10 +318,11 @@ const HBACRules = () => {
     updateIsDisableEnableOp,
   };
 
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage,
-  };
+  const selectedPerPageData = getSelectedPerPageData(
+    rulesList,
+    selectedRules.map((item) => ipaPrimaryKey(item.cn)),
+    (item) => ipaPrimaryKey(item.cn)
+  );
 
   // 'DeleteRules'
   const deleteRulesButtonsData = {

--- a/src/pages/HBACRules/HBACRules.tsx
+++ b/src/pages/HBACRules/HBACRules.tsx
@@ -83,7 +83,7 @@ const HBACRules = () => {
 
   // Derived states - what we get from API
   const rulesDataResponse = useGettingHbacRulesQuery({
-    searchValue: "",
+    searchValue: searchValue,
     sizeLimit: 0,
     apiVersion: apiVersion || API_VERSION_BACKUP,
     startIdx: firstUserIdx,
@@ -156,7 +156,7 @@ const HBACRules = () => {
   // This ensures the data is always up-to-date.
   React.useEffect(() => {
     rulesDataResponse.refetch();
-  }, [page, perPage]);
+  }, []);
 
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
@@ -220,6 +220,7 @@ const HBACRules = () => {
 
   // Update search input valie
   const updateSearchValue = (value: string) => {
+    setPage(1);
     setSearchValue(value);
   };
 
@@ -234,6 +235,7 @@ const HBACRules = () => {
 
   // Issue a search using a specific search value
   const submitSearchValue = () => {
+    setPage(1);
     setShowTableRows(false);
     setSearchIsDisabled(true);
     setRulesTotalCount(0);
@@ -241,8 +243,8 @@ const HBACRules = () => {
       searchValue: searchValue,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: firstUserIdx,
-      stopIdx: lastUserIdx,
+      startIdx: 0,
+      stopIdx: 100,
       entryType: "hbacrule",
     } as GenericPayload).then((result) => {
       // Manage new response here
@@ -278,7 +280,7 @@ const HBACRules = () => {
           }
 
           setRulesTotalCount(totalCount);
-          setRulesList(rulesList);
+          setRulesList(rulesList.slice(0, perPage));
           // Show table elements
           setShowTableRows(true);
         }

--- a/src/pages/HBACRules/HBACRules.tsx
+++ b/src/pages/HBACRules/HBACRules.tsx
@@ -69,8 +69,7 @@ const HBACRules = () => {
   const modalErrors = useApiError([]);
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
 
   // Main states - what user can define / what we could use in page URL
   const [totalCount, setRulesTotalCount] = useState<number>(0);
@@ -202,19 +201,10 @@ const HBACRules = () => {
     setSelectedPerPage(selected);
   };
 
-  // Pagination
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
-  };
-
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
-  };
-
-  // Rules displayed on the first page
-  const updateShownRulesList = (newShownRulesList: HBACRule[]) => {
-    setRulesList(newShownRulesList);
-  };
+  // Reset selected-per-page count whenever the page or page size changes
+  useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
 
   const [selectedRules, setSelectedRules] = useState<HBACRule[]>([]);
 
@@ -322,17 +312,6 @@ const HBACRules = () => {
 
   // Data wrappers
   // TODO: Better separation of concerts
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList: updateShownRulesList,
-    totalCount,
-  };
-
   // - 'BulkSelectorHBACRulesPrep'
   const rulesBulkSelectorData = {
     selected: selectedRules,
@@ -499,7 +478,7 @@ const HBACRules = () => {
       element: (
         <PaginationLayout
           list={rulesList}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -549,7 +528,7 @@ const HBACRules = () => {
             >
               <PaginationLayout
                 list={rulesList}
-                paginationData={paginationData}
+                totalCount={totalCount}
                 variant={PaginationVariant.bottom}
                 widgetId="pagination-options-menu-bottom"
               />

--- a/src/pages/HBACRules/HBACRules.tsx
+++ b/src/pages/HBACRules/HBACRules.tsx
@@ -34,17 +34,15 @@ import AddHBACRule from "src/components/modals/HbacModals/AddHBACRule";
 import DeleteHBACRule from "src/components/modals/HbacModals/DeleteHBACRule";
 import DisableEnableHBACRules from "src/components/modals/HbacModals/DisableEnableHBACRules";
 // Hooks
-import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Utils
 import { API_VERSION_BACKUP, isHbacRuleSelectable } from "src/utils/utils";
 // RPC client
-import { GenericPayload, useSearchEntriesMutation } from "src/services/rpc";
+import { GenericPayload } from "src/services/rpc";
 import { useGettingHbacRulesQuery } from "src/services/rpcHBACRules";
 // Errors
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 import useApiError from "src/hooks/useApiError";
 import useContextualHelpTopic from "src/hooks/useContextualHelpTopic";
 import GlobalErrors from "src/components/errors/GlobalErrors";
@@ -70,12 +68,12 @@ const HBACRules = () => {
   const globalErrors = useApiError([]);
   const modalErrors = useApiError([]);
 
+  // URL parameters: page number, page size, search value
+  const { page, setPage, perPage, setPerPage, searchValue } =
+    useListPageSearchParams();
+
   // Main states - what user can define / what we could use in page URL
-  const [searchValue, setSearchValue] = React.useState("");
-  const [page, setPage] = useState<number>(1);
-  const [perPage, setPerPage] = useState<number>(10);
   const [totalCount, setRulesTotalCount] = useState<number>(0);
-  const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
   // Page indexes
   const firstUserIdx = (page - 1) * perPage;
@@ -218,76 +216,11 @@ const HBACRules = () => {
     setRulesList(newShownRulesList);
   };
 
-  // Update search input valie
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
   const [selectedRules, setSelectedRules] = useState<HBACRule[]>([]);
 
   const clearSelectedRules = () => {
     const emptyList: HBACRule[] = [];
     setSelectedRules(emptyList);
-  };
-
-  const [retrieveRules] = useSearchEntriesMutation({});
-
-  // Issue a search using a specific search value
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    setShowTableRows(false);
-    setSearchIsDisabled(true);
-    setRulesTotalCount(0);
-    retrieveRules({
-      searchValue: search,
-      sizeLimit: 0,
-      apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: 0,
-      stopIdx: 100,
-      entryType: "hbacrule",
-    } as GenericPayload).then((result) => {
-      // Manage new response here
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for HBAC rules",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success
-          const rulesListResult = result.data?.result.results || [];
-          const rulesListSize = result.data?.result.count || 0;
-          const totalCount = result.data?.result.totalCount || 0;
-          const rulesList: HBACRule[] = [];
-
-          for (let i = 0; i < rulesListSize; i++) {
-            rulesList.push(rulesListResult[i].result);
-          }
-
-          setRulesTotalCount(totalCount);
-          setRulesList(rulesList.slice(0, perPage));
-          // Show table elements
-          setShowTableRows(true);
-        }
-        setSearchIsDisabled(false);
-      }
-    });
   };
 
   // Show table rows
@@ -457,13 +390,6 @@ const HBACRules = () => {
     updateIsDisableEnableOp,
   };
 
-  // SearchInputLayout
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
-  };
-
   // List of Toolbar items
   const toolbarItems: ToolbarItem[] = [
     {
@@ -486,8 +412,6 @@ const HBACRules = () => {
           name="search"
           ariaLabel="Search HBAC rules"
           placeholder="Search HBAC rules"
-          searchValueData={searchValueData}
-          isDisabled={searchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/HBACRules/HBACRulesMemberTable.tsx
+++ b/src/pages/HBACRules/HBACRulesMemberTable.tsx
@@ -64,16 +64,6 @@ const HBACRulesMemberTable = (props: PropsToTable) => {
   const [totalCount, setMemberTotalCount] = useState<number>(
     props.members.length
   );
-  const updateSelectedPerPage = () => {
-    // Nothing to do since we are not using bulk selector comp
-    return;
-  };
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
-  };
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
-  };
 
   const resetEntries = () => {
     const firstIdx = (page - 1) * perPage;
@@ -312,18 +302,11 @@ const HBACRulesMemberTable = (props: PropsToTable) => {
     }
   }, [selectedMembers]);
 
-  // Entries displayed on the first page
-  const updateShownEntriesList = (newShownEntriesList: string[]) => {
-    setTableMembers(newShownEntriesList);
-  };
-
   const paginationData = {
     page,
     perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList: updateShownEntriesList,
+    onUpdatePage: setPage,
+    onUpdatePerPage: setPerPage,
     totalCount,
   };
 

--- a/src/pages/HBACServiceGroups/HBACServiceGroups.tsx
+++ b/src/pages/HBACServiceGroups/HBACServiceGroups.tsx
@@ -95,14 +95,13 @@ const HBACServiceGroups = () => {
 
   const {
     data: batchResponse,
-    isLoading: isBatchLoading,
+    isFetching: isBatchFetching,
     error: batchError,
   } = servicesDataResponse;
 
   // Handle data when the API call is finished
   useEffect(() => {
     if (servicesDataResponse.isFetching) {
-      setShowTableRows(false);
       setServicesTotalCount(0);
       globalErrors.clear();
       return;
@@ -126,8 +125,6 @@ const HBACServiceGroups = () => {
       setServicesTotalCount(totalCount);
       // Update the list
       setServicesList(servicesList);
-      // Show table elements
-      setShowTableRows(true);
     }
 
     // API response: Error
@@ -144,7 +141,6 @@ const HBACServiceGroups = () => {
 
   // Refresh button handling
   const refreshServicesData = () => {
-    setShowTableRows(false);
     setServicesTotalCount(0);
     clearSelectedServices();
     servicesDataResponse.refetch();
@@ -179,16 +175,6 @@ const HBACServiceGroups = () => {
     const emptyList: HBACServiceGroup[] = [];
     setSelectedServices(emptyList);
   };
-
-  // Show table rows
-  const [showTableRows, setShowTableRows] = useState(!isBatchLoading);
-
-  // Show table rows only when data is fully retrieved
-  useEffect(() => {
-    if (showTableRows !== !isBatchLoading) {
-      setShowTableRows(!isBatchLoading);
-    }
-  }, [isBatchLoading]);
 
   // Modals functionality
   const [showAddModal, setShowAddModal] = useState(false);
@@ -350,7 +336,7 @@ const HBACServiceGroups = () => {
       element: (
         <SecondaryButton
           onClickHandler={refreshServicesData}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
           dataCy="hbac-service-groups-button-refresh"
         >
           Refresh
@@ -361,7 +347,7 @@ const HBACServiceGroups = () => {
       key: 4,
       element: (
         <SecondaryButton
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || isBatchFetching}
           onClickHandler={onDeleteHandler}
           dataCy="hbac-service-groups-button-delete"
         >
@@ -374,7 +360,7 @@ const HBACServiceGroups = () => {
       element: (
         <SecondaryButton
           onClickHandler={onAddClickHandler}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
           dataCy="hbac-service-groups-button-add"
         >
           Add
@@ -433,7 +419,7 @@ const HBACServiceGroups = () => {
                   ) : (
                     <HBACServiceGroupsTable
                       shownElementsList={servicesList}
-                      showTableRows={showTableRows}
+                      showTableRows={!isBatchFetching}
                       servicesData={servicesTableData}
                       buttonsData={servicesTableButtonsData}
                       paginationData={selectedPerPageData}

--- a/src/pages/HBACServiceGroups/HBACServiceGroups.tsx
+++ b/src/pages/HBACServiceGroups/HBACServiceGroups.tsx
@@ -85,7 +85,7 @@ const HBACServiceGroups = () => {
 
   // Derived states - what we get from API
   const servicesDataResponse = useGettingHbacServiceGroupQuery({
-    searchValue: "",
+    searchValue: searchValue,
     sizeLimit: 0,
     apiVersion: apiVersion || API_VERSION_BACKUP,
     startIdx: firstIdx,
@@ -153,7 +153,7 @@ const HBACServiceGroups = () => {
   // This ensures the data is always up-to-date.
   React.useEffect(() => {
     servicesDataResponse.refetch();
-  }, [page, perPage]);
+  }, []);
 
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
@@ -196,6 +196,7 @@ const HBACServiceGroups = () => {
 
   // Update search input value
   const updateSearchValue = (value: string) => {
+    setPage(1);
     setSearchValue(value);
   };
 
@@ -212,6 +213,7 @@ const HBACServiceGroups = () => {
 
   // Issue a search using a specific search value
   const submitSearchValue = () => {
+    setPage(1);
     setShowTableRows(false);
     setSearchIsDisabled(true);
     setServicesTotalCount(0);
@@ -219,8 +221,8 @@ const HBACServiceGroups = () => {
       searchValue: searchValue,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: firstIdx,
-      stopIdx: lastIdx,
+      startIdx: 0,
+      stopIdx: 100,
       entryType: "hbacsvcgroup",
     } as GenericPayload).then((result) => {
       // Manage new response here
@@ -255,7 +257,7 @@ const HBACServiceGroups = () => {
             servicesList.push(servicesListResult[i].result);
           }
           setServicesTotalCount(totalCount);
-          setServicesList(servicesList);
+          setServicesList(servicesList.slice(0, perPage));
           setShowTableRows(true);
         }
         setSearchIsDisabled(false);

--- a/src/pages/HBACServiceGroups/HBACServiceGroups.tsx
+++ b/src/pages/HBACServiceGroups/HBACServiceGroups.tsx
@@ -33,8 +33,8 @@ import BulkSelectorPrep from "src/components/BulkSelectorPrep";
 import AddHBACServiceGroup from "src/components/modals/HbacModals/AddHBACServiceGroup";
 import DeleteHBACServiceGroup from "src/components/modals/HbacModals/DeleteHBACServiceGroup";
 // Hooks
-import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Utils
 import {
@@ -42,11 +42,9 @@ import {
   isHbacServiceGroupSelectable,
 } from "src/utils/utils";
 // RPC client
-import { GenericPayload, useSearchEntriesMutation } from "src/services/rpc";
+import { GenericPayload } from "src/services/rpc";
 import { useGettingHbacServiceGroupQuery } from "src/services/rpcHBACSvcGroups";
 // Errors
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 import useApiError from "src/hooks/useApiError";
 import useContextualHelpTopic from "src/hooks/useContextualHelpTopic";
 import GlobalErrors from "src/components/errors/GlobalErrors";
@@ -72,12 +70,12 @@ const HBACServiceGroups = () => {
   const globalErrors = useApiError([]);
   const modalErrors = useApiError([]);
 
+  // URL parameters: page number, page size, search value
+  const { page, setPage, perPage, setPerPage, searchValue } =
+    useListPageSearchParams();
+
   // Main states
-  const [searchValue, setSearchValue] = React.useState("");
-  const [page, setPage] = useState<number>(1);
-  const [perPage, setPerPage] = useState<number>(10);
   const [totalCount, setServicesTotalCount] = useState<number>(0);
-  const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
   // Page indexes
   const firstIdx = (page - 1) * perPage;
@@ -194,12 +192,6 @@ const HBACServiceGroups = () => {
     setServicesList(newShownServicesList);
   };
 
-  // Update search input value
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
   const [selectedServices, setSelectedServices] = useState<HBACServiceGroup[]>(
     []
   );
@@ -207,63 +199,6 @@ const HBACServiceGroups = () => {
   const clearSelectedServices = () => {
     const emptyList: HBACServiceGroup[] = [];
     setSelectedServices(emptyList);
-  };
-
-  const [retrieveServices] = useSearchEntriesMutation({});
-
-  // Issue a search using a specific search value
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    setShowTableRows(false);
-    setSearchIsDisabled(true);
-    setServicesTotalCount(0);
-    retrieveServices({
-      searchValue: search,
-      sizeLimit: 0,
-      apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: 0,
-      stopIdx: 100,
-      entryType: "hbacsvcgroup",
-    } as GenericPayload).then((result) => {
-      // Manage new response here
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for HBAC service groups",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success
-          const servicesListResult = result.data?.result.results || [];
-          const servicesListSize = result.data?.result.count || 0;
-          const totalCount = result.data?.result.totalCount || 0;
-          const servicesList: HBACServiceGroup[] = [];
-
-          for (let i = 0; i < servicesListSize; i++) {
-            servicesList.push(servicesListResult[i].result);
-          }
-          setServicesTotalCount(totalCount);
-          setServicesList(servicesList.slice(0, perPage));
-          setShowTableRows(true);
-        }
-        setSearchIsDisabled(false);
-      }
-    });
   };
 
   // Show table rows
@@ -410,13 +345,6 @@ const HBACServiceGroups = () => {
     updateIsDeletion,
   };
 
-  // SearchInputLayout
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
-  };
-
   // List of Toolbar items
   const toolbarItems: ToolbarItem[] = [
     {
@@ -439,8 +367,6 @@ const HBACServiceGroups = () => {
           name="search"
           ariaLabel="Search HBAC service groups"
           placeholder="Search HBAC service groups"
-          searchValueData={searchValueData}
-          isDisabled={searchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/HBACServiceGroups/HBACServiceGroups.tsx
+++ b/src/pages/HBACServiceGroups/HBACServiceGroups.tsx
@@ -212,13 +212,14 @@ const HBACServiceGroups = () => {
   const [retrieveServices] = useSearchEntriesMutation({});
 
   // Issue a search using a specific search value
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     setShowTableRows(false);
     setSearchIsDisabled(true);
     setServicesTotalCount(0);
     retrieveServices({
-      searchValue: searchValue,
+      searchValue: search,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
       startIdx: 0,

--- a/src/pages/HBACServiceGroups/HBACServiceGroups.tsx
+++ b/src/pages/HBACServiceGroups/HBACServiceGroups.tsx
@@ -41,6 +41,10 @@ import {
   API_VERSION_BACKUP,
   isHbacServiceGroupSelectable,
 } from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 // RPC client
 import { GenericPayload } from "src/services/rpc";
 import { useGettingHbacServiceGroupQuery } from "src/services/rpcHBACSvcGroups";
@@ -167,19 +171,6 @@ const HBACServiceGroups = () => {
     setIsDeletion(value);
   };
 
-  // Elements selected (per page)
-  //  - This will help to calculate the remaining elements on a specific page (bulk selector)
-  const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
-
-  const updateSelectedPerPage = (selected: number) => {
-    setSelectedPerPage(selected);
-  };
-
-  // Reset selected-per-page count whenever the page or page size changes
-  useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
-
   const [selectedServices, setSelectedServices] = useState<HBACServiceGroup[]>(
     []
   );
@@ -291,10 +282,11 @@ const HBACServiceGroups = () => {
     updateIsDeleteButtonDisabled,
   };
 
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage,
-  };
+  const selectedPerPageData = getSelectedPerPageData(
+    servicesList,
+    selectedServices.map((item) => ipaPrimaryKey(item.cn)),
+    (item) => ipaPrimaryKey(item.cn)
+  );
 
   // 'DeleteServices'
   const deleteServicesButtonsData = {

--- a/src/pages/HBACServiceGroups/HBACServiceGroups.tsx
+++ b/src/pages/HBACServiceGroups/HBACServiceGroups.tsx
@@ -71,8 +71,7 @@ const HBACServiceGroups = () => {
   const modalErrors = useApiError([]);
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
 
   // Main states
   const [totalCount, setServicesTotalCount] = useState<number>(0);
@@ -176,21 +175,10 @@ const HBACServiceGroups = () => {
     setSelectedPerPage(selected);
   };
 
-  // Pagination
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
-  };
-
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
-  };
-
-  // Services displayed on the first page
-  const updateShownServicesList = (
-    newShownServicesList: HBACServiceGroup[]
-  ) => {
-    setServicesList(newShownServicesList);
-  };
+  // Reset selected-per-page count whenever the page or page size changes
+  useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
 
   const [selectedServices, setSelectedServices] = useState<HBACServiceGroup[]>(
     []
@@ -291,17 +279,6 @@ const HBACServiceGroups = () => {
   };
 
   // Data wrappers
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList: updateShownServicesList,
-    totalCount,
-  };
-
   // - 'BulkSelectorPrep'
   const svcGroupBulkSelectorData = {
     selected: selectedServices,
@@ -430,7 +407,7 @@ const HBACServiceGroups = () => {
       element: (
         <PaginationLayout
           list={servicesList}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -479,7 +456,7 @@ const HBACServiceGroups = () => {
             >
               <PaginationLayout
                 list={servicesList}
-                paginationData={paginationData}
+                totalCount={totalCount}
                 variant={PaginationVariant.bottom}
                 widgetId="pagination-options-menu-bottom"
               />

--- a/src/pages/HBACServiceGroups/HBACServiceGroups.tsx
+++ b/src/pages/HBACServiceGroups/HBACServiceGroups.tsx
@@ -146,12 +146,6 @@ const HBACServiceGroups = () => {
     servicesDataResponse.refetch();
   };
 
-  // Always refetch data when the component is loaded.
-  // This ensures the data is always up-to-date.
-  React.useEffect(() => {
-    servicesDataResponse.refetch();
-  }, []);
-
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
     useState<boolean>(true);

--- a/src/pages/HBACServices/HBACServices.tsx
+++ b/src/pages/HBACServices/HBACServices.tsx
@@ -210,13 +210,14 @@ const HBACServices = () => {
   const [retrieveServices] = useSearchEntriesMutation({});
 
   // Issue a search using a specific search value
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     setShowTableRows(false);
     setSearchIsDisabled(true);
     setServicesTotalCount(0);
     retrieveServices({
-      searchValue: searchValue,
+      searchValue: search,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
       startIdx: 0,

--- a/src/pages/HBACServices/HBACServices.tsx
+++ b/src/pages/HBACServices/HBACServices.tsx
@@ -82,7 +82,7 @@ const HBACServices = () => {
 
   // Derived states - what we get from API
   const servicesDataResponse = useGettingHbacServicesQuery({
-    searchValue: "",
+    searchValue: searchValue,
     sizeLimit: 0,
     apiVersion: apiVersion || API_VERSION_BACKUP,
     startIdx: firstIdx,
@@ -155,7 +155,7 @@ const HBACServices = () => {
   // This ensures the data is always up-to-date.
   React.useEffect(() => {
     servicesDataResponse.refetch();
-  }, [page, perPage]);
+  }, []);
 
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
@@ -196,6 +196,7 @@ const HBACServices = () => {
 
   // Update search input valie
   const updateSearchValue = (value: string) => {
+    setPage(1);
     setSearchValue(value);
   };
 
@@ -210,6 +211,7 @@ const HBACServices = () => {
 
   // Issue a search using a specific search value
   const submitSearchValue = () => {
+    setPage(1);
     setShowTableRows(false);
     setSearchIsDisabled(true);
     setServicesTotalCount(0);
@@ -217,8 +219,8 @@ const HBACServices = () => {
       searchValue: searchValue,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: firstIdx,
-      stopIdx: lastIdx,
+      startIdx: 0,
+      stopIdx: 100,
       entryType: "hbacsvc",
     } as GenericPayload).then((result) => {
       // Manage new response here
@@ -254,7 +256,7 @@ const HBACServices = () => {
           }
 
           setServicesTotalCount(totalCount);
-          setServicesList(servicesList);
+          setServicesList(servicesList.slice(0, perPage));
           // Show table elements
           setShowTableRows(true);
         }

--- a/src/pages/HBACServices/HBACServices.tsx
+++ b/src/pages/HBACServices/HBACServices.tsx
@@ -92,14 +92,13 @@ const HBACServices = () => {
 
   const {
     data: batchResponse,
-    isLoading: isBatchLoading,
+    isFetching: isBatchFetching,
     error: batchError,
   } = servicesDataResponse;
 
   // Handle data when the API call is finished
   useEffect(() => {
     if (servicesDataResponse.isFetching) {
-      setShowTableRows(false);
       // Reset selected users on refresh
       setServicesTotalCount(0);
       globalErrors.clear();
@@ -124,8 +123,6 @@ const HBACServices = () => {
       setServicesTotalCount(totalCount);
       // Update the list
       setServicesList(servicesList);
-      // Show table elements
-      setShowTableRows(true);
     }
 
     // API response: Error
@@ -142,9 +139,6 @@ const HBACServices = () => {
 
   // Refresh button handling
   const refreshServicesData = () => {
-    // Hide table
-    setShowTableRows(false);
-
     // Reset selected users on refresh
     setServicesTotalCount(0);
     clearSelectedServices();
@@ -181,15 +175,6 @@ const HBACServices = () => {
   };
 
   // Show table rows
-  const [showTableRows, setShowTableRows] = useState(!isBatchLoading);
-
-  // Show table rows only when data is fully retrieved
-  useEffect(() => {
-    if (showTableRows !== !isBatchLoading) {
-      setShowTableRows(!isBatchLoading);
-    }
-  }, [isBatchLoading]);
-
   // Modals functionality
   const [showAddModal, setShowAddModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -346,7 +331,7 @@ const HBACServices = () => {
       element: (
         <SecondaryButton
           onClickHandler={refreshServicesData}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
           dataCy="hbac-services-button-refresh"
         >
           Refresh
@@ -357,7 +342,7 @@ const HBACServices = () => {
       key: 4,
       element: (
         <SecondaryButton
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || isBatchFetching}
           onClickHandler={onDeleteHandler}
           dataCy="hbac-services-button-delete"
         >
@@ -370,7 +355,7 @@ const HBACServices = () => {
       element: (
         <SecondaryButton
           onClickHandler={onAddClickHandler}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
           dataCy="hbac-services-button-add"
         >
           Add
@@ -429,7 +414,7 @@ const HBACServices = () => {
                   ) : (
                     <HBACServicesTable
                       shownElementsList={servicesList}
-                      showTableRows={showTableRows}
+                      showTableRows={!isBatchFetching}
                       servicesData={servicesTableData}
                       buttonsData={servicesTableButtonsData}
                       paginationData={selectedPerPageData}

--- a/src/pages/HBACServices/HBACServices.tsx
+++ b/src/pages/HBACServices/HBACServices.tsx
@@ -68,8 +68,7 @@ const HBACServices = () => {
   const modalErrors = useApiError([]);
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
 
   // Main states - what user can define / what we could use in page URL
   const [totalCount, setServicesTotalCount] = useState<number>(0);
@@ -178,19 +177,10 @@ const HBACServices = () => {
     setSelectedPerPage(selected);
   };
 
-  // Pagination
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
-  };
-
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
-  };
-
-  // Services displayed on the first page
-  const updateShownServicesList = (newShownServicesList: HBACService[]) => {
-    setServicesList(newShownServicesList);
-  };
+  // Reset selected-per-page count whenever the page or page size changes
+  useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
 
   const [selectedServices, setSelectedServices] = useState<HBACService[]>([]);
 
@@ -285,17 +275,6 @@ const HBACServices = () => {
 
   // Data wrappers
   // TODO: Better separation of concerts
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList: updateShownServicesList,
-    totalCount,
-  };
-
   // - 'BulkSelectorHBACServicesPrep'
   const rulesBulkSelectorData = {
     selected: selectedServices,
@@ -424,7 +403,7 @@ const HBACServices = () => {
       element: (
         <PaginationLayout
           list={servicesList}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -473,7 +452,7 @@ const HBACServices = () => {
             >
               <PaginationLayout
                 list={servicesList}
-                paginationData={paginationData}
+                totalCount={totalCount}
                 variant={PaginationVariant.bottom}
                 widgetId="pagination-options-menu-bottom"
               />

--- a/src/pages/HBACServices/HBACServices.tsx
+++ b/src/pages/HBACServices/HBACServices.tsx
@@ -38,6 +38,10 @@ import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Utils
 import { API_VERSION_BACKUP, isHbacServiceSelectable } from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 // RPC client
 import { GenericPayload } from "src/services/rpc";
 import { useGettingHbacServicesQuery } from "src/services/rpcHBACServices";
@@ -169,19 +173,6 @@ const HBACServices = () => {
     setIsDeletion(value);
   };
 
-  // Elements selected (per page)
-  //  - This will help to calculate the remaining elements on a specific page (bulk selector)
-  const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
-
-  const updateSelectedPerPage = (selected: number) => {
-    setSelectedPerPage(selected);
-  };
-
-  // Reset selected-per-page count whenever the page or page size changes
-  useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
-
   const [selectedServices, setSelectedServices] = useState<HBACService[]>([]);
 
   const clearSelectedServices = () => {
@@ -287,10 +278,11 @@ const HBACServices = () => {
     updateIsDeleteButtonDisabled,
   };
 
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage,
-  };
+  const selectedPerPageData = getSelectedPerPageData(
+    servicesList,
+    selectedServices.map((item) => ipaPrimaryKey(item.cn)),
+    (item) => ipaPrimaryKey(item.cn)
+  );
 
   // 'DeleteServices'
   const deleteServicesButtonsData = {

--- a/src/pages/HBACServices/HBACServices.tsx
+++ b/src/pages/HBACServices/HBACServices.tsx
@@ -146,12 +146,6 @@ const HBACServices = () => {
     servicesDataResponse.refetch();
   };
 
-  // Always refetch data when the component is loaded.
-  // This ensures the data is always up-to-date.
-  React.useEffect(() => {
-    servicesDataResponse.refetch();
-  }, []);
-
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
     useState<boolean>(true);

--- a/src/pages/HBACServices/HBACServices.tsx
+++ b/src/pages/HBACServices/HBACServices.tsx
@@ -33,17 +33,15 @@ import BulkSelectorPrep from "src/components/BulkSelectorPrep";
 import AddHBACService from "src/components/modals/HbacModals/AddHBACService";
 import DeleteHBACService from "src/components/modals/HbacModals/DeleteHBACService";
 // Hooks
-import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Utils
 import { API_VERSION_BACKUP, isHbacServiceSelectable } from "src/utils/utils";
 // RPC client
-import { GenericPayload, useSearchEntriesMutation } from "src/services/rpc";
+import { GenericPayload } from "src/services/rpc";
 import { useGettingHbacServicesQuery } from "src/services/rpcHBACServices";
 // Errors
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 import useApiError from "src/hooks/useApiError";
 import useContextualHelpTopic from "src/hooks/useContextualHelpTopic";
 import GlobalErrors from "src/components/errors/GlobalErrors";
@@ -69,12 +67,12 @@ const HBACServices = () => {
   const globalErrors = useApiError([]);
   const modalErrors = useApiError([]);
 
+  // URL parameters: page number, page size, search value
+  const { page, setPage, perPage, setPerPage, searchValue } =
+    useListPageSearchParams();
+
   // Main states - what user can define / what we could use in page URL
-  const [searchValue, setSearchValue] = React.useState("");
-  const [page, setPage] = useState<number>(1);
-  const [perPage, setPerPage] = useState<number>(10);
   const [totalCount, setServicesTotalCount] = useState<number>(0);
-  const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
   // Page indexes
   const firstIdx = (page - 1) * perPage;
@@ -194,76 +192,11 @@ const HBACServices = () => {
     setServicesList(newShownServicesList);
   };
 
-  // Update search input valie
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
   const [selectedServices, setSelectedServices] = useState<HBACService[]>([]);
 
   const clearSelectedServices = () => {
     const emptyList: HBACService[] = [];
     setSelectedServices(emptyList);
-  };
-
-  const [retrieveServices] = useSearchEntriesMutation({});
-
-  // Issue a search using a specific search value
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    setShowTableRows(false);
-    setSearchIsDisabled(true);
-    setServicesTotalCount(0);
-    retrieveServices({
-      searchValue: search,
-      sizeLimit: 0,
-      apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: 0,
-      stopIdx: 100,
-      entryType: "hbacsvc",
-    } as GenericPayload).then((result) => {
-      // Manage new response here
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for HBAC services",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success
-          const servicesListResult = result.data?.result.results || [];
-          const servicesListSize = result.data?.result.count || 0;
-          const totalCount = result.data?.result.totalCount || 0;
-          const servicesList: HBACService[] = [];
-
-          for (let i = 0; i < servicesListSize; i++) {
-            servicesList.push(servicesListResult[i].result);
-          }
-
-          setServicesTotalCount(totalCount);
-          setServicesList(servicesList.slice(0, perPage));
-          // Show table elements
-          setShowTableRows(true);
-        }
-        setSearchIsDisabled(false);
-      }
-    });
   };
 
   // Show table rows
@@ -406,13 +339,6 @@ const HBACServices = () => {
     updateIsDeletion,
   };
 
-  // SearchInputLayout
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
-  };
-
   // List of Toolbar items
   const toolbarItems: ToolbarItem[] = [
     {
@@ -435,8 +361,6 @@ const HBACServices = () => {
           name="search"
           ariaLabel="Search HBAC services"
           placeholder="Search HBAC services"
-          searchValueData={searchValueData}
-          isDisabled={searchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/HostGroups/HostGroups.tsx
+++ b/src/pages/HostGroups/HostGroups.tsx
@@ -111,14 +111,13 @@ const HostGroups = () => {
 
   const {
     data: batchResponse,
-    isLoading: isBatchLoading,
+    isFetching: isBatchFetching,
     error: batchError,
   } = groupDataResponse;
 
   // Handle data when the API call is finished
   useEffect(() => {
     if (groupDataResponse.isFetching) {
-      setShowTableRows(false);
       // Reset selected user groups on refresh
       setGroupsTotalCount(0);
       globalErrors.clear();
@@ -143,8 +142,6 @@ const HostGroups = () => {
 
       setGroupsList(groupsList);
       setGroupsTotalCount(totalCount);
-      // Show table elements
-      setShowTableRows(true);
     }
 
     // API response: Error
@@ -173,9 +170,6 @@ const HostGroups = () => {
 
   // Refresh button handling
   const refreshGroupsData = () => {
-    // Hide table
-    setShowTableRows(false);
-
     // Reset selected host groups on refresh
     setGroupsTotalCount(0);
     clearSelectedGroups();
@@ -190,8 +184,6 @@ const HostGroups = () => {
   };
 
   // Show table rows
-  const [showTableRows, setShowTableRows] = useState(!isBatchLoading);
-
   const updateSelectedGroups = (groups: HostGroup[], isSelected: boolean) => {
     let newSelectedGroups: HostGroup[] = [];
     if (isSelected) {
@@ -234,13 +226,6 @@ const HostGroups = () => {
       updateSelectedGroups([group], isSelecting);
     }
   };
-
-  // Show table rows only when data is fully retrieved
-  useEffect(() => {
-    if (showTableRows !== !isBatchLoading) {
-      setShowTableRows(!isBatchLoading);
-    }
-  }, [isBatchLoading]);
 
   // Modals functionality
   const [showAddModal, setShowAddModal] = useState(false);
@@ -348,7 +333,7 @@ const HostGroups = () => {
       element: (
         <SecondaryButton
           onClickHandler={refreshGroupsData}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
           dataCy="host-groups-button-refresh"
         >
           Refresh
@@ -359,7 +344,7 @@ const HostGroups = () => {
       key: 4,
       element: (
         <SecondaryButton
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || isBatchFetching}
           onClickHandler={onDeleteHandler}
           dataCy="host-groups-button-delete"
         >
@@ -372,7 +357,7 @@ const HostGroups = () => {
       element: (
         <SecondaryButton
           onClickHandler={onAddClickHandler}
-          isDisabled={!showTableRows || isDisabledDueError}
+          isDisabled={isBatchFetching || isDisabledDueError}
           dataCy="host-groups-button-add"
         >
           Add
@@ -428,7 +413,7 @@ const HostGroups = () => {
                     <HostGroupsTable
                       elementsList={groupsList}
                       shownElementsList={groupsList}
-                      showTableRows={showTableRows}
+                      showTableRows={!isBatchFetching}
                       groupsData={groupsTableData}
                       buttonsData={groupsTableButtonsData}
                       paginationData={selectedPerPageData}

--- a/src/pages/HostGroups/HostGroups.tsx
+++ b/src/pages/HostGroups/HostGroups.tsx
@@ -162,12 +162,6 @@ const HostGroups = () => {
     }
   }, [groupDataResponse]);
 
-  // Always refetch data when the component is loaded.
-  // This ensures the data is always up-to-date.
-  useEffect(() => {
-    groupDataResponse.refetch();
-  }, [page, perPage]);
-
   // Refresh button handling
   const refreshGroupsData = () => {
     // Reset selected host groups on refresh

--- a/src/pages/HostGroups/HostGroups.tsx
+++ b/src/pages/HostGroups/HostGroups.tsx
@@ -35,19 +35,16 @@ import { HostGroup } from "src/utils/datatypes/globalDataTypes";
 // Utils
 import { API_VERSION_BACKUP, isHostGroupSelectable } from "src/utils/utils";
 // Hooks
-import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Errors
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 import useApiError from "src/hooks/useApiError";
 import useContextualHelpTopic from "src/hooks/useContextualHelpTopic";
 import GlobalErrors from "src/components/errors/GlobalErrors";
 import ModalErrors from "src/components/errors/ModalErrors";
 // RPC client
-import { GenericPayload, useSearchEntriesMutation } from "../../services/rpc";
+import { GenericPayload } from "../../services/rpc";
 import { useGettingHostGroupsQuery } from "../../services/rpcHostGroups";
 
 const HostGroups = () => {
@@ -68,7 +65,7 @@ const HostGroups = () => {
   const [groupsList, setGroupsList] = useState<HostGroup[]>([]);
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   // Handle API calls errors
@@ -78,7 +75,6 @@ const HostGroups = () => {
   // Table comps
   const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
   const [totalCount, setGroupsTotalCount] = useState<number>(0);
-  const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
   const updateSelectedPerPage = (selected: number) => {
     setSelectedPerPage(selected);
@@ -199,74 +195,10 @@ const HostGroups = () => {
     groupDataResponse.refetch();
   };
 
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
   const [selectedGroups, setSelectedGroupsList] = useState<HostGroup[]>([]);
   const clearSelectedGroups = () => {
     const emptyList: HostGroup[] = [];
     setSelectedGroupsList(emptyList);
-  };
-
-  const [retrieveGroup] = useSearchEntriesMutation({});
-
-  // Issue a search using a specific search value
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    setShowTableRows(false);
-    setGroupsTotalCount(0);
-    setSearchIsDisabled(true);
-    retrieveGroup({
-      searchValue: search,
-      sizeLimit: 0,
-      apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: 0,
-      stopIdx: 100,
-      entryType: "hostgroup",
-    } as GenericPayload).then((result) => {
-      // Manage new response here
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for host groups",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success
-          const groupsListResult = result.data?.result.results || [];
-          const groupsListSize = result.data?.result.count || 0;
-          const totalCount = result.data?.result.totalCount || 0;
-          const groupsList: HostGroup[] = [];
-
-          for (let i = 0; i < groupsListSize; i++) {
-            groupsList.push(groupsListResult[i].result);
-          }
-
-          setGroupsList(groupsList.slice(0, perPage));
-          setGroupsTotalCount(totalCount);
-          // Show table elements
-          setShowTableRows(true);
-        }
-        setSearchIsDisabled(false);
-      }
-    });
   };
 
   // Show table rows
@@ -402,13 +334,6 @@ const HostGroups = () => {
     updateIsDeletion,
   };
 
-  // - 'SearchInputLayout'
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
-  };
-
   // List of toolbar items
   const toolbarItems: ToolbarItem[] = [
     {
@@ -431,8 +356,6 @@ const HostGroups = () => {
           name="search"
           ariaLabel="Search host groups"
           placeholder="Search host groups"
-          searchValueData={searchValueData}
-          isDisabled={searchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/HostGroups/HostGroups.tsx
+++ b/src/pages/HostGroups/HostGroups.tsx
@@ -65,8 +65,7 @@ const HostGroups = () => {
   const [groupsList, setGroupsList] = useState<HostGroup[]>([]);
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, setPage, perPage, searchValue } = useListPageSearchParams();
 
   // Handle API calls errors
   const globalErrors = useApiError([]);
@@ -79,12 +78,11 @@ const HostGroups = () => {
   const updateSelectedPerPage = (selected: number) => {
     setSelectedPerPage(selected);
   };
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
-  };
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
-  };
+
+  // Reset selected-per-page count whenever the page or page size changes
+  useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
 
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
@@ -99,10 +97,6 @@ const HostGroups = () => {
 
   const updateIsDeletion = (value: boolean) => {
     setIsDeletion(value);
-  };
-
-  const updateShownGroupsList = (newShownGroupsList: HostGroup[]) => {
-    setGroupsList(newShownGroupsList);
   };
 
   // Button disabled due to error
@@ -280,17 +274,6 @@ const HostGroups = () => {
   const selectableGroupsTable = groupsList.filter(isHostGroupSelectable); // elements per Table
 
   // Data wrappers
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList: updateShownGroupsList,
-    totalCount,
-  };
-
   // - 'BulkSelectorPrep'
   const groupsBulkSelectorData = {
     selected: selectedGroups,
@@ -419,7 +402,7 @@ const HostGroups = () => {
       element: (
         <PaginationLayout
           list={groupsList}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -465,7 +448,7 @@ const HostGroups = () => {
             >
               <PaginationLayout
                 list={groupsList}
-                paginationData={paginationData}
+                totalCount={totalCount}
                 variant={PaginationVariant.bottom}
                 widgetId="pagination-options-menu-bottom"
               />

--- a/src/pages/HostGroups/HostGroups.tsx
+++ b/src/pages/HostGroups/HostGroups.tsx
@@ -34,6 +34,10 @@ import { useAppDispatch, useAppSelector } from "src/store/hooks";
 import { HostGroup } from "src/utils/datatypes/globalDataTypes";
 // Utils
 import { API_VERSION_BACKUP, isHostGroupSelectable } from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 // Hooks
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
@@ -72,17 +76,7 @@ const HostGroups = () => {
   const modalErrors = useApiError([]);
 
   // Table comps
-  const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
   const [totalCount, setGroupsTotalCount] = useState<number>(0);
-
-  const updateSelectedPerPage = (selected: number) => {
-    setSelectedPerPage(selected);
-  };
-
-  // Reset selected-per-page count whenever the page or page size changes
-  useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
 
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
@@ -286,10 +280,11 @@ const HostGroups = () => {
     updateIsDeleteButtonDisabled,
   };
 
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage,
-  };
+  const selectedPerPageData = getSelectedPerPageData(
+    groupsList,
+    selectedGroups.map((item) => ipaPrimaryKey(item.cn)),
+    (item) => ipaPrimaryKey(item.cn)
+  );
 
   // - 'DeleteGroups'
   const deleteGroupsButtonsData = {

--- a/src/pages/HostGroups/HostGroups.tsx
+++ b/src/pages/HostGroups/HostGroups.tsx
@@ -200,6 +200,7 @@ const HostGroups = () => {
   };
 
   const updateSearchValue = (value: string) => {
+    setPage(1);
     setSearchValue(value);
   };
 
@@ -213,6 +214,7 @@ const HostGroups = () => {
 
   // Issue a search using a specific search value
   const submitSearchValue = () => {
+    setPage(1);
     setShowTableRows(false);
     setGroupsTotalCount(0);
     setSearchIsDisabled(true);
@@ -220,8 +222,8 @@ const HostGroups = () => {
       searchValue: searchValue,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: firstIdx,
-      stopIdx: lastIdx,
+      startIdx: 0,
+      stopIdx: 100,
       entryType: "hostgroup",
     } as GenericPayload).then((result) => {
       // Manage new response here
@@ -256,8 +258,7 @@ const HostGroups = () => {
             groupsList.push(groupsListResult[i].result);
           }
 
-          setPage(1);
-          setGroupsList(groupsList);
+          setGroupsList(groupsList.slice(0, perPage));
           setGroupsTotalCount(totalCount);
           // Show table elements
           setShowTableRows(true);

--- a/src/pages/HostGroups/HostGroups.tsx
+++ b/src/pages/HostGroups/HostGroups.tsx
@@ -213,13 +213,14 @@ const HostGroups = () => {
   const [retrieveGroup] = useSearchEntriesMutation({});
 
   // Issue a search using a specific search value
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     setShowTableRows(false);
     setGroupsTotalCount(0);
     setSearchIsDisabled(true);
     retrieveGroup({
-      searchValue: searchValue,
+      searchValue: search,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
       startIdx: 0,

--- a/src/pages/Hosts/Hosts.tsx
+++ b/src/pages/Hosts/Hosts.tsx
@@ -52,7 +52,7 @@ import useContextualHelpTopic from "src/hooks/useContextualHelpTopic";
 import GlobalErrors from "src/components/errors/GlobalErrors";
 import ModalErrors from "src/components/errors/ModalErrors";
 // RPC client
-import { GenericPayload, useSearchEntriesMutation } from "../../services/rpc";
+import { GenericPayload } from "../../services/rpc";
 import {
   useGettingHostQuery,
   useAutoMemberRebuildHostsMutation,
@@ -63,7 +63,7 @@ const Hosts = () => {
   useContextualHelpTopic("hosts");
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   // Update current route data to Redux and highlight the current page in the Nav bar
@@ -87,7 +87,6 @@ const Hosts = () => {
   // Table comps
   const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
   const [totalCount, setHostsTotalCount] = useState<number>(0);
-  const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
   const updateSelectedPerPage = (selected: number) => {
     setSelectedPerPage(selected);
@@ -202,74 +201,10 @@ const Hosts = () => {
     hostDataResponse.refetch();
   };
 
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
   const [selectedHosts, setSelectedHostsList] = useState<Host[]>([]);
   const clearSelectedHosts = () => {
     const emptyList: Host[] = [];
     setSelectedHostsList(emptyList);
-  };
-
-  const [retrieveHost] = useSearchEntriesMutation({});
-
-  // Issue a search using a specific search value
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    setShowTableRows(false);
-    setHostsTotalCount(0);
-    setSearchIsDisabled(true);
-    retrieveHost({
-      searchValue: search,
-      sizeLimit: 0,
-      apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: 0,
-      stopIdx: 100,
-      entryType: "host",
-    } as GenericPayload).then((result) => {
-      // Manage new response here
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for hosts",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success
-          const hostsListResult = result.data?.result.results || [];
-          const hostsListSize = result.data?.result.count || 0;
-          const totalCount = result.data?.result.totalCount || 0;
-          const hostsList: Host[] = [];
-
-          for (let i = 0; i < hostsListSize; i++) {
-            hostsList.push(hostsListResult[i].result);
-          }
-
-          setHostsList(hostsList.slice(0, perPage));
-          setHostsTotalCount(totalCount);
-          // Show table elements
-          setShowTableRows(true);
-        }
-        setSearchIsDisabled(false);
-      }
-    });
   };
 
   // Show table rows
@@ -527,13 +462,6 @@ const Hosts = () => {
     updateIsDeletion,
   };
 
-  // - 'SearchInputLayout'
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
-  };
-
   // Contextual links panel
 
   // List of toolbar items
@@ -558,8 +486,6 @@ const Hosts = () => {
           name="search"
           ariaLabel="Search hosts"
           placeholder="Search hosts"
-          searchValueData={searchValueData}
-          isDisabled={searchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/Hosts/Hosts.tsx
+++ b/src/pages/Hosts/Hosts.tsx
@@ -203,6 +203,7 @@ const Hosts = () => {
   };
 
   const updateSearchValue = (value: string) => {
+    setPage(1);
     setSearchValue(value);
   };
 
@@ -216,6 +217,7 @@ const Hosts = () => {
 
   // Issue a search using a specific search value
   const submitSearchValue = () => {
+    setPage(1);
     setShowTableRows(false);
     setHostsTotalCount(0);
     setSearchIsDisabled(true);
@@ -223,8 +225,8 @@ const Hosts = () => {
       searchValue: searchValue,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: firstHostIdx,
-      stopIdx: lastHostIdx,
+      startIdx: 0,
+      stopIdx: 100,
       entryType: "host",
     } as GenericPayload).then((result) => {
       // Manage new response here
@@ -259,7 +261,7 @@ const Hosts = () => {
             hostsList.push(hostsListResult[i].result);
           }
 
-          setHostsList(hostsList);
+          setHostsList(hostsList.slice(0, perPage));
           setHostsTotalCount(totalCount);
           // Show table elements
           setShowTableRows(true);

--- a/src/pages/Hosts/Hosts.tsx
+++ b/src/pages/Hosts/Hosts.tsx
@@ -168,12 +168,6 @@ const Hosts = () => {
     }
   }, [hostDataResponse]);
 
-  // Always refetch data when the component is loaded.
-  // This ensures the data is always up-to-date.
-  useEffect(() => {
-    hostDataResponse.refetch();
-  }, []);
-
   // Refresh button handling
   const refreshHostsData = () => {
     // Reset selected hosts on refresh

--- a/src/pages/Hosts/Hosts.tsx
+++ b/src/pages/Hosts/Hosts.tsx
@@ -123,14 +123,13 @@ const Hosts = () => {
 
   const {
     data: batchResponse,
-    isLoading: isBatchLoading,
+    isFetching: isBatchFetching,
     error: batchError,
   } = hostDataResponse;
 
   // Handle data when the API call is finished
   useEffect(() => {
     if (hostDataResponse.isFetching) {
-      setShowTableRows(false);
       // Reset selected users on refresh
       setHostsTotalCount(0);
       globalErrors.clear();
@@ -155,8 +154,6 @@ const Hosts = () => {
 
       setHostsList(hostsList);
       setHostsTotalCount(totalCount);
-      // Show table elements
-      setShowTableRows(true);
     }
 
     // API response: Error
@@ -179,9 +176,6 @@ const Hosts = () => {
 
   // Refresh button handling
   const refreshHostsData = () => {
-    // Hide table
-    setShowTableRows(false);
-
     // Reset selected hosts on refresh
     setHostsTotalCount(0);
     clearSelectedHosts();
@@ -196,8 +190,6 @@ const Hosts = () => {
   };
 
   // Show table rows
-  const [showTableRows, setShowTableRows] = useState(!isBatchLoading);
-
   const updateSelectedHosts = (hosts: Host[], isSelected: boolean) => {
     let newSelectedHosts: Host[] = [];
     if (isSelected) {
@@ -240,13 +232,6 @@ const Hosts = () => {
       updateSelectedHosts([host], isSelecting);
     }
   };
-
-  // Show table rows only when data is fully retrieved
-  useEffect(() => {
-    if (showTableRows !== !isBatchLoading) {
-      setShowTableRows(!isBatchLoading);
-    }
-  }, [isBatchLoading]);
 
   // Dropdown kebab
   const [kebabIsOpen, setKebabIsOpen] = useState(false);
@@ -478,7 +463,7 @@ const Hosts = () => {
       element: (
         <SecondaryButton
           onClickHandler={refreshHostsData}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
           dataCy="hosts-button-refresh"
         >
           Refresh
@@ -489,7 +474,7 @@ const Hosts = () => {
       key: 4,
       element: (
         <SecondaryButton
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || isBatchFetching}
           onClickHandler={onDeleteHandler}
           dataCy="hosts-button-delete"
         >
@@ -502,7 +487,7 @@ const Hosts = () => {
       element: (
         <SecondaryButton
           onClickHandler={onAddClickHandler}
-          isDisabled={!showTableRows || isDisabledDueError}
+          isDisabled={isBatchFetching || isDisabledDueError}
           dataCy="hosts-button-add"
         >
           Add
@@ -517,9 +502,9 @@ const Hosts = () => {
           onKebabToggle={onKebabToggle}
           idKebab="main-dropdown-kebab"
           isKebabOpen={kebabIsOpen}
-          dropdownItems={!showTableRows ? [] : dropdownItems}
+          dropdownItems={isBatchFetching ? [] : dropdownItems}
           dataCy="hosts-kebab"
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
         />
       ),
     },
@@ -572,7 +557,7 @@ const Hosts = () => {
                     <HostsTable
                       elementsList={hostsList}
                       shownElementsList={hostsList}
-                      showTableRows={showTableRows}
+                      showTableRows={!isBatchFetching}
                       hostsData={hostsTableData}
                       buttonsData={hostsTableButtonsData}
                       paginationData={selectedPerPageData}

--- a/src/pages/Hosts/Hosts.tsx
+++ b/src/pages/Hosts/Hosts.tsx
@@ -39,6 +39,10 @@ import { useAppDispatch, useAppSelector } from "src/store/hooks";
 import { Host } from "src/utils/datatypes/globalDataTypes";
 // Utils
 import { API_VERSION_BACKUP, isHostSelectable } from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 // Hooks
 import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
@@ -84,17 +88,7 @@ const Hosts = () => {
   const modalErrors = useApiError([]);
 
   // Table comps
-  const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
   const [totalCount, setHostsTotalCount] = useState<number>(0);
-
-  const updateSelectedPerPage = (selected: number) => {
-    setSelectedPerPage(selected);
-  };
-
-  // Reset selected-per-page count whenever the page or page size changes
-  useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
 
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
@@ -414,10 +408,11 @@ const Hosts = () => {
     updateIsDeleteButtonDisabled,
   };
 
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage,
-  };
+  const selectedPerPageData = getSelectedPerPageData(
+    hostsList,
+    selectedHosts.map((item) => ipaPrimaryKey(item.fqdn)),
+    (item) => ipaPrimaryKey(item.fqdn)
+  );
 
   // - 'DeleteHosts'
   const deleteHostsButtonsData = {

--- a/src/pages/Hosts/Hosts.tsx
+++ b/src/pages/Hosts/Hosts.tsx
@@ -216,13 +216,14 @@ const Hosts = () => {
   const [retrieveHost] = useSearchEntriesMutation({});
 
   // Issue a search using a specific search value
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     setShowTableRows(false);
     setHostsTotalCount(0);
     setSearchIsDisabled(true);
     retrieveHost({
-      searchValue: searchValue,
+      searchValue: search,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
       startIdx: 0,

--- a/src/pages/Hosts/Hosts.tsx
+++ b/src/pages/Hosts/Hosts.tsx
@@ -63,8 +63,7 @@ const Hosts = () => {
   useContextualHelpTopic("hosts");
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
 
   // Update current route data to Redux and highlight the current page in the Nav bar
   useUpdateRoute({ pathname: "hosts" });
@@ -91,12 +90,11 @@ const Hosts = () => {
   const updateSelectedPerPage = (selected: number) => {
     setSelectedPerPage(selected);
   };
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
-  };
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
-  };
+
+  // Reset selected-per-page count whenever the page or page size changes
+  useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
 
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
@@ -111,10 +109,6 @@ const Hosts = () => {
 
   const updateIsDeletion = (value: boolean) => {
     setIsDeletion(value);
-  };
-
-  const updateShownHostsList = (newShownHostsList: Host[]) => {
-    setHostsList(newShownHostsList);
   };
 
   // Button disabled due to error
@@ -408,17 +402,6 @@ const Hosts = () => {
   const selectableHostsTable = hostsList.filter(isHostSelectable); // elements per Table
 
   // Data wrappers
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList: updateShownHostsList,
-    totalCount,
-  };
-
   // - 'BulkSelectorPrep'
   const hostsBulkSelectorData = {
     selected: selectedHosts,
@@ -563,7 +546,7 @@ const Hosts = () => {
       element: (
         <PaginationLayout
           list={hostsList}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -609,7 +592,7 @@ const Hosts = () => {
             >
               <PaginationLayout
                 list={hostsList}
-                paginationData={paginationData}
+                totalCount={totalCount}
                 variant={PaginationVariant.bottom}
                 widgetId="pagination-options-menu-bottom"
               />

--- a/src/pages/IDViews/IDViews.tsx
+++ b/src/pages/IDViews/IDViews.tsx
@@ -130,7 +130,7 @@ const IDViews = () => {
 
   // Derived states - what we get from API
   const viewsDataResponse = useGettingIDViewsQuery({
-    searchValue: "",
+    searchValue: searchValue,
     sizeLimit: 0,
     apiVersion: apiVersion || API_VERSION_BACKUP,
     startIdx: firstIdx,
@@ -191,7 +191,7 @@ const IDViews = () => {
   useEffect(() => {
     viewsDataResponse.refetch();
     setIsKebabOpen(false);
-  }, [page, perPage]);
+  }, []);
 
   // Refresh button handling
   const refreshViewsData = () => {
@@ -206,6 +206,7 @@ const IDViews = () => {
   };
 
   const updateSearchValue = (value: string) => {
+    setPage(1);
     setSearchValue(value);
   };
 
@@ -219,6 +220,7 @@ const IDViews = () => {
 
   // Issue a search using a specific search value
   const submitSearchValue = () => {
+    setPage(1);
     setShowTableRows(false);
     setViewsTotalCount(0);
     setSearchIsDisabled(true);
@@ -226,8 +228,8 @@ const IDViews = () => {
       searchValue: searchValue,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: firstIdx,
-      stopIdx: lastIdx,
+      startIdx: 0,
+      stopIdx: 100,
       entryType: "idview",
     } as GenericPayload).then((result) => {
       // Manage new response here
@@ -262,8 +264,7 @@ const IDViews = () => {
             idViewsList.push(viewsListResult[i].result);
           }
 
-          setPage(1);
-          setViewsList(idViewsList);
+          setViewsList(idViewsList.slice(0, perPage));
           setViewsTotalCount(totalCount);
           setIsKebabOpen(false);
           setShowTableRows(true);

--- a/src/pages/IDViews/IDViews.tsx
+++ b/src/pages/IDViews/IDViews.tsx
@@ -165,13 +165,6 @@ const IDViews = () => {
     }
   }, [viewsDataResponse]);
 
-  // Always refetch data when the component is loaded.
-  // This ensures the data is always up-to-date.
-  useEffect(() => {
-    viewsDataResponse.refetch();
-    setIsKebabOpen(false);
-  }, []);
-
   // Refresh button handling
   const refreshViewsData = () => {
     // Reset selected views on refresh

--- a/src/pages/IDViews/IDViews.tsx
+++ b/src/pages/IDViews/IDViews.tsx
@@ -37,6 +37,10 @@ import { useAppSelector, useAppDispatch } from "src/store/hooks";
 import { IDView } from "src/utils/datatypes/globalDataTypes";
 // Utils
 import { API_VERSION_BACKUP, isViewSelectable } from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 // Hooks
 import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
@@ -84,17 +88,7 @@ const IDViews = () => {
   const modalErrors = useApiError([]);
 
   // Table comps
-  const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
   const [totalCount, setViewsTotalCount] = useState<number>(0);
-
-  const updateSelectedPerPage = (selected: number) => {
-    setSelectedPerPage(selected);
-  };
-
-  // Reset selected-per-page count whenever the page or page size changes
-  useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
 
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
@@ -386,10 +380,11 @@ const IDViews = () => {
     updateIsDeleteButtonDisabled,
   };
 
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage,
-  };
+  const selectedPerPageData = getSelectedPerPageData(
+    viewsList,
+    selectedViews.map((item) => ipaPrimaryKey(item.cn)),
+    (item) => ipaPrimaryKey(item.cn)
+  );
 
   // - 'Delete Views'
   const deleteViewsButtonsData = {

--- a/src/pages/IDViews/IDViews.tsx
+++ b/src/pages/IDViews/IDViews.tsx
@@ -77,8 +77,7 @@ const IDViews = () => {
   const [viewsList, setViewsList] = useState<IDView[]>([]);
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, setPage, perPage, searchValue } = useListPageSearchParams();
 
   // Handle API calls errors
   const globalErrors = useApiError([]);
@@ -91,12 +90,11 @@ const IDViews = () => {
   const updateSelectedPerPage = (selected: number) => {
     setSelectedPerPage(selected);
   };
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
-  };
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
-  };
+
+  // Reset selected-per-page count whenever the page or page size changes
+  useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
 
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
@@ -111,10 +109,6 @@ const IDViews = () => {
 
   const updateIsDeletion = (value: boolean) => {
     setIsDeletion(value);
-  };
-
-  const updateShownViewsList = (newShownViewsList: IDView[]) => {
-    setViewsList(newShownViewsList);
   };
 
   // Page indexes
@@ -380,17 +374,6 @@ const IDViews = () => {
   const selectableViewsTable = viewsList.filter(isViewSelectable); // elements per Table
 
   // Data wrappers
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList: updateShownViewsList,
-    totalCount,
-  };
-
   // - 'BulkSelectorIDViewPrep'
   const viewsBulkSelectorData = {
     selected: selectedViews,
@@ -563,7 +546,7 @@ const IDViews = () => {
       element: (
         <PaginationLayout
           list={viewsList}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -609,7 +592,7 @@ const IDViews = () => {
             >
               <PaginationLayout
                 list={viewsList}
-                paginationData={paginationData}
+                totalCount={totalCount}
                 variant={PaginationVariant.bottom}
                 widgetId="pagination-options-menu-bottom"
               />

--- a/src/pages/IDViews/IDViews.tsx
+++ b/src/pages/IDViews/IDViews.tsx
@@ -219,13 +219,14 @@ const IDViews = () => {
   const [retrieveViews] = useSearchEntriesMutation({});
 
   // Issue a search using a specific search value
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     setShowTableRows(false);
     setViewsTotalCount(0);
     setSearchIsDisabled(true);
     retrieveViews({
-      searchValue: searchValue,
+      searchValue: search,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
       startIdx: 0,

--- a/src/pages/IDViews/IDViews.tsx
+++ b/src/pages/IDViews/IDViews.tsx
@@ -120,14 +120,13 @@ const IDViews = () => {
 
   const {
     data: batchResponse,
-    isLoading: isBatchLoading,
+    isFetching: isBatchFetching,
     error: batchError,
   } = viewsDataResponse;
 
   // Handle data when the API call is finished
   useEffect(() => {
     if (viewsDataResponse.isFetching) {
-      setShowTableRows(false);
       // Reset selected ID views on refresh
       setViewsTotalCount(0);
       globalErrors.clear();
@@ -152,7 +151,6 @@ const IDViews = () => {
       setViewsList(idViewsList);
       setViewsTotalCount(totalCount);
       setIsKebabOpen(false);
-      setShowTableRows(true);
     }
 
     // API response: Error
@@ -176,9 +174,6 @@ const IDViews = () => {
 
   // Refresh button handling
   const refreshViewsData = () => {
-    // Hide table
-    setShowTableRows(false);
-
     // Reset selected views on refresh
     setViewsTotalCount(0);
     clearSelectedViews();
@@ -193,8 +188,6 @@ const IDViews = () => {
   };
 
   // Show table rows
-  const [showTableRows, setShowTableRows] = useState(!isBatchLoading);
-
   const updateSelectedViews = (views: IDView[], isSelected: boolean) => {
     let newSelectedViews: IDView[] = [];
     if (isSelected) {
@@ -238,13 +231,6 @@ const IDViews = () => {
       updateSelectedViews([view], isSelecting);
     }
   };
-
-  // Show table rows only when data is fully retrieved
-  useEffect(() => {
-    if (showTableRows !== !isBatchLoading) {
-      setShowTableRows(!isBatchLoading);
-    }
-  }, [isBatchLoading]);
 
   // Modals functionality
   const [showAddModal, setShowAddModal] = useState(false);
@@ -428,7 +414,7 @@ const IDViews = () => {
       data-cy="id-views-kebab-unapply-hosts"
       key="unapply-hosts"
       onClick={openUnapplyHostModal}
-      isDisabled={!showTableRows || totalCount === 0}
+      isDisabled={isBatchFetching || totalCount === 0}
     >
       Unapply from hosts
     </DropdownItem>,
@@ -436,7 +422,7 @@ const IDViews = () => {
       data-cy="id-views-kebab-unapply-hostgroups"
       key="unapply-hostgroups"
       onClick={openUnapplyHostgroupModal}
-      isDisabled={!showTableRows || totalCount === 0}
+      isDisabled={isBatchFetching || totalCount === 0}
     >
       Unapply from host groups
     </DropdownItem>,
@@ -479,7 +465,7 @@ const IDViews = () => {
         <SecondaryButton
           dataCy="id-views-button-refresh"
           onClickHandler={refreshViewsData}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
         >
           Refresh
         </SecondaryButton>
@@ -490,7 +476,7 @@ const IDViews = () => {
       element: (
         <SecondaryButton
           dataCy="id-views-button-delete"
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || isBatchFetching}
           onClickHandler={onDeleteHandler}
         >
           Delete
@@ -503,7 +489,7 @@ const IDViews = () => {
         <SecondaryButton
           dataCy="id-views-button-add"
           onClickHandler={onAddClickHandler}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
         >
           Add
         </SecondaryButton>
@@ -519,7 +505,7 @@ const IDViews = () => {
           idKebab="toggle-action-buttons"
           isKebabOpen={isKebabOpen}
           dropdownItems={dropdownItems}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
         />
       ),
     },
@@ -572,7 +558,7 @@ const IDViews = () => {
                     <IDViewsTable
                       elementsList={viewsList}
                       shownElementsList={viewsList}
-                      showTableRows={showTableRows}
+                      showTableRows={!isBatchFetching}
                       idViewsData={viewsTableData}
                       buttonsData={viewsTableButtonsData}
                       paginationData={selectedPerPageData}

--- a/src/pages/IDViews/IDViews.tsx
+++ b/src/pages/IDViews/IDViews.tsx
@@ -43,18 +43,12 @@ import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Errors
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 import useApiError from "src/hooks/useApiError";
 import useContextualHelpTopic from "src/hooks/useContextualHelpTopic";
 import GlobalErrors from "src/components/errors/GlobalErrors";
 import ModalErrors from "src/components/errors/ModalErrors";
 // RPC client
-import {
-  ErrorResult,
-  GenericPayload,
-  useSearchEntriesMutation,
-} from "../../services/rpc";
+import { ErrorResult, GenericPayload } from "../../services/rpc";
 import {
   useGettingIDViewsQuery,
   useUnapplyHostsMutation,
@@ -83,7 +77,7 @@ const IDViews = () => {
   const [viewsList, setViewsList] = useState<IDView[]>([]);
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   // Handle API calls errors
@@ -93,7 +87,6 @@ const IDViews = () => {
   // Table comps
   const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
   const [totalCount, setViewsTotalCount] = useState<number>(0);
-  const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
   const updateSelectedPerPage = (selected: number) => {
     setSelectedPerPage(selected);
@@ -205,74 +198,10 @@ const IDViews = () => {
     viewsDataResponse.refetch();
   };
 
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
   const [selectedViews, setSelectedViewsList] = useState<IDView[]>([]);
   const clearSelectedViews = () => {
     const emptyList: IDView[] = [];
     setSelectedViewsList(emptyList);
-  };
-
-  const [retrieveViews] = useSearchEntriesMutation({});
-
-  // Issue a search using a specific search value
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    setShowTableRows(false);
-    setViewsTotalCount(0);
-    setSearchIsDisabled(true);
-    retrieveViews({
-      searchValue: search,
-      sizeLimit: 0,
-      apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: 0,
-      stopIdx: 100,
-      entryType: "idview",
-    } as GenericPayload).then((result) => {
-      // Manage new response here
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for ID views",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success
-          const viewsListResult = result.data?.result.results || [];
-          const viewsListSize = result.data?.result.count || 0;
-          const totalCount = result.data?.result.totalCount || 0;
-          const idViewsList: IDView[] = [];
-
-          for (let i = 0; i < viewsListSize; i++) {
-            idViewsList.push(viewsListResult[i].result);
-          }
-
-          setViewsList(idViewsList.slice(0, perPage));
-          setViewsTotalCount(totalCount);
-          setIsKebabOpen(false);
-          setShowTableRows(true);
-        }
-        setSearchIsDisabled(false);
-      }
-    });
   };
 
   // Show table rows
@@ -505,13 +434,6 @@ const IDViews = () => {
     updateIsDeletion,
   };
 
-  // - 'SearchInputLayout'
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
-  };
-
   // Keybob for un-apply actions
   const [isKebabOpen, setIsKebabOpen] = React.useState(false);
   const onKebabToggle = () => {
@@ -564,8 +486,6 @@ const IDViews = () => {
           name="search"
           ariaLabel="Search ID views"
           placeholder="Search ID views"
-          searchValueData={searchValueData}
-          isDisabled={searchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/IDViews/IDViewsAppliedTo.tsx
+++ b/src/pages/IDViews/IDViewsAppliedTo.tsx
@@ -160,6 +160,7 @@ const IDViewsAppliedTo = (props: AppliesToProps) => {
   };
 
   const updateSearchValue = (value: string) => {
+    setPage(1);
     setSearchValue(value);
   };
 

--- a/src/pages/IDViews/IDViewsAppliedTo.tsx
+++ b/src/pages/IDViews/IDViewsAppliedTo.tsx
@@ -55,6 +55,8 @@ import {
   useUnapplyHostgroupsMutation,
 } from "../../services/rpcIDViews";
 import TabLayout from "src/components/layouts/TabLayout";
+// Utils
+import { getSelectedPerPageData } from "src/utils/selectedPerPage";
 
 interface AppliesToProps {
   idView: IDView;
@@ -91,17 +93,7 @@ const IDViewsAppliedTo = (props: AppliesToProps) => {
   const modalErrors = useApiError([]);
 
   // Table comps
-  const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
   const [totalCount, setTotalCount] = useState<number>(0);
-
-  const updateSelectedPerPage = (selected: number) => {
-    setSelectedPerPage(selected);
-  };
-
-  // Reset selected-per-page count whenever the page or page size changes
-  useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
 
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
@@ -174,6 +166,12 @@ const IDViewsAppliedTo = (props: AppliesToProps) => {
     const emptyList: string[] = [];
     setSelectedHosts(emptyList);
   };
+
+  const selectedPerPageData = getSelectedPerPageData(
+    shownHostsList,
+    selectedHosts,
+    (host) => host
+  );
 
   // Unapply functions
   const [showUnapplyHostsModal, setShowUnapplyHostsModal] = useState(false);
@@ -485,11 +483,6 @@ const IDViewsAppliedTo = (props: AppliesToProps) => {
   };
 
   // Data wrappers
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage,
-  };
-
   const hostsTableData = {
     selectedHosts,
     hostsList,

--- a/src/pages/IDViews/IDViewsAppliedTo.tsx
+++ b/src/pages/IDViews/IDViewsAppliedTo.tsx
@@ -84,7 +84,7 @@ const IDViewsAppliedTo = (props: AppliesToProps) => {
   const [shownHostsList, setShownHostsList] = useState<string[]>([]);
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, searchValue, setSearchValue } =
     useListPageSearchParams();
 
   // Handle API calls errors
@@ -97,12 +97,11 @@ const IDViewsAppliedTo = (props: AppliesToProps) => {
   const updateSelectedPerPage = (selected: number) => {
     setSelectedPerPage(selected);
   };
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
-  };
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
-  };
+
+  // Reset selected-per-page count whenever the page or page size changes
+  useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
 
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
@@ -115,10 +114,6 @@ const IDViewsAppliedTo = (props: AppliesToProps) => {
   const [isUnapply, setIsUnapply] = useState(false);
   const updateIsUnapply = (value: boolean) => {
     setIsUnapply(value);
-  };
-
-  const updateShownHosts = (newShownHostsList: string[]) => {
-    setShownHostsList(newShownHostsList);
   };
 
   // Page indexes
@@ -490,17 +485,6 @@ const IDViewsAppliedTo = (props: AppliesToProps) => {
   };
 
   // Data wrappers
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList: updateShownHosts,
-    totalCount,
-  };
-
   const selectedPerPageData = {
     selectedPerPage,
     updateSelectedPerPage,
@@ -676,7 +660,7 @@ const IDViewsAppliedTo = (props: AppliesToProps) => {
       element: (
         <PaginationLayout
           list={hostsList}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -708,7 +692,7 @@ const IDViewsAppliedTo = (props: AppliesToProps) => {
             </OuterScrollContainer>
             <PaginationLayout
               list={hostsList}
-              paginationData={paginationData}
+              totalCount={totalCount}
               variant={PaginationVariant.bottom}
               widgetId="pagination-options-menu-bottom"
             />

--- a/src/pages/IDViews/IDViewsAppliedTo.tsx
+++ b/src/pages/IDViews/IDViewsAppliedTo.tsx
@@ -132,12 +132,6 @@ const IDViewsAppliedTo = (props: AppliesToProps) => {
     }
   }, [idViewFullData, idViewFullDataQuery.isFetching]);
 
-  // Always refetch data when the component is loaded.
-  // This ensures the data is always up-to-date.
-  useEffect(() => {
-    idViewFullDataQuery.refetch();
-  }, [page, perPage]);
-
   // Refresh button handling
   const refreshViewsData = () => {
     setTotalCount(0);

--- a/src/pages/IDViews/IDViewsOverrideGroups.tsx
+++ b/src/pages/IDViews/IDViewsOverrideGroups.tsx
@@ -48,8 +48,7 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
   const dispatch = useAppDispatch();
   const globalErrors = useApiError([]);
 
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
   const [totalCount, setTotalCount] = useState<number>(0);
   const [groupsList, setGroupsList] = useState<IDViewOverrideGroup[]>([]);
   const [selectedGroups, setSelectedGroupsList] = useState<string[]>([]);
@@ -86,6 +85,12 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
   const updateSelectedPerPage = (selected: number) => {
     setSelectedPerPage(selected);
   };
+
+  // Reset selected-per-page count whenever the page or page size changes
+  useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
+
   const selectedPerPageData = {
     selectedPerPage,
     updateSelectedPerPage,
@@ -105,19 +110,6 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
     updateIsDeleteButtonDisabled,
     isDeletion,
     updateIsDeletion,
-  };
-
-  // Pagination
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
-  };
-
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
-  };
-
-  const updateShownGroupsList = (newShownGroupsList: IDViewOverrideGroup[]) => {
-    setGroupsList(newShownGroupsList);
   };
 
   const dataResponse = useGettingIDOverrideGroupsQuery(props.idview);
@@ -202,17 +194,6 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
   };
   const onDeleteModalToggle = () => {
     setShowDeleteModal(!showDeleteModal);
-  };
-
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList: updateShownGroupsList,
-    totalCount,
   };
 
   // - 'Delete modal'
@@ -303,7 +284,7 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
       element: (
         <PaginationLayout
           list={props.groups}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -340,7 +321,7 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
       </div>
       <PaginationLayout
         list={groupsList}
-        paginationData={paginationData}
+        totalCount={totalCount}
         variant={PaginationVariant.bottom}
         widgetId="pagination-options-menu-bottom"
         className="pf-v6-u-pb-0 pf-v6-u-pr-md"

--- a/src/pages/IDViews/IDViewsOverrideGroups.tsx
+++ b/src/pages/IDViews/IDViewsOverrideGroups.tsx
@@ -122,14 +122,13 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
 
   const {
     data: batchResponse,
-    isLoading: isBatchLoading,
+    isFetching: isBatchFetching,
     error: batchError,
   } = dataResponse;
 
   // Handle data when the API call is finished
   useEffect(() => {
     if (dataResponse.isFetching) {
-      setShowTableRows(false);
       // Reset selected on refresh
       setTotalCount(0);
       globalErrors.clear();
@@ -152,7 +151,6 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
       }
       setGroupsList(groupList);
       setTotalCount(total);
-      setShowTableRows(true);
     }
     // API response: Error
     if (
@@ -168,7 +166,7 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
         })
       );
     }
-  }, [dataResponse]);
+  }, [dataResponse.isFetching, dataResponse.data]);
 
   const onRefresh = () => {
     props.onRefresh();
@@ -176,15 +174,6 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
   };
 
   // Show table rows
-  const [showTableRows, setShowTableRows] = useState(!isBatchLoading);
-
-  // Show table rows only when data is fully retrieved
-  useEffect(() => {
-    if (showTableRows !== !isBatchLoading) {
-      setShowTableRows(!isBatchLoading);
-    }
-  }, [isBatchLoading]);
-
   // Modals functionality
   const [showAddModal, setShowAddModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -268,7 +257,7 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
       element: (
         <SecondaryButton
           dataCy="id-views-tab-override-groups-button-delete"
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || isBatchFetching}
           onClickHandler={onDeleteHandler}
         >
           Delete
@@ -281,7 +270,7 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
         <SecondaryButton
           dataCy="id-views-tab-override-groups-button-add"
           onClickHandler={onAddClickHandler}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
         >
           Add
         </SecondaryButton>
@@ -318,7 +307,7 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
               <IDViewsOverrideGroupsTable
                 elementsList={groupsList}
                 shownElementsList={groupsList}
-                showTableRows={showTableRows}
+                showTableRows={!isBatchFetching}
                 overrideEntryData={groupsTableData}
                 buttonsData={viewsTableButtonsData}
                 paginationData={selectedPerPageData}

--- a/src/pages/IDViews/IDViewsOverrideGroups.tsx
+++ b/src/pages/IDViews/IDViewsOverrideGroups.tsx
@@ -48,7 +48,7 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
   const dispatch = useAppDispatch();
   const globalErrors = useApiError([]);
 
-  const { page, perPage, searchValue } = useListPageSearchParams();
+  const { page, perPage } = useListPageSearchParams();
   const [totalCount, setTotalCount] = useState<number>(0);
   const [groupsList, setGroupsList] = useState<IDViewOverrideGroup[]>([]);
   const [selectedGroups, setSelectedGroupsList] = useState<string[]>([]);

--- a/src/pages/IDViews/IDViewsOverrideGroups.tsx
+++ b/src/pages/IDViews/IDViewsOverrideGroups.tsx
@@ -25,8 +25,6 @@ import SearchInputLayout from "src/components/layouts/SearchInputLayout";
 import PaginationLayout from "src/components/layouts/PaginationLayout";
 // Errors
 import GlobalErrors from "src/components/errors/GlobalErrors";
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 // Utils
 import { isGroupOverrideSelectable } from "src/utils/utils";
 import IDViewsOverrideGroupsTable from "src/pages/IDViews/IDViewsOverrideGroupsTable";
@@ -38,11 +36,7 @@ import { IDViewOverrideGroup } from "src/utils/datatypes/globalDataTypes";
 // Icons
 import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
 // RPC
-import {
-  IDOverridePayload,
-  useGettingIDOverrideGroupsQuery,
-  useSearchOverrideEntriesMutation,
-} from "src/services/rpcIdOverrides";
+import { useGettingIDOverrideGroupsQuery } from "src/services/rpcIdOverrides";
 
 interface PropsToOverrides {
   idview: string;
@@ -54,12 +48,11 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
   const dispatch = useAppDispatch();
   const globalErrors = useApiError([]);
 
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
   const [totalCount, setTotalCount] = useState<number>(0);
   const [groupsList, setGroupsList] = useState<IDViewOverrideGroup[]>([]);
   const [selectedGroups, setSelectedGroupsList] = useState<string[]>([]);
-  const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
   const clearSelectedGroups = () => {
     const emptyList: string[] = [];
@@ -125,76 +118,6 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
 
   const updateShownGroupsList = (newShownGroupsList: IDViewOverrideGroup[]) => {
     setGroupsList(newShownGroupsList);
-  };
-
-  // Update search input valie
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
-  const [retrieveEntries] = useSearchOverrideEntriesMutation({});
-
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    setShowTableRows(false);
-    setTotalCount(0);
-    setSearchIsDisabled(true);
-    retrieveEntries({
-      idView: props.idview,
-      searchValue: search,
-      sizeLimit: 0,
-      startIdx: 0,
-      stopIdx: 100,
-      entryType: "idoverridegroup",
-    } as IDOverridePayload).then((result) => {
-      // Manage new response here
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for override groups",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success
-          const groupsListResult = result.data?.result.results || [];
-          const groupsListSize = result.data?.result.count || 0;
-          const totalCount = result.data?.result.totalCount || 0;
-          const groupList: IDViewOverrideGroup[] = [];
-
-          for (let i = 0; i < groupsListSize; i++) {
-            groupList.push(groupsListResult[i].result);
-          }
-          setGroupsList(groupList.slice(0, perPage));
-          setTotalCount(totalCount);
-          // Show table elements
-          setShowTableRows(true);
-        }
-        setSearchIsDisabled(false);
-      }
-    });
-  };
-
-  // SearchInputLayout
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
   };
 
   const dataResponse = useGettingIDOverrideGroupsQuery(props.idview);
@@ -331,8 +254,6 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
           name="search"
           ariaLabel="Search groups"
           placeholder="Search groups"
-          searchValueData={searchValueData}
-          isDisabled={searchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/IDViews/IDViewsOverrideGroups.tsx
+++ b/src/pages/IDViews/IDViewsOverrideGroups.tsx
@@ -40,7 +40,10 @@ import { IDViewOverrideGroup } from "src/utils/datatypes/globalDataTypes";
 // Icons
 import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
 // RPC
-import { useGettingIDOverrideGroupsQuery } from "src/services/rpcIdOverrides";
+import {
+  IDOverridePayload,
+  useGettingIDOverrideGroupsQuery,
+} from "src/services/rpcIdOverrides";
 
 interface PropsToOverrides {
   idview: string;
@@ -52,7 +55,7 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
   const dispatch = useAppDispatch();
   const globalErrors = useApiError([]);
 
-  const { page, perPage } = useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
   const [totalCount, setTotalCount] = useState<number>(0);
   const [groupsList, setGroupsList] = useState<IDViewOverrideGroup[]>([]);
   const [selectedGroups, setSelectedGroupsList] = useState<string[]>([]);
@@ -104,7 +107,18 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
     updateIsDeletion,
   };
 
-  const dataResponse = useGettingIDOverrideGroupsQuery(props.idview);
+  // Page indexes
+  const firstIdx = (page - 1) * perPage;
+  const lastIdx = page * perPage;
+
+  const dataResponse = useGettingIDOverrideGroupsQuery({
+    idView: props.idview,
+    searchValue,
+    sizeLimit: 0,
+    startIdx: firstIdx,
+    stopIdx: lastIdx,
+    entryType: "idoverridegroup",
+  } as IDOverridePayload);
 
   const {
     data: batchResponse,
@@ -128,8 +142,16 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
       dataResponse.data &&
       batchResponse !== undefined
     ) {
-      setGroupsList(batchResponse);
-      setTotalCount(batchResponse.length);
+      const groupsListResult = batchResponse.result.results || [];
+      const groupsListSize = batchResponse.result.count || 0;
+      const total = batchResponse.result.totalCount || 0;
+      const groupList: IDViewOverrideGroup[] = [];
+
+      for (let i = 0; i < groupsListSize; i++) {
+        groupList.push(groupsListResult[i].result);
+      }
+      setGroupsList(groupList);
+      setTotalCount(total);
       setShowTableRows(true);
     }
     // API response: Error
@@ -155,12 +177,6 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
 
   // Show table rows
   const [showTableRows, setShowTableRows] = useState(!isBatchLoading);
-
-  // Always refetch data when the component is loaded.
-  // This ensures the data is always up-to-date.
-  useEffect(() => {
-    dataResponse.refetch();
-  }, [page, perPage]);
 
   // Show table rows only when data is fully retrieved
   useEffect(() => {

--- a/src/pages/IDViews/IDViewsOverrideGroups.tsx
+++ b/src/pages/IDViews/IDViewsOverrideGroups.tsx
@@ -135,14 +135,15 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
 
   const [retrieveEntries] = useSearchOverrideEntriesMutation({});
 
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     setShowTableRows(false);
     setTotalCount(0);
     setSearchIsDisabled(true);
     retrieveEntries({
       idView: props.idview,
-      searchValue: searchValue,
+      searchValue: search,
       sizeLimit: 0,
       startIdx: 0,
       stopIdx: 100,

--- a/src/pages/IDViews/IDViewsOverrideGroups.tsx
+++ b/src/pages/IDViews/IDViewsOverrideGroups.tsx
@@ -27,6 +27,10 @@ import PaginationLayout from "src/components/layouts/PaginationLayout";
 import GlobalErrors from "src/components/errors/GlobalErrors";
 // Utils
 import { isGroupOverrideSelectable } from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 import IDViewsOverrideGroupsTable from "src/pages/IDViews/IDViewsOverrideGroupsTable";
 // Modals
 import AddIdOverrideGroupModal from "src/components/modals/IdOverrideModals/AddIdOverrideGroup";
@@ -78,23 +82,11 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
     setIsDeletion(value);
   };
 
-  // Elements selected (per page)
-  //  - This will help to calculate the remaining elements on a specific page (bulk selector)
-  const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
-
-  const updateSelectedPerPage = (selected: number) => {
-    setSelectedPerPage(selected);
-  };
-
-  // Reset selected-per-page count whenever the page or page size changes
-  useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
-
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage,
-  };
+  const selectedPerPageData = getSelectedPerPageData(
+    groupsList,
+    selectedGroups,
+    (group) => ipaPrimaryKey(group.ipaanchoruuid)
+  );
 
   const selectableTable = groupsList.filter(isGroupOverrideSelectable);
 

--- a/src/pages/IDViews/IDViewsOverrideGroups.tsx
+++ b/src/pages/IDViews/IDViewsOverrideGroups.tsx
@@ -71,10 +71,6 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
     clearSelectedGroups,
   };
 
-  // Page indexes
-  const firstIdx = (page - 1) * perPage;
-  const lastIdx = page * perPage;
-
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
     useState<boolean>(true);
@@ -133,12 +129,14 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
 
   // Update search input valie
   const updateSearchValue = (value: string) => {
+    setPage(1);
     setSearchValue(value);
   };
 
   const [retrieveEntries] = useSearchOverrideEntriesMutation({});
 
   const submitSearchValue = () => {
+    setPage(1);
     setShowTableRows(false);
     setTotalCount(0);
     setSearchIsDisabled(true);
@@ -146,8 +144,8 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
       idView: props.idview,
       searchValue: searchValue,
       sizeLimit: 0,
-      startIdx: firstIdx,
-      stopIdx: lastIdx,
+      startIdx: 0,
+      stopIdx: 100,
       entryType: "idoverridegroup",
     } as IDOverridePayload).then((result) => {
       // Manage new response here
@@ -181,7 +179,7 @@ const IDViewsOverrideGroups = (props: PropsToOverrides) => {
           for (let i = 0; i < groupsListSize; i++) {
             groupList.push(groupsListResult[i].result);
           }
-          setGroupsList(groupList);
+          setGroupsList(groupList.slice(0, perPage));
           setTotalCount(totalCount);
           // Show table elements
           setShowTableRows(true);

--- a/src/pages/IDViews/IDViewsOverrideUsers.tsx
+++ b/src/pages/IDViews/IDViewsOverrideUsers.tsx
@@ -68,10 +68,6 @@ const IDViewsOverrideUsers = (props: PropsToOverrides) => {
     clearSelectedUsers,
   };
 
-  // Page indexes
-  const firstIdx = (page - 1) * perPage;
-  const lastIdx = page * perPage;
-
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
     useState<boolean>(true);
@@ -130,12 +126,14 @@ const IDViewsOverrideUsers = (props: PropsToOverrides) => {
 
   // Update search input valie
   const updateSearchValue = (value: string) => {
+    setPage(1);
     setSearchValue(value);
   };
 
   const [retrieveEntries] = useSearchOverrideEntriesMutation({});
 
   const submitSearchValue = () => {
+    setPage(1);
     setShowTableRows(false);
     setTotalCount(0);
     setSearchIsDisabled(true);
@@ -143,8 +141,8 @@ const IDViewsOverrideUsers = (props: PropsToOverrides) => {
       idView: props.idview,
       searchValue: searchValue,
       sizeLimit: 0,
-      startIdx: firstIdx,
-      stopIdx: lastIdx,
+      startIdx: 0,
+      stopIdx: 100,
       entryType: "idoverrideuser",
     } as IDOverridePayload).then((result) => {
       // Manage new response here
@@ -178,7 +176,7 @@ const IDViewsOverrideUsers = (props: PropsToOverrides) => {
           for (let i = 0; i < usersListSize; i++) {
             userList.push(usersListResult[i].result);
           }
-          setUsersList(userList);
+          setUsersList(userList.slice(0, perPage));
           setTotalCount(totalCount);
           // Show table elements
           setShowTableRows(true);

--- a/src/pages/IDViews/IDViewsOverrideUsers.tsx
+++ b/src/pages/IDViews/IDViewsOverrideUsers.tsx
@@ -132,14 +132,15 @@ const IDViewsOverrideUsers = (props: PropsToOverrides) => {
 
   const [retrieveEntries] = useSearchOverrideEntriesMutation({});
 
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     setShowTableRows(false);
     setTotalCount(0);
     setSearchIsDisabled(true);
     retrieveEntries({
       idView: props.idview,
-      searchValue: searchValue,
+      searchValue: search,
       sizeLimit: 0,
       startIdx: 0,
       stopIdx: 100,

--- a/src/pages/IDViews/IDViewsOverrideUsers.tsx
+++ b/src/pages/IDViews/IDViewsOverrideUsers.tsx
@@ -25,6 +25,10 @@ import PaginationLayout from "src/components/layouts/PaginationLayout";
 import GlobalErrors from "src/components/errors/GlobalErrors";
 // Utils
 import { isUserOverrideSelectable } from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 import IDViewsOverrideUsersTable from "src/pages/IDViews/IDViewsOverrideUsersTable";
 // Modals
 import AddIdOverrideUserModal from "src/components/modals/IdOverrideModals/AddIdOverrideUser";
@@ -75,23 +79,11 @@ const IDViewsOverrideUsers = (props: PropsToOverrides) => {
     setIsDeletion(value);
   };
 
-  // Elements selected (per page)
-  //  - This will help to calculate the remaining elements on a specific page (bulk selector)
-  const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
-
-  const updateSelectedPerPage = (selected: number) => {
-    setSelectedPerPage(selected);
-  };
-
-  // Reset selected-per-page count whenever the page or page size changes
-  useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
-
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage,
-  };
+  const selectedPerPageData = getSelectedPerPageData(
+    usersList,
+    selectedUsers,
+    (user) => ipaPrimaryKey(user.ipaanchoruuid)
+  );
 
   const selectableTable = usersList.filter(isUserOverrideSelectable);
 

--- a/src/pages/IDViews/IDViewsOverrideUsers.tsx
+++ b/src/pages/IDViews/IDViewsOverrideUsers.tsx
@@ -119,14 +119,13 @@ const IDViewsOverrideUsers = (props: PropsToOverrides) => {
 
   const {
     data: batchResponse,
-    isLoading: isBatchLoading,
+    isFetching: isBatchFetching,
     error: batchError,
   } = dataResponse;
 
   // Handle data when the API call is finished
   useEffect(() => {
     if (dataResponse.isFetching) {
-      setShowTableRows(false);
       // Reset selected on refresh
       setTotalCount(0);
       globalErrors.clear();
@@ -149,7 +148,6 @@ const IDViewsOverrideUsers = (props: PropsToOverrides) => {
       }
       setUsersList(userList);
       setTotalCount(total);
-      setShowTableRows(true);
     }
     // API response: Error
     if (
@@ -173,15 +171,6 @@ const IDViewsOverrideUsers = (props: PropsToOverrides) => {
   };
 
   // Show table rows
-  const [showTableRows, setShowTableRows] = useState(!isBatchLoading);
-
-  // Show table rows only when data is fully retrieved
-  useEffect(() => {
-    if (showTableRows !== !isBatchLoading) {
-      setShowTableRows(!isBatchLoading);
-    }
-  }, [isBatchLoading]);
-
   // Modals functionality
   const [showAddModal, setShowAddModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -242,7 +231,7 @@ const IDViewsOverrideUsers = (props: PropsToOverrides) => {
       element: (
         <SecondaryButton
           dataCy="id-views-tab-override-users-button-delete"
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || isBatchFetching}
           onClickHandler={onDeleteHandler}
         >
           Delete
@@ -255,7 +244,7 @@ const IDViewsOverrideUsers = (props: PropsToOverrides) => {
         <SecondaryButton
           dataCy="id-views-tab-override-users-button-add"
           onClickHandler={onAddClickHandler}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
         >
           Add
         </SecondaryButton>
@@ -292,7 +281,7 @@ const IDViewsOverrideUsers = (props: PropsToOverrides) => {
               <IDViewsOverrideUsersTable
                 elementsList={usersList}
                 shownElementsList={usersList}
-                showTableRows={showTableRows}
+                showTableRows={!isBatchFetching}
                 overrideEntryData={usersTableData}
                 buttonsData={viewsTableButtonsData}
                 paginationData={selectedPerPageData}

--- a/src/pages/IDViews/IDViewsOverrideUsers.tsx
+++ b/src/pages/IDViews/IDViewsOverrideUsers.tsx
@@ -23,8 +23,6 @@ import SearchInputLayout from "src/components/layouts/SearchInputLayout";
 import PaginationLayout from "src/components/layouts/PaginationLayout";
 // Errors
 import GlobalErrors from "src/components/errors/GlobalErrors";
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 // Utils
 import { isUserOverrideSelectable } from "src/utils/utils";
 import IDViewsOverrideUsersTable from "src/pages/IDViews/IDViewsOverrideUsersTable";
@@ -34,11 +32,7 @@ import DeleteIdOverrideUsersModal from "src/components/modals/IdOverrideModals/D
 // Data types
 import { IDViewOverrideUser } from "src/utils/datatypes/globalDataTypes";
 // RPC
-import {
-  IDOverridePayload,
-  useGettingIDOverrideUsersQuery,
-  useSearchOverrideEntriesMutation,
-} from "src/services/rpcIdOverrides";
+import { useGettingIDOverrideUsersQuery } from "src/services/rpcIdOverrides";
 
 interface PropsToOverrides {
   idview: string;
@@ -51,12 +45,10 @@ const IDViewsOverrideUsers = (props: PropsToOverrides) => {
 
   const globalErrors = useApiError([]);
 
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
-    useListPageSearchParams();
+  const { page, setPage, perPage, setPerPage } = useListPageSearchParams();
   const [totalCount, setTotalCount] = useState<number>(0);
   const [usersList, setUsersList] = useState<IDViewOverrideUser[]>([]);
   const [selectedUsers, setSelectedUsersList] = useState<string[]>([]);
-  const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
   const clearSelectedUsers = () => {
     const emptyList: string[] = [];
@@ -122,76 +114,6 @@ const IDViewsOverrideUsers = (props: PropsToOverrides) => {
 
   const updateShownUsersList = (newShownUsersList: IDViewOverrideUser[]) => {
     setUsersList(newShownUsersList);
-  };
-
-  // Update search input valie
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
-  const [retrieveEntries] = useSearchOverrideEntriesMutation({});
-
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    setShowTableRows(false);
-    setTotalCount(0);
-    setSearchIsDisabled(true);
-    retrieveEntries({
-      idView: props.idview,
-      searchValue: search,
-      sizeLimit: 0,
-      startIdx: 0,
-      stopIdx: 100,
-      entryType: "idoverrideuser",
-    } as IDOverridePayload).then((result) => {
-      // Manage new response here
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for override users",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success
-          const usersListResult = result.data?.result.results || [];
-          const usersListSize = result.data?.result.count || 0;
-          const totalCount = result.data?.result.totalCount || 0;
-          const userList: IDViewOverrideUser[] = [];
-
-          for (let i = 0; i < usersListSize; i++) {
-            userList.push(usersListResult[i].result);
-          }
-          setUsersList(userList.slice(0, perPage));
-          setTotalCount(totalCount);
-          // Show table elements
-          setShowTableRows(true);
-        }
-        setSearchIsDisabled(false);
-      }
-    });
-  };
-
-  // SearchInputLayout
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
   };
 
   const dataResponse = useGettingIDOverrideUsersQuery(props.idview);
@@ -305,8 +227,6 @@ const IDViewsOverrideUsers = (props: PropsToOverrides) => {
           name="search"
           ariaLabel="Search users"
           placeholder="Search users"
-          searchValueData={searchValueData}
-          isDisabled={searchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/IDViews/IDViewsOverrideUsers.tsx
+++ b/src/pages/IDViews/IDViewsOverrideUsers.tsx
@@ -36,7 +36,10 @@ import DeleteIdOverrideUsersModal from "src/components/modals/IdOverrideModals/D
 // Data types
 import { IDViewOverrideUser } from "src/utils/datatypes/globalDataTypes";
 // RPC
-import { useGettingIDOverrideUsersQuery } from "src/services/rpcIdOverrides";
+import {
+  IDOverridePayload,
+  useGettingIDOverrideUsersQuery,
+} from "src/services/rpcIdOverrides";
 
 interface PropsToOverrides {
   idview: string;
@@ -49,7 +52,7 @@ const IDViewsOverrideUsers = (props: PropsToOverrides) => {
 
   const globalErrors = useApiError([]);
 
-  const { page, perPage } = useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
   const [totalCount, setTotalCount] = useState<number>(0);
   const [usersList, setUsersList] = useState<IDViewOverrideUser[]>([]);
   const [selectedUsers, setSelectedUsersList] = useState<string[]>([]);
@@ -101,7 +104,18 @@ const IDViewsOverrideUsers = (props: PropsToOverrides) => {
     updateIsDeletion,
   };
 
-  const dataResponse = useGettingIDOverrideUsersQuery(props.idview);
+  // Page indexes
+  const firstIdx = (page - 1) * perPage;
+  const lastIdx = page * perPage;
+
+  const dataResponse = useGettingIDOverrideUsersQuery({
+    idView: props.idview,
+    searchValue,
+    sizeLimit: 0,
+    startIdx: firstIdx,
+    stopIdx: lastIdx,
+    entryType: "idoverrideuser",
+  } as IDOverridePayload);
 
   const {
     data: batchResponse,
@@ -125,8 +139,16 @@ const IDViewsOverrideUsers = (props: PropsToOverrides) => {
       dataResponse.data &&
       batchResponse !== undefined
     ) {
-      setUsersList(batchResponse);
-      setTotalCount(batchResponse.length);
+      const usersListResult = batchResponse.result.results || [];
+      const usersListSize = batchResponse.result.count || 0;
+      const total = batchResponse.result.totalCount || 0;
+      const userList: IDViewOverrideUser[] = [];
+
+      for (let i = 0; i < usersListSize; i++) {
+        userList.push(usersListResult[i].result);
+      }
+      setUsersList(userList);
+      setTotalCount(total);
       setShowTableRows(true);
     }
     // API response: Error
@@ -152,12 +174,6 @@ const IDViewsOverrideUsers = (props: PropsToOverrides) => {
 
   // Show table rows
   const [showTableRows, setShowTableRows] = useState(!isBatchLoading);
-
-  // Always refetch data when the component is loaded.
-  // This ensures the data is always up-to-date.
-  useEffect(() => {
-    dataResponse.refetch();
-  }, [page, perPage]);
 
   // Show table rows only when data is fully retrieved
   useEffect(() => {

--- a/src/pages/IDViews/IDViewsOverrideUsers.tsx
+++ b/src/pages/IDViews/IDViewsOverrideUsers.tsx
@@ -45,7 +45,7 @@ const IDViewsOverrideUsers = (props: PropsToOverrides) => {
 
   const globalErrors = useApiError([]);
 
-  const { page, setPage, perPage, setPerPage } = useListPageSearchParams();
+  const { page, perPage } = useListPageSearchParams();
   const [totalCount, setTotalCount] = useState<number>(0);
   const [usersList, setUsersList] = useState<IDViewOverrideUser[]>([]);
   const [selectedUsers, setSelectedUsersList] = useState<string[]>([]);
@@ -82,6 +82,12 @@ const IDViewsOverrideUsers = (props: PropsToOverrides) => {
   const updateSelectedPerPage = (selected: number) => {
     setSelectedPerPage(selected);
   };
+
+  // Reset selected-per-page count whenever the page or page size changes
+  useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
+
   const selectedPerPageData = {
     selectedPerPage,
     updateSelectedPerPage,
@@ -101,19 +107,6 @@ const IDViewsOverrideUsers = (props: PropsToOverrides) => {
     updateIsDeleteButtonDisabled,
     isDeletion,
     updateIsDeletion,
-  };
-
-  // Pagination
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
-  };
-
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
-  };
-
-  const updateShownUsersList = (newShownUsersList: IDViewOverrideUser[]) => {
-    setUsersList(newShownUsersList);
   };
 
   const dataResponse = useGettingIDOverrideUsersQuery(props.idview);
@@ -200,17 +193,6 @@ const IDViewsOverrideUsers = (props: PropsToOverrides) => {
     setShowDeleteModal(!showDeleteModal);
   };
 
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList: updateShownUsersList,
-    totalCount,
-  };
-
   // - 'Delete modal'
   const deleteUsersButtonsData = {
     updateIsDeleteButtonDisabled,
@@ -276,7 +258,7 @@ const IDViewsOverrideUsers = (props: PropsToOverrides) => {
       element: (
         <PaginationLayout
           list={props.users}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -313,7 +295,7 @@ const IDViewsOverrideUsers = (props: PropsToOverrides) => {
       </div>
       <PaginationLayout
         list={usersList}
-        paginationData={paginationData}
+        totalCount={totalCount}
         variant={PaginationVariant.bottom}
         widgetId="pagination-options-menu-bottom"
         className="pf-v6-u-pb-0 pf-v6-u-pr-md"

--- a/src/pages/IdPReferences/IdpReferences.tsx
+++ b/src/pages/IdPReferences/IdpReferences.tsx
@@ -14,7 +14,6 @@ import {
 // Data types
 import { IDPServer } from "src/utils/datatypes/globalDataTypes";
 // Hooks
-import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import useApiError from "src/hooks/useApiError";
@@ -23,15 +22,10 @@ import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Redux
 import { useAppDispatch, useAppSelector } from "src/store/hooks";
 // RPC
-import {
-  useGetIdpEntriesQuery,
-  useSearchIdpEntriesMutation,
-} from "src/services/rpcIdp";
+import { useGetIdpEntriesQuery } from "src/services/rpcIdp";
 // Utils
 import { isIdpServerSelectable } from "src/utils/utils";
 // Components
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 import ToolbarLayout, {
   ToolbarItem,
 } from "src/components/layouts/ToolbarLayout";
@@ -65,7 +59,7 @@ const IdpReferences = () => {
   ) as string;
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   // Handle API calls errors
@@ -77,8 +71,6 @@ const IdpReferences = () => {
 
   // States
   const [idpReferences, setIdpReferences] = React.useState<IDPServer[]>([]);
-  const [isSearchDisabled, setIsSearchDisabled] =
-    React.useState<boolean>(false);
   const [totalCount, setTotalCount] = React.useState<number>(0);
 
   // API calls
@@ -225,59 +217,6 @@ const IdpReferences = () => {
     }
   }, [isLoading]);
 
-  // Search API call
-  const [searchEntry] = useSearchIdpEntriesMutation();
-
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    searchEntry({
-      searchValue: search,
-      apiVersion,
-      sizelimit: 100,
-      startIdx: 0,
-      stopIdx: 200, // Search will consider a max. of elements
-    }).then((result) => {
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for IdPs",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success
-          const listResult = result.data?.result.results || [];
-          const listSize = result.data?.result.count || 0;
-          const totalCount = result.data?.result.totalCount || 0;
-          const elementsList: IDPServer[] = [];
-
-          for (let i = 0; i < listSize; i++) {
-            elementsList.push(listResult[i].result);
-          }
-
-          setTotalCount(totalCount);
-          setIdpReferences(elementsList.slice(0, perPage));
-          setShowTableRows(true);
-        }
-        setIsSearchDisabled(false);
-      }
-    });
-  };
-
   // Data wrappers
   // TODO: Better separation of concerts
   // - 'PaginationLayout'
@@ -289,18 +228,6 @@ const IdpReferences = () => {
     updateSelectedPerPage: setSelectedPerPage,
     updateShownElementsList: setIdpReferences,
     totalCount,
-  };
-
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
-  // SearchInputLayout
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
   };
 
   // - 'BulkSelectorrep'
@@ -360,8 +287,6 @@ const IdpReferences = () => {
           name="search"
           ariaLabel="Search IdP references"
           placeholder="Search IdP references"
-          searchValueData={searchValueData}
-          isDisabled={isSearchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/IdPReferences/IdpReferences.tsx
+++ b/src/pages/IdPReferences/IdpReferences.tsx
@@ -229,6 +229,7 @@ const IdpReferences = () => {
   const [searchEntry] = useSearchIdpEntriesMutation();
 
   const submitSearchValue = () => {
+    setPage(1);
     searchEntry({
       searchValue: searchValue,
       apiVersion,
@@ -268,7 +269,7 @@ const IdpReferences = () => {
           }
 
           setTotalCount(totalCount);
-          setIdpReferences(elementsList);
+          setIdpReferences(elementsList.slice(0, perPage));
           setShowTableRows(true);
         }
         setIsSearchDisabled(false);
@@ -289,10 +290,15 @@ const IdpReferences = () => {
     totalCount,
   };
 
+  const updateSearchValue = (value: string) => {
+    setPage(1);
+    setSearchValue(value);
+  };
+
   // SearchInputLayout
   const searchValueData = {
     searchValue,
-    updateSearchValue: setSearchValue,
+    updateSearchValue,
     submitSearchValue,
   };
 

--- a/src/pages/IdPReferences/IdpReferences.tsx
+++ b/src/pages/IdPReferences/IdpReferences.tsx
@@ -59,8 +59,7 @@ const IdpReferences = () => {
   ) as string;
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
 
   // Handle API calls errors
   const globalErrors = useApiError([]);
@@ -217,19 +216,12 @@ const IdpReferences = () => {
     }
   }, [isLoading]);
 
-  // Data wrappers
-  // TODO: Better separation of concerts
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage: setPage,
-    updatePerPage: setPerPage,
-    updateSelectedPerPage: setSelectedPerPage,
-    updateShownElementsList: setIdpReferences,
-    totalCount,
-  };
+  // Reset the selected per-page count when the page or page size changes
+  React.useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
 
+  // Data wrappers
   // - 'BulkSelectorrep'
   const bulkSelectorData = {
     selected: selectedElements,
@@ -350,7 +342,7 @@ const IdpReferences = () => {
       element: (
         <PaginationLayout
           list={idpReferences}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -424,7 +416,7 @@ const IdpReferences = () => {
             >
               <PaginationLayout
                 list={idpReferences}
-                paginationData={paginationData}
+                totalCount={totalCount}
                 variant={PaginationVariant.bottom}
                 widgetId="pagination-options-menu-bottom"
               />

--- a/src/pages/IdPReferences/IdpReferences.tsx
+++ b/src/pages/IdPReferences/IdpReferences.tsx
@@ -201,12 +201,6 @@ const IdpReferences = () => {
     (item) => ipaPrimaryKey(item.cn)
   );
 
-  // Always refetch data when the component is loaded.
-  // This ensures the data is always up-to-date.
-  React.useEffect(() => {
-    idpsResponse.refetch();
-  }, []);
-
   // Show table rows
   // Data wrappers
   // - 'BulkSelectorrep'

--- a/src/pages/IdPReferences/IdpReferences.tsx
+++ b/src/pages/IdPReferences/IdpReferences.tsx
@@ -228,10 +228,11 @@ const IdpReferences = () => {
   // Search API call
   const [searchEntry] = useSearchIdpEntriesMutation();
 
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     searchEntry({
-      searchValue: searchValue,
+      searchValue: search,
       apiVersion,
       sizelimit: 100,
       startIdx: 0,

--- a/src/pages/IdPReferences/IdpReferences.tsx
+++ b/src/pages/IdPReferences/IdpReferences.tsx
@@ -85,12 +85,11 @@ const IdpReferences = () => {
     stopIdx: lastUserIdx,
   });
 
-  const { data, isLoading, error } = idpsResponse;
+  const { data, isFetching, error } = idpsResponse;
 
   // Handle data when the API call is finished
   React.useEffect(() => {
     if (idpsResponse.isFetching) {
-      setShowTableRows(false);
       // Reset selected elements on refresh
       setTotalCount(0);
       globalErrors.clear();
@@ -111,8 +110,6 @@ const IdpReferences = () => {
       setTotalCount(totalCount);
       // Update the list of elements
       setIdpReferences(elementsList);
-      // Show table elements
-      setShowTableRows(true);
     }
 
     // API response: Error
@@ -139,15 +136,10 @@ const IdpReferences = () => {
 
   // Refresh button handling
   const refreshData = () => {
-    // Hide table
-    setShowTableRows(false);
-
     // Reset selected elements on refresh
     setTotalCount(0);
 
-    idpsResponse.refetch().then(() => {
-      setShowTableRows(true);
-    });
+    idpsResponse.refetch();
   };
 
   // 'Delete' button state
@@ -216,15 +208,6 @@ const IdpReferences = () => {
   }, []);
 
   // Show table rows
-  const [showTableRows, setShowTableRows] = React.useState(!isLoading);
-
-  // Show table rows only when data is fully retrieved
-  React.useEffect(() => {
-    if (showTableRows !== !isLoading) {
-      setShowTableRows(!isLoading);
-    }
-  }, [isLoading]);
-
   // Data wrappers
   // - 'BulkSelectorrep'
   const bulkSelectorData = {
@@ -293,7 +276,7 @@ const IdpReferences = () => {
         <SecondaryButton
           dataCy="idp-references-button-refresh"
           onClickHandler={refreshData}
-          isDisabled={!showTableRows}
+          isDisabled={isFetching}
         >
           Refresh
         </SecondaryButton>
@@ -304,7 +287,7 @@ const IdpReferences = () => {
       element: (
         <SecondaryButton
           dataCy="idp-references-button-delete"
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || isFetching}
           onClickHandler={onOpenDeleteModal}
         >
           Delete
@@ -316,7 +299,7 @@ const IdpReferences = () => {
       element: (
         <SecondaryButton
           dataCy="idp-references-button-add"
-          isDisabled={!showTableRows}
+          isDisabled={isFetching}
           onClickHandler={onOpenAddModal}
         >
           Add
@@ -386,7 +369,7 @@ const IdpReferences = () => {
                       ]}
                       hasCheckboxes={true}
                       pathname="identity-provider-references"
-                      showTableRows={showTableRows}
+                      showTableRows={!isFetching}
                       showLink={true}
                       elementsData={{
                         isElementSelectable: isIdpServerSelectable,

--- a/src/pages/IdPReferences/IdpReferences.tsx
+++ b/src/pages/IdPReferences/IdpReferences.tsx
@@ -25,6 +25,10 @@ import { useAppDispatch, useAppSelector } from "src/store/hooks";
 import { useGetIdpEntriesQuery } from "src/services/rpcIdp";
 // Utils
 import { isIdpServerSelectable } from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 // Components
 import ToolbarLayout, {
   ToolbarItem,
@@ -127,7 +131,6 @@ const IdpReferences = () => {
   const [selectedElements, setSelectedElements] = React.useState<IDPServer[]>(
     []
   );
-  const [selectedPerPage, setSelectedPerPage] = React.useState<number>(0);
 
   const clearSelectedElements = () => {
     const emptyList: IDPServer[] = [];
@@ -200,6 +203,12 @@ const IdpReferences = () => {
     }
   };
 
+  const selectedPerPageData = getSelectedPerPageData(
+    idpReferences,
+    selectedElements.map((item) => ipaPrimaryKey(item.cn)),
+    (item) => ipaPrimaryKey(item.cn)
+  );
+
   // Always refetch data when the component is loaded.
   // This ensures the data is always up-to-date.
   React.useEffect(() => {
@@ -216,11 +225,6 @@ const IdpReferences = () => {
     }
   }, [isLoading]);
 
-  // Reset the selected per-page count when the page or page size changes
-  React.useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
-
   // Data wrappers
   // - 'BulkSelectorrep'
   const bulkSelectorData = {
@@ -228,11 +232,6 @@ const IdpReferences = () => {
     updateSelected: updateSelectedIdpRefs,
     selectableTable: selectableIdpRefsTable,
     nameAttr: "cn",
-  };
-
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage: setSelectedPerPage,
   };
 
   // Modals functionality
@@ -402,10 +401,7 @@ const IdpReferences = () => {
                         isDeletion,
                         updateIsDeletion: (value) => setIsDeletion(value),
                       }}
-                      paginationData={{
-                        selectedPerPage,
-                        updateSelectedPerPage: setSelectedPerPage,
-                      }}
+                      paginationData={selectedPerPageData}
                     />
                   )}
                 </InnerScrollContainer>

--- a/src/pages/IdRanges/IdRanges.tsx
+++ b/src/pages/IdRanges/IdRanges.tsx
@@ -182,11 +182,12 @@ const IdRanges = () => {
   const [isSearchDisabled, setIsSearchDisabled] =
     React.useState<boolean>(false);
 
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     setSearchOverride(null);
     searchEntry({
-      searchValue: searchValue,
+      searchValue: search,
       apiVersion,
       sizelimit: 100,
       startIdx: 0,

--- a/src/pages/IdRanges/IdRanges.tsx
+++ b/src/pages/IdRanges/IdRanges.tsx
@@ -183,6 +183,7 @@ const IdRanges = () => {
     React.useState<boolean>(false);
 
   const submitSearchValue = () => {
+    setPage(1);
     setSearchOverride(null);
     searchEntry({
       searchValue: searchValue,
@@ -220,7 +221,7 @@ const IdRanges = () => {
             elementsList.push(listResult[i].result as IdRange);
           }
 
-          setSearchOverride({ list: elementsList, total });
+          setSearchOverride({ list: elementsList.slice(0, perPage), total });
         }
         setIsSearchDisabled(false);
       }
@@ -261,6 +262,7 @@ const IdRanges = () => {
   const searchValueData = {
     searchValue,
     updateSearchValue: (v: string) => {
+      setPage(1);
       setSearchOverride(null);
       setSearchValue(v);
     },

--- a/src/pages/IdRanges/IdRanges.tsx
+++ b/src/pages/IdRanges/IdRanges.tsx
@@ -156,9 +156,6 @@ const IdRanges = () => {
     idRangesDataResponse.refetch();
   };
 
-  // Show table rows
-  const showTableRows = !isFetching && queryDerived.ready;
-
   // Compute shown list and total
   const shownElementsList = queryDerived.list;
   const totalCount = queryDerived.total;
@@ -225,7 +222,7 @@ const IdRanges = () => {
         <SecondaryButton
           dataCy="id-ranges-button-refresh"
           onClickHandler={refreshData}
-          isDisabled={!showTableRows}
+          isDisabled={isFetching || !queryDerived.ready}
         >
           Refresh
         </SecondaryButton>
@@ -235,7 +232,9 @@ const IdRanges = () => {
       key: 4,
       element: (
         <SecondaryButton
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={
+            isDeleteButtonDisabled || isFetching || !queryDerived.ready
+          }
           dataCy="id-ranges-button-delete"
           onClickHandler={() => setShowDeleteModal(true)}
         >
@@ -247,7 +246,7 @@ const IdRanges = () => {
       key: 5,
       element: (
         <SecondaryButton
-          isDisabled={!showTableRows}
+          isDisabled={isFetching || !queryDerived.ready}
           dataCy="id-ranges-button-add"
           onClickHandler={() => setShowAddModal(true)}
         >
@@ -322,7 +321,7 @@ const IdRanges = () => {
                       ]}
                       hasCheckboxes={true}
                       pathname="id-ranges"
-                      showTableRows={showTableRows}
+                      showTableRows={!isFetching && queryDerived.ready}
                       showLink={true}
                       elementsData={{
                         isElementSelectable: isIdRangeSelectable,

--- a/src/pages/IdRanges/IdRanges.tsx
+++ b/src/pages/IdRanges/IdRanges.tsx
@@ -38,6 +38,10 @@ import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import useContextualHelpTopic from "src/hooks/useContextualHelpTopic";
 import BulkSelectorPrep from "src/components/BulkSelectorPrep";
 import { isIdRangeSelectable } from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 import AddIdRangeModal from "src/components/modals/IdRanges/AddIdRangeModal";
 import DeleteModal from "src/components/modals/IdRanges/DeleteModal";
 
@@ -60,7 +64,6 @@ const IdRanges = () => {
   // URL parameters: page number, page size, search value
   const { page, perPage, searchValue } = useListPageSearchParams();
 
-  const [selectedPerPage, setSelectedPerPage] = React.useState<number>(0);
   const [showAddModal, setShowAddModal] = React.useState<boolean>(false);
 
   // Handle API calls errors
@@ -70,12 +73,7 @@ const IdRanges = () => {
   const firstIdx = (page - 1) * perPage;
   const lastIdx = page * perPage;
 
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage: setSelectedPerPage,
-  };
-
-  // Selection state for checkboxes
+  // Handle API calls errors
   const [selectedElements, setSelectedElements] = React.useState<IdRange[]>([]);
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
     React.useState<boolean>(true);
@@ -180,10 +178,11 @@ const IdRanges = () => {
     nameAttr: "cn",
   };
 
-  // Reset the selected per-page count when the page or page size changes
-  React.useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
+  const selectedPerPageData = getSelectedPerPageData(
+    shownElementsList,
+    selectedElements.map((item) => ipaPrimaryKey(item.cn)),
+    (item) => ipaPrimaryKey(item.cn)
+  );
 
   // List of Toolbar items
   const toolbarItems: ToolbarItem[] = [
@@ -338,10 +337,7 @@ const IdRanges = () => {
                         isDeletion,
                         updateIsDeletion: setIsDeletion,
                       }}
-                      paginationData={{
-                        selectedPerPage,
-                        updateSelectedPerPage: setSelectedPerPage,
-                      }}
+                      paginationData={selectedPerPageData}
                     />
                   )}
                 </InnerScrollContainer>

--- a/src/pages/IdRanges/IdRanges.tsx
+++ b/src/pages/IdRanges/IdRanges.tsx
@@ -58,8 +58,7 @@ const IdRanges = () => {
   ) as string;
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
 
   const [selectedPerPage, setSelectedPerPage] = React.useState<number>(0);
   const [showAddModal, setShowAddModal] = React.useState<boolean>(false);
@@ -181,14 +180,10 @@ const IdRanges = () => {
     nameAttr: "cn",
   };
 
-  // Data wrappers
-  const paginationData = {
-    page,
-    perPage,
-    updatePage: setPage,
-    updatePerPage: setPerPage,
-    totalCount,
-  };
+  // Reset the selected per-page count when the page or page size changes
+  React.useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
 
   // List of Toolbar items
   const toolbarItems: ToolbarItem[] = [
@@ -279,7 +274,7 @@ const IdRanges = () => {
       element: (
         <PaginationLayout
           list={shownElementsList}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -357,7 +352,7 @@ const IdRanges = () => {
             >
               <PaginationLayout
                 list={shownElementsList}
-                paginationData={paginationData}
+                totalCount={totalCount}
                 variant={PaginationVariant.bottom}
                 widgetId="pagination-options-menu-bottom"
               />

--- a/src/pages/IdRanges/IdRanges.tsx
+++ b/src/pages/IdRanges/IdRanges.tsx
@@ -12,23 +12,17 @@ import {
   OuterScrollContainer,
 } from "@patternfly/react-table";
 // Hooks
-import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useApiError from "src/hooks/useApiError";
 import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Redux
 import { useAppSelector, useAppDispatch } from "src/store/hooks";
 // RPC
-import {
-  useGetIdRangeEntriesQuery,
-  useSearchIdRangesEntriesMutation,
-} from "src/services/rpcIdRanges";
+import { useGetIdRangeEntriesQuery } from "src/services/rpcIdRanges";
 import { IdRange } from "src/utils/datatypes/globalDataTypes";
 // React router
 import { useNavigate } from "react-router";
 // Components
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 import ToolbarLayout, {
   ToolbarItem,
 } from "src/components/layouts/ToolbarLayout";
@@ -64,7 +58,7 @@ const IdRanges = () => {
   ) as string;
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   const [selectedPerPage, setSelectedPerPage] = React.useState<number>(0);
@@ -145,12 +139,6 @@ const IdRanges = () => {
     return { list: elementsList, total, ready: true };
   }, [isSuccess, batchResponse]);
 
-  // Track search override results (when using the Search input)
-  const [searchOverride, setSearchOverride] = React.useState<{
-    list: IdRange[];
-    total: number;
-  } | null>(null);
-
   // Clear alerts while fetching
   React.useEffect(() => {
     if (isFetching) {
@@ -168,72 +156,15 @@ const IdRanges = () => {
 
   // Refresh button handling
   const refreshData = () => {
-    setSearchOverride(null);
     idRangesDataResponse.refetch();
   };
 
   // Show table rows
-  const showTableRows =
-    !isFetching && (searchOverride !== null || queryDerived.ready);
-
-  // Search API call (batch)
-  const [searchEntry] = useSearchIdRangesEntriesMutation();
-
-  const [isSearchDisabled, setIsSearchDisabled] =
-    React.useState<boolean>(false);
-
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    setSearchOverride(null);
-    searchEntry({
-      searchValue: search,
-      apiVersion,
-      sizelimit: 100,
-      startIdx: 0,
-      stopIdx: 200,
-    }).then((result) => {
-      if ("data" in result && result.data !== undefined) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let errMsg: string | undefined = "";
-          if ("error" in searchError) {
-            errMsg = searchError.error;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: errMsg || "Error when searching for elements",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success
-          const listResult = result.data?.result.results || [];
-          const listSize = result.data?.result.count || 0;
-          const total = result.data?.result.totalCount || 0;
-          const elementsList: IdRange[] = [];
-
-          for (let i = 0; i < listSize; i++) {
-            elementsList.push(listResult[i].result as IdRange);
-          }
-
-          setSearchOverride({ list: elementsList.slice(0, perPage), total });
-        }
-        setIsSearchDisabled(false);
-      }
-    });
-  };
+  const showTableRows = !isFetching && queryDerived.ready;
 
   // Compute shown list and total
-  const shownElementsList = searchOverride
-    ? searchOverride.list
-    : queryDerived.list;
-  const totalCount = searchOverride ? searchOverride.total : queryDerived.total;
+  const shownElementsList = queryDerived.list;
+  const totalCount = queryDerived.total;
 
   // Selection helpers
   const selectableIdRangesTable = shownElementsList.filter(isIdRangeSelectable);
@@ -257,17 +188,6 @@ const IdRanges = () => {
     updatePage: setPage,
     updatePerPage: setPerPage,
     totalCount,
-  };
-
-  // SearchInputLayout
-  const searchValueData = {
-    searchValue,
-    updateSearchValue: (v: string) => {
-      setPage(1);
-      setSearchOverride(null);
-      setSearchValue(v);
-    },
-    submitSearchValue,
   };
 
   // List of Toolbar items
@@ -296,8 +216,6 @@ const IdRanges = () => {
           name="search"
           ariaLabel="Search ID ranges"
           placeholder="Search ID ranges"
-          searchValueData={searchValueData}
-          isDisabled={isSearchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/Netgroups/Netgroups.tsx
+++ b/src/pages/Netgroups/Netgroups.tsx
@@ -152,12 +152,6 @@ const Netgroups = () => {
     }
   }, [groupDataResponse]);
 
-  // Always refetch data when the component is loaded.
-  // This ensures the data is always up-to-date.
-  useEffect(() => {
-    groupDataResponse.refetch();
-  }, [page, perPage]);
-
   // Refresh button handling
   const refreshGroupsData = () => {
     // Reset selected netgroups on refresh

--- a/src/pages/Netgroups/Netgroups.tsx
+++ b/src/pages/Netgroups/Netgroups.tsx
@@ -190,6 +190,7 @@ const Netgroups = () => {
   };
 
   const updateSearchValue = (value: string) => {
+    setPage(1);
     setSearchValue(value);
   };
 
@@ -203,6 +204,7 @@ const Netgroups = () => {
 
   // Issue a search using a specific search value
   const submitSearchValue = () => {
+    setPage(1);
     setShowTableRows(false);
     setGroupsTotalCount(0);
     setSearchIsDisabled(true);
@@ -210,8 +212,8 @@ const Netgroups = () => {
       searchValue: searchValue,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: firstIdx,
-      stopIdx: lastIdx,
+      startIdx: 0,
+      stopIdx: 100,
       entryType: "netgroup",
     } as GenericPayload).then((result) => {
       // Manage new response here
@@ -246,8 +248,7 @@ const Netgroups = () => {
             groupsList.push(groupsListResult[i].result);
           }
 
-          setPage(1);
-          setGroupsList(groupsList);
+          setGroupsList(groupsList.slice(0, perPage));
           setGroupsTotalCount(totalCount);
           // Show table elements
           setShowTableRows(true);

--- a/src/pages/Netgroups/Netgroups.tsx
+++ b/src/pages/Netgroups/Netgroups.tsx
@@ -203,13 +203,14 @@ const Netgroups = () => {
   const [retrieveGroup] = useSearchEntriesMutation({});
 
   // Issue a search using a specific search value
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     setShowTableRows(false);
     setGroupsTotalCount(0);
     setSearchIsDisabled(true);
     retrieveGroup({
-      searchValue: searchValue,
+      searchValue: search,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
       startIdx: 0,

--- a/src/pages/Netgroups/Netgroups.tsx
+++ b/src/pages/Netgroups/Netgroups.tsx
@@ -35,19 +35,16 @@ import { Netgroup } from "src/utils/datatypes/globalDataTypes";
 // Utils
 import { API_VERSION_BACKUP, isNetgroupSelectable } from "src/utils/utils";
 // Hooks
-import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Errors
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 import useApiError from "src/hooks/useApiError";
 import useContextualHelpTopic from "src/hooks/useContextualHelpTopic";
 import GlobalErrors from "src/components/errors/GlobalErrors";
 import ModalErrors from "src/components/errors/ModalErrors";
 // RPC client
-import { GenericPayload, useSearchEntriesMutation } from "../../services/rpc";
+import { GenericPayload } from "../../services/rpc";
 import { useGettingNetgroupsQuery } from "../../services/rpcNetgroups";
 
 const Netgroups = () => {
@@ -68,7 +65,7 @@ const Netgroups = () => {
   const [groupsList, setGroupsList] = useState<Netgroup[]>([]);
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   // Handle API calls errors
@@ -78,7 +75,6 @@ const Netgroups = () => {
   // Table comps
   const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
   const [totalCount, setGroupsTotalCount] = useState<number>(0);
-  const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
   const updateSelectedPerPage = (selected: number) => {
     setSelectedPerPage(selected);
@@ -189,74 +185,10 @@ const Netgroups = () => {
     groupDataResponse.refetch();
   };
 
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
   const [selectedGroups, setSelectedGroupsList] = useState<Netgroup[]>([]);
   const clearSelectedGroups = () => {
     const emptyList: Netgroup[] = [];
     setSelectedGroupsList(emptyList);
-  };
-
-  const [retrieveGroup] = useSearchEntriesMutation({});
-
-  // Issue a search using a specific search value
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    setShowTableRows(false);
-    setGroupsTotalCount(0);
-    setSearchIsDisabled(true);
-    retrieveGroup({
-      searchValue: search,
-      sizeLimit: 0,
-      apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: 0,
-      stopIdx: 100,
-      entryType: "netgroup",
-    } as GenericPayload).then((result) => {
-      // Manage new response here
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for netgroups",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success
-          const groupsListResult = result.data?.result.results || [];
-          const groupsListSize = result.data?.result.count || 0;
-          const totalCount = result.data?.result.totalCount || 0;
-          const groupsList: Netgroup[] = [];
-
-          for (let i = 0; i < groupsListSize; i++) {
-            groupsList.push(groupsListResult[i].result);
-          }
-
-          setGroupsList(groupsList.slice(0, perPage));
-          setGroupsTotalCount(totalCount);
-          // Show table elements
-          setShowTableRows(true);
-        }
-        setSearchIsDisabled(false);
-      }
-    });
   };
 
   // Show table rows
@@ -392,13 +324,6 @@ const Netgroups = () => {
     updateIsDeletion,
   };
 
-  // - 'SearchInputLayout'
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
-  };
-
   // List of toolbar items
   const toolbarItems: ToolbarItem[] = [
     {
@@ -421,8 +346,6 @@ const Netgroups = () => {
           name="search"
           ariaLabel="Search netgroups"
           placeholder="Search netgroups"
-          searchValueData={searchValueData}
-          isDisabled={searchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/Netgroups/Netgroups.tsx
+++ b/src/pages/Netgroups/Netgroups.tsx
@@ -108,14 +108,13 @@ const Netgroups = () => {
 
   const {
     data: batchResponse,
-    isLoading: isBatchLoading,
+    isFetching: isBatchFetching,
     error: batchError,
   } = groupDataResponse;
 
   // Handle data when the API call is finished
   useEffect(() => {
     if (groupDataResponse.isFetching) {
-      setShowTableRows(false);
       // Reset selected user groups on refresh
       setGroupsTotalCount(0);
       globalErrors.clear();
@@ -139,8 +138,6 @@ const Netgroups = () => {
 
       setGroupsList(groupsList);
       setGroupsTotalCount(totalCount);
-      // Show table elements
-      setShowTableRows(true);
     }
 
     // API response: Error
@@ -163,9 +160,6 @@ const Netgroups = () => {
 
   // Refresh button handling
   const refreshGroupsData = () => {
-    // Hide table
-    setShowTableRows(false);
-
     // Reset selected netgroups on refresh
     setGroupsTotalCount(0);
     clearSelectedGroups();
@@ -180,8 +174,6 @@ const Netgroups = () => {
   };
 
   // Show table rows
-  const [showTableRows, setShowTableRows] = useState(!isBatchLoading);
-
   const updateSelectedGroups = (groups: Netgroup[], isSelected: boolean) => {
     let newSelectedGroups: Netgroup[] = [];
     if (isSelected) {
@@ -224,13 +216,6 @@ const Netgroups = () => {
       updateSelectedGroups([group], isSelecting);
     }
   };
-
-  // Show table rows only when data is fully retrieved
-  useEffect(() => {
-    if (showTableRows !== !isBatchLoading) {
-      setShowTableRows(!isBatchLoading);
-    }
-  }, [isBatchLoading]);
 
   // Modals functionality
   const [showAddModal, setShowAddModal] = useState(false);
@@ -338,7 +323,7 @@ const Netgroups = () => {
       element: (
         <SecondaryButton
           onClickHandler={refreshGroupsData}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
           dataCy="netgroups-button-refresh"
         >
           Refresh
@@ -349,7 +334,7 @@ const Netgroups = () => {
       key: 4,
       element: (
         <SecondaryButton
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || isBatchFetching}
           onClickHandler={onDeleteHandler}
           dataCy="netgroups-button-delete"
         >
@@ -362,7 +347,7 @@ const Netgroups = () => {
       element: (
         <SecondaryButton
           onClickHandler={onAddClickHandler}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
           dataCy="netgroups-button-add"
         >
           Add
@@ -422,7 +407,7 @@ const Netgroups = () => {
                     <NetgroupsTable
                       elementsList={groupsList}
                       shownElementsList={groupsList}
-                      showTableRows={showTableRows}
+                      showTableRows={!isBatchFetching}
                       groupsData={groupsTableData}
                       buttonsData={groupsTableButtonsData}
                       paginationData={selectedPerPageData}

--- a/src/pages/Netgroups/Netgroups.tsx
+++ b/src/pages/Netgroups/Netgroups.tsx
@@ -34,6 +34,10 @@ import { useAppDispatch, useAppSelector } from "src/store/hooks";
 import { Netgroup } from "src/utils/datatypes/globalDataTypes";
 // Utils
 import { API_VERSION_BACKUP, isNetgroupSelectable } from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 // Hooks
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
@@ -72,17 +76,7 @@ const Netgroups = () => {
   const modalErrors = useApiError([]);
 
   // Table comps
-  const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
   const [totalCount, setGroupsTotalCount] = useState<number>(0);
-
-  const updateSelectedPerPage = (selected: number) => {
-    setSelectedPerPage(selected);
-  };
-
-  // Reset selected-per-page count whenever the page or page size changes
-  useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
 
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
@@ -276,10 +270,11 @@ const Netgroups = () => {
     updateIsDeleteButtonDisabled,
   };
 
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage,
-  };
+  const selectedPerPageData = getSelectedPerPageData(
+    groupsList,
+    selectedGroups.map((item) => ipaPrimaryKey(item.cn)),
+    (item) => ipaPrimaryKey(item.cn)
+  );
 
   // - 'DeleteGroups'
   const deleteGroupsButtonsData = {

--- a/src/pages/Netgroups/Netgroups.tsx
+++ b/src/pages/Netgroups/Netgroups.tsx
@@ -65,8 +65,7 @@ const Netgroups = () => {
   const [groupsList, setGroupsList] = useState<Netgroup[]>([]);
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, setPage, perPage, searchValue } = useListPageSearchParams();
 
   // Handle API calls errors
   const globalErrors = useApiError([]);
@@ -79,12 +78,11 @@ const Netgroups = () => {
   const updateSelectedPerPage = (selected: number) => {
     setSelectedPerPage(selected);
   };
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
-  };
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
-  };
+
+  // Reset selected-per-page count whenever the page or page size changes
+  useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
 
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
@@ -99,10 +97,6 @@ const Netgroups = () => {
 
   const updateIsDeletion = (value: boolean) => {
     setIsDeletion(value);
-  };
-
-  const updateShownGroupsList = (newShownGroupsList: Netgroup[]) => {
-    setGroupsList(newShownGroupsList);
   };
 
   // Page indexes
@@ -270,17 +264,6 @@ const Netgroups = () => {
   const selectableGroupsTable = groupsList.filter(isNetgroupSelectable); // elements per Table
 
   // Data wrappers
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList: updateShownGroupsList,
-    totalCount,
-  };
-
   // - 'BulkSelectorPrep'
   const groupsBulkSelectorData = {
     selected: selectedGroups,
@@ -409,7 +392,7 @@ const Netgroups = () => {
       element: (
         <PaginationLayout
           list={groupsList}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -459,7 +442,7 @@ const Netgroups = () => {
             >
               <PaginationLayout
                 list={groupsList}
-                paginationData={paginationData}
+                totalCount={totalCount}
                 variant={PaginationVariant.bottom}
                 widgetId="pagination-options-menu-bottom"
               />

--- a/src/pages/Netgroups/NetgroupsMemberTable.tsx
+++ b/src/pages/Netgroups/NetgroupsMemberTable.tsx
@@ -74,16 +74,6 @@ const NetgroupsMemberTable = (props: PropsToTable) => {
   const [totalCount, setMemberTotalCount] = useState<number>(
     props.members.length
   );
-  const updateSelectedPerPage = () => {
-    // Nothing to do since we are not using bulk selector comp
-    return;
-  };
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
-  };
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
-  };
 
   // External host modal
   const [externalHostName, setExternalHost] = useState<string>("");
@@ -372,18 +362,11 @@ const NetgroupsMemberTable = (props: PropsToTable) => {
     }
   }, [selectedMembers]);
 
-  // Entries displayed on the first page
-  const updateShownEntriesList = (newShownEntriesList: string[]) => {
-    setTableMembers(newShownEntriesList);
-  };
-
   const paginationData = {
     page,
     perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList: updateShownEntriesList,
+    onUpdatePage: setPage,
+    onUpdatePerPage: setPerPage,
     totalCount,
   };
 

--- a/src/pages/OtpTokens/EnableDisableOtpTokensModal.tsx
+++ b/src/pages/OtpTokens/EnableDisableOtpTokensModal.tsx
@@ -23,7 +23,6 @@ interface EnableDisableOtpTokensModalProps {
   elementsList: string[];
   setElementsList: (elementsList: OtpToken[]) => void;
   operation: "enable" | "disable";
-  setShowTableRows: (value: boolean) => void;
   onRefresh: () => void;
 }
 

--- a/src/pages/OtpTokens/OtpTokens.tsx
+++ b/src/pages/OtpTokens/OtpTokens.tsx
@@ -238,12 +238,13 @@ const OtpTokens = () => {
   // Search API call
   const [searchEntry] = useSearchOtpTokensEntriesMutation();
 
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     setSearchValue(searchValue);
     setIsSearchDisabled(true);
     searchEntry({
-      searchValue: searchValue,
+      searchValue: search,
       apiVersion,
       sizelimit: 100,
       startIdx: 0,

--- a/src/pages/OtpTokens/OtpTokens.tsx
+++ b/src/pages/OtpTokens/OtpTokens.tsx
@@ -25,6 +25,10 @@ import { useAppDispatch, useAppSelector } from "src/store/hooks";
 import { useGetOtpTokensFullDataQuery } from "src/services/rpcOtpTokens";
 // Utils
 import { isOtpTokenSelectable } from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 import { apiToOtpToken } from "src/utils/otpTokensUtils";
 // Components
 import ToolbarLayout, {
@@ -129,7 +133,6 @@ const OtpTokens = () => {
   const [selectedElements, setSelectedElements] = React.useState<OtpToken[]>(
     []
   );
-  const [selectedPerPage, setSelectedPerPage] = React.useState<number>(0);
 
   // Refresh button handling
   const refreshData = () => {
@@ -226,10 +229,13 @@ const OtpTokens = () => {
     setShowTableRows(!isLoading);
   }, [isLoading]);
 
-  // Reset the selected per-page count when the page or page size changes
-  React.useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
+  const selectedPerPageData = getSelectedPerPageData(
+    otpTokens,
+    selectedElements.map((otpToken) =>
+      ipaPrimaryKey(otpToken.ipatokenuniqueid)
+    ),
+    (otpToken) => ipaPrimaryKey(otpToken.ipatokenuniqueid)
+  );
 
   // Data wrappers
   // - 'BulkSelectorrep'
@@ -238,11 +244,6 @@ const OtpTokens = () => {
     updateSelected: updateSelectedOtpTokens,
     selectableTable: selectableOtpTokensTable,
     nameAttr: "ipatokenuniqueid",
-  };
-
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage: setSelectedPerPage,
   };
 
   // Modals functionality
@@ -441,10 +442,7 @@ const OtpTokens = () => {
                           setIsDisableButtonDisabled(value),
                         isDisableEnableOp: true,
                       }}
-                      paginationData={{
-                        selectedPerPage,
-                        updateSelectedPerPage: setSelectedPerPage,
-                      }}
+                      paginationData={selectedPerPageData}
                       statusElementName="ipatokendisabled"
                       invertStatusValue={true}
                     />

--- a/src/pages/OtpTokens/OtpTokens.tsx
+++ b/src/pages/OtpTokens/OtpTokens.tsx
@@ -273,7 +273,7 @@ const OtpTokens = () => {
           // Success
           const otpTokens = result.data?.result || [];
           setTotalCount(result.data?.totalCount || otpTokens.length);
-          setOtpTokens(otpTokens);
+          setOtpTokens(otpTokens.slice(0, perPage));
           setShowTableRows(true);
         }
         setIsSearchDisabled(false);
@@ -294,10 +294,15 @@ const OtpTokens = () => {
     totalCount,
   };
 
+  const updateSearchValue = (value: string) => {
+    setPage(1);
+    setSearchValue(value);
+  };
+
   // - 'SearchInputLayout'
   const searchValueData = {
     searchValue,
-    updateSearchValue: setSearchValue,
+    updateSearchValue,
     submitSearchValue,
   };
 

--- a/src/pages/OtpTokens/OtpTokens.tsx
+++ b/src/pages/OtpTokens/OtpTokens.tsx
@@ -60,8 +60,7 @@ const OtpTokens = () => {
   ) as string;
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
 
   // Handle API calls errors
   const globalErrors = useApiError([]);
@@ -227,19 +226,12 @@ const OtpTokens = () => {
     setShowTableRows(!isLoading);
   }, [isLoading]);
 
-  // Data wrappers
-  // TODO: Better separation of concerts
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage: setPage,
-    updatePerPage: setPerPage,
-    updateSelectedPerPage: setSelectedPerPage,
-    updateShownElementsList: setOtpTokens,
-    totalCount,
-  };
+  // Reset the selected per-page count when the page or page size changes
+  React.useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
 
+  // Data wrappers
   // - 'BulkSelectorrep'
   const bulkSelectorData = {
     selected: selectedElements,
@@ -379,7 +371,7 @@ const OtpTokens = () => {
       element: (
         <PaginationLayout
           list={otpTokens}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -465,7 +457,7 @@ const OtpTokens = () => {
             >
               <PaginationLayout
                 list={otpTokens}
-                paginationData={paginationData}
+                totalCount={totalCount}
                 variant={PaginationVariant.bottom}
                 widgetId="pagination-options-menu-bottom"
               />

--- a/src/pages/OtpTokens/OtpTokens.tsx
+++ b/src/pages/OtpTokens/OtpTokens.tsx
@@ -86,12 +86,11 @@ const OtpTokens = () => {
     stopIdx: lastUserIdx,
   });
 
-  const { data, isLoading, error } = otpTokensResponse;
+  const { data, isFetching, error } = otpTokensResponse;
 
   // Handle data when the API call is finished
   React.useEffect(() => {
     if (otpTokensResponse.isFetching) {
-      setShowTableRows(false);
       // Reset selected elements on refresh
       setTotalCount(0);
       globalErrors.clear();
@@ -124,8 +123,6 @@ const OtpTokens = () => {
 
       setOtpTokens(elementsList);
       setTotalCount(otpTokensResponse.data.result.totalCount);
-      // Show table elements
-      setShowTableRows(true);
     }
   }, [otpTokensResponse]);
 
@@ -136,15 +133,10 @@ const OtpTokens = () => {
 
   // Refresh button handling
   const refreshData = () => {
-    // Hide table
-    setShowTableRows(false);
-
     // Reset selected elements on refresh
     setTotalCount(0);
 
-    otpTokensResponse.refetch().then(() => {
-      setShowTableRows(true);
-    });
+    otpTokensResponse.refetch();
   };
 
   // Refresh data every time the component is rendered to ensure
@@ -221,14 +213,6 @@ const OtpTokens = () => {
     }
   };
 
-  // Show table rows
-  const [showTableRows, setShowTableRows] = React.useState<boolean>(!isLoading);
-
-  // Show table rows only when data is fully retrieved
-  React.useEffect(() => {
-    setShowTableRows(!isLoading);
-  }, [isLoading]);
-
   const selectedPerPageData = getSelectedPerPageData(
     otpTokens,
     selectedElements.map((otpToken) =>
@@ -304,7 +288,7 @@ const OtpTokens = () => {
         <SecondaryButton
           dataCy="otp-tokens-button-refresh"
           onClickHandler={refreshData}
-          isDisabled={!showTableRows}
+          isDisabled={isFetching}
         >
           Refresh
         </SecondaryButton>
@@ -314,7 +298,7 @@ const OtpTokens = () => {
       key: 4,
       element: (
         <SecondaryButton
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || isFetching}
           dataCy="otp-tokens-button-delete"
           onClickHandler={() => setShowDeleteModal(true)}
         >
@@ -326,7 +310,7 @@ const OtpTokens = () => {
       key: 5,
       element: (
         <SecondaryButton
-          isDisabled={!showTableRows}
+          isDisabled={isFetching}
           dataCy="otp-tokens-button-add"
           onClickHandler={() => setShowAddModal(true)}
         >
@@ -338,7 +322,7 @@ const OtpTokens = () => {
       key: 6,
       element: (
         <SecondaryButton
-          isDisabled={isEnableButtonDisabled || !showTableRows}
+          isDisabled={isEnableButtonDisabled || isFetching}
           dataCy="otp-tokens-button-enable"
           onClickHandler={onEnableOperation}
         >
@@ -350,7 +334,7 @@ const OtpTokens = () => {
       key: 7,
       element: (
         <SecondaryButton
-          isDisabled={isDisableButtonDisabled || !showTableRows}
+          isDisabled={isDisableButtonDisabled || isFetching}
           dataCy="otp-tokens-button-disable"
           onClickHandler={onDisableOperation}
         >
@@ -422,7 +406,7 @@ const OtpTokens = () => {
                       ]}
                       hasCheckboxes={true}
                       pathname="otp-tokens"
-                      showTableRows={showTableRows}
+                      showTableRows={!isFetching}
                       showLink={true}
                       elementsData={{
                         isElementSelectable: isOtpTokenSelectable,
@@ -489,7 +473,6 @@ const OtpTokens = () => {
           )}
           setElementsList={setSelectedElements}
           operation={operation}
-          setShowTableRows={setShowTableRows}
           onRefresh={refreshData}
         />
       </div>

--- a/src/pages/OtpTokens/OtpTokens.tsx
+++ b/src/pages/OtpTokens/OtpTokens.tsx
@@ -14,7 +14,6 @@ import {
 // Data types
 import { OtpToken } from "src/utils/datatypes/globalDataTypes";
 // Hooks
-import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import useApiError from "src/hooks/useApiError";
@@ -23,16 +22,11 @@ import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Redux
 import { useAppDispatch, useAppSelector } from "src/store/hooks";
 // RPC
-import {
-  useGetOtpTokensFullDataQuery,
-  useSearchOtpTokensEntriesMutation,
-} from "src/services/rpcOtpTokens";
+import { useGetOtpTokensFullDataQuery } from "src/services/rpcOtpTokens";
 // Utils
 import { isOtpTokenSelectable } from "src/utils/utils";
 import { apiToOtpToken } from "src/utils/otpTokensUtils";
 // Components
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 import ToolbarLayout, {
   ToolbarItem,
 } from "src/components/layouts/ToolbarLayout";
@@ -66,7 +60,7 @@ const OtpTokens = () => {
   ) as string;
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   // Handle API calls errors
@@ -78,8 +72,6 @@ const OtpTokens = () => {
 
   // States
   const [otpTokens, setOtpTokens] = React.useState<OtpToken[]>([]);
-  const [isSearchDisabled, setIsSearchDisabled] =
-    React.useState<boolean>(false);
   const [totalCount, setTotalCount] = React.useState<number>(0);
 
   // API calls
@@ -235,53 +227,6 @@ const OtpTokens = () => {
     setShowTableRows(!isLoading);
   }, [isLoading]);
 
-  // Search API call
-  const [searchEntry] = useSearchOtpTokensEntriesMutation();
-
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    setSearchValue(searchValue);
-    setIsSearchDisabled(true);
-    searchEntry({
-      searchValue: search,
-      apiVersion,
-      sizelimit: 100,
-      startIdx: 0,
-      stopIdx: 100, // Search will consider a max. of elements
-    }).then((result) => {
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for OTP tokens",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success
-          const otpTokens = result.data?.result || [];
-          setTotalCount(result.data?.totalCount || otpTokens.length);
-          setOtpTokens(otpTokens.slice(0, perPage));
-          setShowTableRows(true);
-        }
-        setIsSearchDisabled(false);
-      }
-    });
-  };
-
   // Data wrappers
   // TODO: Better separation of concerts
   // - 'PaginationLayout'
@@ -293,18 +238,6 @@ const OtpTokens = () => {
     updateSelectedPerPage: setSelectedPerPage,
     updateShownElementsList: setOtpTokens,
     totalCount,
-  };
-
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
-  // - 'SearchInputLayout'
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
   };
 
   // - 'BulkSelectorrep'
@@ -363,8 +296,6 @@ const OtpTokens = () => {
           name="search"
           ariaLabel="Search OTP tokens"
           placeholder="Search"
-          searchValueData={searchValueData}
-          isDisabled={isSearchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/OtpTokens/OtpTokens.tsx
+++ b/src/pages/OtpTokens/OtpTokens.tsx
@@ -139,12 +139,6 @@ const OtpTokens = () => {
     otpTokensResponse.refetch();
   };
 
-  // Refresh data every time the component is rendered to ensure
-  // the data is up to date when the user is deleting from the settings page
-  React.useEffect(() => {
-    refreshData();
-  }, []);
-
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
     React.useState<boolean>(true);

--- a/src/pages/OtpTokens/OtpTokensSettings.tsx
+++ b/src/pages/OtpTokens/OtpTokensSettings.tsx
@@ -550,7 +550,6 @@ const OtpTokensSettings = (props: OtpTokensSettingsProps) => {
           elementsList={[ipaObject["ipatokenuniqueid"]]}
           setElementsList={() => {}}
           operation={operation}
-          setShowTableRows={() => {}}
           onRefresh={props.onRefresh}
         />
         <DeleteOtpTokensModal

--- a/src/pages/PasswordPolicies/PasswordPolicies.tsx
+++ b/src/pages/PasswordPolicies/PasswordPolicies.tsx
@@ -262,10 +262,11 @@ const PasswordPolicies = () => {
   // Search API call
   const [searchEntry] = useSearchPwdPolicyEntriesMutation();
 
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     searchEntry({
-      searchValue: searchValue,
+      searchValue: search,
       apiVersion,
       sizelimit: 100,
       startIdx: 0,

--- a/src/pages/PasswordPolicies/PasswordPolicies.tsx
+++ b/src/pages/PasswordPolicies/PasswordPolicies.tsx
@@ -211,12 +211,6 @@ const PasswordPolicies = () => {
     (item) => ipaPrimaryKey(item.cn)
   );
 
-  // Always refetch data when the component is loaded.
-  // This ensures the data is always up-to-date.
-  React.useEffect(() => {
-    pwPoliciesResponse.refetch();
-  }, []);
-
   // Show table rows
   // Data wrappers
   // TODO: Better separation of concerts

--- a/src/pages/PasswordPolicies/PasswordPolicies.tsx
+++ b/src/pages/PasswordPolicies/PasswordPolicies.tsx
@@ -255,6 +255,7 @@ const PasswordPolicies = () => {
 
   // Update search input valie
   const updateSearchValue = (value: string) => {
+    setPage(1);
     setSearchValue(value);
   };
 
@@ -262,6 +263,7 @@ const PasswordPolicies = () => {
   const [searchEntry] = useSearchPwdPolicyEntriesMutation();
 
   const submitSearchValue = () => {
+    setPage(1);
     searchEntry({
       searchValue: searchValue,
       apiVersion,
@@ -301,7 +303,7 @@ const PasswordPolicies = () => {
           }
 
           setTotalCount(totalCount);
-          setPwPolicies(elementsList);
+          setPwPolicies(elementsList.slice(0, perPage));
           setShowTableRows(true);
         }
         setSearchIsDisabled(false);

--- a/src/pages/PasswordPolicies/PasswordPolicies.tsx
+++ b/src/pages/PasswordPolicies/PasswordPolicies.tsx
@@ -36,6 +36,10 @@ import GlobalErrors from "src/components/errors/GlobalErrors";
 import MainTable from "src/components/tables/MainTable";
 import BulkSelectorPrep from "src/components/BulkSelectorPrep";
 import { isPwPolicySelectable } from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 // Modals
 import AddModal from "src/components/modals/PwPoliciesModals/AddModal";
 import DeleteModal from "src/components/modals/PwPoliciesModals/DeleteModal";
@@ -127,16 +131,6 @@ const PasswordPolicies = () => {
   const [selectedElements, setSelectedElements] = React.useState<PwPolicy[]>(
     []
   );
-  const [selectedPerPage, setSelectedPerPage] = React.useState<number>(0);
-
-  const updateSelectedPerPage = (selected: number) => {
-    setSelectedPerPage(selected);
-  };
-
-  // Reset selected-per-page count whenever the page or page size changes
-  React.useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
 
   const clearSelectedElements = () => {
     const emptyList: PwPolicy[] = [];
@@ -219,6 +213,12 @@ const PasswordPolicies = () => {
     }
   };
 
+  const selectedPerPageData = getSelectedPerPageData(
+    pwPolicies,
+    selectedElements.map((item) => ipaPrimaryKey(item.cn)),
+    (item) => ipaPrimaryKey(item.cn)
+  );
+
   // Always refetch data when the component is loaded.
   // This ensures the data is always up-to-date.
   React.useEffect(() => {
@@ -247,11 +247,6 @@ const PasswordPolicies = () => {
     updateSelected: updateSelectedPwPolicies,
     selectableTable: selectablePwPoliciesTable,
     nameAttr: "cn",
-  };
-
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage,
   };
 
   // Modals functionality
@@ -414,10 +409,7 @@ const PasswordPolicies = () => {
                         isDeletion,
                         updateIsDeletion,
                       }}
-                      paginationData={{
-                        selectedPerPage,
-                        updateSelectedPerPage,
-                      }}
+                      paginationData={selectedPerPageData}
                     />
                   )}
                 </InnerScrollContainer>

--- a/src/pages/PasswordPolicies/PasswordPolicies.tsx
+++ b/src/pages/PasswordPolicies/PasswordPolicies.tsx
@@ -14,7 +14,6 @@ import {
 // Data types
 import { PwPolicy } from "src/utils/datatypes/globalDataTypes";
 // Hooks
-import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import useApiError from "src/hooks/useApiError";
@@ -23,12 +22,7 @@ import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Redux
 import { useAppDispatch, useAppSelector } from "src/store/hooks";
 // Components
-import {
-  useGetPwPoliciesEntriesQuery,
-  useSearchPwdPolicyEntriesMutation,
-} from "src/services/rpcPwdPolicies";
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
+import { useGetPwPoliciesEntriesQuery } from "src/services/rpcPwdPolicies";
 import ToolbarLayout, {
   ToolbarItem,
 } from "src/components/layouts/ToolbarLayout";
@@ -61,7 +55,7 @@ const PasswordPolicies = () => {
   ) as string;
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   // Handle API calls errors
@@ -73,8 +67,6 @@ const PasswordPolicies = () => {
 
   // States
   const [pwPolicies, setPwPolicies] = React.useState<PwPolicy[]>([]);
-  const [searchIsDisabled, setSearchIsDisabled] =
-    React.useState<boolean>(false);
   const [totalCount, setTotalCount] = React.useState<number>(0);
 
   // API calls
@@ -253,65 +245,6 @@ const PasswordPolicies = () => {
     setPwPolicies(newShownElementsList);
   };
 
-  // Update search input valie
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
-  // Search API call
-  const [searchEntry] = useSearchPwdPolicyEntriesMutation();
-
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    searchEntry({
-      searchValue: search,
-      apiVersion,
-      sizelimit: 100,
-      startIdx: 0,
-      stopIdx: 200, // Search will consider a max. of elements
-    }).then((result) => {
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for subordinate IDs",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success
-          const listResult = result.data?.result.results || [];
-          const listSize = result.data?.result.count || 0;
-          const totalCount = result.data?.result.totalCount || 0;
-          const elementsList: PwPolicy[] = [];
-
-          for (let i = 0; i < listSize; i++) {
-            elementsList.push(listResult[i].result);
-          }
-
-          setTotalCount(totalCount);
-          setPwPolicies(elementsList.slice(0, perPage));
-          setShowTableRows(true);
-        }
-        setSearchIsDisabled(false);
-      }
-    });
-  };
-
   // Data wrappers
   // TODO: Better separation of concerts
   // - 'PaginationLayout'
@@ -327,13 +260,6 @@ const PasswordPolicies = () => {
 
   const buttonsData = {
     updateIsDeleteButtonDisabled,
-  };
-
-  // SearchInputLayout
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
   };
 
   // - 'BulkSelectorrep'
@@ -391,8 +317,6 @@ const PasswordPolicies = () => {
           name="search"
           ariaLabel="Search password policies"
           placeholder="Search password policies"
-          searchValueData={searchValueData}
-          isDisabled={searchIsDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/PasswordPolicies/PasswordPolicies.tsx
+++ b/src/pages/PasswordPolicies/PasswordPolicies.tsx
@@ -81,12 +81,11 @@ const PasswordPolicies = () => {
     stopIdx: lastUserIdx,
   });
 
-  const { data, isLoading, error } = pwPoliciesResponse;
+  const { data, isFetching, error } = pwPoliciesResponse;
 
   // Handle data when the API call is finished
   React.useEffect(() => {
     if (pwPoliciesResponse.isFetching) {
-      setShowTableRows(false);
       // Reset selected elements on refresh
       setTotalCount(0);
       globalErrors.clear();
@@ -111,8 +110,6 @@ const PasswordPolicies = () => {
       setTotalCount(totalCount);
       // Update the list of elements
       setPwPolicies(elementsList);
-      // Show table elements
-      setShowTableRows(true);
     }
 
     // API response: Error
@@ -139,15 +136,10 @@ const PasswordPolicies = () => {
 
   // Refresh button handling
   const refreshData = () => {
-    // Hide table
-    setShowTableRows(false);
-
     // Reset selected elements on refresh
     setTotalCount(0);
 
-    pwPoliciesResponse.refetch().then(() => {
-      setShowTableRows(true);
-    });
+    pwPoliciesResponse.refetch();
   };
 
   // 'Delete' button state
@@ -226,15 +218,6 @@ const PasswordPolicies = () => {
   }, []);
 
   // Show table rows
-  const [showTableRows, setShowTableRows] = React.useState(!isLoading);
-
-  // Show table rows only when data is fully retrieved
-  React.useEffect(() => {
-    if (showTableRows !== !isLoading) {
-      setShowTableRows(!isLoading);
-    }
-  }, [isLoading]);
-
   // Data wrappers
   // TODO: Better separation of concerts
   const buttonsData = {
@@ -306,7 +289,7 @@ const PasswordPolicies = () => {
         <SecondaryButton
           dataCy="password-policies-button-refresh"
           onClickHandler={refreshData}
-          isDisabled={!showTableRows}
+          isDisabled={isFetching}
         >
           Refresh
         </SecondaryButton>
@@ -317,7 +300,7 @@ const PasswordPolicies = () => {
       element: (
         <SecondaryButton
           dataCy="password-policies-button-delete"
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || isFetching}
           onClickHandler={onOpenDeleteModal}
         >
           Delete
@@ -329,7 +312,7 @@ const PasswordPolicies = () => {
       element: (
         <SecondaryButton
           dataCy="password-policies-button-add"
-          isDisabled={!showTableRows}
+          isDisabled={isFetching}
           onClickHandler={onOpenAddModal}
         >
           Add
@@ -395,7 +378,7 @@ const PasswordPolicies = () => {
                       columnNames={["Group", "Priority"]}
                       hasCheckboxes={true}
                       pathname="password-policies"
-                      showTableRows={showTableRows}
+                      showTableRows={!isFetching}
                       showLink={true}
                       elementsData={{
                         isElementSelectable: isPwPolicySelectable,

--- a/src/pages/PasswordPolicies/PasswordPolicies.tsx
+++ b/src/pages/PasswordPolicies/PasswordPolicies.tsx
@@ -55,8 +55,7 @@ const PasswordPolicies = () => {
   ) as string;
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
 
   // Handle API calls errors
   const globalErrors = useApiError([]);
@@ -133,6 +132,11 @@ const PasswordPolicies = () => {
   const updateSelectedPerPage = (selected: number) => {
     setSelectedPerPage(selected);
   };
+
+  // Reset selected-per-page count whenever the page or page size changes
+  React.useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
 
   const clearSelectedElements = () => {
     const emptyList: PwPolicy[] = [];
@@ -231,33 +235,8 @@ const PasswordPolicies = () => {
     }
   }, [isLoading]);
 
-  // Pagination
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
-  };
-
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
-  };
-
-  // Elements displayed on the first page
-  const updateShownElementsList = (newShownElementsList: PwPolicy[]) => {
-    setPwPolicies(newShownElementsList);
-  };
-
   // Data wrappers
   // TODO: Better separation of concerts
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList: updateShownElementsList,
-    totalCount,
-  };
-
   const buttonsData = {
     updateIsDeleteButtonDisabled,
   };
@@ -380,7 +359,7 @@ const PasswordPolicies = () => {
       element: (
         <PaginationLayout
           list={pwPolicies}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -449,7 +428,7 @@ const PasswordPolicies = () => {
             >
               <PaginationLayout
                 list={pwPolicies}
-                paginationData={paginationData}
+                totalCount={totalCount}
                 variant={PaginationVariant.bottom}
                 widgetId="pagination-options-menu-bottom"
               />

--- a/src/pages/PreservedUsers/PreservedUsers.tsx
+++ b/src/pages/PreservedUsers/PreservedUsers.tsx
@@ -39,6 +39,10 @@ import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Utils
 import { API_VERSION_BACKUP, isUserSelectable } from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 import { GenericPayload } from "../../services/rpc";
 import { useGettingPreservedUserQuery } from "../../services/rpcUsers";
 import useApiError from "src/hooks/useApiError";
@@ -167,19 +171,6 @@ const PreservedUsers = () => {
     setIsDeletion(value);
   };
 
-  // Elements selected (per page)
-  //  - This will help to calculate the remaining elements on a specific page (bulk selector)
-  const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
-
-  const updateSelectedPerPage = (selected: number) => {
-    setSelectedPerPage(selected);
-  };
-
-  // Reset selected-per-page count whenever the page or page size changes
-  useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
-
   // Show table rows
   const [showTableRows, setShowTableRows] = useState(!isBatchLoading);
 
@@ -280,10 +271,11 @@ const PreservedUsers = () => {
     updateIsDeleteButtonDisabled,
   };
 
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage,
-  };
+  const selectedPerPageData = getSelectedPerPageData(
+    preservedUsersList,
+    selectedUsers.map((item) => ipaPrimaryKey(item.uid)),
+    (item) => ipaPrimaryKey(item.uid)
+  );
 
   // 'DeleteUsers'
   const deleteUsersButtonsData = {

--- a/src/pages/PreservedUsers/PreservedUsers.tsx
+++ b/src/pages/PreservedUsers/PreservedUsers.tsx
@@ -144,12 +144,6 @@ const PreservedUsers = () => {
     userDataResponse.refetch();
   };
 
-  // Always refetch data when the component is loaded.
-  // This ensures the data is always up-to-date.
-  React.useEffect(() => {
-    userDataResponse.refetch();
-  }, []);
-
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
     useState<boolean>(true);

--- a/src/pages/PreservedUsers/PreservedUsers.tsx
+++ b/src/pages/PreservedUsers/PreservedUsers.tsx
@@ -90,14 +90,13 @@ const PreservedUsers = () => {
 
   const {
     data: batchResponse,
-    isLoading: isBatchLoading,
+    isFetching: isBatchFetching,
     error: batchError,
   } = userDataResponse;
 
   // Handle data when the API call is finished
   useEffect(() => {
     if (userDataResponse.isFetching) {
-      setShowTableRows(false);
       // Reset selected users on refresh
       setUsersTotalCount(0);
       globalErrors.clear();
@@ -122,8 +121,6 @@ const PreservedUsers = () => {
       setUsersTotalCount(totalCount);
       // Update the list of users
       setPreservedUsersList(usersList);
-      // Show table elements
-      setShowTableRows(true);
     }
 
     // API response: Error
@@ -140,9 +137,6 @@ const PreservedUsers = () => {
 
   // Refresh button handling
   const refreshUsersData = () => {
-    // Hide table
-    setShowTableRows(false);
-
     // Reset selected users on refresh
     setUsersTotalCount(0);
     clearSelectedUsers();
@@ -172,15 +166,6 @@ const PreservedUsers = () => {
   };
 
   // Show table rows
-  const [showTableRows, setShowTableRows] = useState(!isBatchLoading);
-
-  // Show table rows only when data is fully retrieved
-  useEffect(() => {
-    if (showTableRows !== !isBatchLoading) {
-      setShowTableRows(!isBatchLoading);
-    }
-  }, [isBatchLoading]);
-
   // Table-related shared functionality
   // - Selectable checkboxes on table
   const selectableUsersTable = preservedUsersList.filter(isUserSelectable); // elements per Table
@@ -339,7 +324,7 @@ const PreservedUsers = () => {
       element: (
         <SecondaryButton
           onClickHandler={refreshUsersData}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
           dataCy="preserved-users-button-refresh"
         >
           Refresh
@@ -350,7 +335,7 @@ const PreservedUsers = () => {
       key: 4,
       element: (
         <SecondaryButton
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || isBatchFetching}
           onClickHandler={onDeleteHandler}
           dataCy="preserved-users-button-delete"
         >
@@ -362,7 +347,7 @@ const PreservedUsers = () => {
       key: 5,
       element: (
         <SecondaryButton
-          isDisabled={!showTableRows || selectedUsers.length === 0}
+          isDisabled={isBatchFetching || selectedUsers.length === 0}
           onClickHandler={onRestoreHandler}
           dataCy="preserved-users-button-restore"
         >
@@ -374,7 +359,7 @@ const PreservedUsers = () => {
       key: 6,
       element: (
         <SecondaryButton
-          isDisabled={!showTableRows || selectedUsers.length === 0}
+          isDisabled={isBatchFetching || selectedUsers.length === 0}
           onClickHandler={onStageHandler}
           dataCy="preserved-users-button-stage"
         >
@@ -436,7 +421,7 @@ const PreservedUsers = () => {
                     <UsersTable
                       shownElementsList={preservedUsersList}
                       from="preserved-users"
-                      showTableRows={showTableRows}
+                      showTableRows={!isBatchFetching}
                       usersData={usersTableData}
                       buttonsData={usersTableButtonsData}
                       paginationData={selectedPerPageData}

--- a/src/pages/PreservedUsers/PreservedUsers.tsx
+++ b/src/pages/PreservedUsers/PreservedUsers.tsx
@@ -197,6 +197,7 @@ const PreservedUsers = () => {
 
   // Filter (Input search)
   const updateSearchValue = (value: string) => {
+    setPage(1);
     setSearchValue(value);
   };
 
@@ -205,6 +206,7 @@ const PreservedUsers = () => {
 
   // Issue a search using a specific search value
   const submitSearchValue = () => {
+    setPage(1);
     setShowTableRows(false);
     setUsersTotalCount(0);
     setSearchIsDisabled(true);
@@ -213,8 +215,8 @@ const PreservedUsers = () => {
       searchValue: searchValue,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: firstUserIdx,
-      stopIdx: lastUserIdx,
+      startIdx: 0,
+      stopIdx: 100,
       entryType: "preserved",
     } as GenericPayload).then((result) => {
       // Manage new response here
@@ -249,7 +251,7 @@ const PreservedUsers = () => {
             usersList.push(usersListResult[i].result);
           }
 
-          setPreservedUsersList(usersList);
+          setPreservedUsersList(usersList.slice(0, perPage));
           setUsersTotalCount(totalCount);
           // Show table elements
           setShowTableRows(true);

--- a/src/pages/PreservedUsers/PreservedUsers.tsx
+++ b/src/pages/PreservedUsers/PreservedUsers.tsx
@@ -205,14 +205,15 @@ const PreservedUsers = () => {
   const [retrieveUser] = useSearchEntriesMutation({});
 
   // Issue a search using a specific search value
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     setShowTableRows(false);
     setUsersTotalCount(0);
     setSearchIsDisabled(true);
 
     retrieveUser({
-      searchValue: searchValue,
+      searchValue: search,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
       startIdx: 0,

--- a/src/pages/PreservedUsers/PreservedUsers.tsx
+++ b/src/pages/PreservedUsers/PreservedUsers.tsx
@@ -34,16 +34,12 @@ import DeleteUsers from "src/components/modals/UserModals/DeleteUsers";
 import StagePreservedUsers from "src/components/modals/UserModals/StagePreservedUsers";
 import RestorePreservedUsers from "src/components/modals/UserModals/RestorePreservedUsers";
 // Hooks
-import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
-// Errors
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 // Utils
 import { API_VERSION_BACKUP, isUserSelectable } from "src/utils/utils";
-import { GenericPayload, useSearchEntriesMutation } from "../../services/rpc";
+import { GenericPayload } from "../../services/rpc";
 import { useGettingPreservedUserQuery } from "../../services/rpcUsers";
 import useApiError from "src/hooks/useApiError";
 import useContextualHelpTopic from "src/hooks/useContextualHelpTopic";
@@ -55,7 +51,7 @@ const PreservedUsers = () => {
   useContextualHelpTopic("preserved-users");
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   // Update current route data to Redux and highlight the current page in the Nav bar
@@ -75,7 +71,6 @@ const PreservedUsers = () => {
 
   // Main states - what user can define / what we could use in page URL
   const [totalCount, setUsersTotalCount] = useState<number>(0);
-  const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
   // Page indexes
   const firstUserIdx = (page - 1) * perPage;
@@ -193,73 +188,6 @@ const PreservedUsers = () => {
   // Users displayed on the first page
   const updateShownUsersList = (newShownUsersList: User[]) => {
     setPreservedUsersList(newShownUsersList);
-  };
-
-  // Filter (Input search)
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
-  // Issue search with filter
-  const [retrieveUser] = useSearchEntriesMutation({});
-
-  // Issue a search using a specific search value
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    setShowTableRows(false);
-    setUsersTotalCount(0);
-    setSearchIsDisabled(true);
-
-    retrieveUser({
-      searchValue: search,
-      sizeLimit: 0,
-      apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: 0,
-      stopIdx: 100,
-      entryType: "preserved",
-    } as GenericPayload).then((result) => {
-      // Manage new response here
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for preserved users",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success
-          const usersListResult = result.data?.result.results || [];
-          const usersListSize = result.data?.result.count || 0;
-          const totalCount = result.data?.result.totalCount || 0;
-          const usersList: User[] = [];
-
-          for (let i = 0; i < usersListSize; i++) {
-            usersList.push(usersListResult[i].result);
-          }
-
-          setPreservedUsersList(usersList.slice(0, perPage));
-          setUsersTotalCount(totalCount);
-          // Show table elements
-          setShowTableRows(true);
-        }
-        setSearchIsDisabled(false);
-      }
-    });
   };
 
   // Show table rows
@@ -404,13 +332,6 @@ const PreservedUsers = () => {
     updateIsDeletion,
   };
 
-  // SearchInputLayout
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
-  };
-
   // List of Toolbar items
   const toolbarItems: ToolbarItem[] = [
     {
@@ -433,8 +354,6 @@ const PreservedUsers = () => {
           name="search"
           ariaLabel="Search preserved users"
           placeholder="Search preserved users"
-          searchValueData={searchValueData}
-          isDisabled={searchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/PreservedUsers/PreservedUsers.tsx
+++ b/src/pages/PreservedUsers/PreservedUsers.tsx
@@ -51,8 +51,7 @@ const PreservedUsers = () => {
   useContextualHelpTopic("preserved-users");
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
 
   // Update current route data to Redux and highlight the current page in the Nav bar
   useUpdateRoute({ pathname: "preserved-users" });
@@ -176,19 +175,10 @@ const PreservedUsers = () => {
     setSelectedPerPage(selected);
   };
 
-  // Pagination
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
-  };
-
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
-  };
-
-  // Users displayed on the first page
-  const updateShownUsersList = (newShownUsersList: User[]) => {
-    setPreservedUsersList(newShownUsersList);
-  };
+  // Reset selected-per-page count whenever the page or page size changes
+  useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
 
   // Show table rows
   const [showTableRows, setShowTableRows] = useState(!isBatchLoading);
@@ -277,17 +267,6 @@ const PreservedUsers = () => {
   };
 
   // Data wrappers
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList: updateShownUsersList,
-    totalCount,
-  };
-
   // - 'BulkSelectorPrep'
   const usersBulkSelectorData = {
     selected: selectedUsers,
@@ -429,7 +408,7 @@ const PreservedUsers = () => {
       element: (
         <PaginationLayout
           list={preservedUsersList}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -480,7 +459,7 @@ const PreservedUsers = () => {
             >
               <PaginationLayout
                 list={preservedUsersList}
-                paginationData={paginationData}
+                totalCount={totalCount}
                 variant={PaginationVariant.bottom}
                 widgetId="pagination-options-menu-bottom"
               />

--- a/src/pages/Privileges/Privileges.tsx
+++ b/src/pages/Privileges/Privileges.tsx
@@ -98,11 +98,13 @@ const Privileges = () => {
 
   // Derive privilegesList and totalCount from query response or search results
   const { elementsList, totalCount } = useMemo(() => {
-    // If search is active and has results, use search data
+    // If search is active and has results, paginate client-side
     if (isSearchActive && searchData) {
+      const start = (page - 1) * perPage;
+      const end = start + perPage;
       return {
-        elementsList: searchData.elementsList,
-        totalCount: searchData.totalCount,
+        elementsList: searchData.elementsList.slice(start, end),
+        totalCount: searchData.elementsList.length,
       };
     }
 
@@ -123,7 +125,7 @@ const Privileges = () => {
     }
 
     return { elementsList: [], totalCount: 0 };
-  }, [batchResponse, isSearchActive, searchData]);
+  }, [batchResponse, isSearchActive, searchData, page, perPage]);
 
   // Derive showTableRows from loading states
   const showTableRows = useMemo(() => {
@@ -188,7 +190,7 @@ const Privileges = () => {
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
       startIdx: 0,
-      stopIdx: perPage,
+      stopIdx: 100,
     }).then((result) => {
       if ("data" in result) {
         const searchError = result.data?.error as
@@ -307,9 +309,14 @@ const Privileges = () => {
     updateSelectedPerPage: setSelectedPerPage,
   };
 
+  const updateSearchValue = (value: string) => {
+    setPage(1);
+    setSearchValue(value);
+  };
+
   const searchValueData = {
     searchValue,
-    updateSearchValue: setSearchValue,
+    updateSearchValue,
     submitSearchValue,
   };
 

--- a/src/pages/Privileges/Privileges.tsx
+++ b/src/pages/Privileges/Privileges.tsx
@@ -102,9 +102,6 @@ const Privileges = () => {
     return { elementsList: [], totalCount: 0 };
   }, [batchResponse]);
 
-  // Derive showTableRows from loading states
-  const showTableRows = !isFetching && !isBatchLoading;
-
   // Clear errors when fetching starts
   React.useEffect(() => {
     if (isFetching) {
@@ -241,7 +238,7 @@ const Privileges = () => {
       element: (
         <SecondaryButton
           onClickHandler={refreshData}
-          isDisabled={!showTableRows}
+          isDisabled={isFetching}
           dataCy="privileges-button-refresh"
         >
           Refresh
@@ -252,7 +249,7 @@ const Privileges = () => {
       key: 4,
       element: (
         <SecondaryButton
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || isFetching}
           onClickHandler={() => setShowDeleteModal(true)}
           dataCy="privileges-button-delete"
         >
@@ -265,7 +262,7 @@ const Privileges = () => {
       element: (
         <SecondaryButton
           onClickHandler={() => setShowAddModal(true)}
-          isDisabled={!showTableRows}
+          isDisabled={isFetching}
           dataCy="privileges-button-add"
         >
           Add
@@ -329,7 +326,7 @@ const Privileges = () => {
                     columnNames={columnNames}
                     hasCheckboxes={true}
                     pathname="privileges"
-                    showTableRows={showTableRows}
+                    showTableRows={!isFetching}
                     showLink={true}
                     elementsData={{
                       isElementSelectable: isPrivilegeSelectable,

--- a/src/pages/Privileges/Privileges.tsx
+++ b/src/pages/Privileges/Privileges.tsx
@@ -180,13 +180,14 @@ const Privileges = () => {
 
   const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     setSearchIsDisabled(true);
     setIsSearchActive(true);
 
     searchPrivileges({
-      searchValue: searchValue,
+      searchValue: search,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
       startIdx: 0,

--- a/src/pages/Privileges/Privileges.tsx
+++ b/src/pages/Privileges/Privileges.tsx
@@ -13,10 +13,7 @@ import {
   OuterScrollContainer,
 } from "@patternfly/react-table";
 // Data types
-import {
-  Privilege,
-  SearchDataResultType,
-} from "src/utils/datatypes/globalDataTypes";
+import { Privilege } from "src/utils/datatypes/globalDataTypes";
 import { ToolbarItem } from "src/components/layouts/ToolbarLayout";
 // Redux
 import { useAppDispatch, useAppSelector } from "src/store/hooks";
@@ -35,7 +32,6 @@ import BulkSelectorPrep from "src/components/BulkSelectorPrep";
 import AddPrivilegeModal from "src/components/modals/PrivilegeModals/AddPrivilegeModal";
 import DeletePrivilegesModal from "src/components/modals/PrivilegeModals/DeletePrivilegesModal";
 // Hooks
-import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import useContextualHelpTopic from "src/hooks/useContextualHelpTopic";
@@ -43,13 +39,8 @@ import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Utils
 import { API_VERSION_BACKUP, isPrivilegeSelectable } from "src/utils/utils";
 // RPC client
-import {
-  useGetPrivilegesFullDataQuery,
-  useSearchPrivilegesEntriesMutation,
-} from "src/services/rpcPrivileges";
+import { useGetPrivilegesFullDataQuery } from "src/services/rpcPrivileges";
 // Errors
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 import useApiError from "src/hooks/useApiError";
 import GlobalErrors from "src/components/errors/GlobalErrors";
 import ModalErrors from "src/components/errors/ModalErrors";
@@ -64,8 +55,7 @@ const Privileges = () => {
     (state) => state.global.environment.api_version
   ) as string;
 
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
-    useListPageSearchParams();
+  const { page, setPage, perPage, setPerPage } = useListPageSearchParams();
 
   const globalErrors = useApiError([]);
   const modalErrors = useApiError([]);
@@ -88,27 +78,8 @@ const Privileges = () => {
     error: batchError,
   } = privilegesDataResponse;
 
-  // Search state - overrides query data when active
-  const [searchPrivileges, searchResult] = useSearchPrivilegesEntriesMutation(
-    {}
-  );
-  const [isSearchActive, setIsSearchActive] = useState(false);
-  const [searchData, setSearchData] =
-    useState<SearchDataResultType<Privilege> | null>(null);
-
-  // Derive privilegesList and totalCount from query response or search results
+  // Derive privilegesList and totalCount from query response
   const { elementsList, totalCount } = useMemo(() => {
-    // If search is active and has results, paginate client-side
-    if (isSearchActive && searchData) {
-      const start = (page - 1) * perPage;
-      const end = start + perPage;
-      return {
-        elementsList: searchData.elementsList.slice(start, end),
-        totalCount: searchData.elementsList.length,
-      };
-    }
-
-    // Otherwise derive from query response
     if (batchResponse?.result) {
       const privilegesListResult = batchResponse.result.results;
       const privilegesListSize = batchResponse.result.count;
@@ -125,15 +96,10 @@ const Privileges = () => {
     }
 
     return { elementsList: [], totalCount: 0 };
-  }, [batchResponse, isSearchActive, searchData, page, perPage]);
+  }, [batchResponse]);
 
   // Derive showTableRows from loading states
-  const showTableRows = useMemo(() => {
-    if (isSearchActive) {
-      return !searchResult.isLoading;
-    }
-    return !isFetching && !isBatchLoading;
-  }, [isFetching, isBatchLoading, isSearchActive, searchResult.isLoading]);
+  const showTableRows = !isFetching && !isBatchLoading;
 
   // Clear errors when fetching starts
   React.useEffect(() => {
@@ -159,8 +125,6 @@ const Privileges = () => {
   }, [privilegesDataResponse.isError, isBatchLoading, isFetching]);
 
   const refreshData = () => {
-    setIsSearchActive(false);
-    setSearchData(null);
     clearSelectedPrivileges();
     privilegesDataResponse.refetch();
   };
@@ -176,62 +140,6 @@ const Privileges = () => {
 
   const clearSelectedPrivileges = () => {
     setSelectedPrivileges([]);
-  };
-
-  const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
-
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    setSearchIsDisabled(true);
-    setIsSearchActive(true);
-
-    searchPrivileges({
-      searchValue: search,
-      sizeLimit: 0,
-      apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: 0,
-      stopIdx: 100,
-    }).then((result) => {
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for privileges",
-              variant: "danger",
-            })
-          );
-          setIsSearchActive(false);
-          setSearchData(null);
-        } else {
-          const privilegesListResult = result.data?.result.results || [];
-          const privilegesListSize = result.data?.result.count || 0;
-          const searchTotalCount = result.data?.result.totalCount || 0;
-          const privileges: Privilege[] = [];
-
-          for (let i = 0; i < privilegesListSize; i++) {
-            privileges.push(privilegesListResult[i].result);
-          }
-
-          setSearchData({
-            elementsList: privileges,
-            totalCount: searchTotalCount,
-          });
-        }
-        setSearchIsDisabled(false);
-      }
-    });
   };
 
   const [showAddModal, setShowAddModal] = useState(false);
@@ -282,15 +190,6 @@ const Privileges = () => {
     updatePage: setPage,
     updatePerPage: setPerPage,
     updateSelectedPerPage: setSelectedPerPage,
-    updateShownElementsList: (privileges: Privilege[]) => {
-      if (isSearchActive) {
-        setSearchData((prev) =>
-          prev
-            ? { ...prev, elementsList: privileges }
-            : { elementsList: privileges, totalCount: 0 }
-        );
-      }
-    },
     totalCount,
   };
 
@@ -308,17 +207,6 @@ const Privileges = () => {
   const selectedPerPageData = {
     selectedPerPage,
     updateSelectedPerPage: setSelectedPerPage,
-  };
-
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
   };
 
   const columnNames = ["Privilege name", "Description"];
@@ -345,8 +233,6 @@ const Privileges = () => {
           name="search"
           ariaLabel="Search privileges"
           placeholder="Search"
-          searchValueData={searchValueData}
-          isDisabled={searchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/Privileges/Privileges.tsx
+++ b/src/pages/Privileges/Privileges.tsx
@@ -55,7 +55,7 @@ const Privileges = () => {
     (state) => state.global.environment.api_version
   ) as string;
 
-  const { page, perPage } = useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
 
   const globalErrors = useApiError([]);
   const modalErrors = useApiError([]);
@@ -64,7 +64,7 @@ const Privileges = () => {
   const lastIdx = page * perPage;
 
   const privilegesDataResponse = useGetPrivilegesFullDataQuery({
-    searchValue: "",
+    searchValue: searchValue,
     sizeLimit: 0,
     apiVersion: apiVersion || API_VERSION_BACKUP,
     startIdx: firstIdx,

--- a/src/pages/Privileges/Privileges.tsx
+++ b/src/pages/Privileges/Privileges.tsx
@@ -38,6 +38,10 @@ import useContextualHelpTopic from "src/hooks/useContextualHelpTopic";
 import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Utils
 import { API_VERSION_BACKUP, isPrivilegeSelectable } from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 // RPC client
 import { useGetPrivilegesFullDataQuery } from "src/services/rpcPrivileges";
 // Errors
@@ -134,13 +138,6 @@ const Privileges = () => {
 
   const [isDeletion, setIsDeletion] = useState(false);
 
-  const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
-
-  // Reset selected-per-page count whenever the page or page size changes
-  React.useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
-
   const [selectedPrivileges, setSelectedPrivileges] = useState<Privilege[]>([]);
 
   const clearSelectedPrivileges = () => {
@@ -189,6 +186,12 @@ const Privileges = () => {
     }
   };
 
+  const selectedPerPageData = getSelectedPerPageData(
+    elementsList,
+    selectedPrivileges.map((item) => ipaPrimaryKey(item.cn)),
+    (item) => ipaPrimaryKey(item.cn)
+  );
+
   const bulkSelectorData = {
     selected: selectedPrivileges,
     updateSelected: updateSelectedPrivileges,
@@ -198,11 +201,6 @@ const Privileges = () => {
 
   const buttonsData = {
     updateIsDeleteButtonDisabled: setIsDeleteButtonDisabled,
-  };
-
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage: setSelectedPerPage,
   };
 
   const columnNames = ["Privilege name", "Description"];
@@ -345,10 +343,7 @@ const Privileges = () => {
                       isDeletion,
                       updateIsDeletion: setIsDeletion,
                     }}
-                    paginationData={{
-                      selectedPerPage,
-                      updateSelectedPerPage: setSelectedPerPage,
-                    }}
+                    paginationData={selectedPerPageData}
                   />
                 )}
               </InnerScrollContainer>

--- a/src/pages/Privileges/Privileges.tsx
+++ b/src/pages/Privileges/Privileges.tsx
@@ -55,7 +55,7 @@ const Privileges = () => {
     (state) => state.global.environment.api_version
   ) as string;
 
-  const { page, setPage, perPage, setPerPage } = useListPageSearchParams();
+  const { page, perPage } = useListPageSearchParams();
 
   const globalErrors = useApiError([]);
   const modalErrors = useApiError([]);
@@ -136,6 +136,11 @@ const Privileges = () => {
 
   const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
 
+  // Reset selected-per-page count whenever the page or page size changes
+  React.useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
+
   const [selectedPrivileges, setSelectedPrivileges] = useState<Privilege[]>([]);
 
   const clearSelectedPrivileges = () => {
@@ -182,15 +187,6 @@ const Privileges = () => {
     if (isPrivilegeSelectable(privilege)) {
       updateSelectedPrivileges([privilege], isSelecting);
     }
-  };
-
-  const paginationData = {
-    page,
-    perPage,
-    updatePage: setPage,
-    updatePerPage: setPerPage,
-    updateSelectedPerPage: setSelectedPerPage,
-    totalCount,
   };
 
   const bulkSelectorData = {
@@ -296,7 +292,7 @@ const Privileges = () => {
       element: (
         <PaginationLayout
           list={elementsList}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -361,7 +357,7 @@ const Privileges = () => {
           <FlexItem style={{ flex: "0 0 auto", position: "sticky", bottom: 0 }}>
             <PaginationLayout
               list={elementsList}
-              paginationData={paginationData}
+              totalCount={totalCount}
               variant={PaginationVariant.bottom}
               widgetId="pagination-options-menu-bottom"
             />

--- a/src/pages/Roles/Roles.tsx
+++ b/src/pages/Roles/Roles.tsx
@@ -179,13 +179,14 @@ const Roles = () => {
 
   const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     setSearchIsDisabled(true);
     setIsSearchActive(true);
 
     searchRoles({
-      searchValue: searchValue,
+      searchValue: search,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
       startIdx: 0,

--- a/src/pages/Roles/Roles.tsx
+++ b/src/pages/Roles/Roles.tsx
@@ -13,10 +13,7 @@ import {
   OuterScrollContainer,
 } from "@patternfly/react-table";
 // Data types
-import {
-  Role,
-  SearchDataResultType,
-} from "src/utils/datatypes/globalDataTypes";
+import { Role } from "src/utils/datatypes/globalDataTypes";
 import { ToolbarItem } from "src/components/layouts/ToolbarLayout";
 // Redux
 import { useAppDispatch, useAppSelector } from "src/store/hooks";
@@ -35,7 +32,6 @@ import BulkSelectorPrep from "src/components/BulkSelectorPrep";
 import AddRoleModal from "src/components/modals/RoleModals/AddRoleModal";
 import DeleteRolesModal from "src/components/modals/RoleModals/DeleteRolesModal";
 // Hooks
-import { addAlert } from "src/store/Global/alerts-slice";
 import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
@@ -43,13 +39,8 @@ import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import { API_VERSION_BACKUP, isRoleSelectable } from "src/utils/utils";
 // RPC client
 import { GenericPayload } from "src/services/rpc";
-import {
-  useGettingRolesQuery,
-  useSearchRolesEntriesMutation,
-} from "src/services/rpcRoles";
+import { useGettingRolesQuery } from "src/services/rpcRoles";
 // Errors
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 import useApiError from "src/hooks/useApiError";
 import useContextualHelpTopic from "src/hooks/useContextualHelpTopic";
 import GlobalErrors from "src/components/errors/GlobalErrors";
@@ -65,7 +56,7 @@ const Roles = () => {
     (state) => state.global.environment.api_version
   ) as string;
 
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   const globalErrors = useApiError([]);
@@ -89,25 +80,8 @@ const Roles = () => {
     error: batchError,
   } = rolesDataResponse;
 
-  // Search state - overrides query data when active
-  const [searchRoles, searchResult] = useSearchRolesEntriesMutation({});
-  const [isSearchActive, setIsSearchActive] = useState(false);
-  const [searchData, setSearchData] =
-    useState<SearchDataResultType<Role> | null>(null);
-
-  // Derive rolesList and totalCount from query response or search results
+  // Derive rolesList and totalCount from query response
   const { elementsList, totalCount } = useMemo(() => {
-    // If search is active and has results, paginate client-side
-    if (isSearchActive && searchData) {
-      const start = (page - 1) * perPage;
-      const end = start + perPage;
-      return {
-        elementsList: searchData.elementsList.slice(start, end),
-        totalCount: searchData.elementsList.length,
-      };
-    }
-
-    // Otherwise derive from query response
     if (batchResponse?.result) {
       const rolesListResult = batchResponse.result.results;
       const rolesListSize = batchResponse.result.count;
@@ -124,15 +98,10 @@ const Roles = () => {
     }
 
     return { elementsList: [], totalCount: 0 };
-  }, [batchResponse, isSearchActive, searchData, page, perPage]);
+  }, [batchResponse]);
 
   // Derive showTableRows from loading states
-  const showTableRows = useMemo(() => {
-    if (isSearchActive) {
-      return !searchResult.isLoading;
-    }
-    return !isFetching && !isBatchLoading;
-  }, [isFetching, isBatchLoading, isSearchActive, searchResult.isLoading]);
+  const showTableRows = !isFetching && !isBatchLoading;
 
   // Clear errors when fetching starts
   React.useEffect(() => {
@@ -154,8 +123,6 @@ const Roles = () => {
   }, [rolesDataResponse.isError, isBatchLoading, isFetching]);
 
   const refreshData = () => {
-    setIsSearchActive(false);
-    setSearchData(null);
     clearSelectedRoles();
     rolesDataResponse.refetch();
   };
@@ -175,62 +142,6 @@ const Roles = () => {
 
   const clearSelectedRoles = () => {
     setSelectedRoles([]);
-  };
-
-  const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
-
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    setSearchIsDisabled(true);
-    setIsSearchActive(true);
-
-    searchRoles({
-      searchValue: search,
-      sizeLimit: 0,
-      apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: 0,
-      stopIdx: 100,
-    }).then((result) => {
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for roles",
-              variant: "danger",
-            })
-          );
-          setIsSearchActive(false);
-          setSearchData(null);
-        } else {
-          const rolesListResult = result.data?.result.results || [];
-          const rolesListSize = result.data?.result.count || 0;
-          const searchTotalCount = result.data?.result.totalCount || 0;
-          const roles: Role[] = [];
-
-          for (let i = 0; i < rolesListSize; i++) {
-            roles.push(rolesListResult[i].result);
-          }
-
-          setSearchData({
-            elementsList: roles,
-            totalCount: searchTotalCount,
-          });
-        }
-        setSearchIsDisabled(false);
-      }
-    });
   };
 
   const [showAddModal, setShowAddModal] = useState(false);
@@ -278,15 +189,6 @@ const Roles = () => {
     updatePage: setPage,
     updatePerPage: setPerPage,
     updateSelectedPerPage: setSelectedPerPage,
-    updateShownElementsList: (roles: Role[]) => {
-      if (isSearchActive) {
-        setSearchData((prev) =>
-          prev
-            ? { ...prev, elementsList: roles }
-            : { elementsList: roles, totalCount: 0 }
-        );
-      }
-    },
     totalCount,
   };
 
@@ -304,17 +206,6 @@ const Roles = () => {
   const selectedPerPageData = {
     selectedPerPage,
     updateSelectedPerPage: setSelectedPerPage,
-  };
-
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
   };
 
   const columnNames = ["Role name", "Description"];
@@ -341,8 +232,6 @@ const Roles = () => {
           name="search"
           ariaLabel="Search roles"
           placeholder="Search"
-          searchValueData={searchValueData}
-          isDisabled={searchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/Roles/Roles.tsx
+++ b/src/pages/Roles/Roles.tsx
@@ -37,6 +37,10 @@ import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 // Utils
 import { API_VERSION_BACKUP, isRoleSelectable } from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 // RPC client
 import { GenericPayload } from "src/services/rpc";
 import { useGettingRolesQuery } from "src/services/rpcRoles";
@@ -135,13 +139,6 @@ const Roles = () => {
 
   const [isDeletion, setIsDeletion] = useState(false);
 
-  const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
-
-  // Reset selected-per-page count whenever the page or page size changes
-  React.useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
-
   const [selectedRoles, setSelectedRoles] = useState<Role[]>([]);
 
   const clearSelectedRoles = () => {
@@ -187,6 +184,12 @@ const Roles = () => {
     }
   };
 
+  const selectedPerPageData = getSelectedPerPageData(
+    elementsList,
+    selectedRoles.map((item) => ipaPrimaryKey(item.cn)),
+    (item) => ipaPrimaryKey(item.cn)
+  );
+
   const bulkSelectorData = {
     selected: selectedRoles,
     updateSelected: updateSelectedRoles,
@@ -196,11 +199,6 @@ const Roles = () => {
 
   const buttonsData = {
     updateIsDeleteButtonDisabled: setIsDeleteButtonDisabled,
-  };
-
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage: setSelectedPerPage,
   };
 
   const columnNames = ["Role name", "Description"];
@@ -339,10 +337,7 @@ const Roles = () => {
                       isDeletion,
                       updateIsDeletion: setIsDeletion,
                     }}
-                    paginationData={{
-                      selectedPerPage,
-                      updateSelectedPerPage: setSelectedPerPage,
-                    }}
+                    paginationData={selectedPerPageData}
                   />
                 )}
               </InnerScrollContainer>

--- a/src/pages/Roles/Roles.tsx
+++ b/src/pages/Roles/Roles.tsx
@@ -78,7 +78,6 @@ const Roles = () => {
 
   const {
     data: batchResponse,
-    isLoading: isBatchLoading,
     isFetching,
     error: batchError,
   } = rolesDataResponse;
@@ -103,9 +102,6 @@ const Roles = () => {
     return { elementsList: [], totalCount: 0 };
   }, [batchResponse]);
 
-  // Derive showTableRows from loading states
-  const showTableRows = !isFetching && !isBatchLoading;
-
   // Clear errors when fetching starts
   React.useEffect(() => {
     if (isFetching) {
@@ -116,14 +112,13 @@ const Roles = () => {
   // Handle query errors
   React.useEffect(() => {
     if (
-      !isBatchLoading &&
       !isFetching &&
       rolesDataResponse.isError &&
       rolesDataResponse.error !== undefined
     ) {
       window.location.reload();
     }
-  }, [rolesDataResponse.isError, isBatchLoading, isFetching]);
+  }, [rolesDataResponse.isError, isFetching]);
 
   const refreshData = () => {
     clearSelectedRoles();
@@ -239,7 +234,7 @@ const Roles = () => {
       element: (
         <SecondaryButton
           onClickHandler={refreshData}
-          isDisabled={!showTableRows}
+          isDisabled={isFetching}
           dataCy="roles-button-refresh"
         >
           Refresh
@@ -250,7 +245,7 @@ const Roles = () => {
       key: 4,
       element: (
         <SecondaryButton
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || isFetching}
           onClickHandler={() => setShowDeleteModal(true)}
           dataCy="roles-button-delete"
         >
@@ -263,7 +258,7 @@ const Roles = () => {
       element: (
         <SecondaryButton
           onClickHandler={() => setShowAddModal(true)}
-          isDisabled={!showTableRows}
+          isDisabled={isFetching}
           dataCy="roles-button-add"
         >
           Add
@@ -323,7 +318,7 @@ const Roles = () => {
                     columnNames={columnNames}
                     hasCheckboxes={true}
                     pathname="roles"
-                    showTableRows={showTableRows}
+                    showTableRows={!isFetching}
                     showLink={true}
                     elementsData={{
                       isElementSelectable: isRoleSelectable,

--- a/src/pages/Roles/Roles.tsx
+++ b/src/pages/Roles/Roles.tsx
@@ -56,8 +56,7 @@ const Roles = () => {
     (state) => state.global.environment.api_version
   ) as string;
 
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
 
   const globalErrors = useApiError([]);
   const modalErrors = useApiError([]);
@@ -138,6 +137,11 @@ const Roles = () => {
 
   const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
 
+  // Reset selected-per-page count whenever the page or page size changes
+  React.useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
+
   const [selectedRoles, setSelectedRoles] = useState<Role[]>([]);
 
   const clearSelectedRoles = () => {
@@ -181,15 +185,6 @@ const Roles = () => {
     if (isRoleSelectable(role)) {
       updateSelectedRoles([role], isSelecting);
     }
-  };
-
-  const paginationData = {
-    page,
-    perPage,
-    updatePage: setPage,
-    updatePerPage: setPerPage,
-    updateSelectedPerPage: setSelectedPerPage,
-    totalCount,
   };
 
   const bulkSelectorData = {
@@ -295,7 +290,7 @@ const Roles = () => {
       element: (
         <PaginationLayout
           list={elementsList}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -356,7 +351,7 @@ const Roles = () => {
           <FlexItem style={{ flex: "0 0 auto", position: "sticky", bottom: 0 }}>
             <PaginationLayout
               list={elementsList}
-              paginationData={paginationData}
+              totalCount={totalCount}
               variant={PaginationVariant.bottom}
               widgetId="pagination-options-menu-bottom"
             />

--- a/src/pages/Roles/Roles.tsx
+++ b/src/pages/Roles/Roles.tsx
@@ -125,10 +125,6 @@ const Roles = () => {
     rolesDataResponse.refetch();
   };
 
-  React.useEffect(() => {
-    rolesDataResponse.refetch();
-  }, []);
-
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
     useState<boolean>(true);
 

--- a/src/pages/Roles/Roles.tsx
+++ b/src/pages/Roles/Roles.tsx
@@ -75,7 +75,7 @@ const Roles = () => {
   const lastIdx = page * perPage;
 
   const rolesDataResponse = useGettingRolesQuery({
-    searchValue: "",
+    searchValue: searchValue,
     sizeLimit: 0,
     apiVersion: apiVersion || API_VERSION_BACKUP,
     startIdx: firstIdx,
@@ -97,11 +97,13 @@ const Roles = () => {
 
   // Derive rolesList and totalCount from query response or search results
   const { elementsList, totalCount } = useMemo(() => {
-    // If search is active and has results, use search data
+    // If search is active and has results, paginate client-side
     if (isSearchActive && searchData) {
+      const start = (page - 1) * perPage;
+      const end = start + perPage;
       return {
-        elementsList: searchData.elementsList,
-        totalCount: searchData.totalCount,
+        elementsList: searchData.elementsList.slice(start, end),
+        totalCount: searchData.elementsList.length,
       };
     }
 
@@ -122,7 +124,7 @@ const Roles = () => {
     }
 
     return { elementsList: [], totalCount: 0 };
-  }, [batchResponse, isSearchActive, searchData]);
+  }, [batchResponse, isSearchActive, searchData, page, perPage]);
 
   // Derive showTableRows from loading states
   const showTableRows = useMemo(() => {
@@ -159,10 +161,8 @@ const Roles = () => {
   };
 
   React.useEffect(() => {
-    if (!isSearchActive) {
-      rolesDataResponse.refetch();
-    }
-  }, [page, perPage]);
+    rolesDataResponse.refetch();
+  }, []);
 
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
     useState<boolean>(true);
@@ -180,6 +180,7 @@ const Roles = () => {
   const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
   const submitSearchValue = () => {
+    setPage(1);
     setSearchIsDisabled(true);
     setIsSearchActive(true);
 
@@ -187,8 +188,8 @@ const Roles = () => {
       searchValue: searchValue,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: firstIdx,
-      stopIdx: lastIdx,
+      startIdx: 0,
+      stopIdx: 100,
     }).then((result) => {
       if ("data" in result) {
         const searchError = result.data?.error as
@@ -304,9 +305,14 @@ const Roles = () => {
     updateSelectedPerPage: setSelectedPerPage,
   };
 
+  const updateSearchValue = (value: string) => {
+    setPage(1);
+    setSearchValue(value);
+  };
+
   const searchValueData = {
     searchValue,
-    updateSearchValue: setSearchValue,
+    updateSearchValue,
     submitSearchValue,
   };
 

--- a/src/pages/Roles/RolesPrivileges.tsx
+++ b/src/pages/Roles/RolesPrivileges.tsx
@@ -55,7 +55,7 @@ const RolesPrivileges = (props: PropsToRolesPrivileges) => {
   }, [roleData, roleQuery.isFetching]);
 
   // Get parameters from URL
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   // Other states
@@ -238,9 +238,6 @@ const RolesPrivileges = (props: PropsToRolesPrivileges) => {
   return (
     <TabLayout id="privileges">
       <MemberOfToolbar
-        searchText={searchValue}
-        onSearchTextChange={setSearchValue}
-        onSearch={() => {}}
         searchPlaceholder="Search privileges"
         searchAriaLabel="Search privileges"
         refreshButtonEnabled={isRefreshButtonEnabled}

--- a/src/pages/Roles/RolesPrivileges.tsx
+++ b/src/pages/Roles/RolesPrivileges.tsx
@@ -90,9 +90,6 @@ const RolesPrivileges = (props: PropsToRolesPrivileges) => {
     return toLoad.map((name) => ({ cn: name }));
   }, [privilegeNames, searchValue, page, perPage]);
 
-  // Computed "states"
-  const showTableRows = !roleQuery.isFetching;
-
   // Dialogs and actions
   const [showAddModal, setShowAddModal] = React.useState(false);
   const [showDeleteModal, setShowDeleteModal] = React.useState(false);
@@ -257,7 +254,7 @@ const RolesPrivileges = (props: PropsToRolesPrivileges) => {
         propertiesToShow={properties}
         checkedItems={privilegesSelected}
         onCheckItemsChange={setPrivilegesSelected}
-        showTableRows={showTableRows}
+        showTableRows={!roleQuery.isFetching}
       />
       {getFilteredCount() > 0 && (
         <PaginationLayout

--- a/src/pages/Roles/RolesPrivileges.tsx
+++ b/src/pages/Roles/RolesPrivileges.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo } from "react";
 // PatternFly
-import { Pagination, PaginationVariant } from "@patternfly/react-core";
+import { PaginationVariant } from "@patternfly/react-core";
 // Data types
 import { Role } from "src/utils/datatypes/globalDataTypes";
 // Components
@@ -10,6 +10,7 @@ import MemberOfAddModal, {
   AvailableItems,
 } from "src/components/MemberOf/MemberOfAddModal";
 import MemberOfDeleteModal from "src/components/MemberOf/MemberOfDeleteModal";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
 // Layouts
 import TabLayout from "src/components/layouts/TabLayout";
 // Redux
@@ -55,8 +56,7 @@ const RolesPrivileges = (props: PropsToRolesPrivileges) => {
   }, [roleData, roleQuery.isFetching]);
 
   // Get parameters from URL
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, setPage, perPage, searchValue } = useListPageSearchParams();
 
   // Other states
   const [privilegesSelected, setPrivilegesSelected] = React.useState<string[]>(
@@ -248,10 +248,6 @@ const RolesPrivileges = (props: PropsToRolesPrivileges) => {
         onAddButtonClick={() => setShowAddModal(true)}
         helpIconEnabled={true}
         totalItems={getFilteredCount()}
-        perPage={perPage}
-        page={page}
-        onPerPageChange={setPerPage}
-        onPageChange={setPage}
       />
       <MemberTable
         entityList={privileges}
@@ -264,15 +260,12 @@ const RolesPrivileges = (props: PropsToRolesPrivileges) => {
         showTableRows={showTableRows}
       />
       {getFilteredCount() > 0 && (
-        <Pagination
-          className="pf-v6-u-pb-0 pf-v6-u-pr-md"
-          itemCount={getFilteredCount()}
-          widgetId="pagination-options-menu-bottom"
-          perPage={perPage}
-          page={page}
+        <PaginationLayout
+          list={[]}
+          totalCount={getFilteredCount()}
           variant={PaginationVariant.bottom}
-          onSetPage={(_e, page) => setPage(page)}
-          onPerPageSelect={(_e, perPage) => setPerPage(perPage)}
+          widgetId="pagination-options-menu-bottom"
+          className="pf-v6-u-pb-0 pf-v6-u-pr-md"
         />
       )}
       <MemberOfAddModal

--- a/src/pages/SELinuxUserMaps/SELinuxUserMaps.tsx
+++ b/src/pages/SELinuxUserMaps/SELinuxUserMaps.tsx
@@ -61,8 +61,7 @@ const SELinuxUserMaps = () => {
     (state) => state.global.environment.api_version
   ) as string;
 
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
 
   const globalErrors = useApiError([]);
 
@@ -184,14 +183,10 @@ const SELinuxUserMaps = () => {
     mapsResponse.refetch();
   }, []);
 
-  const paginationData = {
-    page,
-    perPage,
-    updatePage: setPage,
-    updatePerPage: setPerPage,
-    updateSelectedPerPage: setSelectedPerPage,
-    totalCount,
-  };
+  // Reset the selected per-page count when the page or page size changes
+  React.useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
 
   const bulkSelectorData = {
     selected: selectedElements,
@@ -336,7 +331,7 @@ const SELinuxUserMaps = () => {
       element: (
         <PaginationLayout
           list={selinuxUserMaps}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -411,7 +406,7 @@ const SELinuxUserMaps = () => {
             >
               <PaginationLayout
                 list={selinuxUserMaps}
-                paginationData={paginationData}
+                totalCount={totalCount}
                 variant={PaginationVariant.bottom}
                 widgetId="pagination-options-menu-bottom"
               />

--- a/src/pages/SELinuxUserMaps/SELinuxUserMaps.tsx
+++ b/src/pages/SELinuxUserMaps/SELinuxUserMaps.tsx
@@ -181,10 +181,6 @@ const SELinuxUserMaps = () => {
     (item) => ipaPrimaryKey(item.cn)
   );
 
-  React.useEffect(() => {
-    mapsResponse.refetch();
-  }, []);
-
   const bulkSelectorData = {
     selected: selectedElements,
     updateSelected: updateSelectedMaps,

--- a/src/pages/SELinuxUserMaps/SELinuxUserMaps.tsx
+++ b/src/pages/SELinuxUserMaps/SELinuxUserMaps.tsx
@@ -14,7 +14,6 @@ import {
 // Data types
 import { SELinuxUserMap } from "src/utils/datatypes/globalDataTypes";
 // Hooks
-import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import useApiError from "src/hooks/useApiError";
@@ -23,18 +22,13 @@ import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Redux
 import { useAppSelector, useAppDispatch } from "src/store/hooks";
 // RPC
-import {
-  useGetSelinuxUserMapsFullDataQuery,
-  useSearchSelinuxUserMapsEntriesMutation,
-} from "src/services/rpcSelinuxUserMaps";
+import { useGetSelinuxUserMapsFullDataQuery } from "src/services/rpcSelinuxUserMaps";
 // Utils
 import { apiToSelinuxUserMap } from "src/utils/selinuxUserMapUtils";
 import { isSelinuxUserMapSelectable } from "src/utils/utils";
 // React router
 import { useNavigate } from "react-router";
 // Components
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 import ToolbarLayout, {
   ToolbarItem,
 } from "src/components/layouts/ToolbarLayout";
@@ -67,15 +61,13 @@ const SELinuxUserMaps = () => {
     (state) => state.global.environment.api_version
   ) as string;
 
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   const globalErrors = useApiError([]);
 
   const firstIdx = (page - 1) * perPage;
   const lastIdx = page * perPage;
-
-  const [isSearchDisabled, setIsSearchDisabled] = React.useState(false);
 
   const mapsResponse = useGetSelinuxUserMapsFullDataQuery({
     searchValue,
@@ -192,43 +184,6 @@ const SELinuxUserMaps = () => {
     mapsResponse.refetch();
   }, []);
 
-  const [searchEntry] = useSearchSelinuxUserMapsEntriesMutation();
-
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    searchEntry({
-      searchValue: search,
-      apiVersion,
-      sizelimit: 100,
-      startIdx: 0,
-      stopIdx: 100,
-    }).then((result) => {
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for SELinux user maps",
-              variant: "danger",
-            })
-          );
-        }
-        setIsSearchDisabled(false);
-      }
-    });
-  };
-
   const paginationData = {
     page,
     perPage,
@@ -236,17 +191,6 @@ const SELinuxUserMaps = () => {
     updatePerPage: setPerPage,
     updateSelectedPerPage: setSelectedPerPage,
     totalCount,
-  };
-
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
   };
 
   const bulkSelectorData = {
@@ -305,8 +249,6 @@ const SELinuxUserMaps = () => {
           name="search"
           ariaLabel="Search SELinux user maps"
           placeholder="Search"
-          searchValueData={searchValueData}
-          isDisabled={isSearchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/SELinuxUserMaps/SELinuxUserMaps.tsx
+++ b/src/pages/SELinuxUserMaps/SELinuxUserMaps.tsx
@@ -195,6 +195,7 @@ const SELinuxUserMaps = () => {
   const [searchEntry] = useSearchSelinuxUserMapsEntriesMutation();
 
   const submitSearchValue = () => {
+    setPage(1);
     searchEntry({
       searchValue,
       apiVersion,
@@ -236,9 +237,14 @@ const SELinuxUserMaps = () => {
     totalCount,
   };
 
+  const updateSearchValue = (value: string) => {
+    setPage(1);
+    setSearchValue(value);
+  };
+
   const searchValueData = {
     searchValue,
-    updateSearchValue: setSearchValue,
+    updateSearchValue,
     submitSearchValue,
   };
 

--- a/src/pages/SELinuxUserMaps/SELinuxUserMaps.tsx
+++ b/src/pages/SELinuxUserMaps/SELinuxUserMaps.tsx
@@ -26,6 +26,10 @@ import { useGetSelinuxUserMapsFullDataQuery } from "src/services/rpcSelinuxUserM
 // Utils
 import { apiToSelinuxUserMap } from "src/utils/selinuxUserMapUtils";
 import { isSelinuxUserMapSelectable } from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 // React router
 import { useNavigate } from "react-router";
 // Components
@@ -126,7 +130,6 @@ const SELinuxUserMaps = () => {
   const [selectedElements, setSelectedElements] = React.useState<
     SELinuxUserMap[]
   >([]);
-  const [selectedPerPage, setSelectedPerPage] = React.useState<number>(0);
 
   const refreshData = () => {
     setSelectedElements([]);
@@ -179,25 +182,21 @@ const SELinuxUserMaps = () => {
     }
   };
 
+  const selectedPerPageData = getSelectedPerPageData(
+    selinuxUserMaps,
+    selectedElements.map((item) => ipaPrimaryKey(item.cn)),
+    (item) => ipaPrimaryKey(item.cn)
+  );
+
   React.useEffect(() => {
     mapsResponse.refetch();
   }, []);
-
-  // Reset the selected per-page count when the page or page size changes
-  React.useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
 
   const bulkSelectorData = {
     selected: selectedElements,
     updateSelected: updateSelectedMaps,
     selectableTable: selectableMapsTable,
     nameAttr: "cn",
-  };
-
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage: setSelectedPerPage,
   };
 
   const [showAddModal, setShowAddModal] = React.useState<boolean>(false);
@@ -391,10 +390,7 @@ const SELinuxUserMaps = () => {
                           setIsDisableButtonDisabled(value),
                         isDisableEnableOp: true,
                       }}
-                      paginationData={{
-                        selectedPerPage,
-                        updateSelectedPerPage: setSelectedPerPage,
-                      }}
+                      paginationData={selectedPerPageData}
                       statusElementName="ipaenabledflag"
                     />
                   )}

--- a/src/pages/SELinuxUserMaps/SELinuxUserMaps.tsx
+++ b/src/pages/SELinuxUserMaps/SELinuxUserMaps.tsx
@@ -80,7 +80,7 @@ const SELinuxUserMaps = () => {
     stopIdx: lastIdx,
   });
 
-  const { data, isLoading, error } = mapsResponse;
+  const { data, isFetching, error } = mapsResponse;
 
   React.useEffect(() => {
     if (mapsResponse.isFetching) {
@@ -119,13 +119,6 @@ const SELinuxUserMaps = () => {
     }
     return 0;
   }, [mapsResponse.isSuccess, mapsResponse.data]);
-
-  const showTableRows = React.useMemo(() => {
-    if (mapsResponse.isFetching) {
-      return false;
-    }
-    return !isLoading;
-  }, [mapsResponse.isFetching, isLoading]);
 
   const [selectedElements, setSelectedElements] = React.useState<
     SELinuxUserMap[]
@@ -258,7 +251,7 @@ const SELinuxUserMaps = () => {
         <SecondaryButton
           dataCy="selinux-user-maps-button-refresh"
           onClickHandler={refreshData}
-          isDisabled={!showTableRows}
+          isDisabled={isFetching}
         >
           Refresh
         </SecondaryButton>
@@ -268,7 +261,7 @@ const SELinuxUserMaps = () => {
       key: 4,
       element: (
         <SecondaryButton
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || isFetching}
           dataCy="selinux-user-maps-button-delete"
           onClickHandler={() => setShowDeleteModal(true)}
         >
@@ -280,7 +273,7 @@ const SELinuxUserMaps = () => {
       key: 5,
       element: (
         <SecondaryButton
-          isDisabled={!showTableRows}
+          isDisabled={isFetching}
           dataCy="selinux-user-maps-button-add"
           onClickHandler={() => setShowAddModal(true)}
         >
@@ -292,7 +285,7 @@ const SELinuxUserMaps = () => {
       key: 6,
       element: (
         <SecondaryButton
-          isDisabled={isDisableButtonDisabled || !showTableRows}
+          isDisabled={isDisableButtonDisabled || isFetching}
           onClickHandler={onDisableOperation}
           dataCy="selinux-user-maps-button-disable"
         >
@@ -304,7 +297,7 @@ const SELinuxUserMaps = () => {
       key: 7,
       element: (
         <SecondaryButton
-          isDisabled={isEnableButtonDisabled || !showTableRows}
+          isDisabled={isEnableButtonDisabled || isFetching}
           onClickHandler={onEnableOperation}
           dataCy="selinux-user-maps-button-enable"
         >
@@ -370,7 +363,7 @@ const SELinuxUserMaps = () => {
                       columnNames={columnNames}
                       hasCheckboxes={true}
                       pathname="selinux-user-maps"
-                      showTableRows={showTableRows}
+                      showTableRows={!isFetching}
                       showLink={false}
                       elementsData={{
                         isElementSelectable: isSelinuxUserMapSelectable,

--- a/src/pages/SELinuxUserMaps/SELinuxUserMaps.tsx
+++ b/src/pages/SELinuxUserMaps/SELinuxUserMaps.tsx
@@ -194,10 +194,11 @@ const SELinuxUserMaps = () => {
 
   const [searchEntry] = useSearchSelinuxUserMapsEntriesMutation();
 
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     searchEntry({
-      searchValue,
+      searchValue: search,
       apiVersion,
       sizelimit: 100,
       startIdx: 0,

--- a/src/pages/Services/Services.tsx
+++ b/src/pages/Services/Services.tsx
@@ -111,6 +111,7 @@ const Services = () => {
   const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
   const updateSearchValue = (value: string) => {
+    setPage(1);
     setSearchValue(value);
   };
 
@@ -124,6 +125,7 @@ const Services = () => {
 
   // Issue search with filter
   const submitSearchValue = () => {
+    setPage(1);
     setShowTableRows(false);
     setServicesTotalCount(0);
     setSearchIsDisabled(true);
@@ -131,8 +133,8 @@ const Services = () => {
       searchValue: searchValue,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: firstServiceIdx,
-      stopIdx: lastServiceIdx,
+      startIdx: 0,
+      stopIdx: 100,
       entryType: "service",
     } as GenericPayload).then((result) => {
       // Manage new response here
@@ -167,7 +169,7 @@ const Services = () => {
             serviceList.push(serviceListResult[i].result);
           }
 
-          setServicesList(serviceList);
+          setServicesList(serviceList.slice(0, perPage));
           setServicesTotalCount(totalCount);
           // Show table elements
           setShowTableRows(true);
@@ -290,7 +292,7 @@ const Services = () => {
 
   // Derived states - what we get from API
   const servicesDataResponse = useGettingServicesQuery({
-    searchValue: "",
+    searchValue: searchValue,
     sizeLimit: 0,
     apiVersion: apiVersion || API_VERSION_BACKUP,
     startIdx: firstServiceIdx,

--- a/src/pages/Services/Services.tsx
+++ b/src/pages/Services/Services.tsx
@@ -263,12 +263,6 @@ const Services = () => {
     }
   }, [servicesDataResponse]);
 
-  // Always refetch data when the component is loaded.
-  // This ensures the data is always up-to-date.
-  useEffect(() => {
-    servicesDataResponse.refetch();
-  }, []);
-
   // Refresh button handling
   const refreshServicesData = () => {
     // Reset selected hosts on refresh

--- a/src/pages/Services/Services.tsx
+++ b/src/pages/Services/Services.tsx
@@ -100,9 +100,6 @@ const Services = () => {
     setSelectedServicesList(emptyList);
   };
 
-  // Show table rows
-  const [showTableRows, setShowTableRows] = useState(false);
-
   // Modals functionality
   const [showAddModal, setShowAddModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -222,14 +219,13 @@ const Services = () => {
 
   const {
     data: batchResponse,
-    isLoading: isBatchLoading,
+    isFetching: isBatchFetching,
     error: batchError,
   } = servicesDataResponse;
 
   // Handle data when the API call is finished
   useEffect(() => {
     if (servicesDataResponse.isFetching) {
-      setShowTableRows(false);
       // Reset selected users on refresh
       setServicesTotalCount(0);
       globalErrors.clear();
@@ -253,8 +249,6 @@ const Services = () => {
 
       setServicesList(servicesList);
       setServicesTotalCount(totalCount);
-      // Show table elements
-      setShowTableRows(true);
     }
 
     // API response: Error
@@ -275,18 +269,8 @@ const Services = () => {
     servicesDataResponse.refetch();
   }, []);
 
-  // Show table rows only when data is fully retrieved
-  useEffect(() => {
-    if (showTableRows !== !isBatchLoading) {
-      setShowTableRows(!isBatchLoading);
-    }
-  }, [isBatchLoading]);
-
   // Refresh button handling
   const refreshServicesData = () => {
-    // Hide table
-    setShowTableRows(false);
-
     // Reset selected hosts on refresh
     setServicesTotalCount(0);
     clearSelectedServices();
@@ -375,7 +359,7 @@ const Services = () => {
       element: (
         <SecondaryButton
           onClickHandler={refreshServicesData}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
           dataCy="services-button-refresh"
         >
           Refresh
@@ -398,7 +382,7 @@ const Services = () => {
       key: 5,
       element: (
         <SecondaryButton
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
           onClickHandler={onAddClickHandler}
           dataCy="services-button-add"
         >
@@ -456,7 +440,7 @@ const Services = () => {
                     <ServicesTable
                       elementsList={servicesList}
                       shownElementsList={servicesList}
-                      showTableRows={showTableRows}
+                      showTableRows={!isBatchFetching}
                       servicesData={servicesTableData}
                       buttonsData={servicesTableButtonsData}
                       paginationData={selectedPerPageData}

--- a/src/pages/Services/Services.tsx
+++ b/src/pages/Services/Services.tsx
@@ -44,10 +44,8 @@ import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 import useApiError from "../../hooks/useApiError";
 import GlobalErrors from "../../components/errors/GlobalErrors";
 import ModalErrors from "../../components/errors/ModalErrors";
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 // RPC client
-import { useSearchEntriesMutation, GenericPayload } from "../../services/rpc";
+import { GenericPayload } from "../../services/rpc";
 import { useGetHostsListQuery } from "../../services/rpcHosts";
 import { useGettingServicesQuery } from "../../services/rpcServices";
 
@@ -67,7 +65,7 @@ const Services = () => {
   ) as string;
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   // Handle API calls errors
@@ -107,77 +105,10 @@ const Services = () => {
   const firstServiceIdx = (page - 1) * perPage;
   const lastServiceIdx = page * perPage;
 
-  // Filter (Input search)
-  const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
-
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
   const [selectedServices, setSelectedServicesList] = useState<Service[]>([]);
   const clearSelectedServices = () => {
     const emptyList: Service[] = [];
     setSelectedServicesList(emptyList);
-  };
-
-  const [retrieveServices] = useSearchEntriesMutation({});
-
-  // Issue search with filter
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    setShowTableRows(false);
-    setServicesTotalCount(0);
-    setSearchIsDisabled(true);
-    retrieveServices({
-      searchValue: search,
-      sizeLimit: 0,
-      apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: 0,
-      stopIdx: 100,
-      entryType: "service",
-    } as GenericPayload).then((result) => {
-      // Manage new response here
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for services",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success
-          const serviceListResult = result.data?.result.results || [];
-          const serviceListSize = result.data?.result.count || 0;
-          const totalCount = result.data?.result.totalCount || 0;
-          const serviceList: Service[] = [];
-
-          for (let i = 0; i < serviceListSize; i++) {
-            serviceList.push(serviceListResult[i].result);
-          }
-
-          setServicesList(serviceList.slice(0, perPage));
-          setServicesTotalCount(totalCount);
-          // Show table elements
-          setShowTableRows(true);
-        }
-        setSearchIsDisabled(false);
-      }
-    });
   };
 
   // Show table rows
@@ -375,13 +306,6 @@ const Services = () => {
   };
 
   // Data wrappers
-  // - 'SearchInputLayout'
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
-  };
-
   // - 'BulkSelectorPrep'
   const servicesBulkSelectorData = {
     selected: selectedServices,
@@ -458,8 +382,6 @@ const Services = () => {
           name="search"
           ariaLabel="Search services"
           placeholder="Search services"
-          searchValueData={searchValueData}
-          isDisabled={searchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/Services/Services.tsx
+++ b/src/pages/Services/Services.tsx
@@ -31,6 +31,10 @@ import { useAppDispatch, useAppSelector } from "../../store/hooks";
 import { Host, Service } from "../../utils/datatypes/globalDataTypes";
 // Utils
 import { API_VERSION_BACKUP, isServiceSelectable } from "../../utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 // Modals
 import AddService from "../../components/modals/AddService";
 import DeleteServices from "../../components/modals/DeleteServices";
@@ -83,18 +87,6 @@ const Services = () => {
   const updateIsDeletion = (value: boolean) => {
     setIsDeletion(value);
   };
-
-  // Elements selected (per page)
-  //  - This will help to calculate the remaining elements on a specific page (bulk selector)
-  const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
-  const updateSelectedPerPage = (selected: number) => {
-    setSelectedPerPage(selected);
-  };
-
-  // Reset selected-per-page count whenever the page or page size changes
-  useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
 
   const [totalCount, setServicesTotalCount] = useState<number>(0);
 
@@ -315,10 +307,11 @@ const Services = () => {
     updateIsDeleteButtonDisabled,
   };
 
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage,
-  };
+  const selectedPerPageData = getSelectedPerPageData(
+    servicesList,
+    selectedServices.map((item) => ipaPrimaryKey(item.krbcanonicalname)),
+    (item) => ipaPrimaryKey(item.krbcanonicalname)
+  );
 
   // - 'ServicesTable'
   const servicesTableData = {

--- a/src/pages/Services/Services.tsx
+++ b/src/pages/Services/Services.tsx
@@ -65,8 +65,7 @@ const Services = () => {
   ) as string;
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
 
   // Handle API calls errors
   const globalErrors = useApiError([]);
@@ -92,13 +91,11 @@ const Services = () => {
     setSelectedPerPage(selected);
   };
 
-  // Pagination
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
-  };
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
-  };
+  // Reset selected-per-page count whenever the page or page size changes
+  useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
+
   const [totalCount, setServicesTotalCount] = useState<number>(0);
 
   // Page indexes
@@ -323,17 +320,6 @@ const Services = () => {
     updateSelectedPerPage,
   };
 
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList: setHostsList,
-    totalCount,
-  };
-
   // - 'ServicesTable'
   const servicesTableData = {
     isServiceSelectable,
@@ -445,7 +431,7 @@ const Services = () => {
       element: (
         <PaginationLayout
           list={servicesList}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -492,7 +478,7 @@ const Services = () => {
             >
               <PaginationLayout
                 list={servicesList}
-                paginationData={paginationData}
+                totalCount={totalCount}
                 variant={PaginationVariant.bottom}
                 widgetId="pagination-options-menu-bottom"
               />

--- a/src/pages/Services/Services.tsx
+++ b/src/pages/Services/Services.tsx
@@ -124,13 +124,14 @@ const Services = () => {
   const [retrieveServices] = useSearchEntriesMutation({});
 
   // Issue search with filter
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     setShowTableRows(false);
     setServicesTotalCount(0);
     setSearchIsDisabled(true);
     retrieveServices({
-      searchValue: searchValue,
+      searchValue: search,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
       startIdx: 0,

--- a/src/pages/StageUsers/StageUsers.tsx
+++ b/src/pages/StageUsers/StageUsers.tsx
@@ -91,14 +91,13 @@ const StageUsers = () => {
 
   const {
     data: batchResponse,
-    isLoading: isBatchLoading,
+    isFetching: isBatchFetching,
     error: batchError,
   } = userDataResponse;
 
   // Handle data when the API call is finished
   useEffect(() => {
     if (userDataResponse.isFetching) {
-      setShowTableRows(false);
       // Reset selected users on refresh
       setUsersTotalCount(0);
       globalErrors.clear();
@@ -123,8 +122,6 @@ const StageUsers = () => {
       setUsersTotalCount(totalCount);
       // Update the list of users
       setStageUsersList(usersList);
-      // Show table elements
-      setShowTableRows(true);
     }
 
     // API response: Error
@@ -141,9 +138,6 @@ const StageUsers = () => {
 
   // Refresh button handling
   const refreshUsersData = () => {
-    // Hide table
-    setShowTableRows(false);
-
     // Reset selected users on refresh
     setUsersTotalCount(0);
     clearSelectedUsers();
@@ -171,16 +165,6 @@ const StageUsers = () => {
   const updateIsDeletion = (value: boolean) => {
     setIsDeletion(value);
   };
-
-  // Show table rows
-  const [showTableRows, setShowTableRows] = useState(!isBatchLoading);
-
-  // Show table rows only when data is fully retrieved
-  useEffect(() => {
-    if (showTableRows !== !isBatchLoading) {
-      setShowTableRows(!isBatchLoading);
-    }
-  }, [isBatchLoading]);
 
   const [selectedUsers, setSelectedUsers] = useState<User[]>([]);
 
@@ -343,7 +327,7 @@ const StageUsers = () => {
       element: (
         <SecondaryButton
           onClickHandler={refreshUsersData}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
           dataCy="stage-users-button-refresh"
         >
           Refresh
@@ -354,7 +338,7 @@ const StageUsers = () => {
       key: 4,
       element: (
         <SecondaryButton
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || isBatchFetching}
           onClickHandler={onDeleteHandler}
           dataCy="stage-users-button-delete"
         >
@@ -367,7 +351,7 @@ const StageUsers = () => {
       element: (
         <SecondaryButton
           onClickHandler={onAddClickHandler}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
           dataCy="stage-users-button-add"
         >
           Add
@@ -378,7 +362,7 @@ const StageUsers = () => {
       key: 6,
       element: (
         <SecondaryButton
-          isDisabled={!showTableRows || selectedUsers.length === 0}
+          isDisabled={isBatchFetching || selectedUsers.length === 0}
           onClickHandler={onActivateHandler}
           dataCy="stage-users-button-activate"
         >
@@ -440,7 +424,7 @@ const StageUsers = () => {
                     <UsersTable
                       shownElementsList={stageUsersList}
                       from="stage-users"
-                      showTableRows={showTableRows}
+                      showTableRows={!isBatchFetching}
                       usersData={usersTableData}
                       buttonsData={usersTableButtonsData}
                       paginationData={selectedPerPageData}
@@ -469,7 +453,6 @@ const StageUsers = () => {
         <AddUser
           show={showAddModal}
           from="stage-users"
-          setShowTableRows={setShowTableRows}
           handleModalToggle={onAddModalToggle}
           onOpenAddModal={onAddClickHandler}
           onCloseAddModal={onCloseAddModal}

--- a/src/pages/StageUsers/StageUsers.tsx
+++ b/src/pages/StageUsers/StageUsers.tsx
@@ -206,14 +206,15 @@ const StageUsers = () => {
   const [retrieveUser] = useSearchEntriesMutation({});
 
   // Issue a search using a specific search value
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     setShowTableRows(false);
     setUsersTotalCount(0);
     setSearchIsDisabled(true);
 
     retrieveUser({
-      searchValue: searchValue,
+      searchValue: search,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
       startIdx: 0,

--- a/src/pages/StageUsers/StageUsers.tsx
+++ b/src/pages/StageUsers/StageUsers.tsx
@@ -145,12 +145,6 @@ const StageUsers = () => {
     userDataResponse.refetch();
   };
 
-  // Always refetch data when the component is loaded.
-  // This ensures the data is always up-to-date.
-  React.useEffect(() => {
-    userDataResponse.refetch();
-  }, []);
-
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
     useState<boolean>(true);

--- a/src/pages/StageUsers/StageUsers.tsx
+++ b/src/pages/StageUsers/StageUsers.tsx
@@ -18,7 +18,6 @@ import { ToolbarItem } from "src/components/layouts/ToolbarLayout";
 // Redux
 import { useAppSelector, useAppDispatch } from "src/store/hooks";
 // Hooks
-import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
@@ -40,11 +39,8 @@ import AddUser from "src/components/modals/UserModals/AddUser";
 import ActivateStageUsers from "src/components/modals/UserModals/ActivateStageUsers";
 // Utils
 import { API_VERSION_BACKUP, isUserSelectable } from "src/utils/utils";
-// Errors
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 // RPC client
-import { GenericPayload, useSearchEntriesMutation } from "../../services/rpc";
+import { GenericPayload } from "../../services/rpc";
 import { useGettingStageUserQuery } from "../../services/rpcUsers";
 import useApiError from "src/hooks/useApiError";
 import useContextualHelpTopic from "src/hooks/useContextualHelpTopic";
@@ -59,7 +55,7 @@ const StageUsers = () => {
   useUpdateRoute({ pathname: "stage-users" });
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   // Retrieve API version from environment data
@@ -76,7 +72,6 @@ const StageUsers = () => {
 
   // Main states - what user can define / what we could use in page URL
   const [totalCount, setUsersTotalCount] = useState<number>(0);
-  const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
   // Page indexes
   const firstUserIdx = (page - 1) * perPage;
@@ -194,73 +189,6 @@ const StageUsers = () => {
   // Users displayed on the first page
   const updateShownUsersList = (newShownUsersList: User[]) => {
     setStageUsersList(newShownUsersList);
-  };
-
-  // Filter (Input search)
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
-  // Issue search with filter
-  const [retrieveUser] = useSearchEntriesMutation({});
-
-  // Issue a search using a specific search value
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    setShowTableRows(false);
-    setUsersTotalCount(0);
-    setSearchIsDisabled(true);
-
-    retrieveUser({
-      searchValue: search,
-      sizeLimit: 0,
-      apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: 0,
-      stopIdx: 100,
-      entryType: "stage",
-    } as GenericPayload).then((result) => {
-      // Manage new response here
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for stage users",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success
-          const usersListResult = result.data?.result.results || [];
-          const usersListSize = result.data?.result.count || 0;
-          const totalCount = result.data?.result.totalCount || 0;
-          const usersList: User[] = [];
-
-          for (let i = 0; i < usersListSize; i++) {
-            usersList.push(usersListResult[i].result);
-          }
-
-          setStageUsersList(usersList.slice(0, perPage));
-          setUsersTotalCount(totalCount);
-          // Show table elements
-          setShowTableRows(true);
-        }
-        setSearchIsDisabled(false);
-      }
-    });
   };
 
   // Show table rows
@@ -408,13 +336,6 @@ const StageUsers = () => {
     updateIsDeletion,
   };
 
-  // 'SearchInputLayout'
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
-  };
-
   // List of Toolbar items
   const toolbarItems: ToolbarItem[] = [
     {
@@ -437,8 +358,6 @@ const StageUsers = () => {
           name="search"
           ariaLabel="Search stage users"
           placeholder="Search stage users"
-          searchValueData={searchValueData}
-          isDisabled={searchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/StageUsers/StageUsers.tsx
+++ b/src/pages/StageUsers/StageUsers.tsx
@@ -55,8 +55,7 @@ const StageUsers = () => {
   useUpdateRoute({ pathname: "stage-users" });
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
 
   // Retrieve API version from environment data
   const apiVersion = useAppSelector(
@@ -177,19 +176,10 @@ const StageUsers = () => {
     setSelectedPerPage(selected);
   };
 
-  // Pagination
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
-  };
-
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
-  };
-
-  // Users displayed on the first page
-  const updateShownUsersList = (newShownUsersList: User[]) => {
-    setStageUsersList(newShownUsersList);
-  };
+  // Reset selected-per-page count whenever the page or page size changes
+  useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
 
   // Show table rows
   const [showTableRows, setShowTableRows] = useState(!isBatchLoading);
@@ -282,17 +272,6 @@ const StageUsers = () => {
   const selectableUsersTable = stageUsersList.filter(isUserSelectable); // elements per Table
 
   // Data wrappers
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList: updateShownUsersList,
-    totalCount,
-  };
-
   // - 'BulkSelectorPrep'
   const usersBulkSelectorData = {
     selected: selectedUsers,
@@ -433,7 +412,7 @@ const StageUsers = () => {
       element: (
         <PaginationLayout
           list={stageUsersList}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -484,7 +463,7 @@ const StageUsers = () => {
             >
               <PaginationLayout
                 list={stageUsersList}
-                paginationData={paginationData}
+                totalCount={totalCount}
                 variant={PaginationVariant.bottom}
                 widgetId="pagination-options-menu-bottom"
               />

--- a/src/pages/StageUsers/StageUsers.tsx
+++ b/src/pages/StageUsers/StageUsers.tsx
@@ -39,6 +39,10 @@ import AddUser from "src/components/modals/UserModals/AddUser";
 import ActivateStageUsers from "src/components/modals/UserModals/ActivateStageUsers";
 // Utils
 import { API_VERSION_BACKUP, isUserSelectable } from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 // RPC client
 import { GenericPayload } from "../../services/rpc";
 import { useGettingStageUserQuery } from "../../services/rpcUsers";
@@ -168,19 +172,6 @@ const StageUsers = () => {
     setIsDeletion(value);
   };
 
-  // Elements selected (per page)
-  //  - This will help to calculate the remaining elements on a specific page (bulk selector)
-  const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
-
-  const updateSelectedPerPage = (selected: number) => {
-    setSelectedPerPage(selected);
-  };
-
-  // Reset selected-per-page count whenever the page or page size changes
-  useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
-
   // Show table rows
   const [showTableRows, setShowTableRows] = useState(!isBatchLoading);
 
@@ -284,10 +275,11 @@ const StageUsers = () => {
     updateIsDeleteButtonDisabled,
   };
 
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage,
-  };
+  const selectedPerPageData = getSelectedPerPageData(
+    stageUsersList,
+    selectedUsers.map((item) => ipaPrimaryKey(item.uid)),
+    (item) => ipaPrimaryKey(item.uid)
+  );
 
   // 'DeleteUsers'
   const deleteUsersButtonsData = {

--- a/src/pages/StageUsers/StageUsers.tsx
+++ b/src/pages/StageUsers/StageUsers.tsx
@@ -198,6 +198,7 @@ const StageUsers = () => {
 
   // Filter (Input search)
   const updateSearchValue = (value: string) => {
+    setPage(1);
     setSearchValue(value);
   };
 
@@ -206,6 +207,7 @@ const StageUsers = () => {
 
   // Issue a search using a specific search value
   const submitSearchValue = () => {
+    setPage(1);
     setShowTableRows(false);
     setUsersTotalCount(0);
     setSearchIsDisabled(true);
@@ -214,8 +216,8 @@ const StageUsers = () => {
       searchValue: searchValue,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: firstUserIdx,
-      stopIdx: lastUserIdx,
+      startIdx: 0,
+      stopIdx: 100,
       entryType: "stage",
     } as GenericPayload).then((result) => {
       // Manage new response here
@@ -250,7 +252,7 @@ const StageUsers = () => {
             usersList.push(usersListResult[i].result);
           }
 
-          setStageUsersList(usersList);
+          setStageUsersList(usersList.slice(0, perPage));
           setUsersTotalCount(totalCount);
           // Show table elements
           setShowTableRows(true);

--- a/src/pages/SubordinateIDs/SubIdsStatistics.tsx
+++ b/src/pages/SubordinateIDs/SubIdsStatistics.tsx
@@ -46,16 +46,13 @@ const SubIdsStatistics = () => {
     rangesize: 0,
     remaining_subids: 0,
   });
-  const [showTableRows, setShowTableRows] = React.useState<boolean>(false);
 
   // API call
   const subidStatsResponse = useSubidStatsQuery();
-  const { data, isLoading, error } = subidStatsResponse;
+  const { data, isFetching, error } = subidStatsResponse;
 
   React.useEffect(() => {
-    setShowTableRows(!isLoading);
-
-    if (!isLoading && error) {
+    if (!isFetching && error) {
       dispatch(
         addAlert({
           name: "Error fetching data",
@@ -65,18 +62,15 @@ const SubIdsStatistics = () => {
       );
     }
 
-    if (!isLoading && data) {
+    if (!isFetching && data) {
       const subidStats = data.result.result;
       setSubidStats(subidStats as unknown as SubidStats);
     }
-  }, [data, isLoading]);
+  }, [data, error, isFetching, dispatch]);
 
   // On refresh
   const onRefresh = () => {
-    setShowTableRows(false);
-    subidStatsResponse.refetch().then(() => {
-      setShowTableRows(true);
-    });
+    subidStatsResponse.refetch();
   };
 
   // List of Toolbar items
@@ -88,7 +82,7 @@ const SubIdsStatistics = () => {
           variant="secondary"
           data-cy="subids-statistics-button-refresh"
           onClick={onRefresh}
-          isDisabled={!showTableRows}
+          isDisabled={isFetching}
         >
           Refresh
         </Button>
@@ -169,7 +163,7 @@ const SubIdsStatistics = () => {
                 classes={"pf-v6-u-mt-md"}
                 tableId={"subid-stats-table"}
                 tableHeader={header}
-                tableBody={!showTableRows ? skeleton : body}
+                tableBody={isFetching ? skeleton : body}
                 isStickyHeader={false}
               />
             </GridItem>

--- a/src/pages/SubordinateIDs/SubordinateIDs.tsx
+++ b/src/pages/SubordinateIDs/SubordinateIDs.tsx
@@ -134,12 +134,6 @@ const SubordinateIDs = () => {
     subIdsDataResponse.refetch();
   };
 
-  // Always refetch data when the component is loaded.
-  // This ensures the data is always up-to-date.
-  React.useEffect(() => {
-    subIdsDataResponse.refetch();
-  }, []);
-
   // Modals functionality
   const [showAddModal, setShowAddModal] = React.useState(false);
 

--- a/src/pages/SubordinateIDs/SubordinateIDs.tsx
+++ b/src/pages/SubordinateIDs/SubordinateIDs.tsx
@@ -32,8 +32,6 @@ import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayou
 
 import MainTable from "src/components/tables/MainTable";
 // Errors
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 import useApiError from "src/hooks/useApiError";
 import useContextualHelpTopic from "src/hooks/useContextualHelpTopic";
 import GlobalErrors from "src/components/errors/GlobalErrors";
@@ -41,7 +39,6 @@ import GlobalErrors from "src/components/errors/GlobalErrors";
 import {
   SubIdDataPayload,
   useGetSubIdEntriesQuery,
-  useSearchSubIdEntriesMutation,
 } from "src/services/rpcSubIds";
 // Modals
 import AddModal from "src/components/modals/SubIdsModals/AddModal";
@@ -61,7 +58,7 @@ const SubordinateIDs = () => {
   ) as string;
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   // Handle API calls errors
@@ -73,7 +70,6 @@ const SubordinateIDs = () => {
 
   // States
   const [subIds, setSubIds] = React.useState<SubId[]>([]);
-  const [searchDisabled, setSearchIsDisabled] = React.useState<boolean>(false);
   const [totalCount, setTotalCount] = React.useState<number>(0);
 
   // API calls
@@ -178,65 +174,6 @@ const SubordinateIDs = () => {
     setSubIds(newShownElementsList);
   };
 
-  // Update search input valie
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
-  // Search API call
-  const [searchEntry] = useSearchSubIdEntriesMutation();
-
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    searchEntry({
-      searchValue: search,
-      apiVersion,
-      sizelimit: 100,
-      startIdx: 0,
-      stopIdx: 200, // Search will consider a max. of elements
-    }).then((result) => {
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for subordinate IDs",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success
-          const listResult = result.data?.result.results || [];
-          const listSize = result.data?.result.count || 0;
-          const totalCount = result.data?.result.totalCount || 0;
-          const elementsList: SubId[] = [];
-
-          for (let i = 0; i < listSize; i++) {
-            elementsList.push(listResult[i].result);
-          }
-
-          setTotalCount(totalCount);
-          setSubIds(elementsList.slice(0, perPage));
-          setShowTableRows(true);
-        }
-        setSearchIsDisabled(false);
-      }
-    });
-  };
-
   // Data wrappers
   // TODO: Better separation of concerts
   // - 'PaginationLayout'
@@ -248,13 +185,6 @@ const SubordinateIDs = () => {
     updateSelectedPerPage: () => {},
     updateShownElementsList: updateShownElementsList,
     totalCount,
-  };
-
-  // SearchInputLayout
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
   };
 
   // Modals functionality
@@ -278,8 +208,6 @@ const SubordinateIDs = () => {
           name="search"
           ariaLabel="Search subordinate IDs"
           placeholder="Search subordinate IDs"
-          searchValueData={searchValueData}
-          isDisabled={searchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/SubordinateIDs/SubordinateIDs.tsx
+++ b/src/pages/SubordinateIDs/SubordinateIDs.tsx
@@ -14,7 +14,6 @@ import {
 // Data types
 import { SubId } from "src/utils/datatypes/globalDataTypes";
 // Hooks
-import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";

--- a/src/pages/SubordinateIDs/SubordinateIDs.tsx
+++ b/src/pages/SubordinateIDs/SubordinateIDs.tsx
@@ -180,6 +180,7 @@ const SubordinateIDs = () => {
 
   // Update search input valie
   const updateSearchValue = (value: string) => {
+    setPage(1);
     setSearchValue(value);
   };
 
@@ -187,6 +188,7 @@ const SubordinateIDs = () => {
   const [searchEntry] = useSearchSubIdEntriesMutation();
 
   const submitSearchValue = () => {
+    setPage(1);
     searchEntry({
       searchValue: searchValue,
       apiVersion,
@@ -226,7 +228,7 @@ const SubordinateIDs = () => {
           }
 
           setTotalCount(totalCount);
-          setSubIds(elementsList);
+          setSubIds(elementsList.slice(0, perPage));
           setShowTableRows(true);
         }
         setSearchIsDisabled(false);

--- a/src/pages/SubordinateIDs/SubordinateIDs.tsx
+++ b/src/pages/SubordinateIDs/SubordinateIDs.tsx
@@ -187,10 +187,11 @@ const SubordinateIDs = () => {
   // Search API call
   const [searchEntry] = useSearchSubIdEntriesMutation();
 
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     searchEntry({
-      searchValue: searchValue,
+      searchValue: search,
       apiVersion,
       sizelimit: 100,
       startIdx: 0,

--- a/src/pages/SubordinateIDs/SubordinateIDs.tsx
+++ b/src/pages/SubordinateIDs/SubordinateIDs.tsx
@@ -58,8 +58,7 @@ const SubordinateIDs = () => {
   ) as string;
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
 
   // Handle API calls errors
   const globalErrors = useApiError([]);
@@ -160,33 +159,6 @@ const SubordinateIDs = () => {
     }
   }, [isBatchLoading]);
 
-  // Pagination
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
-  };
-
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
-  };
-
-  // Elements displayed on the first page
-  const updateShownElementsList = (newShownElementsList: SubId[]) => {
-    setSubIds(newShownElementsList);
-  };
-
-  // Data wrappers
-  // TODO: Better separation of concerts
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage: () => {},
-    updateShownElementsList: updateShownElementsList,
-    totalCount,
-  };
-
   // Modals functionality
   const [showAddModal, setShowAddModal] = React.useState(false);
 
@@ -259,7 +231,7 @@ const SubordinateIDs = () => {
       element: (
         <PaginationLayout
           list={subIds}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -322,7 +294,7 @@ const SubordinateIDs = () => {
             >
               <PaginationLayout
                 list={subIds}
-                paginationData={paginationData}
+                totalCount={totalCount}
                 variant={PaginationVariant.bottom}
                 widgetId="pagination-options-menu-bottom"
               />

--- a/src/pages/SubordinateIDs/SubordinateIDs.tsx
+++ b/src/pages/SubordinateIDs/SubordinateIDs.tsx
@@ -81,14 +81,13 @@ const SubordinateIDs = () => {
 
   const {
     data: batchResponse,
-    isLoading: isBatchLoading,
+    isFetching: isBatchFetching,
     error: batchError,
   } = subIdsDataResponse;
 
   // Handle data when the API call is finished
   React.useEffect(() => {
     if (subIdsDataResponse.isFetching) {
-      setShowTableRows(false);
       // Reset selected elements on refresh
       setTotalCount(0);
       globalErrors.clear();
@@ -113,8 +112,6 @@ const SubordinateIDs = () => {
       setTotalCount(totalCount);
       // Update the list of elements
       setSubIds(elementsList);
-      // Show table elements
-      setShowTableRows(true);
     }
 
     // API response: Error
@@ -131,15 +128,10 @@ const SubordinateIDs = () => {
 
   // Refresh button handling
   const refreshData = () => {
-    // Hide table
-    setShowTableRows(false);
-
     // Reset selected elements on refresh
     setTotalCount(0);
 
-    subIdsDataResponse.refetch().then(() => {
-      setShowTableRows(true);
-    });
+    subIdsDataResponse.refetch();
   };
 
   // Always refetch data when the component is loaded.
@@ -147,16 +139,6 @@ const SubordinateIDs = () => {
   React.useEffect(() => {
     subIdsDataResponse.refetch();
   }, []);
-
-  // Show table rows
-  const [showTableRows, setShowTableRows] = React.useState(!isBatchLoading);
-
-  // Show table rows only when data is fully retrieved
-  React.useEffect(() => {
-    if (showTableRows !== !isBatchLoading) {
-      setShowTableRows(!isBatchLoading);
-    }
-  }, [isBatchLoading]);
 
   // Modals functionality
   const [showAddModal, setShowAddModal] = React.useState(false);
@@ -194,7 +176,7 @@ const SubordinateIDs = () => {
         <SecondaryButton
           dataCy="subids-button-refresh"
           onClickHandler={refreshData}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
         >
           Refresh
         </SecondaryButton>
@@ -205,7 +187,7 @@ const SubordinateIDs = () => {
       element: (
         <SecondaryButton
           dataCy="subids-button-add"
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
           onClickHandler={onOpenAddModal}
         >
           Add
@@ -281,7 +263,7 @@ const SubordinateIDs = () => {
                       ]}
                       hasCheckboxes={false}
                       pathname="subordinate-ids"
-                      showTableRows={showTableRows}
+                      showTableRows={!isBatchFetching}
                       showLink={true}
                     />
                   )}

--- a/src/pages/SudoCmdGroups/SudoCmdGroups.tsx
+++ b/src/pages/SudoCmdGroups/SudoCmdGroups.tsx
@@ -90,14 +90,13 @@ const SudoCmds = () => {
 
   const {
     data: batchResponse,
-    isLoading: isBatchLoading,
+    isFetching: isBatchFetching,
     error: batchError,
   } = cmdGroupsDataResponse;
 
   // Handle data when the API call is finished
   useEffect(() => {
     if (cmdGroupsDataResponse.isFetching) {
-      setShowTableRows(false);
       // Reset selected entries on refresh
       setCmdGroupsTotalCount(0);
       globalErrors.clear();
@@ -122,8 +121,6 @@ const SudoCmds = () => {
       setCmdGroupsTotalCount(totalCount);
       // Update the list
       setCmdGroupsList(cmdGroupsList);
-      // Show table elements
-      setShowTableRows(true);
     }
 
     // API response: Error
@@ -140,7 +137,6 @@ const SudoCmds = () => {
 
   // Refresh button handling
   const refreshData = () => {
-    setShowTableRows(false);
     setCmdGroupsTotalCount(0);
     clearSelectedCmdGroups();
     cmdGroupsDataResponse.refetch();
@@ -173,16 +169,6 @@ const SudoCmds = () => {
     const emptyList: SudoCmdGroup[] = [];
     setSelectedCmds(emptyList);
   };
-
-  // Show table rows
-  const [showTableRows, setShowTableRows] = useState(!isBatchLoading);
-
-  // Show table rows only when data is fully retrieved
-  useEffect(() => {
-    if (showTableRows !== !isBatchLoading) {
-      setShowTableRows(!isBatchLoading);
-    }
-  }, [isBatchLoading]);
 
   // Modals functionality
   const [showAddModal, setShowAddModal] = useState(false);
@@ -337,7 +323,7 @@ const SudoCmds = () => {
       element: (
         <SecondaryButton
           onClickHandler={refreshData}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
           dataCy="sudo-command-groups-button-refresh"
         >
           Refresh
@@ -348,7 +334,7 @@ const SudoCmds = () => {
       key: 4,
       element: (
         <SecondaryButton
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || isBatchFetching}
           onClickHandler={onDeleteHandler}
           dataCy="sudo-command-groups-button-delete"
         >
@@ -361,7 +347,7 @@ const SudoCmds = () => {
       element: (
         <SecondaryButton
           onClickHandler={onAddClickHandler}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
           dataCy="sudo-command-groups-button-add"
         >
           Add
@@ -420,7 +406,7 @@ const SudoCmds = () => {
                   ) : (
                     <SudoCmdGroupsTable
                       shownElementsList={cmdList}
-                      showTableRows={showTableRows}
+                      showTableRows={!isBatchFetching}
                       cmdGroupsData={cmdGroupsTableData}
                       buttonsData={cmdsTableButtonsData}
                       paginationData={selectedPerPageData}

--- a/src/pages/SudoCmdGroups/SudoCmdGroups.tsx
+++ b/src/pages/SudoCmdGroups/SudoCmdGroups.tsx
@@ -68,8 +68,7 @@ const SudoCmds = () => {
   const modalErrors = useApiError([]);
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
   const [totalCount, setCmdGroupsTotalCount] = useState<number>(0);
 
   // Page indexes
@@ -172,19 +171,10 @@ const SudoCmds = () => {
     setSelectedPerPage(selected);
   };
 
-  // Pagination
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
-  };
-
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
-  };
-
-  // Commands displayed on the first page
-  const updateShownCmdGroupsList = (newShownCmdsList: SudoCmdGroup[]) => {
-    setCmdGroupsList(newShownCmdsList);
-  };
+  // Reset selected-per-page count whenever the page or page size changes
+  useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
 
   const [selectedCmdGroups, setSelectedCmds] = useState<SudoCmdGroup[]>([]);
 
@@ -278,17 +268,6 @@ const SudoCmds = () => {
   };
 
   // Data wrappers
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList: updateShownCmdGroupsList,
-    totalCount,
-  };
-
   // - 'BulkSelector'
   const cmdsBulkSelectorData = {
     selected: selectedCmdGroups,
@@ -415,7 +394,7 @@ const SudoCmds = () => {
       element: (
         <PaginationLayout
           list={cmdList}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -464,7 +443,7 @@ const SudoCmds = () => {
             >
               <PaginationLayout
                 list={cmdList}
-                paginationData={paginationData}
+                totalCount={totalCount}
                 variant={PaginationVariant.bottom}
                 widgetId="pagination-options-menu-bottom"
               />

--- a/src/pages/SudoCmdGroups/SudoCmdGroups.tsx
+++ b/src/pages/SudoCmdGroups/SudoCmdGroups.tsx
@@ -206,13 +206,14 @@ const SudoCmds = () => {
   const [retrieveCmds] = useSearchEntriesMutation({});
 
   // Issue a search using a specific search value
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     setShowTableRows(false);
     setSearchIsDisabled(true);
     setCmdGroupsTotalCount(0);
     retrieveCmds({
-      searchValue: searchValue,
+      searchValue: search,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
       startIdx: 0,

--- a/src/pages/SudoCmdGroups/SudoCmdGroups.tsx
+++ b/src/pages/SudoCmdGroups/SudoCmdGroups.tsx
@@ -33,18 +33,15 @@ import BulkSelectorPrep from "src/components/BulkSelectorPrep";
 import AddSudoCmdGroup from "src/components/modals/SudoModals/AddSudoCmdGroup";
 import DeleteSudoCmdGroups from "src/components/modals/SudoModals/DeleteSudoCmdGroups";
 // Hooks
-import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Utils
 import { API_VERSION_BACKUP, isSudoCmdGroupSelectable } from "src/utils/utils";
 // RPC client
-import { GenericPayload, useSearchEntriesMutation } from "src/services/rpc";
+import { GenericPayload } from "src/services/rpc";
 import { useGettingSudoCmdGroupsQuery } from "src/services/rpcSudoCmdGroups";
 // Errors
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 import useApiError from "src/hooks/useApiError";
 import useContextualHelpTopic from "src/hooks/useContextualHelpTopic";
 import GlobalErrors from "src/components/errors/GlobalErrors";
@@ -71,10 +68,9 @@ const SudoCmds = () => {
   const modalErrors = useApiError([]);
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
   const [totalCount, setCmdGroupsTotalCount] = useState<number>(0);
-  const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
   // Page indexes
   const firstIdx = (page - 1) * perPage;
@@ -190,76 +186,11 @@ const SudoCmds = () => {
     setCmdGroupsList(newShownCmdsList);
   };
 
-  // Update search input valie
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
   const [selectedCmdGroups, setSelectedCmds] = useState<SudoCmdGroup[]>([]);
 
   const clearSelectedCmdGroups = () => {
     const emptyList: SudoCmdGroup[] = [];
     setSelectedCmds(emptyList);
-  };
-
-  const [retrieveCmds] = useSearchEntriesMutation({});
-
-  // Issue a search using a specific search value
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    setShowTableRows(false);
-    setSearchIsDisabled(true);
-    setCmdGroupsTotalCount(0);
-    retrieveCmds({
-      searchValue: search,
-      sizeLimit: 0,
-      apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: 0,
-      stopIdx: 100,
-      entryType: "sudocmdgroup",
-    } as GenericPayload).then((result) => {
-      // Manage new response here
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for sudo command groups",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success
-          const cmdsListResult = result.data?.result.results || [];
-          const cmdsListSize = result.data?.result.count || 0;
-          const totalCount = result.data?.result.totalCount || 0;
-          const cmdsList: SudoCmdGroup[] = [];
-
-          for (let i = 0; i < cmdsListSize; i++) {
-            cmdsList.push(cmdsListResult[i].result);
-          }
-
-          setCmdGroupsTotalCount(totalCount);
-          setCmdGroupsList(cmdsList.slice(0, perPage));
-          // Show table elements
-          setShowTableRows(true);
-        }
-        setSearchIsDisabled(false);
-      }
-    });
   };
 
   // Show table rows
@@ -399,13 +330,6 @@ const SudoCmds = () => {
     updateIsDeletion,
   };
 
-  // SearchInputLayout
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
-  };
-
   // List of Toolbar items
   const toolbarItems: ToolbarItem[] = [
     {
@@ -428,8 +352,6 @@ const SudoCmds = () => {
           name="search"
           ariaLabel="Search sudo command groups"
           placeholder="Search sudo command groups"
-          searchValueData={searchValueData}
-          isDisabled={searchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/SudoCmdGroups/SudoCmdGroups.tsx
+++ b/src/pages/SudoCmdGroups/SudoCmdGroups.tsx
@@ -142,12 +142,6 @@ const SudoCmds = () => {
     cmdGroupsDataResponse.refetch();
   };
 
-  // Always refetch data when the component is loaded.
-  // This ensures the data is always up-to-date.
-  React.useEffect(() => {
-    cmdGroupsDataResponse.refetch();
-  }, []);
-
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
     useState<boolean>(true);

--- a/src/pages/SudoCmdGroups/SudoCmdGroups.tsx
+++ b/src/pages/SudoCmdGroups/SudoCmdGroups.tsx
@@ -82,7 +82,7 @@ const SudoCmds = () => {
 
   // Derived states - what we get from API
   const cmdGroupsDataResponse = useGettingSudoCmdGroupsQuery({
-    searchValue: "",
+    searchValue: searchValue,
     sizeLimit: 0,
     apiVersion: apiVersion || API_VERSION_BACKUP,
     startIdx: firstIdx,
@@ -151,7 +151,7 @@ const SudoCmds = () => {
   // This ensures the data is always up-to-date.
   React.useEffect(() => {
     cmdGroupsDataResponse.refetch();
-  }, [page, perPage]);
+  }, []);
 
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
@@ -192,6 +192,7 @@ const SudoCmds = () => {
 
   // Update search input valie
   const updateSearchValue = (value: string) => {
+    setPage(1);
     setSearchValue(value);
   };
 
@@ -206,6 +207,7 @@ const SudoCmds = () => {
 
   // Issue a search using a specific search value
   const submitSearchValue = () => {
+    setPage(1);
     setShowTableRows(false);
     setSearchIsDisabled(true);
     setCmdGroupsTotalCount(0);
@@ -213,8 +215,8 @@ const SudoCmds = () => {
       searchValue: searchValue,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: firstIdx,
-      stopIdx: lastIdx,
+      startIdx: 0,
+      stopIdx: 100,
       entryType: "sudocmdgroup",
     } as GenericPayload).then((result) => {
       // Manage new response here
@@ -250,7 +252,7 @@ const SudoCmds = () => {
           }
 
           setCmdGroupsTotalCount(totalCount);
-          setCmdGroupsList(cmdsList);
+          setCmdGroupsList(cmdsList.slice(0, perPage));
           // Show table elements
           setShowTableRows(true);
         }

--- a/src/pages/SudoCmdGroups/SudoCmdGroups.tsx
+++ b/src/pages/SudoCmdGroups/SudoCmdGroups.tsx
@@ -38,6 +38,10 @@ import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Utils
 import { API_VERSION_BACKUP, isSudoCmdGroupSelectable } from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 // RPC client
 import { GenericPayload } from "src/services/rpc";
 import { useGettingSudoCmdGroupsQuery } from "src/services/rpcSudoCmdGroups";
@@ -163,19 +167,6 @@ const SudoCmds = () => {
     setIsDeletion(value);
   };
 
-  // Elements selected (per page)
-  //  - This will help to calculate the remaining elements on a specific page (bulk selector)
-  const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
-
-  const updateSelectedPerPage = (selected: number) => {
-    setSelectedPerPage(selected);
-  };
-
-  // Reset selected-per-page count whenever the page or page size changes
-  useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
-
   const [selectedCmdGroups, setSelectedCmds] = useState<SudoCmdGroup[]>([]);
 
   const clearSelectedCmdGroups = () => {
@@ -267,6 +258,12 @@ const SudoCmds = () => {
     }
   };
 
+  const selectedPerPageData = getSelectedPerPageData(
+    cmdList,
+    selectedCmdGroups.map((item) => ipaPrimaryKey(item.cn)),
+    (item) => ipaPrimaryKey(item.cn)
+  );
+
   // Data wrappers
   // - 'BulkSelector'
   const cmdsBulkSelectorData = {
@@ -278,11 +275,6 @@ const SudoCmds = () => {
 
   const buttonsData = {
     updateIsDeleteButtonDisabled,
-  };
-
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage,
   };
 
   const deleteCmdsButtonsData = {

--- a/src/pages/SudoCmds/SudoCmds.tsx
+++ b/src/pages/SudoCmds/SudoCmds.tsx
@@ -90,14 +90,13 @@ const SudoCmds = () => {
 
   const {
     data: batchResponse,
-    isLoading: isBatchLoading,
+    isFetching: isBatchFetching,
     error: batchError,
   } = cmdsDataResponse;
 
   // Handle data when the API call is finished
   useEffect(() => {
     if (cmdsDataResponse.isFetching) {
-      setShowTableRows(false);
       // Reset selected entries on refresh
       setCmdsTotalCount(0);
       globalErrors.clear();
@@ -122,8 +121,6 @@ const SudoCmds = () => {
       setCmdsTotalCount(totalCount);
       // Update the list
       setCmdsList(cmdsList);
-      // Show table elements
-      setShowTableRows(true);
     }
 
     // API response: Error
@@ -140,8 +137,6 @@ const SudoCmds = () => {
 
   // Refresh button handling
   const refreshData = () => {
-    // Hide table
-    setShowTableRows(false);
     setCmdsTotalCount(0);
     clearSelectedCmds();
 
@@ -175,16 +170,6 @@ const SudoCmds = () => {
     const emptyList: SudoCmd[] = [];
     setSelectedCmds(emptyList);
   };
-
-  // Show table rows
-  const [showTableRows, setShowTableRows] = useState(!isBatchLoading);
-
-  // Show table rows only when data is fully retrieved
-  useEffect(() => {
-    if (showTableRows !== !isBatchLoading) {
-      setShowTableRows(!isBatchLoading);
-    }
-  }, [isBatchLoading]);
 
   // Modals functionality
   const [showAddModal, setShowAddModal] = useState(false);
@@ -338,7 +323,7 @@ const SudoCmds = () => {
       element: (
         <SecondaryButton
           onClickHandler={refreshData}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
           dataCy="sudo-commands-button-refresh"
         >
           Refresh
@@ -349,7 +334,7 @@ const SudoCmds = () => {
       key: 4,
       element: (
         <SecondaryButton
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || isBatchFetching}
           onClickHandler={onDeleteHandler}
           dataCy="sudo-commands-button-delete"
         >
@@ -362,7 +347,7 @@ const SudoCmds = () => {
       element: (
         <SecondaryButton
           onClickHandler={onAddClickHandler}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
           dataCy="sudo-commands-button-add"
         >
           Add
@@ -421,7 +406,7 @@ const SudoCmds = () => {
                   ) : (
                     <SudoCmdsTable
                       shownElementsList={cmdList}
-                      showTableRows={showTableRows}
+                      showTableRows={!isBatchFetching}
                       cmdsData={cmdsTableData}
                       buttonsData={cmdsTableButtonsData}
                       paginationData={selectedPerPageData}

--- a/src/pages/SudoCmds/SudoCmds.tsx
+++ b/src/pages/SudoCmds/SudoCmds.tsx
@@ -68,8 +68,7 @@ const SudoCmds = () => {
   const modalErrors = useApiError([]);
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
   const [totalCount, setCmdsTotalCount] = useState<number>(0);
 
   // Page indexes
@@ -174,19 +173,10 @@ const SudoCmds = () => {
     setSelectedPerPage(selected);
   };
 
-  // Pagination
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
-  };
-
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
-  };
-
-  // Commands displayed on the first page
-  const updateShownCmdsList = (newShownCmdsList: SudoCmd[]) => {
-    setCmdsList(newShownCmdsList);
-  };
+  // Reset selected-per-page count whenever the page or page size changes
+  useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
 
   const [selectedCmds, setSelectedCmds] = useState<SudoCmd[]>([]);
 
@@ -277,17 +267,6 @@ const SudoCmds = () => {
   };
 
   // Data wrappers
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList: updateShownCmdsList,
-    totalCount,
-  };
-
   // - 'BulkSelector'
   const cmdsBulkSelectorData = {
     selected: selectedCmds,
@@ -416,7 +395,7 @@ const SudoCmds = () => {
       element: (
         <PaginationLayout
           list={cmdList}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -465,7 +444,7 @@ const SudoCmds = () => {
             >
               <PaginationLayout
                 list={cmdList}
-                paginationData={paginationData}
+                totalCount={totalCount}
                 variant={PaginationVariant.bottom}
                 widgetId="pagination-options-menu-bottom"
               />

--- a/src/pages/SudoCmds/SudoCmds.tsx
+++ b/src/pages/SudoCmds/SudoCmds.tsx
@@ -82,7 +82,7 @@ const SudoCmds = () => {
 
   // Derived states - what we get from API
   const cmdsDataResponse = useGettingSudoCmdsQuery({
-    searchValue: "",
+    searchValue: searchValue,
     sizeLimit: 0,
     apiVersion: apiVersion || API_VERSION_BACKUP,
     startIdx: firstIdx,
@@ -153,7 +153,7 @@ const SudoCmds = () => {
   // This ensures the data is always up-to-date.
   React.useEffect(() => {
     cmdsDataResponse.refetch();
-  }, [page, perPage]);
+  }, []);
 
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
@@ -194,6 +194,7 @@ const SudoCmds = () => {
 
   // Update search input valie
   const updateSearchValue = (value: string) => {
+    setPage(1);
     setSearchValue(value);
   };
 
@@ -208,6 +209,7 @@ const SudoCmds = () => {
 
   // Issue a search using a specific search value
   const submitSearchValue = () => {
+    setPage(1);
     setShowTableRows(false);
     setSearchIsDisabled(true);
     setCmdsTotalCount(0);
@@ -215,8 +217,8 @@ const SudoCmds = () => {
       searchValue: searchValue,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: firstIdx,
-      stopIdx: lastIdx,
+      startIdx: 0,
+      stopIdx: 100,
       entryType: "sudocmd",
     } as GenericPayload).then((result) => {
       // Manage new response here
@@ -252,7 +254,7 @@ const SudoCmds = () => {
           }
 
           setCmdsTotalCount(totalCount);
-          setCmdsList(cmdsList);
+          setCmdsList(cmdsList.slice(0, perPage));
           // Show table elements
           setShowTableRows(true);
         }

--- a/src/pages/SudoCmds/SudoCmds.tsx
+++ b/src/pages/SudoCmds/SudoCmds.tsx
@@ -33,18 +33,15 @@ import BulkSelectorPrep from "src/components/BulkSelectorPrep";
 import AddSudoCmd from "src/components/modals/SudoModals/AddSudoCmd";
 import DeleteSudoCmd from "src/components/modals/SudoModals/DeleteSudoCmd";
 // Hooks
-import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Utils
 import { API_VERSION_BACKUP, isSudoCmdSelectable } from "src/utils/utils";
 // RPC client
-import { GenericPayload, useSearchEntriesMutation } from "src/services/rpc";
+import { GenericPayload } from "src/services/rpc";
 import { useGettingSudoCmdsQuery } from "src/services/rpcSudoCmds";
 // Errors
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 import useApiError from "src/hooks/useApiError";
 import useContextualHelpTopic from "src/hooks/useContextualHelpTopic";
 import GlobalErrors from "src/components/errors/GlobalErrors";
@@ -71,10 +68,9 @@ const SudoCmds = () => {
   const modalErrors = useApiError([]);
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
   const [totalCount, setCmdsTotalCount] = useState<number>(0);
-  const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
   // Page indexes
   const firstIdx = (page - 1) * perPage;
@@ -192,76 +188,11 @@ const SudoCmds = () => {
     setCmdsList(newShownCmdsList);
   };
 
-  // Update search input valie
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
   const [selectedCmds, setSelectedCmds] = useState<SudoCmd[]>([]);
 
   const clearSelectedCmds = () => {
     const emptyList: SudoCmd[] = [];
     setSelectedCmds(emptyList);
-  };
-
-  const [retrieveCmds] = useSearchEntriesMutation({});
-
-  // Issue a search using a specific search value
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    setShowTableRows(false);
-    setSearchIsDisabled(true);
-    setCmdsTotalCount(0);
-    retrieveCmds({
-      searchValue: search,
-      sizeLimit: 0,
-      apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: 0,
-      stopIdx: 100,
-      entryType: "sudocmd",
-    } as GenericPayload).then((result) => {
-      // Manage new response here
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for sudo commands",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success
-          const cmdsListResult = result.data?.result.results || [];
-          const cmdsListSize = result.data?.result.count || 0;
-          const totalCount = result.data?.result.totalCount || 0;
-          const cmdsList: SudoCmd[] = [];
-
-          for (let i = 0; i < cmdsListSize; i++) {
-            cmdsList.push(cmdsListResult[i].result);
-          }
-
-          setCmdsTotalCount(totalCount);
-          setCmdsList(cmdsList.slice(0, perPage));
-          // Show table elements
-          setShowTableRows(true);
-        }
-        setSearchIsDisabled(false);
-      }
-    });
   };
 
   // Show table rows
@@ -400,13 +331,6 @@ const SudoCmds = () => {
     updateIsDeletion,
   };
 
-  // SearchInputLayout
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
-  };
-
   // List of Toolbar items
   const toolbarItems: ToolbarItem[] = [
     {
@@ -429,8 +353,6 @@ const SudoCmds = () => {
           name="search"
           ariaLabel="Search sudo commands"
           placeholder="Search sudo commands"
-          searchValueData={searchValueData}
-          isDisabled={searchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/SudoCmds/SudoCmds.tsx
+++ b/src/pages/SudoCmds/SudoCmds.tsx
@@ -208,13 +208,14 @@ const SudoCmds = () => {
   const [retrieveCmds] = useSearchEntriesMutation({});
 
   // Issue a search using a specific search value
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     setShowTableRows(false);
     setSearchIsDisabled(true);
     setCmdsTotalCount(0);
     retrieveCmds({
-      searchValue: searchValue,
+      searchValue: search,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
       startIdx: 0,

--- a/src/pages/SudoCmds/SudoCmds.tsx
+++ b/src/pages/SudoCmds/SudoCmds.tsx
@@ -143,12 +143,6 @@ const SudoCmds = () => {
     cmdsDataResponse.refetch();
   };
 
-  // Always refetch data when the component is loaded.
-  // This ensures the data is always up-to-date.
-  React.useEffect(() => {
-    cmdsDataResponse.refetch();
-  }, []);
-
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
     useState<boolean>(true);

--- a/src/pages/SudoCmds/SudoCmds.tsx
+++ b/src/pages/SudoCmds/SudoCmds.tsx
@@ -38,6 +38,10 @@ import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Utils
 import { API_VERSION_BACKUP, isSudoCmdSelectable } from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 // RPC client
 import { GenericPayload } from "src/services/rpc";
 import { useGettingSudoCmdsQuery } from "src/services/rpcSudoCmds";
@@ -165,19 +169,6 @@ const SudoCmds = () => {
     setIsDeletion(value);
   };
 
-  // Elements selected (per page)
-  //  - This will help to calculate the remaining elements on a specific page (bulk selector)
-  const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
-
-  const updateSelectedPerPage = (selected: number) => {
-    setSelectedPerPage(selected);
-  };
-
-  // Reset selected-per-page count whenever the page or page size changes
-  useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
-
   const [selectedCmds, setSelectedCmds] = useState<SudoCmd[]>([]);
 
   const clearSelectedCmds = () => {
@@ -266,6 +257,12 @@ const SudoCmds = () => {
     }
   };
 
+  const selectedPerPageData = getSelectedPerPageData(
+    cmdList,
+    selectedCmds.map((item) => ipaPrimaryKey(item.sudocmd)),
+    (item) => ipaPrimaryKey(item.sudocmd)
+  );
+
   // Data wrappers
   // - 'BulkSelector'
   const cmdsBulkSelectorData = {
@@ -277,11 +274,6 @@ const SudoCmds = () => {
 
   const buttonsData = {
     updateIsDeleteButtonDisabled,
-  };
-
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage,
   };
 
   // 'DeleteSudoCmds'

--- a/src/pages/SudoRules/SudoRules.tsx
+++ b/src/pages/SudoRules/SudoRules.tsx
@@ -229,13 +229,14 @@ const SudoRules = () => {
   const [retrieveRules] = useSearchEntriesMutation({});
 
   // Issue a search using a specific search value
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     setShowTableRows(false);
     setSearchIsDisabled(true);
     setRulesTotalCount(0);
     retrieveRules({
-      searchValue: searchValue,
+      searchValue: search,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
       startIdx: 0,

--- a/src/pages/SudoRules/SudoRules.tsx
+++ b/src/pages/SudoRules/SudoRules.tsx
@@ -69,8 +69,7 @@ const SudoRules = () => {
   const modalErrors = useApiError([]);
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
 
   const [totalCount, setRulesTotalCount] = useState<number>(0);
 
@@ -195,19 +194,10 @@ const SudoRules = () => {
     setSelectedPerPage(selected);
   };
 
-  // Pagination
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
-  };
-
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
-  };
-
-  // Rules displayed on the first page
-  const updateShownRulesList = (newShownRulesList: SudoRule[]) => {
-    setRulesList(newShownRulesList);
-  };
+  // Reset selected-per-page count whenever the page or page size changes
+  useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
 
   const [selectedRules, setSelectedRules] = useState<SudoRule[]>([]);
 
@@ -315,17 +305,6 @@ const SudoRules = () => {
 
   // Data wrappers
   // TODO: Better separation of concerts
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList: updateShownRulesList,
-    totalCount,
-  };
-
   // - 'BulkSelectorSudoRulesPrep'
   const rulesBulkSelectorData = {
     selected: selectedRules,
@@ -492,7 +471,7 @@ const SudoRules = () => {
       element: (
         <PaginationLayout
           list={rulesList}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -541,7 +520,7 @@ const SudoRules = () => {
             >
               <PaginationLayout
                 list={rulesList}
-                paginationData={paginationData}
+                totalCount={totalCount}
                 variant={PaginationVariant.bottom}
                 widgetId="pagination-options-menu-bottom"
               />

--- a/src/pages/SudoRules/SudoRules.tsx
+++ b/src/pages/SudoRules/SudoRules.tsx
@@ -34,18 +34,15 @@ import AddSudoRule from "src/components/modals/SudoModals/AddSudoRule";
 import DeleteSudoRule from "src/components/modals/SudoModals/DeleteSudoRule";
 import DisableEnableSudoRules from "src/components/modals/SudoModals/DisableEnableSudoRules";
 // Hooks
-import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Utils
 import { API_VERSION_BACKUP, isSudoRuleSelectable } from "src/utils/utils";
 // RPC client
-import { GenericPayload, useSearchEntriesMutation } from "src/services/rpc";
+import { GenericPayload } from "src/services/rpc";
 import { useGettingSudoRulesQuery } from "src/services/rpcSudoRules";
 // Errors
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 import useApiError from "src/hooks/useApiError";
 import useContextualHelpTopic from "src/hooks/useContextualHelpTopic";
 import GlobalErrors from "src/components/errors/GlobalErrors";
@@ -72,11 +69,10 @@ const SudoRules = () => {
   const modalErrors = useApiError([]);
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   const [totalCount, setRulesTotalCount] = useState<number>(0);
-  const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
   // Page indexes
   const firstIdx = (page - 1) * perPage;
@@ -213,76 +209,11 @@ const SudoRules = () => {
     setRulesList(newShownRulesList);
   };
 
-  // Update search input valie
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
   const [selectedRules, setSelectedRules] = useState<SudoRule[]>([]);
 
   const clearSelectedRules = () => {
     const emptyList: SudoRule[] = [];
     setSelectedRules(emptyList);
-  };
-
-  const [retrieveRules] = useSearchEntriesMutation({});
-
-  // Issue a search using a specific search value
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    setShowTableRows(false);
-    setSearchIsDisabled(true);
-    setRulesTotalCount(0);
-    retrieveRules({
-      searchValue: search,
-      sizeLimit: 0,
-      apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: 0,
-      stopIdx: 100,
-      entryType: "sudorule",
-    } as GenericPayload).then((result) => {
-      // Manage new response here
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for sudo rules",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success
-          const rulesListResult = result.data?.result.results || [];
-          const rulesListSize = result.data?.result.count || 0;
-          const totalCount = result.data?.result.totalCount || 0;
-          const rulesList: SudoRule[] = [];
-
-          for (let i = 0; i < rulesListSize; i++) {
-            rulesList.push(rulesListResult[i].result);
-          }
-
-          setRulesTotalCount(totalCount);
-          setRulesList(rulesList.slice(0, perPage));
-          // Show table elements
-          setShowTableRows(true);
-        }
-        setSearchIsDisabled(false);
-      }
-    });
   };
 
   // Show table rows
@@ -452,13 +383,6 @@ const SudoRules = () => {
     updateIsDisableEnableOp,
   };
 
-  // SearchInputLayout
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
-  };
-
   // List of Toolbar items
   const toolbarItems: ToolbarItem[] = [
     {
@@ -481,8 +405,6 @@ const SudoRules = () => {
           name="search"
           ariaLabel="Search sudo rules"
           placeholder="Search sudo rules"
-          searchValueData={searchValueData}
-          isDisabled={searchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/SudoRules/SudoRules.tsx
+++ b/src/pages/SudoRules/SudoRules.tsx
@@ -39,6 +39,10 @@ import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Utils
 import { API_VERSION_BACKUP, isSudoRuleSelectable } from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 // RPC client
 import { GenericPayload } from "src/services/rpc";
 import { useGettingSudoRulesQuery } from "src/services/rpcSudoRules";
@@ -186,19 +190,6 @@ const SudoRules = () => {
     setIsDisableEnableOp(value);
   };
 
-  // Elements selected (per page)
-  //  - This will help to calculate the remaining elements on a specific page (bulk selector)
-  const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
-
-  const updateSelectedPerPage = (selected: number) => {
-    setSelectedPerPage(selected);
-  };
-
-  // Reset selected-per-page count whenever the page or page size changes
-  useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
-
   const [selectedRules, setSelectedRules] = useState<SudoRule[]>([]);
 
   const clearSelectedRules = () => {
@@ -303,6 +294,12 @@ const SudoRules = () => {
     }
   };
 
+  const selectedPerPageData = getSelectedPerPageData(
+    rulesList,
+    selectedRules.map((item) => ipaPrimaryKey(item.cn)),
+    (item) => ipaPrimaryKey(item.cn)
+  );
+
   // Data wrappers
   // TODO: Better separation of concerts
   // - 'BulkSelectorSudoRulesPrep'
@@ -318,11 +315,6 @@ const SudoRules = () => {
     updateIsEnableButtonDisabled,
     updateIsDisableButtonDisabled,
     updateIsDisableEnableOp,
-  };
-
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage,
   };
 
   // 'DeleteRules'

--- a/src/pages/SudoRules/SudoRules.tsx
+++ b/src/pages/SudoRules/SudoRules.tsx
@@ -84,7 +84,7 @@ const SudoRules = () => {
 
   // Derived states - what we get from API
   const rulesDataResponse = useGettingSudoRulesQuery({
-    searchValue: "",
+    searchValue: searchValue,
     sizeLimit: 0,
     apiVersion: apiVersion || API_VERSION_BACKUP,
     startIdx: firstIdx,
@@ -153,7 +153,7 @@ const SudoRules = () => {
   // This ensures the data is always up-to-date.
   React.useEffect(() => {
     rulesDataResponse.refetch();
-  }, [page, perPage]);
+  }, []);
 
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
@@ -215,6 +215,7 @@ const SudoRules = () => {
 
   // Update search input valie
   const updateSearchValue = (value: string) => {
+    setPage(1);
     setSearchValue(value);
   };
 
@@ -229,6 +230,7 @@ const SudoRules = () => {
 
   // Issue a search using a specific search value
   const submitSearchValue = () => {
+    setPage(1);
     setShowTableRows(false);
     setSearchIsDisabled(true);
     setRulesTotalCount(0);
@@ -236,8 +238,8 @@ const SudoRules = () => {
       searchValue: searchValue,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: firstIdx,
-      stopIdx: lastIdx,
+      startIdx: 0,
+      stopIdx: 100,
       entryType: "sudorule",
     } as GenericPayload).then((result) => {
       // Manage new response here
@@ -273,7 +275,7 @@ const SudoRules = () => {
           }
 
           setRulesTotalCount(totalCount);
-          setRulesList(rulesList);
+          setRulesList(rulesList.slice(0, perPage));
           // Show table elements
           setShowTableRows(true);
         }

--- a/src/pages/SudoRules/SudoRules.tsx
+++ b/src/pages/SudoRules/SudoRules.tsx
@@ -92,14 +92,13 @@ const SudoRules = () => {
 
   const {
     data: batchResponse,
-    isLoading: isBatchLoading,
+    isFetching: isBatchFetching,
     error: batchError,
   } = rulesDataResponse;
 
   // Handle data when the API call is finished
   useEffect(() => {
     if (rulesDataResponse.isFetching) {
-      setShowTableRows(false);
       // Reset selected users on refresh
       setRulesTotalCount(0);
       globalErrors.clear();
@@ -124,8 +123,6 @@ const SudoRules = () => {
       setRulesTotalCount(totalCount);
       // Update the list
       setRulesList(rulesList);
-      // Show table elements
-      setShowTableRows(true);
     }
 
     // API response: Error
@@ -142,7 +139,6 @@ const SudoRules = () => {
 
   // Refresh button handling
   const refreshRulesData = () => {
-    setShowTableRows(false);
     setRulesTotalCount(0);
     clearSelectedRules();
     rulesDataResponse.refetch();
@@ -196,16 +192,6 @@ const SudoRules = () => {
     const emptyList: SudoRule[] = [];
     setSelectedRules(emptyList);
   };
-
-  // Show table rows
-  const [showTableRows, setShowTableRows] = useState(!isBatchLoading);
-
-  // Show table rows only when data is fully retrieved
-  useEffect(() => {
-    if (showTableRows !== !isBatchLoading) {
-      setShowTableRows(!isBatchLoading);
-    }
-  }, [isBatchLoading]);
 
   // Modals functionality
   const [showAddModal, setShowAddModal] = useState(false);
@@ -390,7 +376,7 @@ const SudoRules = () => {
       element: (
         <SecondaryButton
           onClickHandler={refreshRulesData}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
           dataCy="sudo-rules-button-refresh"
         >
           Refresh
@@ -401,7 +387,7 @@ const SudoRules = () => {
       key: 4,
       element: (
         <SecondaryButton
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || isBatchFetching}
           onClickHandler={onDeleteHandler}
           dataCy="sudo-rules-button-delete"
         >
@@ -414,7 +400,7 @@ const SudoRules = () => {
       element: (
         <SecondaryButton
           onClickHandler={onAddClickHandler}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
           dataCy="sudo-rules-button-add"
         >
           Add
@@ -425,7 +411,7 @@ const SudoRules = () => {
       key: 6,
       element: (
         <SecondaryButton
-          isDisabled={isDisableButtonDisabled || !showTableRows}
+          isDisabled={isDisableButtonDisabled || isBatchFetching}
           onClickHandler={() => onEnableDisableHandler(true)}
           dataCy="sudo-rules-button-disable"
         >
@@ -437,7 +423,7 @@ const SudoRules = () => {
       key: 7,
       element: (
         <SecondaryButton
-          isDisabled={isEnableButtonDisabled || !showTableRows}
+          isDisabled={isEnableButtonDisabled || isBatchFetching}
           onClickHandler={() => onEnableDisableHandler(false)}
           dataCy="sudo-rules-button-enable"
         >
@@ -497,7 +483,7 @@ const SudoRules = () => {
                   ) : (
                     <SudoRulesTable
                       shownElementsList={rulesList}
-                      showTableRows={showTableRows}
+                      showTableRows={!isBatchFetching}
                       rulesData={rulesTableData}
                       buttonsData={rulesTableButtonsData}
                       paginationData={selectedPerPageData}

--- a/src/pages/SudoRules/SudoRules.tsx
+++ b/src/pages/SudoRules/SudoRules.tsx
@@ -144,12 +144,6 @@ const SudoRules = () => {
     rulesDataResponse.refetch();
   };
 
-  // Always refetch data when the component is loaded.
-  // This ensures the data is always up-to-date.
-  React.useEffect(() => {
-    rulesDataResponse.refetch();
-  }, []);
-
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
     useState<boolean>(true);

--- a/src/pages/Trusts/EnableDisableTrustedDomainsModal.tsx
+++ b/src/pages/Trusts/EnableDisableTrustedDomainsModal.tsx
@@ -20,7 +20,6 @@ interface EnableDisableTrustedDomainsProps {
   domainNames: string[];
   setDomainNames: (domainNames: string[]) => void;
   operation: "enable" | "disable";
-  setShowTableRows: (value: boolean) => void;
   onRefresh: () => void;
 }
 
@@ -69,19 +68,16 @@ const EnableDisableTrustedDomainsModal = (
         }
       })
       .finally(() => {
-        props.setShowTableRows(true);
         onClose();
       });
   };
 
   const onClose = () => {
-    props.setShowTableRows(true);
     props.setDomainNames([]);
     props.onClose();
   };
 
   const onCloseWithoutClearingElements = () => {
-    props.setShowTableRows(true);
     props.onClose();
   };
 

--- a/src/pages/Trusts/TrustedDomains.tsx
+++ b/src/pages/Trusts/TrustedDomains.tsx
@@ -61,7 +61,7 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
   useUpdateRoute({ pathname: "trusted-domains" });
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage } = useListPageSearchParams();
+  const { page, perPage } = useListPageSearchParams();
 
   // Calculate pagination parameters for server-side pagination
   const startIdx = (page - 1) * perPage;
@@ -250,18 +250,12 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
       });
   };
 
-  // Data wrappers
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage: setPage,
-    updatePerPage: setPerPage,
-    updateSelectedPerPage: setSelectedPerPage,
-    updateShownElementsList: setTrustDomains,
-    totalCount,
-  };
+  // Reset the selected per-page count when the page or page size changes
+  React.useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
 
+  // Data wrappers
   // - 'BulkSelectorprep'
   const bulkSelectorData = {
     selected: selectedElements,
@@ -405,7 +399,7 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
       element: (
         <PaginationLayout
           list={trustDomains}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -506,7 +500,7 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
             >
               <PaginationLayout
                 list={trustDomains}
-                paginationData={paginationData}
+                totalCount={totalCount}
                 variant={PaginationVariant.bottom}
                 widgetId="pagination-options-menu-bottom"
                 className="pf-v6-u-pb-0 pf-v6-u-pr-md"

--- a/src/pages/Trusts/TrustedDomains.tsx
+++ b/src/pages/Trusts/TrustedDomains.tsx
@@ -18,8 +18,6 @@ import { TrustDomain } from "src/utils/datatypes/globalDataTypes";
 // RPC
 import {
   useTrustDomainsFindQuery,
-  useSearchTrustDomainsEntriesMutation,
-  TrustDomainFindPayload,
   useFetchTrustDomainsMutation,
 } from "src/services/rpcTrusts";
 // Redux
@@ -39,8 +37,6 @@ import ToolbarLayout, {
   ToolbarItem,
 } from "src/components/layouts/ToolbarLayout";
 import GlobalErrors from "src/components/errors/GlobalErrors";
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 import SecondaryButton from "src/components/layouts/SecondaryButton";
 import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
 
@@ -65,8 +61,7 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
   useUpdateRoute({ pathname: "trusted-domains" });
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
-    useListPageSearchParams();
+  const { page, setPage, perPage, setPerPage } = useListPageSearchParams();
 
   // Calculate pagination parameters for server-side pagination
   const startIdx = (page - 1) * perPage;
@@ -77,7 +72,6 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
 
   // States
   const [trustDomains, setTrustDomains] = React.useState<TrustDomain[]>([]);
-  const [isSearchDisabled, setIsSearchDisabled] = React.useState(false);
   const [totalCount, setTotalCount] = React.useState(0);
 
   // API calls
@@ -222,58 +216,6 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
   // Show table rows
   const [showTableRows, setShowTableRows] = React.useState<boolean>(!isLoading);
 
-  // Search API call
-  const [searchEntry] = useSearchTrustDomainsEntriesMutation();
-
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    const payload: TrustDomainFindPayload = {
-      trustId: props.trustId,
-      searchValue: search,
-      sizelimit: 0,
-    };
-
-    setIsSearchDisabled(true);
-
-    searchEntry(payload)
-      .then((result) => {
-        if ("data" in result) {
-          const searchError = result.data?.error as
-            | FetchBaseQueryError
-            | SerializedError;
-
-          if (searchError) {
-            dispatch(
-              addAlert({
-                name: "submit-search-value-error",
-                title: "Error searching for trusted domains",
-                variant: "danger",
-              })
-            );
-          } else {
-            const trustDomains = (
-              result.data?.result.result as unknown as Record<string, unknown>[]
-            ).map((item) => apiToTrustDomain(item));
-            setTrustDomains(trustDomains.slice(0, perPage));
-            setTotalCount(trustDomains.length);
-            setShowTableRows(true);
-          }
-        } else {
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: "Error searching for trusted domains",
-              variant: "danger",
-            })
-          );
-        }
-      })
-      .finally(() => {
-        setIsSearchDisabled(false);
-      });
-  };
-
   // Fetch trusted domains
   const [isFetching, setIsFetching] = React.useState<boolean>(false);
 
@@ -318,18 +260,6 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
     updateSelectedPerPage: setSelectedPerPage,
     updateShownElementsList: setTrustDomains,
     totalCount,
-  };
-
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
-  // SearchInputLayout
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
   };
 
   // - 'BulkSelectorprep'
@@ -388,8 +318,6 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
           name="search"
           ariaLabel="Search trusted domains"
           placeholder="Search trusted domains"
-          searchValueData={searchValueData}
-          isDisabled={isSearchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/Trusts/TrustedDomains.tsx
+++ b/src/pages/Trusts/TrustedDomains.tsx
@@ -225,11 +225,12 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
   // Search API call
   const [searchEntry] = useSearchTrustDomainsEntriesMutation();
 
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     const payload: TrustDomainFindPayload = {
       trustId: props.trustId,
-      searchValue: searchValue,
+      searchValue: search,
       sizelimit: 0,
     };
 

--- a/src/pages/Trusts/TrustedDomains.tsx
+++ b/src/pages/Trusts/TrustedDomains.tsx
@@ -31,6 +31,10 @@ import useContextualHelpTopic from "src/hooks/useContextualHelpTopic";
 import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Utils
 import { isTrustDomainSelectable } from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 import { apiToTrustDomain } from "src/utils/trustsUtils";
 // Components
 import ToolbarLayout, {
@@ -111,7 +115,6 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
   const [selectedElements, setSelectedElements] = React.useState<TrustDomain[]>(
     []
   );
-  const [selectedPerPage, setSelectedPerPage] = React.useState<number>(0);
 
   // Refresh button handling
   const refreshData = () => {
@@ -250,10 +253,11 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
       });
   };
 
-  // Reset the selected per-page count when the page or page size changes
-  React.useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
+  const selectedPerPageData = getSelectedPerPageData(
+    trustDomains,
+    selectedElements.map((trustDomain) => ipaPrimaryKey(trustDomain.cn)),
+    (trustDomain) => ipaPrimaryKey(trustDomain.cn)
+  );
 
   // Data wrappers
   // - 'BulkSelectorprep'
@@ -262,11 +266,6 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
     updateSelected: updateSelectedTrustDomains,
     selectableTable: selectableTrustDomainsTable,
     nameAttr: "cn",
-  };
-
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage: setSelectedPerPage,
   };
 
   // Modals functionality
@@ -483,10 +482,7 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
                               setIsDisableButtonDisabled(value),
                             isDisableEnableOp: true,
                           }}
-                          paginationData={{
-                            selectedPerPage,
-                            updateSelectedPerPage: setSelectedPerPage,
-                          }}
+                          paginationData={selectedPerPageData}
                           statusElementName="domain_enabled"
                         />
                       )}

--- a/src/pages/Trusts/TrustedDomains.tsx
+++ b/src/pages/Trusts/TrustedDomains.tsx
@@ -85,12 +85,11 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
     sizelimit: perPage,
   });
 
-  const { data, isLoading, error } = trustDomainsResponse;
+  const { data, isFetching, error } = trustDomainsResponse;
 
   // Handle data when the API call is finished
   React.useEffect(() => {
     if (trustDomainsResponse.isFetching) {
-      setShowTableRows(false);
       setTotalCount(0);
       globalErrors.clear();
       return;
@@ -107,7 +106,6 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
       ).slice(startIdx, stopIdx);
       setTrustDomains(paginatedData.map((item) => apiToTrustDomain(item)));
       setTotalCount(paginatedData.length);
-      setShowTableRows(true);
     }
   }, [trustDomainsResponse]);
 
@@ -121,21 +119,15 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
     // Reset selected elements on refresh
     setSelectedElements([]);
 
-    trustDomainsResponse
-      .refetch()
-      .then(() => {
-        setShowTableRows(true);
-      })
-      .catch(() => {
-        dispatch(
-          addAlert({
-            name: "refresh-trusted-domains-error",
-            title: "Error refreshing trusted domains",
-            variant: "danger",
-          })
-        );
-        setShowTableRows(true); // Show table even if there's an error
-      });
+    trustDomainsResponse.refetch().catch(() => {
+      dispatch(
+        addAlert({
+          name: "refresh-trusted-domains-error",
+          title: "Error refreshing trusted domains",
+          variant: "danger",
+        })
+      );
+    });
   };
 
   // Toolbar buttons states
@@ -216,15 +208,12 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
     trustDomainsResponse.refetch();
   }, []);
 
-  // Show table rows
-  const [showTableRows, setShowTableRows] = React.useState<boolean>(!isLoading);
-
   // Fetch trusted domains
-  const [isFetching, setIsFetching] = React.useState<boolean>(false);
+  const [isFetchingDomains, setIsFetchingDomains] =
+    React.useState<boolean>(false);
 
   const fetchTrustedDomains = () => {
-    setIsFetching(true);
-    setShowTableRows(false);
+    setIsFetchingDomains(true);
 
     fetchTrustDomains(props.trustId)
       .then((result) => {
@@ -248,10 +237,11 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
         }
       })
       .finally(() => {
-        setIsFetching(false);
-        setShowTableRows(true);
+        setIsFetchingDomains(false);
       });
   };
+
+  const isTableLoading = isFetching || isFetchingDomains;
 
   const selectedPerPageData = getSelectedPerPageData(
     trustDomains,
@@ -326,7 +316,7 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
         <SecondaryButton
           dataCy="trusted-domains-button-refresh"
           onClickHandler={refreshData}
-          isDisabled={!showTableRows}
+          isDisabled={isTableLoading}
         >
           Refresh
         </SecondaryButton>
@@ -336,7 +326,7 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
       key: 4,
       element: (
         <SecondaryButton
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || isTableLoading}
           dataCy="trusted-domains-button-delete"
           onClickHandler={() => setShowDeleteModal(true)}
         >
@@ -348,7 +338,7 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
       key: 5,
       element: (
         <SecondaryButton
-          isDisabled={!showTableRows || isDisableButtonDisabled}
+          isDisabled={isTableLoading || isDisableButtonDisabled}
           dataCy="trusted-domains-button-disable"
           onClickHandler={onDisableOperation}
         >
@@ -360,7 +350,7 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
       key: 6,
       element: (
         <SecondaryButton
-          isDisabled={!showTableRows || isEnableButtonDisabled}
+          isDisabled={isTableLoading || isEnableButtonDisabled}
           dataCy="trusted-domains-button-enable"
           onClickHandler={onEnableOperation}
         >
@@ -372,7 +362,7 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
       key: 7,
       element: (
         <SecondaryButton
-          isDisabled={!showTableRows || isFetching}
+          isDisabled={isTableLoading || isFetchingDomains}
           dataCy="trusted-domains-button-fetch-domains"
           onClickHandler={fetchTrustedDomains}
         >
@@ -439,7 +429,7 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
                     <GlobalErrors errors={globalErrors.getAll()} />
                   ) : (
                     <>
-                      {isLoading || !showTableRows ? (
+                      {isTableLoading ? (
                         spinner
                       ) : (
                         <MainTable
@@ -460,7 +450,7 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
                           ]}
                           hasCheckboxes={true}
                           pathname="trusted-domains"
-                          showTableRows={showTableRows}
+                          showTableRows={!isTableLoading}
                           showLink={false}
                           elementsData={{
                             isElementSelectable: isTrustDomainSelectable,
@@ -515,7 +505,6 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
             )
           }
           operation={operation}
-          setShowTableRows={setShowTableRows}
           onRefresh={refreshData}
         />
         <DeleteTrustedDomainsModal

--- a/src/pages/Trusts/TrustedDomains.tsx
+++ b/src/pages/Trusts/TrustedDomains.tsx
@@ -202,12 +202,6 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
     }
   };
 
-  // Always refetch data when the component is loaded.
-  // This ensures the data is always up-to-date.
-  React.useEffect(() => {
-    trustDomainsResponse.refetch();
-  }, []);
-
   // Fetch trusted domains
   const [isFetchingDomains, setIsFetchingDomains] =
     React.useState<boolean>(false);

--- a/src/pages/Trusts/TrustedDomains.tsx
+++ b/src/pages/Trusts/TrustedDomains.tsx
@@ -226,6 +226,7 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
   const [searchEntry] = useSearchTrustDomainsEntriesMutation();
 
   const submitSearchValue = () => {
+    setPage(1);
     const payload: TrustDomainFindPayload = {
       trustId: props.trustId,
       searchValue: searchValue,
@@ -253,9 +254,8 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
             const trustDomains = (
               result.data?.result.result as unknown as Record<string, unknown>[]
             ).map((item) => apiToTrustDomain(item));
-            const paginatedData = trustDomains.slice(startIdx, stopIdx);
-            setTrustDomains(paginatedData);
-            setTotalCount(paginatedData.length);
+            setTrustDomains(trustDomains.slice(0, perPage));
+            setTotalCount(trustDomains.length);
             setShowTableRows(true);
           }
         } else {
@@ -319,10 +319,15 @@ const TrustedDomains = (props: TrustedDomainsProps) => {
     totalCount,
   };
 
+  const updateSearchValue = (value: string) => {
+    setPage(1);
+    setSearchValue(value);
+  };
+
   // SearchInputLayout
   const searchValueData = {
     searchValue,
-    updateSearchValue: setSearchValue,
+    updateSearchValue,
     submitSearchValue,
   };
 

--- a/src/pages/Trusts/Trusts.tsx
+++ b/src/pages/Trusts/Trusts.tsx
@@ -26,6 +26,10 @@ import { useGetTrustsFullDataQuery } from "src/services/rpcTrusts";
 // Utils
 import { apiToTrust } from "src/utils/trustsUtils";
 import { isTrustSelectable } from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 // React router
 import { useNavigate } from "react-router";
 // Components
@@ -136,7 +140,6 @@ const Trusts = () => {
 
   // Selected elements
   const [selectedElements, setSelectedElements] = React.useState<Trust[]>([]);
-  const [selectedPerPage, setSelectedPerPage] = React.useState<number>(0);
 
   // Refresh button handling
   const refreshData = () => {
@@ -205,10 +208,11 @@ const Trusts = () => {
     trustsResponse.refetch();
   }, []);
 
-  // Reset the selected per-page count when the page or page size changes
-  React.useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
+  const selectedPerPageData = getSelectedPerPageData(
+    trusts,
+    selectedElements.map((trust) => ipaPrimaryKey(trust.cn)),
+    (trust) => ipaPrimaryKey(trust.cn)
+  );
 
   // Data wrappers
   // - 'BulkSelectorprep'
@@ -217,11 +221,6 @@ const Trusts = () => {
     updateSelected: updateSelectedTrusts,
     selectableTable: selectableTrustsTable,
     nameAttr: "cn",
-  };
-
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage: setSelectedPerPage,
   };
 
   // Modals functionality
@@ -368,10 +367,7 @@ const Trusts = () => {
                         updateIsDeletion: (value) => setIsDeletion(value),
                         isDisableEnableOp: true,
                       }}
-                      paginationData={{
-                        selectedPerPage,
-                        updateSelectedPerPage: setSelectedPerPage,
-                      }}
+                      paginationData={selectedPerPageData}
                     />
                   )}
                 </InnerScrollContainer>

--- a/src/pages/Trusts/Trusts.tsx
+++ b/src/pages/Trusts/Trusts.tsx
@@ -219,6 +219,7 @@ const Trusts = () => {
   const [searchEntry] = useSearchTrustsEntriesMutation();
 
   const submitSearchValue = () => {
+    setPage(1);
     searchEntry({
       searchValue,
       apiVersion,
@@ -267,10 +268,15 @@ const Trusts = () => {
     totalCount,
   };
 
+  const updateSearchValue = (value: string) => {
+    setPage(1);
+    setSearchValue(value);
+  };
+
   // SearchInputLayout
   const searchValueData = {
     searchValue,
-    updateSearchValue: setSearchValue,
+    updateSearchValue,
     submitSearchValue,
   };
 

--- a/src/pages/Trusts/Trusts.tsx
+++ b/src/pages/Trusts/Trusts.tsx
@@ -84,7 +84,7 @@ const Trusts = () => {
     stopIdx: lastUserIdx,
   });
 
-  const { data, isLoading, error } = trustsResponse;
+  const { data, isFetching, error } = trustsResponse;
 
   // Process data and update state when response changes
   React.useEffect(() => {
@@ -129,14 +129,6 @@ const Trusts = () => {
     }
     return 0;
   }, [trustsResponse.isSuccess, trustsResponse.data]);
-
-  // Compute derived state for showTableRows
-  const showTableRows = React.useMemo(() => {
-    if (trustsResponse.isFetching) {
-      return false;
-    }
-    return !isLoading;
-  }, [trustsResponse.isFetching, isLoading]);
 
   // Selected elements
   const [selectedElements, setSelectedElements] = React.useState<Trust[]>([]);
@@ -266,7 +258,7 @@ const Trusts = () => {
         <SecondaryButton
           dataCy="trusts-button-refresh"
           onClickHandler={refreshData}
-          isDisabled={!showTableRows}
+          isDisabled={isFetching}
         >
           Refresh
         </SecondaryButton>
@@ -276,7 +268,7 @@ const Trusts = () => {
       key: 4,
       element: (
         <SecondaryButton
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || isFetching}
           dataCy="trusts-button-delete"
           onClickHandler={() => setShowDeleteModal(true)}
         >
@@ -288,7 +280,7 @@ const Trusts = () => {
       key: 5,
       element: (
         <SecondaryButton
-          isDisabled={!showTableRows}
+          isDisabled={isFetching}
           dataCy="trusts-button-add"
           onClickHandler={() => setShowAddModal(true)}
         >
@@ -351,7 +343,7 @@ const Trusts = () => {
                       columnNames={["Realm name"]}
                       hasCheckboxes={true}
                       pathname="trusts"
-                      showTableRows={showTableRows}
+                      showTableRows={!isFetching}
                       showLink={true}
                       elementsData={{
                         isElementSelectable: isTrustSelectable,

--- a/src/pages/Trusts/Trusts.tsx
+++ b/src/pages/Trusts/Trusts.tsx
@@ -14,7 +14,6 @@ import {
 // Data types
 import { Trust } from "src/utils/datatypes/globalDataTypes";
 // Hooks
-import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import useApiError from "src/hooks/useApiError";
@@ -23,18 +22,13 @@ import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Redux
 import { useAppSelector, useAppDispatch } from "src/store/hooks";
 // RPC
-import {
-  useGetTrustsFullDataQuery,
-  useSearchTrustsEntriesMutation,
-} from "src/services/rpcTrusts";
+import { useGetTrustsFullDataQuery } from "src/services/rpcTrusts";
 // Utils
 import { apiToTrust } from "src/utils/trustsUtils";
 import { isTrustSelectable } from "src/utils/utils";
 // React router
 import { useNavigate } from "react-router";
 // Components
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 import ToolbarLayout, {
   ToolbarItem,
 } from "src/components/layouts/ToolbarLayout";
@@ -68,7 +62,7 @@ const Trusts = () => {
   ) as string;
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   // Handle API calls errors
@@ -77,9 +71,6 @@ const Trusts = () => {
   // Page indexes
   const firstUserIdx = (page - 1) * perPage;
   const lastUserIdx = page * perPage;
-
-  // States
-  const [isSearchDisabled, setIsSearchDisabled] = React.useState(false);
 
   // API calls
   const trustsResponse = useGetTrustsFullDataQuery({
@@ -215,48 +206,6 @@ const Trusts = () => {
     trustsResponse.refetch();
   }, []);
 
-  // Search API call
-  const [searchEntry] = useSearchTrustsEntriesMutation();
-
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    searchEntry({
-      searchValue: search,
-      apiVersion,
-      sizelimit: 100,
-      startIdx: 0,
-      stopIdx: 100,
-    }).then((result) => {
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for elements",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success - data will be updated through the API response
-          // No need to manually set state as it's computed from the response
-        }
-        setIsSearchDisabled(false);
-      }
-    });
-  };
-
   // Data wrappers
   // TODO: Better separation of concerts
   // - 'PaginationLayout'
@@ -267,18 +216,6 @@ const Trusts = () => {
     updatePerPage: setPerPage,
     updateSelectedPerPage: setSelectedPerPage,
     totalCount,
-  };
-
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
-  // SearchInputLayout
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
   };
 
   // - 'BulkSelectorprep'
@@ -322,8 +259,6 @@ const Trusts = () => {
           name="search"
           ariaLabel="Search trusts"
           placeholder="Search trusts"
-          searchValueData={searchValueData}
-          isDisabled={isSearchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/Trusts/Trusts.tsx
+++ b/src/pages/Trusts/Trusts.tsx
@@ -194,12 +194,6 @@ const Trusts = () => {
     }
   };
 
-  // Always refetch data when the component is loaded.
-  // This ensures the data is always up-to-date.
-  React.useEffect(() => {
-    trustsResponse.refetch();
-  }, []);
-
   const selectedPerPageData = getSelectedPerPageData(
     trusts,
     selectedElements.map((trust) => ipaPrimaryKey(trust.cn)),

--- a/src/pages/Trusts/Trusts.tsx
+++ b/src/pages/Trusts/Trusts.tsx
@@ -218,10 +218,11 @@ const Trusts = () => {
   // Search API call
   const [searchEntry] = useSearchTrustsEntriesMutation();
 
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     searchEntry({
-      searchValue,
+      searchValue: search,
       apiVersion,
       sizelimit: 100,
       startIdx: 0,

--- a/src/pages/Trusts/Trusts.tsx
+++ b/src/pages/Trusts/Trusts.tsx
@@ -62,8 +62,7 @@ const Trusts = () => {
   ) as string;
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, perPage, searchValue } = useListPageSearchParams();
 
   // Handle API calls errors
   const globalErrors = useApiError([]);
@@ -206,18 +205,12 @@ const Trusts = () => {
     trustsResponse.refetch();
   }, []);
 
-  // Data wrappers
-  // TODO: Better separation of concerts
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage: setPage,
-    updatePerPage: setPerPage,
-    updateSelectedPerPage: setSelectedPerPage,
-    totalCount,
-  };
+  // Reset the selected per-page count when the page or page size changes
+  React.useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
 
+  // Data wrappers
   // - 'BulkSelectorprep'
   const bulkSelectorData = {
     selected: selectedElements,
@@ -322,7 +315,7 @@ const Trusts = () => {
       element: (
         <PaginationLayout
           list={trusts}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -389,7 +382,7 @@ const Trusts = () => {
             >
               <PaginationLayout
                 list={trusts}
-                paginationData={paginationData}
+                totalCount={totalCount}
                 variant={PaginationVariant.bottom}
                 widgetId="pagination-options-menu-bottom"
               />

--- a/src/pages/UserGroups/UserGroups.tsx
+++ b/src/pages/UserGroups/UserGroups.tsx
@@ -153,11 +153,6 @@ const UserGroups = () => {
     }
   }, [groupDataResponse]);
 
-  // Always refetch data when the page changes
-  useEffect(() => {
-    groupDataResponse.refetch();
-  }, [page, perPage]);
-
   // Refresh button handling
   const refreshGroupsData = () => {
     // Reset selected user groups on refresh

--- a/src/pages/UserGroups/UserGroups.tsx
+++ b/src/pages/UserGroups/UserGroups.tsx
@@ -65,8 +65,7 @@ const UserGroups = () => {
   const [groupsList, setGroupsList] = useState<UserGroup[]>([]);
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue } =
-    useListPageSearchParams();
+  const { page, setPage, perPage, searchValue } = useListPageSearchParams();
 
   // Handle API calls errors
   const globalErrors = useApiError([]);
@@ -79,12 +78,11 @@ const UserGroups = () => {
   const updateSelectedPerPage = (selected: number) => {
     setSelectedPerPage(selected);
   };
-  const updatePage = (newPage: number) => {
-    setPage(newPage);
-  };
-  const updatePerPage = (newSetPerPage: number) => {
-    setPerPage(newSetPerPage);
-  };
+
+  // Reset selected-per-page count whenever the page or page size changes
+  useEffect(() => {
+    setSelectedPerPage(0);
+  }, [page, perPage]);
 
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
@@ -99,10 +97,6 @@ const UserGroups = () => {
 
   const updateIsDeletion = (value: boolean) => {
     setIsDeletion(value);
-  };
-
-  const updateShownGroupsList = (newShownGroupsList: UserGroup[]) => {
-    setGroupsList(newShownGroupsList);
   };
 
   // Page indexes
@@ -270,17 +264,6 @@ const UserGroups = () => {
   const selectableGroupsTable = groupsList.filter(isUserGroupSelectable); // elements per Table
 
   // Data wrappers
-  // - 'PaginationLayout'
-  const paginationData = {
-    page,
-    perPage,
-    updatePage,
-    updatePerPage,
-    updateSelectedPerPage,
-    updateShownElementsList: updateShownGroupsList,
-    totalCount,
-  };
-
   // - 'BulkSelectorPrep'
   const groupsBulkSelectorData = {
     selected: selectedGroups,
@@ -409,7 +392,7 @@ const UserGroups = () => {
       element: (
         <PaginationLayout
           list={groupsList}
-          paginationData={paginationData}
+          totalCount={totalCount}
           widgetId="pagination-options-menu-top"
           isCompact={true}
         />
@@ -455,7 +438,7 @@ const UserGroups = () => {
             >
               <PaginationLayout
                 list={groupsList}
-                paginationData={paginationData}
+                totalCount={totalCount}
                 variant={PaginationVariant.bottom}
                 widgetId="pagination-options-menu-bottom"
               />

--- a/src/pages/UserGroups/UserGroups.tsx
+++ b/src/pages/UserGroups/UserGroups.tsx
@@ -37,19 +37,16 @@ import { API_VERSION_BACKUP, isUserGroupSelectable } from "src/utils/utils";
 // Redux
 import { useAppDispatch } from "src/store/hooks";
 // Hooks
-import { addAlert } from "src/store/Global/alerts-slice";
 import useUpdateRoute from "src/hooks/useUpdateRoute";
 import useListPageSearchParams from "src/hooks/useListPageSearchParams";
 import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
 // Errors
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { SerializedError } from "@reduxjs/toolkit";
 import useApiError from "src/hooks/useApiError";
 import useContextualHelpTopic from "src/hooks/useContextualHelpTopic";
 import GlobalErrors from "src/components/errors/GlobalErrors";
 import ModalErrors from "src/components/errors/ModalErrors";
 // RPC client
-import { GenericPayload, useSearchEntriesMutation } from "../../services/rpc";
+import { GenericPayload } from "../../services/rpc";
 import { useGettingGroupsQuery } from "../../services/rpcUserGroups";
 
 const UserGroups = () => {
@@ -68,7 +65,7 @@ const UserGroups = () => {
   const [groupsList, setGroupsList] = useState<UserGroup[]>([]);
 
   // URL parameters: page number, page size, search value
-  const { page, setPage, perPage, setPerPage, searchValue, setSearchValue } =
+  const { page, setPage, perPage, setPerPage, searchValue } =
     useListPageSearchParams();
 
   // Handle API calls errors
@@ -78,7 +75,6 @@ const UserGroups = () => {
   // Table comps
   const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
   const [totalCount, setGroupsTotalCount] = useState<number>(0);
-  const [searchDisabled, setSearchIsDisabled] = useState<boolean>(false);
 
   const updateSelectedPerPage = (selected: number) => {
     setSelectedPerPage(selected);
@@ -189,75 +185,10 @@ const UserGroups = () => {
     groupDataResponse.refetch();
   };
 
-  const updateSearchValue = (value: string) => {
-    setPage(1);
-    setSearchValue(value);
-  };
-
   const [selectedGroups, setSelectedGroupsList] = useState<UserGroup[]>([]);
   const clearSelectedGroups = () => {
     const emptyList: UserGroup[] = [];
     setSelectedGroupsList(emptyList);
-  };
-
-  const [retrieveGroup] = useSearchEntriesMutation({});
-
-  // Issue a search using a specific search value
-  const submitSearchValue = (value?: string) => {
-    const search = value ?? searchValue;
-    setPage(1);
-    setShowTableRows(false);
-    setGroupsTotalCount(0);
-    setSearchIsDisabled(true);
-    retrieveGroup({
-      searchValue: search,
-      sizeLimit: 0,
-      apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: 0,
-      stopIdx: 100,
-      entryType: "usergroup",
-    } as GenericPayload).then((result) => {
-      // Manage new response here
-      if ("data" in result) {
-        const searchError = result.data?.error as
-          | FetchBaseQueryError
-          | SerializedError;
-
-        if (searchError) {
-          // Error
-          let error: string | undefined = "";
-          if ("error" in searchError) {
-            error = searchError.error;
-          } else if ("message" in searchError) {
-            error = searchError.message;
-          }
-          dispatch(
-            addAlert({
-              name: "submit-search-value-error",
-              title: error || "Error when searching for user groups",
-              variant: "danger",
-            })
-          );
-        } else {
-          // Success
-          const groupsListResult = result.data?.result.results || [];
-          const groupsListSize = result.data?.result.count || 0;
-          const totalCount = result.data?.result.totalCount || 0;
-          const groupsList: UserGroup[] = [];
-
-          for (let i = 0; i < groupsListSize; i++) {
-            groupsList.push(groupsListResult[i].result);
-          }
-
-          // Update 'user groups' slice data
-          setGroupsList(groupsList.slice(0, perPage));
-          setGroupsTotalCount(totalCount);
-          // Show table elements
-          setShowTableRows(true);
-        }
-        setSearchIsDisabled(false);
-      }
-    });
   };
 
   // Show table rows
@@ -393,13 +324,6 @@ const UserGroups = () => {
     updateIsDeletion,
   };
 
-  // - 'SearchInputLayout'
-  const searchValueData = {
-    searchValue,
-    updateSearchValue,
-    submitSearchValue,
-  };
-
   // List of toolbar items
   const toolbarItems: ToolbarItem[] = [
     {
@@ -422,8 +346,6 @@ const UserGroups = () => {
           name="search"
           ariaLabel="Search user groups"
           placeholder="Search user groups"
-          searchValueData={searchValueData}
-          isDisabled={searchDisabled}
         />
       ),
       toolbarItemVariant: ToolbarItemVariant.label,

--- a/src/pages/UserGroups/UserGroups.tsx
+++ b/src/pages/UserGroups/UserGroups.tsx
@@ -203,13 +203,14 @@ const UserGroups = () => {
   const [retrieveGroup] = useSearchEntriesMutation({});
 
   // Issue a search using a specific search value
-  const submitSearchValue = () => {
+  const submitSearchValue = (value?: string) => {
+    const search = value ?? searchValue;
     setPage(1);
     setShowTableRows(false);
     setGroupsTotalCount(0);
     setSearchIsDisabled(true);
     retrieveGroup({
-      searchValue: searchValue,
+      searchValue: search,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
       startIdx: 0,

--- a/src/pages/UserGroups/UserGroups.tsx
+++ b/src/pages/UserGroups/UserGroups.tsx
@@ -190,6 +190,7 @@ const UserGroups = () => {
   };
 
   const updateSearchValue = (value: string) => {
+    setPage(1);
     setSearchValue(value);
   };
 
@@ -203,6 +204,7 @@ const UserGroups = () => {
 
   // Issue a search using a specific search value
   const submitSearchValue = () => {
+    setPage(1);
     setShowTableRows(false);
     setGroupsTotalCount(0);
     setSearchIsDisabled(true);
@@ -210,8 +212,8 @@ const UserGroups = () => {
       searchValue: searchValue,
       sizeLimit: 0,
       apiVersion: apiVersion || API_VERSION_BACKUP,
-      startIdx: firstIdx,
-      stopIdx: lastIdx,
+      startIdx: 0,
+      stopIdx: 100,
       entryType: "usergroup",
     } as GenericPayload).then((result) => {
       // Manage new response here
@@ -247,8 +249,7 @@ const UserGroups = () => {
           }
 
           // Update 'user groups' slice data
-          setPage(1);
-          setGroupsList(groupsList);
+          setGroupsList(groupsList.slice(0, perPage));
           setGroupsTotalCount(totalCount);
           // Show table elements
           setShowTableRows(true);

--- a/src/pages/UserGroups/UserGroups.tsx
+++ b/src/pages/UserGroups/UserGroups.tsx
@@ -34,6 +34,10 @@ import { useAppSelector } from "src/store/hooks";
 import { UserGroup } from "src/utils/datatypes/globalDataTypes";
 // Utils
 import { API_VERSION_BACKUP, isUserGroupSelectable } from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
 // Redux
 import { useAppDispatch } from "src/store/hooks";
 // Hooks
@@ -72,17 +76,7 @@ const UserGroups = () => {
   const modalErrors = useApiError([]);
 
   // Table comps
-  const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
   const [totalCount, setGroupsTotalCount] = useState<number>(0);
-
-  const updateSelectedPerPage = (selected: number) => {
-    setSelectedPerPage(selected);
-  };
-
-  // Reset selected-per-page count whenever the page or page size changes
-  useEffect(() => {
-    setSelectedPerPage(0);
-  }, [page, perPage]);
 
   // 'Delete' button state
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
@@ -276,10 +270,11 @@ const UserGroups = () => {
     updateIsDeleteButtonDisabled,
   };
 
-  const selectedPerPageData = {
-    selectedPerPage,
-    updateSelectedPerPage,
-  };
+  const selectedPerPageData = getSelectedPerPageData(
+    groupsList,
+    selectedGroups.map((item) => ipaPrimaryKey(item.cn)),
+    (item) => ipaPrimaryKey(item.cn)
+  );
 
   // - 'DeleteGroups'
   const deleteGroupsButtonsData = {

--- a/src/pages/UserGroups/UserGroups.tsx
+++ b/src/pages/UserGroups/UserGroups.tsx
@@ -108,14 +108,13 @@ const UserGroups = () => {
 
   const {
     data: batchResponse,
-    isLoading: isBatchLoading,
+    isFetching: isBatchFetching,
     error: batchError,
   } = groupDataResponse;
 
   // Handle data when the API call is finished
   useEffect(() => {
     if (groupDataResponse.isFetching) {
-      setShowTableRows(false);
       // Reset selected user groups on refresh
       setGroupsTotalCount(0);
       globalErrors.clear();
@@ -140,8 +139,6 @@ const UserGroups = () => {
       // Update 'Groups' slice data
       setGroupsList(groupsList);
       setGroupsTotalCount(totalCount);
-      // Show table elements
-      setShowTableRows(true);
     }
 
     // API response: Error
@@ -163,9 +160,6 @@ const UserGroups = () => {
 
   // Refresh button handling
   const refreshGroupsData = () => {
-    // Hide table
-    setShowTableRows(false);
-
     // Reset selected user groups on refresh
     setGroupsTotalCount(0);
     clearSelectedGroups();
@@ -178,9 +172,6 @@ const UserGroups = () => {
     const emptyList: UserGroup[] = [];
     setSelectedGroupsList(emptyList);
   };
-
-  // Show table rows
-  const [showTableRows, setShowTableRows] = useState(!isBatchLoading);
 
   const updateSelectedGroups = (groups: UserGroup[], isSelected: boolean) => {
     let newSelectedGroups: UserGroup[] = [];
@@ -224,13 +215,6 @@ const UserGroups = () => {
       updateSelectedGroups([group], isSelecting);
     }
   };
-
-  // Show table rows only when data is fully retrieved
-  useEffect(() => {
-    if (showTableRows !== !isBatchLoading) {
-      setShowTableRows(!isBatchLoading);
-    }
-  }, [isBatchLoading]);
 
   // Modals functionality
   const [showAddModal, setShowAddModal] = useState(false);
@@ -338,7 +322,7 @@ const UserGroups = () => {
       element: (
         <SecondaryButton
           onClickHandler={refreshGroupsData}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
           dataCy="user-groups-button-refresh"
         >
           Refresh
@@ -349,7 +333,7 @@ const UserGroups = () => {
       key: 4,
       element: (
         <SecondaryButton
-          isDisabled={isDeleteButtonDisabled || !showTableRows}
+          isDisabled={isDeleteButtonDisabled || isBatchFetching}
           onClickHandler={onDeleteHandler}
           dataCy="user-groups-button-delete"
         >
@@ -362,7 +346,7 @@ const UserGroups = () => {
       element: (
         <SecondaryButton
           onClickHandler={onAddClickHandler}
-          isDisabled={!showTableRows}
+          isDisabled={isBatchFetching}
           dataCy="user-groups-button-add"
         >
           Add
@@ -418,7 +402,7 @@ const UserGroups = () => {
                     <UserGroupsTable
                       elementsList={groupsList}
                       shownElementsList={groupsList}
-                      showTableRows={showTableRows}
+                      showTableRows={!isBatchFetching}
                       groupsData={groupsTableData}
                       buttonsData={groupsTableButtonsData}
                       paginationData={selectedPerPageData}

--- a/src/services/rpc.ts
+++ b/src/services/rpc.ts
@@ -230,6 +230,9 @@ export const getBatchCommand = (commandData: Command[], apiVersion: string) => {
 export const api = createApi({
   reducerPath: "api",
   baseQuery: fetchBaseQuery({ baseUrl: "/" }), // TODO: Global settings!
+  // We want to always refetch, because we've managed to mess up
+  // the caching logic and this is easier than fixing it :)
+  keepUnusedDataFor: 0,
   tagTypes: [
     "ObjectMetadata",
     "FullUser",
@@ -289,6 +292,7 @@ export const api = createApi({
       transformResponse: (response: ShowRPCResponse): Metadata =>
         response.result,
       providesTags: ["ObjectMetadata"],
+      keepUnusedDataFor: 3600,
     }),
     // Basic find/show query: Hosts, Services, ...
     gettingGeneric: build.query<BatchRPCResponse, GenericPayload>({

--- a/src/services/rpc.ts
+++ b/src/services/rpc.ts
@@ -295,7 +295,10 @@ export const api = createApi({
       keepUnusedDataFor: 3600,
     }),
     // Basic find/show query: Hosts, Services, ...
-    gettingGeneric: build.query<BatchRPCResponse, GenericPayload>({
+    gettingGeneric: build.query<
+      BatchRPCResponse,
+      Omit<GenericPayload, "method">
+    >({
       async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
         const {
           searchValue,

--- a/src/services/rpcAutomember.ts
+++ b/src/services/rpcAutomember.ts
@@ -65,6 +65,11 @@ export interface AutomemberShowPayload {
   type: string;
 }
 
+export interface AutomemberRulesSearchResult {
+  automemberRules: AutomemberEntry[];
+  totalCount: number;
+}
+
 export interface AutomemberModPayload {
   automemberId: string;
   type: string;
@@ -148,11 +153,11 @@ const extendedApi = api.injectEndpoints({
      * Find automembers and groups.
      * Combines the data to build the 'AutomemberEntry' data type
      * @param GenericPayload
-     * @returns List of automember entries with 'automemberRule' and 'description'
+     * @returns Paginated automember rules and total match count
      *
      */
-    searchUserGroupRulesEntries: build.mutation<
-      AutomemberEntry[],
+    searchUserGroupRulesEntries: build.query<
+      AutomemberRulesSearchResult,
       GenericPayload
     >({
       async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
@@ -228,23 +233,29 @@ const extendedApi = api.injectEndpoints({
           .length as number;
 
         // COMBINE RESULTS AND RETURN
-        const fullAutomemberIdsList: AutomemberEntry[] = [];
-        for (let i = 0; i < groupsItemsCount && i < stopIdx; i++) {
-          for (let j = 0; j < automemberIds.length; j++) {
+        const automemberRules: AutomemberEntry[] = [];
+        for (let j = 0; j < automemberIds.length; j++) {
+          for (let i = 0; i < groupsItemsCount; i++) {
             const groupId = responseDataGroup.result.result[i] as groupType;
             if (groupId.cn[0] === automemberIds[j]) {
-              fullAutomemberIdsList.push({
+              automemberRules.push({
                 automemberRule: groupId.cn[0] as string,
                 description: groupId.description
                   ? (groupId.description[0] as string)
                   : "",
               });
+              break;
             }
           }
         }
 
         // Return results
-        return { data: fullAutomemberIdsList };
+        return {
+          data: {
+            automemberRules,
+            totalCount: automembersItemsCount,
+          },
+        };
       },
     }),
     /**
@@ -304,11 +315,11 @@ const extendedApi = api.injectEndpoints({
      * Find automembers and groups.
      * Combines the data to build the 'AutomemberEntry' data type
      * @param GenericPayload
-     * @returns List of automember entries with 'automemberRule' and 'description'
+     * @returns Paginated automember rules and total match count
      *
      */
-    searchHostGroupRulesEntries: build.mutation<
-      AutomemberEntry[],
+    searchHostGroupRulesEntries: build.query<
+      AutomemberRulesSearchResult,
       GenericPayload
     >({
       async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
@@ -361,7 +372,7 @@ const extendedApi = api.injectEndpoints({
           automemberIds.push(cn[0] as string);
         }
 
-        // FETCH USER GROUPS DATA
+        // FETCH HOST GROUPS DATA
         // Prepare search parameters
         const groupParams = {
           version: apiVersion,
@@ -384,23 +395,29 @@ const extendedApi = api.injectEndpoints({
           .length as number;
 
         // COMBINE RESULTS AND RETURN
-        const fullAutomemberIdsList: AutomemberEntry[] = [];
-        for (let i = 0; i < groupsItemsCount && i < stopIdx; i++) {
-          for (let j = 0; j < automemberIds.length; j++) {
+        const automemberRules: AutomemberEntry[] = [];
+        for (let j = 0; j < automemberIds.length; j++) {
+          for (let i = 0; i < groupsItemsCount; i++) {
             const groupId = responseDataGroup.result.result[i] as groupType;
             if (groupId.cn[0] === automemberIds[j]) {
-              fullAutomemberIdsList.push({
+              automemberRules.push({
                 automemberRule: groupId.cn[0] as string,
                 description: groupId.description
                   ? (groupId.description[0] as string)
                   : "",
               });
+              break;
             }
           }
         }
 
         // Return results
-        return { data: fullAutomemberIdsList };
+        return {
+          data: {
+            automemberRules,
+            totalCount: automembersItemsCount,
+          },
+        };
       },
     }),
     /**
@@ -514,12 +531,12 @@ const extendedApi = api.injectEndpoints({
 
 export const {
   useDefaultGroupShowQuery,
-  useSearchUserGroupRulesEntriesMutation,
+  useSearchUserGroupRulesEntriesQuery,
   useAutomemberFindBasicInfoQuery,
   useAddToAutomemberMutation,
   useDeleteFromAutomemberMutation,
   useChangeDefaultGroupMutation,
-  useSearchHostGroupRulesEntriesMutation,
+  useSearchHostGroupRulesEntriesQuery,
   useAutomemberShowQuery,
   useSaveAutomemberMutation,
   useAutomemberAddConditionMutation,

--- a/src/services/rpcAutomember.ts
+++ b/src/services/rpcAutomember.ts
@@ -65,7 +65,7 @@ export interface AutomemberShowPayload {
   type: string;
 }
 
-export interface AutomemberRulesSearchResult {
+interface AutomemberRulesSearchResult {
   automemberRules: AutomemberEntry[];
   totalCount: number;
 }

--- a/src/services/rpcCertMapping.ts
+++ b/src/services/rpcCertMapping.ts
@@ -18,7 +18,7 @@ import {
 
 /**
  * Password policies-related endpoints: useCertMapRuleFindQuery, useGetCertMapRuleEntriesQuery,
- *                             useSearchCertMapRuleEntriesMutation, useCertMapConfigFindQuery,
+ *                             useCertMapConfigFindQuery,
  *                             useCertMapConfigModMutation, useMatchCertificateMutation,
  *                             useCertMapShowQuery, useCertMapRuleModMutation, useCertMapRuleDisableMutation,
  *                             useCertMapRuleEnableMutation
@@ -75,86 +75,6 @@ const extendedApi = api.injectEndpoints({
      *
      */
     getCertMapRuleEntries: build.query<
-      BatchRPCResponse,
-      CertMapFullDataPayload
-    >({
-      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
-        const { searchValue, apiVersion, sizelimit, startIdx, stopIdx } =
-          payloadData;
-
-        if (apiVersion === undefined) {
-          return {
-            error: {
-              status: "CUSTOM_ERROR",
-              data: "",
-              error: "API version not available",
-            },
-          };
-        }
-
-        // FETCH CERT. MAPPING DATA VIA "certmaprule_find" COMMAND
-        // Prepare search parameters
-        const certMapIdsParams = {
-          pkey_only: true,
-          sizelimit: sizelimit,
-          version: apiVersion,
-        };
-
-        // Prepare payload
-        const payloadDataCertMap: Command = {
-          method: "certmaprule_find",
-          params: [[searchValue], certMapIdsParams],
-        };
-
-        // Make call using 'fetchWithBQ'
-        const getResultCertMap = await fetchWithBQ(
-          getCommand(payloadDataCertMap)
-        );
-        // Return possible errors
-        if (getResultCertMap.error) {
-          return { error: getResultCertMap.error };
-        }
-        // If no error: cast and assign 'ids'
-        const responseDataCertMap = getResultCertMap.data as FindRPCResponse;
-
-        const certMapIds: string[] = [];
-        const certMapItemsCount = responseDataCertMap.result.result
-          .length as number;
-
-        for (let i = startIdx; i < certMapItemsCount && i < stopIdx; i++) {
-          const certMapId = responseDataCertMap.result.result[i] as cnType;
-          const { cn } = certMapId;
-          certMapIds.push(cn[0] as string);
-        }
-
-        // FETCH CERT. MAPPING DATA VIA "certmaprule_show" COMMAND
-        const commands: Command[] = [];
-        certMapIds.forEach((certMapId) => {
-          commands.push({
-            method: "certmaprule_show",
-            params: [[certMapId], {}],
-          });
-        });
-
-        const certMapShowResult = await fetchWithBQ(
-          getBatchCommand(commands, apiVersion)
-        );
-
-        const response = certMapShowResult.data as BatchRPCResponse;
-        if (response) {
-          response.result.totalCount = certMapItemsCount;
-        }
-
-        // Return results
-        return { data: response };
-      },
-    }),
-    /**
-     * Search for a specific password policy.
-     * @param CertMapFullDataPayload
-     * @returns Certificate mapping entries that match with the search criteria
-     */
-    searchCertMapRuleEntries: build.mutation<
       BatchRPCResponse,
       CertMapFullDataPayload
     >({
@@ -474,7 +394,6 @@ const extendedApi = api.injectEndpoints({
 
 export const {
   useGetCertMapRuleEntriesQuery,
-  useSearchCertMapRuleEntriesMutation,
   useCertMapConfigFindQuery,
   useCertMapConfigModMutation,
   useMatchCertificateMutation,

--- a/src/services/rpcDnsForwardZones.ts
+++ b/src/services/rpcDnsForwardZones.ts
@@ -10,16 +10,13 @@ import {
 import { API_VERSION_BACKUP } from "../utils/utils";
 // Data types
 import {
-  DNSForwardZone,
   dnsZoneType,
   IDNSForwardPolicy,
 } from "src/utils/datatypes/globalDataTypes";
-import { apiToDnsForwardZone } from "src/utils/dnsForwardZonesUtils";
 
 /**
  * Forward DNS zones-related endpoints: useAddDnsForwardZoneMutation, useDnsForwardZoneDeleteMutation,
  *        useDnsForwardZoneDisableMutation, useDnsForwardZoneEnableMutation, useGetDnsForwardZonesFullDataQuery,
- *        useSearchDnsForwardZonesEntriesMutation
  *
  * API commands:
  * - dnsforwardzone_add: https://freeipa.readthedocs.io/en/latest/api/dnsforwardzone_add.html
@@ -85,14 +82,6 @@ interface DnsForwardZonesFullDataPayload {
   apiVersion: string;
   startIdx: number;
   stopIdx: number;
-}
-
-interface DnsForwardZoneBatchResponse {
-  error: string;
-  id: string;
-  principal: string;
-  version: string;
-  result: DNSForwardZone[];
 }
 
 /**
@@ -319,103 +308,6 @@ const extendedApi = api.injectEndpoints({
         });
       },
     }),
-    /**
-     * Search for a specific DNS zone
-     * @param {DnsForwardZonesFullDataPayload} payload - The payload containing search parameters
-     * @returns {DnsForwardZoneBatchResponse} - List of DNS zones full data
-     */
-    searchDnsForwardZonesEntries: build.mutation<
-      DnsForwardZoneBatchResponse,
-      DnsForwardZonesFullDataPayload
-    >({
-      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
-        const { searchValue, apiVersion, startIdx, stopIdx } = payloadData;
-
-        if (apiVersion === undefined) {
-          return {
-            error: {
-              status: "CUSTOM_ERROR",
-              data: "",
-              error: "API version not available",
-            },
-          };
-        }
-
-        // FETCH DNS ZONES DATA VIA "dnszone_find" COMMAND
-        // Prepare search parameters
-        const dnsForwardZonesIdsParams: DnsForwardZonesFindPayload = {
-          pkeyOnly: true,
-          version: apiVersion,
-          searchValue,
-        };
-
-        // Make call using 'fetchWithBQ'
-        const getResultDnsForwardZones = await fetchWithBQ(
-          dnsForwardZonesFind(dnsForwardZonesIdsParams, "dnsforwardzone_find")
-        );
-        // Return possible errors
-        if (getResultDnsForwardZones.error) {
-          return { error: getResultDnsForwardZones.error };
-        }
-        // If no error: cast and assign 'ids'
-        const responseDataDnsForwardZones =
-          getResultDnsForwardZones.data as FindRPCResponse;
-
-        const dnsZonesIds: string[] = [];
-        const dnsZonesItemsCount = responseDataDnsForwardZones.result.result
-          .length as number;
-
-        for (let i = startIdx; i < dnsZonesItemsCount && i < stopIdx; i++) {
-          const dnsZoneId = responseDataDnsForwardZones.result.result[
-            i
-          ] as dnsZoneType;
-          const dnsName = dnsZoneId.idnsname[0]["__dns_name__"];
-          if (dnsName) {
-            dnsZonesIds.push(dnsName as string);
-          }
-        }
-
-        // FETCH DNS ZONE DATA VIA "dnsforwardzone_show" COMMAND
-        const commands: Command[] = [];
-        dnsZonesIds.forEach((dnsZoneId) => {
-          commands.push({
-            method: "dnsforwardzone_show",
-            params: [[dnsZoneId], {}],
-          });
-        });
-
-        const dnsForwardZonesShowResult = await fetchWithBQ(
-          getBatchCommand(commands, apiVersion)
-        );
-
-        const response = dnsForwardZonesShowResult.data as BatchRPCResponse;
-        if (response) {
-          response.result.totalCount = dnsZonesItemsCount;
-        }
-
-        // Handle the '__dns_name__' fields
-        const dnsForwardZones: DNSForwardZone[] = [];
-        const count = response.result.totalCount;
-        for (let i = 0; i < count; i++) {
-          const dnsZone = response.result.results[i].result as Record<
-            string,
-            unknown
-          >;
-          // Convert API object to DNSForwardZone type
-          const convertedDnsForwardZone: DNSForwardZone =
-            apiToDnsForwardZone(dnsZone);
-          dnsForwardZones.push(convertedDnsForwardZone);
-        }
-
-        // Return results
-        return {
-          data: {
-            ...response,
-            result: dnsForwardZones,
-          },
-        };
-      },
-    }),
   }),
   overrideExisting: false,
 });
@@ -428,5 +320,4 @@ export const {
   useDnsForwardZoneEnableMutation,
   useGetDnsForwardZoneDetailsQuery,
   useGetDnsForwardZonesFullDataQuery,
-  useSearchDnsForwardZonesEntriesMutation,
 } = extendedApi;

--- a/src/services/rpcDnsServers.ts
+++ b/src/services/rpcDnsServers.ts
@@ -76,48 +76,6 @@ const extendedApi = api.injectEndpoints({
       },
     }),
     /**
-     * Search for a specific DNS server (Mutation)
-     * @param {DnsServersFindPayload} payload - The payload containing search parameters
-     * @returns {DnsServersFindResponse} - Response data or error
-     *
-     */
-    searchDnsServersEntries: build.mutation<
-      DnsServersFindResponse,
-      DnsServersFindPayload
-    >({
-      query: (payload) => {
-        const dnsServersParams = {
-          pkey_only: payload.pkeyOnly !== undefined ? payload.pkeyOnly : true,
-          sizelimit: payload.sizeLimit,
-          version: payload.version || API_VERSION_BACKUP,
-        };
-
-        return getCommand({
-          method: "dnsserver_find",
-          params: [[payload.searchValue], dnsServersParams],
-        });
-      },
-      transformResponse: (response: FindRPCResponse) => {
-        const listResult = response.result.result;
-        const listSize = response.result.count;
-        const error = response.error;
-        const dnsServerIdList: string[] = [];
-
-        if (error && typeof error === "object") {
-          return { data: [], error: error.message };
-        } else if (error && typeof error === "string") {
-          return { data: [], error: error };
-        }
-
-        for (let i = 0; i < listSize; i++) {
-          const item = listResult[i] as DnsServersFindResult;
-          dnsServerIdList.push(item.idnsserverid);
-        }
-
-        return { data: dnsServerIdList, error: null };
-      },
-    }),
-    /**
      * Get DNS servers details
      * @param {string} dnsServerId - The ID of the DNS server
      * @returns {Promise<FindRPCResponse>} - Promise with the response data
@@ -171,7 +129,6 @@ const extendedApi = api.injectEndpoints({
 
 export const {
   useDnsServersFindQuery,
-  useSearchDnsServersEntriesMutation,
   useDnsServersShowQuery,
   useDnsServersModMutation,
 } = extendedApi;

--- a/src/services/rpcDnsZones.ts
+++ b/src/services/rpcDnsZones.ts
@@ -9,13 +9,11 @@ import {
 } from "./rpc";
 // utils
 import { API_VERSION_BACKUP } from "../utils/utils";
-import { apiToDnsZone } from "src/utils/dnsZonesUtils";
 import { apiToDnsRecord } from "src/utils/dnsRecordUtils";
 // Data types
 import {
   DNSRecord,
   DnsRecordType,
-  DNSZone,
   dnsZoneType,
   RecordType,
   RecordTypeData,
@@ -39,14 +37,6 @@ interface DnsZonesFullDataPayload {
   sizelimit: number;
   startIdx: number;
   stopIdx: number;
-}
-
-interface DnsZoneBatchResponse {
-  error: string;
-  id: string;
-  principal: string;
-  version: string;
-  result: DNSZone[];
 }
 
 export interface AddDnsZonePayload {
@@ -77,7 +67,7 @@ export interface DnsZoneModPayload {
   nsec3paramrecord?: string;
 }
 
-export interface FindDnsRecordPayload {
+interface FindDnsRecordPayload {
   dnsZoneId: string;
   recordName: string;
   sizeLimit?: number;
@@ -319,108 +309,6 @@ const extendedApi = api.injectEndpoints({
         },
       }
     ),
-    /**
-     * Search for a specific DNS zone
-     * @param {DnsZonesFullDataPayload} payload - The payload containing search parameters
-     * @returns {DnsZoneBatchResponse} - List of DNS zones full data
-     */
-    searchDnsZonesEntries: build.mutation<
-      DnsZoneBatchResponse,
-      DnsZonesFullDataPayload
-    >({
-      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
-        const { searchValue, apiVersion, sizelimit, startIdx, stopIdx } =
-          payloadData;
-
-        if (apiVersion === undefined) {
-          return {
-            error: {
-              status: "CUSTOM_ERROR",
-              data: "",
-              error: "API version not available",
-            },
-          };
-        }
-
-        // FETCH DNS ZONES DATA VIA "dnszone_find" COMMAND
-        // Prepare search parameters
-        const dnsZonesIdsParams = {
-          pkey_only: true,
-          sizelimit: sizelimit,
-          version: apiVersion,
-        };
-
-        // Prepare payload
-        const payloadDataDnsZones: Command = {
-          method: "dnszone_find",
-          params: [[searchValue], dnsZonesIdsParams],
-        };
-
-        // Make call using 'fetchWithBQ'
-        const getResultDnsZones = await fetchWithBQ(
-          getCommand(payloadDataDnsZones)
-        );
-        // Return possible errors
-        if (getResultDnsZones.error) {
-          return { error: getResultDnsZones.error };
-        }
-        // If no error: cast and assign 'ids'
-        const responseDataDnsZones = getResultDnsZones.data as FindRPCResponse;
-
-        const dnsZonesIds: string[] = [];
-        const dnsZonesItemsCount = responseDataDnsZones.result.result
-          .length as number;
-
-        for (let i = startIdx; i < dnsZonesItemsCount && i < stopIdx; i++) {
-          const dnsZoneId = responseDataDnsZones.result.result[
-            i
-          ] as dnsZoneType;
-          const dnsName = dnsZoneId.idnsname[0]["__dns_name__"];
-          if (dnsName) {
-            dnsZonesIds.push(dnsName as string);
-          }
-        }
-
-        // FETCH DNS ZONE DATA VIA "dnszone_show" COMMAND
-        const commands: Command[] = [];
-        dnsZonesIds.forEach((dnsZoneId) => {
-          commands.push({
-            method: "dnszone_show",
-            params: [[dnsZoneId], {}],
-          });
-        });
-
-        const dnsZonesShowResult = await fetchWithBQ(
-          getBatchCommand(commands, apiVersion)
-        );
-
-        const response = dnsZonesShowResult.data as BatchRPCResponse;
-        if (response) {
-          response.result.totalCount = dnsZonesItemsCount;
-        }
-
-        // Handle the '__dns_name__' fields
-        const dnsZones: DNSZone[] = [];
-        const count = response.result.totalCount;
-        for (let i = 0; i < count; i++) {
-          const dnsZone = response.result.results[i].result as Record<
-            string,
-            unknown
-          >;
-          // Convert API object to DNSZone type
-          const convertedDnsZone: DNSZone = apiToDnsZone(dnsZone);
-          dnsZones.push(convertedDnsZone);
-        }
-
-        // Return results
-        return {
-          data: {
-            ...response,
-            result: dnsZones,
-          },
-        };
-      },
-    }),
     /**
      * Add DNS zone
      * @param {AddDnsZonePayload} payload - The payload containing new DNS zone data
@@ -751,137 +639,6 @@ const extendedApi = api.injectEndpoints({
       },
     }),
     /**
-     * Find DNS records
-     * @param {FindDnsRecordPayload} payload - The payload containing DNS zone ID and record name
-     * @returns {DnsRecordBatchResponse} - Promise with the response data
-     */
-    searchDnsRecordsEntries: build.mutation<
-      DnsRecordBatchResponse,
-      FindDnsRecordPayload
-    >({
-      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
-        const {
-          dnsZoneId,
-          recordName,
-          sizeLimit,
-          startIdx = 0,
-          stopIdx,
-          version,
-        } = payloadData;
-
-        const apiVersion = version || API_VERSION_BACKUP;
-        const limit = stopIdx ? Math.max(stopIdx, 100) : sizeLimit || 100;
-
-        // FETCH DNS RECORDS DATA VIA "dnsrecord_find" COMMAND
-        const dnsRecordParams = {
-          pkey_only: true,
-          sizelimit: limit,
-          version: apiVersion,
-        };
-
-        // Prepare payload
-        const payloadDataDnsRecords: Command = {
-          method: "dnsrecord_find",
-          params: [[dnsZoneId, recordName], dnsRecordParams],
-        };
-
-        // Make call using 'fetchWithBQ'
-        const getResultDnsRecords = await fetchWithBQ(
-          getCommand(payloadDataDnsRecords)
-        );
-        // Return possible errors
-        if (getResultDnsRecords.error) {
-          return { error: getResultDnsRecords.error };
-        }
-        // If no error: cast and assign 'ids'
-        const responseDataDnsRecords =
-          getResultDnsRecords.data as FindRPCResponse;
-
-        const dnsRecordsIds: string[] = [];
-        const dnsRecordsItemsCount = responseDataDnsRecords.result.result
-          .length as number;
-
-        // Apply pagination using startIdx and stopIdx
-        const effectiveStopIdx = stopIdx || dnsRecordsItemsCount;
-
-        for (
-          let i = startIdx;
-          i < dnsRecordsItemsCount && i < effectiveStopIdx;
-          i++
-        ) {
-          const dnsRecordId = responseDataDnsRecords.result.result[
-            i
-          ] as dnsZoneType;
-          const dnsRecordType = dnsRecordId.idnsname[0]["__dns_name__"];
-          if (dnsRecordType) {
-            dnsRecordsIds.push(dnsRecordType);
-          }
-        }
-
-        // FETCH DNS RECORDS DATA VIA "dnsrecord_show" COMMAND
-        const commands: Command[] = [];
-        dnsRecordsIds.forEach((recordType) => {
-          commands.push({
-            method: "dnsrecord_show",
-            params: [
-              [dnsZoneId, recordType],
-              { all: true, rights: true, structured: true },
-            ],
-          });
-        });
-
-        const dnsZonesShowResult = await fetchWithBQ(
-          getBatchCommand(commands, apiVersion)
-        );
-
-        const response = dnsZonesShowResult.data as BatchRPCResponse;
-
-        // Handle the '__dns_name__' fields
-        const dnsRecords: DNSRecord[] = [];
-        const records = response.result.results as unknown as BatchResult[];
-
-        records.forEach((dnsRec) => {
-          // Convert API object to 'DNSRecord' type
-          const convertedDnsRecord: DNSRecord = apiToDnsRecord(dnsRec.result);
-          const nsrecordsTypesList = dnsRec.result.dnsrecords as RecordType[];
-
-          // Extract the types into a string format (e.g. "A, NS, ...")
-          const types: string[] = [];
-          convertedDnsRecord.dnsrecords.map((dnsRecord) => {
-            types.push(dnsRecord.dnstype);
-          });
-          const typesString = types.join(", ");
-
-          // Extract the data into a string format (e.g. "dns1.example.com, dns2.example.com, ...")
-          const data: string[] = [];
-          convertedDnsRecord.dnsrecords.map((dnsRecord) => {
-            data.push(dnsRecord.dnsdata);
-          });
-          const dataString = data.join(", ");
-
-          if (nsrecordsTypesList !== undefined) {
-            convertedDnsRecord.dnsrecords = nsrecordsTypesList.map(() => ({
-              dnstype: typesString,
-              dnsdata: dataString,
-            }));
-            dnsRecords.push(convertedDnsRecord);
-          }
-
-          // Add 'dnsrecord_type' and 'dnsrecord_data' to the 'convertedDnsRecord'
-          convertedDnsRecord.dnsrecord_types = typesString;
-          convertedDnsRecord.dnsrecord_data = dataString;
-        });
-
-        return {
-          data: {
-            ...response,
-            count: responseDataDnsRecords.result.count,
-            result: dnsRecords,
-          },
-        };
-      },
-    }),
-    /**
      * Add DNS record
      * @param {DynamicAddDnsRecordPayload} payload - The payload containing DNS zone ID and record data
      * @returns {Promise<FindRPCResponse>} - Promise with the response data
@@ -1032,7 +789,6 @@ const extendedApi = api.injectEndpoints({
 
 export const {
   useGetDnsZonesFullDataQuery,
-  useSearchDnsZonesEntriesMutation,
   useAddDnsZoneMutation,
   useDnsZoneDeleteMutation,
   useDnsZoneDisableMutation,
@@ -1042,7 +798,6 @@ export const {
   useAddDnsZonePermissionMutation,
   useRemoveDnsZonePermissionMutation,
   useDnsRecordFindQuery,
-  useSearchDnsRecordsEntriesMutation,
   useAddDnsRecordMutation,
   useDnsRecordDeleteMutation,
   useShowDnsRecordQuery,

--- a/src/services/rpcIdOverrides.ts
+++ b/src/services/rpcIdOverrides.ts
@@ -8,10 +8,7 @@ import {
 } from "./rpc";
 import { API_VERSION_BACKUP } from "../utils/utils";
 // Data types
-import {
-  IDViewOverrideUser,
-  IDViewOverrideGroup,
-} from "src/utils/datatypes/globalDataTypes";
+import { IDViewOverrideUser } from "src/utils/datatypes/globalDataTypes";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query/react";
 
 /**
@@ -79,6 +76,77 @@ interface OverrideType {
   dn: string;
   ipaanchoruuid: string;
 }
+
+type FetchWithBQ = (
+  arg: ReturnType<typeof getCommand> | ReturnType<typeof getBatchCommand>
+  // RTK Query's fetchWithBQ returns MaybePromise; keep this loose for reuse.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+) => any;
+
+const searchOverrideEntriesQueryFn = async (
+  payloadData: IDOverridePayload,
+  fetchWithBQ: FetchWithBQ
+) => {
+  const { idView, searchValue, sizeLimit, startIdx, stopIdx, entryType } =
+    payloadData;
+
+  const params = {
+    sizelimit: sizeLimit,
+    version: API_VERSION_BACKUP,
+    all: true,
+  };
+
+  const findResult = await fetchWithBQ(
+    getCommand({
+      method: entryType + "_find",
+      params: [[idView, searchValue], params],
+    })
+  );
+  if (findResult.error) {
+    return { error: findResult.error as FetchBaseQueryError };
+  }
+
+  const responseData = findResult.data as FindRPCResponse;
+  const ids: string[] = [];
+  const itemsCount = responseData.result.result.length as number;
+  for (let i = startIdx; i < itemsCount && i < stopIdx; i++) {
+    const overrideId = responseData.result.result[i] as OverrideType;
+    const { ipaanchoruuid } = overrideId;
+    ids.push(ipaanchoruuid[0] as string);
+  }
+
+  const payloadDataBatch: Command[] = ids.map((id) => ({
+    method: entryType + "_show",
+    params: [[idView, id], {}],
+  }));
+
+  if (payloadDataBatch.length === 0) {
+    return {
+      data: {
+        result: {
+          results: [],
+          count: 0,
+          totalCount: itemsCount,
+        },
+      } as unknown as BatchRPCResponse,
+    };
+  }
+
+  const partialInfoResult = await fetchWithBQ(
+    getBatchCommand(payloadDataBatch, API_VERSION_BACKUP)
+  );
+
+  const response = partialInfoResult.data as BatchRPCResponse;
+  if (response) {
+    response.result.totalCount = itemsCount;
+  }
+
+  return response
+    ? { data: response }
+    : {
+        error: partialInfoResult.error as unknown as FetchBaseQueryError,
+      };
+};
 
 const extendedApi = api.injectEndpoints({
   endpoints: (build) => ({
@@ -218,96 +286,20 @@ const extendedApi = api.injectEndpoints({
         return getBatchCommand(groupsToDeletePayload, API_VERSION_BACKUP);
       },
     }),
-    gettingIDOverrideUsers: build.query<IDViewOverrideUser[], string>({
-      query: (idview) => {
-        const findCmd: Command = {
-          method: "idoverrideuser_find",
-          params: [[idview], { version: API_VERSION_BACKUP }],
-        };
-        return getCommand(findCmd);
-      },
-      transformResponse: (response: FindRPCResponse): IDViewOverrideUser[] => {
-        if (response.result?.result) {
-          return response.result.result as unknown as IDViewOverrideUser[];
-        }
-        return [];
-      },
-    }),
-    gettingIDOverrideGroups: build.query<IDViewOverrideGroup[], string>({
-      query: (idview) => {
-        const findCmd: Command = {
-          method: "idoverridegroup_find",
-          params: [[idview], { version: API_VERSION_BACKUP }],
-        };
-        return getCommand(findCmd);
-      },
-      transformResponse: (response: FindRPCResponse): IDViewOverrideGroup[] => {
-        if (response.result?.result) {
-          return response.result.result as unknown as IDViewOverrideGroup[];
-        }
-        return [];
-      },
-    }),
-    // Refresh entries by search value (mutation instead of query)
-    searchOverrideEntries: build.mutation<BatchRPCResponse, IDOverridePayload>({
+    gettingIDOverrideUsers: build.query<BatchRPCResponse, IDOverridePayload>({
       async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
-        const { idView, searchValue, sizeLimit, startIdx, stopIdx, entryType } =
-          payloadData;
-
-        // Prepare search parameters
-        const params = {
-          sizelimit: sizeLimit,
-          version: API_VERSION_BACKUP,
-          all: true,
-        };
-
-        // Prepare payload
-        const payloadDataIds: Command = {
-          method: entryType + "_find",
-          params: [[idView, searchValue], params],
-        };
-
-        // Make call using 'fetchWithBQ'
-        const getGroupIDsResult = await fetchWithBQ(getCommand(payloadDataIds));
-        // Return possible errors
-        if (getGroupIDsResult.error) {
-          return { error: getGroupIDsResult.error as FetchBaseQueryError };
-        }
-        // If no error: cast and assign 'ids'
-        const responseData = getGroupIDsResult.data as FindRPCResponse;
-        const ids: string[] = [];
-        const itemsCount = responseData.result.result.length as number;
-        for (let i = startIdx; i < itemsCount && i < stopIdx; i++) {
-          const overrideId = responseData.result.result[i] as OverrideType;
-          const { ipaanchoruuid } = overrideId;
-
-          ids.push(ipaanchoruuid[0] as string);
-        }
-
-        // 2ND CALL - GET PARTIAL INFO
-        // Prepare payload
-        let payloadDataBatch: Command[] = [];
-        payloadDataBatch = ids.map((id) => ({
-          method: entryType + "_show",
-          params: [[idView, id], {}],
-        }));
-
-        // Make call using 'fetchWithBQ'
-        const partialInfoResult = await fetchWithBQ(
-          getBatchCommand(payloadDataBatch as Command[], API_VERSION_BACKUP)
+        return searchOverrideEntriesQueryFn(
+          { ...payloadData, entryType: "idoverrideuser" },
+          fetchWithBQ
         );
-
-        const response = partialInfoResult.data as BatchRPCResponse;
-        if (response) {
-          response.result.totalCount = itemsCount;
-        }
-
-        // Return results
-        return response
-          ? { data: response }
-          : {
-              error: partialInfoResult.error as unknown as FetchBaseQueryError,
-            };
+      },
+    }),
+    gettingIDOverrideGroups: build.query<BatchRPCResponse, IDOverridePayload>({
+      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
+        return searchOverrideEntriesQueryFn(
+          { ...payloadData, entryType: "idoverridegroup" },
+          fetchWithBQ
+        );
       },
     }),
     /**
@@ -353,6 +345,5 @@ export const {
   useRemoveIDOverrideUsersMutation,
   useGettingIDOverrideUsersQuery,
   useGettingIDOverrideGroupsQuery,
-  useSearchOverrideEntriesMutation,
   useSearchIdOverrideUsersQuery,
 } = extendedApi;

--- a/src/services/rpcIdRanges.ts
+++ b/src/services/rpcIdRanges.ts
@@ -50,65 +50,6 @@ export interface AddIdRangePayload {
 const extendedApi = api.injectEndpoints({
   endpoints: (build) => ({
     /**
-     * Search for specific ID ranges (Mutation)
-     * @param {IdRangesFindPayload} payload - The payload containing search parameters
-     * @returns {IdRangesFindResponse} - Response data or error
-     */
-    searchIdRangesEntries: build.mutation<BatchRPCResponse, IdRangeDataPayload>(
-      {
-        async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
-          const { searchValue, apiVersion, sizelimit, startIdx, stopIdx } =
-            payloadData;
-
-          // Prepare find parameters
-          const params = {
-            pkey_only: true,
-            sizelimit: sizelimit,
-            version: apiVersion || API_VERSION_BACKUP,
-          };
-
-          // idrange_find
-          const findResult = await fetchWithBQ(
-            getCommand({
-              method: "idrange_find",
-              params: [[searchValue], params],
-            })
-          );
-          if (findResult.error) {
-            return { error: findResult.error };
-          }
-          const findData = findResult.data as FindRPCResponse;
-          const listSize = findData.result.result.length as number;
-
-          // Build list of cns for the requested range
-          const cnList: string[] = [];
-          for (let i = startIdx; i < listSize && i < stopIdx; i++) {
-            const entry = findData.result.result[i] as IdRangesFindResult;
-            const cn = entry?.cn?.[0] as string | undefined;
-            if (cn) cnList.push(cn);
-          }
-
-          // Batch show
-          const commands: Command[] = cnList.map((cn) => ({
-            method: "idrange_show",
-            params: [[cn], {}],
-          }));
-
-          const batchShow = await fetchWithBQ(
-            getBatchCommand(commands, apiVersion)
-          );
-          if (batchShow.error) {
-            return { error: batchShow.error };
-          }
-          const response = batchShow.data as BatchRPCResponse;
-          if (response) {
-            response.result.totalCount = listSize;
-          }
-          return { data: response };
-        },
-      }
-    ),
-    /**
      * Get a paginated list of ID Range entries with details (batch of idrange_show)
      * @param {IdRangeDataPayload} payload - The payload containing pagination and search parameters
      * @returns {BatchRPCResponse} - Response data (batched idrange_show) or error
@@ -236,7 +177,6 @@ const extendedApi = api.injectEndpoints({
 });
 
 export const {
-  useSearchIdRangesEntriesMutation,
   useGetIdRangeEntriesQuery,
   useAddIdRangeMutation,
   useDeleteIdRangesMutation,

--- a/src/services/rpcIdp.ts
+++ b/src/services/rpcIdp.ts
@@ -14,7 +14,7 @@ import { API_VERSION_BACKUP } from "src/utils/utils";
 import { apiToIdpServer } from "src/utils/ipdServerUtils";
 
 /**
- * IdP-related endpoints: useGetIdpEntriesQuery, useSearchIdpEntriesMutation
+ * IdP-related endpoints: useGetIdpEntriesQuery
  *                        useIdpAddMutation, useIdpDeleteMutation, useIdpShowQuery,
  *                        useIdpModMutation
  *
@@ -105,83 +105,6 @@ const extendedApi = api.injectEndpoints({
      *
      */
     getIdpEntries: build.query<BatchRPCResponse, IdpFullDataPayload>({
-      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
-        const { searchValue, apiVersion, sizelimit, startIdx, stopIdx } =
-          payloadData;
-
-        if (apiVersion === undefined) {
-          return {
-            error: {
-              status: "CUSTOM_ERROR",
-              data: "",
-              error: "API version not available",
-            } as FetchBaseQueryError,
-          };
-        }
-
-        // FETCH IDP DATA VIA "idp_find" COMMAND
-        // Prepare search parameters
-        const idpFindParams = {
-          pkey_only: true,
-          sizelimit: sizelimit,
-          version: apiVersion,
-        };
-
-        // Prepare payload
-        const payloadDataIdpFind: Command = {
-          method: "idp_find",
-          params: [[searchValue], idpFindParams],
-        };
-
-        // Make call using 'fetchWithBQ'
-        const getResultIdpFind = await fetchWithBQ(
-          getCommand(payloadDataIdpFind)
-        );
-        // Return possible errors
-        if (getResultIdpFind.error) {
-          return { error: getResultIdpFind.error as FetchBaseQueryError };
-        }
-        // If no error: cast and assign 'ids'
-        const responseDataIdpFind = getResultIdpFind.data as FindRPCResponse;
-
-        const idpIds: string[] = [];
-        const idpItemsCount = responseDataIdpFind.result.result
-          .length as number;
-
-        for (let i = startIdx; i < idpItemsCount && i < stopIdx; i++) {
-          const idpId = responseDataIdpFind.result.result[i] as cnType;
-          const { cn } = idpId;
-          idpIds.push(cn[0] as string);
-        }
-
-        // FETCH IDP DATA VIA "idp_show" COMMAND
-        const commands: Command[] = [];
-        idpIds.forEach((idpId) => {
-          commands.push({
-            method: "idp_show",
-            params: [[idpId], {}],
-          });
-        });
-
-        const idpShowResult = await fetchWithBQ(
-          getBatchCommand(commands, apiVersion)
-        );
-
-        const response = idpShowResult.data as BatchRPCResponse;
-        if (response) {
-          response.result.totalCount = idpItemsCount;
-        }
-
-        // Return results
-        return { data: response };
-      },
-    }),
-    /**
-     * Search for a specific IdP server.
-     * @param IdpFullDataPayload
-     * @returns IdP entries that match with the search criteria
-     */
-    searchIdpEntries: build.mutation<BatchRPCResponse, IdpFullDataPayload>({
       async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
         const { searchValue, apiVersion, sizelimit, startIdx, stopIdx } =
           payloadData;
@@ -410,7 +333,6 @@ const extendedApi = api.injectEndpoints({
 
 export const {
   useGetIdpEntriesQuery,
-  useSearchIdpEntriesMutation,
   useIdpAddMutation,
   useIdpDeleteMutation,
   useIdpShowQuery,

--- a/src/services/rpcOtpTokens.ts
+++ b/src/services/rpcOtpTokens.ts
@@ -6,15 +6,12 @@ import {
   FindRPCResponse,
   getCommand,
 } from "./rpc";
-// utils
-import { apiToOtpToken } from "../utils/otpTokensUtils";
 // Data types
-import { OtpToken, OtpTokenType } from "../utils/datatypes/globalDataTypes";
+import { OtpTokenType } from "../utils/datatypes/globalDataTypes";
 import { API_VERSION_BACKUP } from "src/utils/utils";
 
 /**
- * Otp tokens-related endpoints:   useGetOtpTokensFullDataQuery,
- *   searchOtpTokensEntries
+ * Otp tokens-related endpoints:   useGetOtpTokensFullDataQuery
  *
  * API commands:
  * - otptoken_find: https://freeipa.readthedocs.io/en/latest/api/otptoken_find.html
@@ -27,15 +24,6 @@ interface OtpTokensFullDataPayload {
   sizelimit: number;
   startIdx: number;
   stopIdx: number;
-}
-
-interface OtpTokensBatchResponse {
-  error: string;
-  id: string;
-  principal: string;
-  version: string;
-  result: OtpToken[];
-  totalCount: number;
 }
 
 export interface OtpTokensModifyPayload {
@@ -136,108 +124,6 @@ const extendedApi = api.injectEndpoints({
           response.result.totalCount = otpTokensItemsCount;
         }
         return { data: response };
-      },
-    }),
-    /**
-     * Search for a specific OTP token
-     * @param {OtpTokensFullDataPayload} payload - The payload containing search parameters
-     * @returns {OtpTokensBatchResponse} - List of OTP tokens full data
-     *
-     */
-    searchOtpTokensEntries: build.mutation<
-      OtpTokensBatchResponse,
-      OtpTokensFullDataPayload
-    >({
-      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
-        const { searchValue, apiVersion, sizelimit, startIdx, stopIdx } =
-          payloadData;
-        if (apiVersion === undefined) {
-          return {
-            error: {
-              status: "CUSTOM_ERROR",
-              data: "",
-              error: "API version not available",
-            },
-          };
-        }
-
-        // FETCH OTP TOKENS DATA VIA "otptoken_find" COMMAND
-        // Prepare search parameters
-        const otpTokensIdsParams = {
-          pkey_only: true,
-          sizelimit: sizelimit,
-          version: apiVersion,
-        };
-        // Prepare payload
-        const payloadDataOtpTokens: Command = {
-          method: "otptoken_find",
-          params: [[searchValue], otpTokensIdsParams],
-        };
-
-        // Make call using 'fetchWithBQ'
-        const getResultOtpTokens = await fetchWithBQ(
-          getCommand(payloadDataOtpTokens)
-        );
-        // Return possible errors
-        if (getResultOtpTokens.error) {
-          return { error: getResultOtpTokens.error };
-        }
-        // If no error: cast and assign 'ids'
-        const responseDataOtpTokens =
-          getResultOtpTokens.data as FindRPCResponse;
-        const otpTokensIds: string[] = [];
-        const otpTokensItemsCount = responseDataOtpTokens.result.result
-          .length as number;
-
-        for (let i = startIdx; i < otpTokensItemsCount && i < stopIdx; i++) {
-          const otpTokenId = responseDataOtpTokens.result.result[
-            i
-          ] as OtpTokenType;
-          const { ipatokenuniqueid } = otpTokenId;
-          otpTokensIds.push(ipatokenuniqueid[0] as string);
-        }
-
-        // FETCH OTP TOKENS DATA VIA "otptoken_show" COMMAND
-        const commands: Command[] = [];
-        otpTokensIds.map((otpTokenId) => {
-          commands.push({
-            method: "otptoken_show",
-            params: [[otpTokenId], {}],
-          });
-        });
-
-        const batchShow = await fetchWithBQ(
-          getBatchCommand(commands, apiVersion)
-        );
-        if (batchShow.error) {
-          return { error: batchShow.error };
-        }
-        const response = batchShow.data as BatchRPCResponse;
-        if (response) {
-          response.result.totalCount = otpTokensItemsCount;
-        }
-
-        // Handle the '__base64__' fields
-        const otpTokens: OtpToken[] = [];
-        const count = response.result.totalCount;
-        for (let i = 0; i < count; i++) {
-          const otpToken = response.result.results[i].result as Record<
-            string,
-            unknown
-          >;
-          // Convert API object to OtpToken type
-          const convertedOtpToken: OtpToken = apiToOtpToken(otpToken);
-          otpTokens.push(convertedOtpToken);
-        }
-
-        // Return results
-        return {
-          data: {
-            ...response,
-            result: otpTokens,
-            totalCount: otpTokensItemsCount,
-          },
-        };
       },
     }),
     /**
@@ -357,7 +243,6 @@ export interface OtpTokenManagedByPayload {
 
 export const {
   useGetOtpTokensFullDataQuery,
-  useSearchOtpTokensEntriesMutation,
   useDeleteOtpTokensMutation,
   useModifyOtpTokensMutation,
   useGetOtpTokenQuery,

--- a/src/services/rpcPrivileges.ts
+++ b/src/services/rpcPrivileges.ts
@@ -180,65 +180,6 @@ const extendedApi = api.injectEndpoints({
         return getBatchCommand(commands, API_VERSION_BACKUP);
       },
     }),
-    /**
-     * Search privileges via two-step privilege_find + privilege_show pattern
-     * @param {PrivilegesFullDataPayload} - Search parameters
-     * @returns {BatchRPCResponse} - Batch response with privilege data
-     */
-    searchPrivilegesEntries: build.mutation<
-      BatchRPCResponse,
-      PrivilegesFullDataPayload
-    >({
-      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
-        const { searchValue, sizeLimit, apiVersion, startIdx, stopIdx } =
-          payloadData;
-
-        const params = {
-          pkey_only: true,
-          sizelimit: sizeLimit,
-          version: apiVersion,
-        };
-
-        // Step 1: Find privilege IDs
-        const findCommand: Command = {
-          method: "privilege_find",
-          params: [[searchValue], params],
-        };
-
-        const findResult = await fetchWithBQ(getCommand(findCommand));
-        if (findResult.error) {
-          return { error: findResult.error as FetchBaseQueryError };
-        }
-
-        const findResponse = findResult.data as FindRPCResponse;
-        const totalCount = findResponse.result.result.length as number;
-        const ids: string[] = [];
-
-        for (let i = startIdx; i < totalCount && i < stopIdx; i++) {
-          const privilegeId = findResponse.result.result[i] as cnType;
-          ids.push(privilegeId.cn[0] as string);
-        }
-
-        // Step 2: Batch show for each privilege
-        const showCommands: Command[] = ids.map((id) => ({
-          method: "privilege_show",
-          params: [[id], { no_members: true }],
-        }));
-
-        const showResult = await fetchWithBQ(
-          getBatchCommand(showCommands, apiVersion)
-        );
-
-        const response = showResult.data as BatchRPCResponse;
-        if (response) {
-          response.result.totalCount = totalCount;
-        }
-
-        return response
-          ? { data: response }
-          : { error: showResult.error as FetchBaseQueryError };
-      },
-    }),
   }),
   overrideExisting: false,
 });
@@ -259,6 +200,5 @@ export const {
   useGetPrivilegesInfoByNameQuery,
   useAddPrivilegeMutation,
   useDeletePrivilegesMutation,
-  useSearchPrivilegesEntriesMutation,
   useSavePrivilegeMutation,
 } = extendedApi;

--- a/src/services/rpcPwdPolicies.ts
+++ b/src/services/rpcPwdPolicies.ts
@@ -166,86 +166,6 @@ const extendedApi = api.injectEndpoints({
       },
     }),
     /**
-     * Search for a specific password policy.
-     * @param SubIdDataPayload
-     * @returns Subordinate ID entries that match with the search criteria
-     */
-    searchPwdPolicyEntries: build.mutation<
-      BatchRPCResponse,
-      PwPolicyFullDataPayload
-    >({
-      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
-        const { searchValue, apiVersion, sizelimit, startIdx, stopIdx } =
-          payloadData;
-
-        if (apiVersion === undefined) {
-          return {
-            error: {
-              status: "CUSTOM_ERROR",
-              data: "",
-              error: "API version not available",
-            } as FetchBaseQueryError,
-          };
-        }
-
-        // FETCH PWD POLICIES DATA VIA "pwpolicy_find" COMMAND
-        // Prepare search parameters
-        const pwPolicyIdsParams = {
-          pkey_only: true,
-          sizelimit: sizelimit,
-          version: apiVersion,
-        };
-
-        // Prepare payload
-        const payloadDataPwPolicy: Command = {
-          method: "pwpolicy_find",
-          params: [[searchValue], pwPolicyIdsParams],
-        };
-
-        // Make call using 'fetchWithBQ'
-        const getResultPwdPolicy = await fetchWithBQ(
-          getCommand(payloadDataPwPolicy)
-        );
-        // Return possible errors
-        if (getResultPwdPolicy.error) {
-          return { error: getResultPwdPolicy.error as FetchBaseQueryError };
-        }
-        // If no error: cast and assign 'ids'
-        const responseDataPwPolicy = getResultPwdPolicy.data as FindRPCResponse;
-
-        const pwPolicyIds: string[] = [];
-        const pwPolicyItemsCount = responseDataPwPolicy.result.result
-          .length as number;
-
-        for (let i = startIdx; i < pwPolicyItemsCount && i < stopIdx; i++) {
-          const pwPolicyId = responseDataPwPolicy.result.result[i] as cnType;
-          const { cn } = pwPolicyId;
-          pwPolicyIds.push(cn[0] as string);
-        }
-
-        // FETCH PASSWORD POLICY DATA VIA "pwpolicy_show" COMMAND
-        const commands: Command[] = [];
-        pwPolicyIds.forEach((pwPolicyId) => {
-          commands.push({
-            method: "pwpolicy_show",
-            params: [[pwPolicyId], {}],
-          });
-        });
-
-        const pwdPolicyShowResult = await fetchWithBQ(
-          getBatchCommand(commands, apiVersion)
-        );
-
-        const response = pwdPolicyShowResult.data as BatchRPCResponse;
-        if (response) {
-          response.result.totalCount = pwPolicyItemsCount;
-        }
-
-        // Return results
-        return { data: response };
-      },
-    }),
-    /**
      * Add a new password policy
      * @param {PwPolicyAddPayload} - Payload with the new password policy data
      * @returns {Promise<FindRPCResponse>} - Promise with the response data
@@ -360,7 +280,6 @@ const extendedApi = api.injectEndpoints({
 export const {
   usePwPolicyFindQuery,
   useGetPwPoliciesEntriesQuery,
-  useSearchPwdPolicyEntriesMutation,
   usePwPolicyAddMutation,
   usePwPolicyDeleteMutation,
   usePwPolicyShowQuery,

--- a/src/services/rpcRoles.ts
+++ b/src/services/rpcRoles.ts
@@ -9,8 +9,7 @@ import {
 } from "./rpc";
 import { apiToRole } from "src/utils/rolesUtils";
 import { API_VERSION_BACKUP } from "../utils/utils";
-import { Role, cnType } from "../utils/datatypes/globalDataTypes";
-import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
+import { Role } from "../utils/datatypes/globalDataTypes";
 
 /**
  * Roles-related endpoints: addToRoles, removeFromRoles, getRolesInfoByName, addRole, deleteRoles
@@ -33,14 +32,6 @@ interface RoleShowPayload {
 interface RoleAddPayload {
   cn: string;
   description?: string;
-}
-
-interface RolesSearchPayload {
-  searchValue: string;
-  sizeLimit: number;
-  apiVersion: string;
-  startIdx: number;
-  stopIdx: number;
 }
 
 export interface RoleMemberPayload {
@@ -184,63 +175,6 @@ const extendedApi = api.injectEndpoints({
       },
     }),
     /**
-     * Search roles via two-step role_find + role_show pattern
-     * @param {RolesSearchPayload} - Search parameters
-     * @returns {BatchRPCResponse} - Batch response with role data
-     */
-    searchRolesEntries: build.mutation<BatchRPCResponse, RolesSearchPayload>({
-      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
-        const { searchValue, sizeLimit, apiVersion, startIdx, stopIdx } =
-          payloadData;
-
-        const params = {
-          pkey_only: true,
-          sizelimit: sizeLimit,
-          version: apiVersion,
-          all: true,
-        };
-
-        // Step 1: Find role IDs
-        const findCommand: Command = {
-          method: "role_find",
-          params: [[searchValue], params],
-        };
-
-        const findResult = await fetchWithBQ(getCommand(findCommand));
-        if (findResult.error) {
-          return { error: findResult.error as FetchBaseQueryError };
-        }
-
-        const findResponse = findResult.data as FindRPCResponse;
-        const totalCount = findResponse.result.result.length as number;
-        const ids: string[] = [];
-
-        for (let i = startIdx; i < totalCount && i < stopIdx; i++) {
-          const roleId = findResponse.result.result[i] as cnType;
-          ids.push(roleId.cn[0] as string);
-        }
-
-        // Step 2: Batch show for each role
-        const showCommands: Command[] = ids.map((id) => ({
-          method: "role_show",
-          params: [[id], { no_members: true }],
-        }));
-
-        const showResult = await fetchWithBQ(
-          getBatchCommand(showCommands, apiVersion)
-        );
-
-        const response = showResult.data as BatchRPCResponse;
-        if (response) {
-          response.result.totalCount = totalCount;
-        }
-
-        return response
-          ? { data: response }
-          : { error: showResult.error as FetchBaseQueryError };
-      },
-    }),
-    /**
      * Get a single role by cn (with members)
      * @param {string} cn - Role cn
      * @returns {Role} - Role data with members
@@ -365,7 +299,6 @@ export const {
   useGetRolesInfoByNameQuery,
   useAddRoleMutation,
   useDeleteRolesMutation,
-  useSearchRolesEntriesMutation,
   useSaveRoleMutation,
   useGetRoleByIdQuery,
   useAddAsMemberRoleMutation,

--- a/src/services/rpcSelinuxUserMaps.ts
+++ b/src/services/rpcSelinuxUserMaps.ts
@@ -93,62 +93,6 @@ const extendedApi = api.injectEndpoints({
         return { data: response };
       },
     }),
-
-    searchSelinuxUserMapsEntries: build.mutation<
-      BatchRPCResponse,
-      SelinuxUserMapsFullDataPayload
-    >({
-      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
-        const { searchValue, apiVersion, sizelimit, startIdx, stopIdx } =
-          payloadData;
-        const apiVersionUsed = apiVersion || API_VERSION_BACKUP;
-
-        const findParams = {
-          pkey_only: true,
-          sizelimit: sizelimit,
-          version: apiVersionUsed,
-        };
-
-        const findCommand: Command = {
-          method: "selinuxusermap_find",
-          params: [[searchValue], findParams],
-        };
-
-        const findResult = await fetchWithBQ(getCommand(findCommand));
-
-        if (findResult.error) {
-          return { error: findResult.error };
-        }
-
-        const findResponse = findResult.data as FindRPCResponse;
-        const ids: string[] = [];
-        const totalCount = findResponse.result.result.length as number;
-
-        for (let i = startIdx; i < totalCount && i < stopIdx; i++) {
-          const item = findResponse.result.result[
-            i
-          ] as unknown as FindSelinuxUserMapArgs;
-          ids.push(item.cn[0]);
-        }
-
-        const showCommands: Command[] = ids.map((id) => ({
-          method: "selinuxusermap_show",
-          params: [[id], {}],
-        }));
-
-        const showResult = await fetchWithBQ(
-          getBatchCommand(showCommands, apiVersionUsed)
-        );
-
-        const response = showResult.data as BatchRPCResponse;
-        if (response) {
-          response.result.totalCount = totalCount;
-        }
-
-        return { data: response };
-      },
-    }),
-
     addSelinuxUserMap: build.mutation<
       FindRPCResponse,
       SelinuxUserMapAddPayload
@@ -204,7 +148,6 @@ const extendedApi = api.injectEndpoints({
 
 export const {
   useGetSelinuxUserMapsFullDataQuery,
-  useSearchSelinuxUserMapsEntriesMutation,
   useAddSelinuxUserMapMutation,
   useDeleteSelinuxUserMapsMutation,
   useEnableSelinuxUserMapsMutation,

--- a/src/services/rpcSubIds.ts
+++ b/src/services/rpcSubIds.ts
@@ -172,81 +172,6 @@ const extendedApi = api.injectEndpoints({
       },
     }),
     /**
-     * Search for a specific subordinate ID.
-     * @param SubIdDataPayload
-     * @returns Subordinate ID entry
-     */
-    searchSubIdEntries: build.mutation<BatchRPCResponse, SubIdDataPayload>({
-      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
-        const { searchValue, apiVersion, sizelimit, startIdx, stopIdx } =
-          payloadData;
-
-        if (apiVersion === undefined) {
-          return {
-            error: {
-              status: "CUSTOM_ERROR",
-              data: "",
-              error: "API version not available",
-            } as FetchBaseQueryError,
-          };
-        }
-
-        // FETCH SUBID DATA VIA "subid_find" COMMAND
-        // Prepare search parameters
-        const subidsParams = {
-          pkey_only: true,
-          sizelimit: sizelimit,
-          version: apiVersion,
-        };
-
-        // Prepare payload
-        const payloadDataSubids: Command = {
-          method: "subid_find",
-          params: [[searchValue], subidsParams],
-        };
-
-        // Make call using 'fetchWithBQ'
-        const getResultSubid = await fetchWithBQ(getCommand(payloadDataSubids));
-        // Return possible errors
-        if (getResultSubid.error) {
-          return { error: getResultSubid.error as FetchBaseQueryError };
-        }
-        // If no error: cast and assign 'ids'
-        const responseDataSubid = getResultSubid.data as FindRPCResponse;
-
-        const subidIds: string[] = [];
-        const subidsItemsCount = responseDataSubid.result.result
-          .length as number;
-
-        for (let i = startIdx; i < subidsItemsCount && i < stopIdx; i++) {
-          const subidId = responseDataSubid.result.result[i] as SubId;
-          const { ipauniqueid } = subidId;
-          subidIds.push(ipauniqueid[0] as string);
-        }
-
-        // FETCH SUBID DATA VIA "subid_show" COMMAND
-        const commands: Command[] = [];
-        subidIds.forEach((subidId) => {
-          commands.push({
-            method: "subid_show",
-            params: [[subidId], {}],
-          });
-        });
-
-        const subIdsShowResult = await fetchWithBQ(
-          getBatchCommand(commands, apiVersion)
-        );
-
-        const response = subIdsShowResult.data as BatchRPCResponse;
-        if (response) {
-          response.result.totalCount = subidsItemsCount;
-        }
-
-        // Return results
-        return { data: response };
-      },
-    }),
-    /**
      * Retrieves all subordinate IDs (unique IDs).
      * @param SubidFindPayload
      * @returns FindRPCResponse
@@ -326,7 +251,6 @@ export const {
   useGetSubIdsInfoByNameQuery,
   useAssignSubIdsMutation,
   useGetSubIdEntriesQuery,
-  useSearchSubIdEntriesMutation,
   useSubidFindQuery,
   useSubidStatsQuery,
   useSubidShowQuery,

--- a/src/services/rpcTrusts.ts
+++ b/src/services/rpcTrusts.ts
@@ -65,7 +65,7 @@ export interface GlobalTrustConfigPayload {
   ipantfallbackprimarygroup: string;
 }
 
-export interface TrustDomainFindPayload {
+interface TrustDomainFindPayload {
   trustId: string;
   searchValue?: string;
   sizelimit: number;
@@ -91,90 +91,6 @@ const extendedApi = api.injectEndpoints({
      *
      */
     getTrustsFullData: build.query<BatchRPCResponse, TrustsFullDataPayload>({
-      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
-        const { searchValue, apiVersion, sizelimit, startIdx, stopIdx } =
-          payloadData;
-        const apiVersionUsed = apiVersion || API_VERSION_BACKUP;
-
-        // FETCH TRUSTS DATA VIA "trust_find" COMMAND
-        // Prepare search parameters
-        const trustsIdsParams = {
-          pkey_only: true,
-          sizelimit: sizelimit,
-          version: apiVersionUsed,
-        };
-
-        // Prepare payload
-        const payloadDataTrusts: Command = {
-          method: "trust_find",
-          params: [[searchValue], trustsIdsParams],
-        };
-
-        // Make call using 'fetchWithBQ'
-        const getResultTrusts = await fetchWithBQ(
-          getCommand(payloadDataTrusts)
-        );
-
-        // Return possible errors
-        if (getResultTrusts.error) {
-          return { error: getResultTrusts.error };
-        }
-
-        // If no error: cast and assign 'ids'
-        const responseDataTrusts = getResultTrusts.data as FindRPCResponse;
-        const trustsIds: string[] = [];
-        const trustsItemsCount = responseDataTrusts.result.result
-          .length as number;
-
-        for (let i = startIdx; i < trustsItemsCount && i < stopIdx; i++) {
-          const trustId = responseDataTrusts.result.result[i] as FindTrustArgs;
-          trustsIds.push(trustId.cn[0]);
-        }
-
-        // FETCH TRUST DATA VIA "trust_show" COMMAND
-        const commands: Command[] = [];
-        trustsIds.map((trustId) => {
-          commands.push({
-            method: "trust_show",
-            params: [[trustId], {}],
-          });
-        });
-
-        const trustsShowResult = await fetchWithBQ(
-          getBatchCommand(commands, apiVersionUsed)
-        );
-
-        const response = trustsShowResult.data as BatchRPCResponse;
-        if (response) {
-          response.result.totalCount = trustsItemsCount;
-        }
-
-        // Return results
-        const results: Trust[] = [];
-        for (
-          let i = startIdx;
-          i < response.result.totalCount && i < stopIdx;
-          i++
-        ) {
-          const trust = response.result.results[i].result as Record<
-            string,
-            unknown
-          >;
-          results.push(apiToTrust(trust));
-        }
-
-        return { data: response };
-      },
-    }),
-    /**
-     * Search for a specific Trust
-     * @param {TrustsFullDataPayload} payload - The payload containing search parameters
-     * @returns {BatchRPCResponse} - List of Trusts full data
-     */
-    searchTrustsEntries: build.mutation<
-      BatchRPCResponse,
-      TrustsFullDataPayload
-    >({
       async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
         const { searchValue, apiVersion, sizelimit, startIdx, stopIdx } =
           payloadData;
@@ -399,23 +315,6 @@ const extendedApi = api.injectEndpoints({
         });
       },
     }),
-    /*
-     * Search for trusted domains
-     * @param {TrustDomainFindPayload} payload - The payload containing the search parameters
-     * @returns {FindRPCResponse} - Promise with the response data
-     */
-    searchTrustDomainsEntries: build.mutation<
-      FindRPCResponse,
-      TrustDomainFindPayload
-    >({
-      query: (payload) => {
-        const { trustId, searchValue, sizelimit } = payload;
-        return getCommand({
-          method: "trustdomain_find",
-          params: [[trustId, searchValue || ""], { sizelimit }],
-        });
-      },
-    }),
     /**
      * Fetch trusted domains
      * @param {string} trustId - The ID of the trust
@@ -482,7 +381,6 @@ const extendedApi = api.injectEndpoints({
 
 export const {
   useGetTrustsFullDataQuery,
-  useSearchTrustsEntriesMutation,
   useAddTrustMutation,
   useDeleteTrustsMutation,
   useTrustShowQuery,
@@ -490,7 +388,6 @@ export const {
   useGlobalTrustConfigShowQuery,
   useGlobalTrustConfigModMutation,
   useTrustDomainsFindQuery,
-  useSearchTrustDomainsEntriesMutation,
   useFetchTrustDomainsMutation,
   useEnableDisableTrustDomainsMutation,
   useDeleteTrustedDomainsMutation,

--- a/src/services/rpcUsers.ts
+++ b/src/services/rpcUsers.ts
@@ -8,6 +8,7 @@ import {
   BatchRPCResponse,
   FindRPCResponse,
   useGettingGenericQuery,
+  GenericPayload,
 } from "./rpc";
 import { apiToUser, userToApi } from "../utils/userUtils";
 import { apiToPwPolicy } from "../utils/pwPolicyUtils";
@@ -607,20 +608,25 @@ const extendedApi = api.injectEndpoints({
   overrideExisting: false,
 });
 
+type UsersPayload = Pick<
+  Omit<GenericPayload, "method">,
+  "searchValue" | "apiVersion" | "sizeLimit" | "startIdx" | "stopIdx"
+>;
+
 // Active Users
-export const useGettingActiveUserQuery = (payloadData) => {
+export const useGettingActiveUserQuery = (payloadData: UsersPayload) => {
   payloadData["objName"] = "user";
   payloadData["objAttr"] = "uid";
   return useGettingGenericQuery(payloadData);
 };
 // Stage Users
-export const useGettingStageUserQuery = (payloadData) => {
+export const useGettingStageUserQuery = (payloadData: UsersPayload) => {
   payloadData["objName"] = "stageuser";
   payloadData["objAttr"] = "uid";
   return useGettingGenericQuery(payloadData);
 };
 // Preserved users
-export const useGettingPreservedUserQuery = (payloadData) => {
+export const useGettingPreservedUserQuery = (payloadData: UsersPayload) => {
   payloadData["objName"] = "preserved";
   payloadData["objAttr"] = "uid";
   return useGettingGenericQuery(payloadData);

--- a/src/services/rpci18n.ts
+++ b/src/services/rpci18n.ts
@@ -23,6 +23,7 @@ const extendedApi = api.injectEndpoints({
           params: [[], { version: API_VERSION_BACKUP }],
         },
       }),
+      keepUnusedDataFor: 3600,
     }),
   }),
   overrideExisting: false,

--- a/src/utils/selectedPerPage.ts
+++ b/src/utils/selectedPerPage.ts
@@ -1,0 +1,40 @@
+/**
+ * IPA attributes are often multi-valued string[]; the primary key is the first value.
+ */
+export function ipaPrimaryKey(value: string | string[] | undefined): string {
+  if (Array.isArray(value)) {
+    return value[0] ?? "";
+  }
+  return value ?? "";
+}
+
+/**
+ * Count how many of the currently shown page elements are in the selection.
+ */
+export function countSelectedOnPage<T>(
+  shownElements: T[],
+  selectedKeys: Iterable<string>,
+  getKey: (item: T) => string
+): number {
+  const keys =
+    selectedKeys instanceof Set ? selectedKeys : new Set(selectedKeys);
+  return shownElements.filter((el) => keys.has(getKey(el))).length;
+}
+
+/**
+ * Derives selected-per-page count for bulk selector / table pagination data.
+ * `updateSelectedPerPage` is a no-op kept for API compatibility with tables
+ * that still call it after row selection.
+ */
+export function getSelectedPerPageData<T>(
+  shownElements: T[],
+  selectedKeys: Iterable<string>,
+  getKey: (item: T) => string
+) {
+  return {
+    selectedPerPage: countSelectedOnPage(shownElements, selectedKeys, getKey),
+    updateSelectedPerPage: (selected: number) => {
+      void selected;
+    },
+  };
+}

--- a/src/utils/testUtils.tsx
+++ b/src/utils/testUtils.tsx
@@ -2,9 +2,10 @@ import React, { PropsWithChildren } from "react";
 import { render } from "@testing-library/react";
 import type { RenderOptions } from "@testing-library/react";
 import { Provider } from "react-redux";
-
 import ManagedAlerts from "src/components/ManagedAlerts";
 import { setupStore } from "src/store/store";
+import { useSearchParams } from "react-router";
+import { MemoryRouter } from "react-router";
 
 export function renderWithAlerts(
   ui: React.ReactElement,
@@ -25,3 +26,34 @@ export function renderWithAlerts(
     ...render(ui, { wrapper: Wrapper, ...renderOptions }),
   };
 }
+
+const SearchParamsProbe = ({
+  onParams,
+}: {
+  onParams: (params: URLSearchParams) => void;
+}) => {
+  const [params] = useSearchParams();
+  onParams(params);
+  return null;
+};
+
+export const renderWithRouter = (
+  ui: React.ReactElement,
+  initialEntry = "/"
+) => {
+  let latestParams = new URLSearchParams();
+  const result = render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      {ui}
+      <SearchParamsProbe
+        onParams={(params) => {
+          latestParams = params;
+        }}
+      />
+    </MemoryRouter>
+  );
+  return {
+    ...result,
+    getParams: () => latestParams,
+  };
+};


### PR DESCRIPTION
Fix search from non-first pages returning
wrong or empty results

Reset pagination to page 1 and use `startIdx: 0`
when submitting a search. Previously, search used
the current page offset, which skipped matching
entries in the LDAP result set. Fixed across all
affected pages, and updated the corresponding
`main-pages` file.

Assisted-by: Claude <noreply@anthropic.com>

## Summary by Sourcery

Reset search pagination and result indices so searches always start from the first page and return complete results across all affected listing pages.

Bug Fixes:
- Fix searches performed from non-first pages returning empty or incomplete results by resetting to page 1.
- Ensure LDAP-backed searches consistently query from the first result up to the current page size instead of using paginated offsets.

Documentation:
- Update the main-pages walkthrough design document to reflect the corrected search pagination behavior.