### PR TITLE
Add Privileges > 'Permissions' page

### DIFF
--- a/doc/designs/components/02-lists.md
+++ b/doc/designs/components/02-lists.md
@@ -61,18 +61,23 @@ Kerberos principal alias management.
 
 Dual-pane list selector used inside `MemberOfAddModal` for picking items to add.
 
-**Search behaviour (`isSearchable` + `onSearchTextChange`):**
+**Search behaviour (`searchProps`):**
 
-| `onSearchTextChange` provided? | Filtering mode | `onChange` (keystroke) | `onSearch` (Enter / button) | `onClear` |
+Pass an optional `searchProps` object to show a search input in the available
+pane. Omit it when search is not needed.
+
+| `searchProps` provided? | Search input | `onChange` (keystroke) | `onSearch` (Enter / button) | `onClear` |
 |---|----|----|----|---|
-| **Yes** (server-side search) | Server handles filtering | Updates input text only | Calls `onSearchTextChange` → triggers RTK Query | Resets input + calls `onSearchTextChange("")` |
-| **No** (client-only) | Client-side `isVisible` | Filters local list per-keystroke | — | Resets local filter |
+| **Yes** | Shown | Updates filter text; narrows the displayed list via a memoized `filteredAvailableOptions` list | Calls `searchProps.onSearchTextChange` → triggers RTK Query | Resets filter + calls `searchProps.onSearchTextChange("")` |
+| **No** | Hidden | — | — | — |
 
-> **Important:** When `onSearchTextChange` is connected to an RTK Query (via
-> `adderSearchValue`), `DualListSelectorGeneric` does **not** apply client-side
-> `isVisible` filtering — the server already returns filtered results. The search
-> input only fires the query on **submit** (Enter / search button), not on every
-> keystroke, matching the same pattern as `SearchInputLayout`.
+> **Important:** Visible options are derived from a memoized filter over
+> `availableOptions` (replacing the old per-option `isVisible` flag). When
+> `searchProps.onSearchTextChange` is connected to an RTK Query (via
+> `adderSearchValue`), the server query fires on **submit** (Enter / search
+> button), not on every keystroke — matching the same pattern as
+> `SearchInputLayout`. Keystrokes still narrow the currently loaded options
+> locally until the user submits a new search.
 
 **Props:**
 | Prop | Type | Description |
@@ -85,8 +90,7 @@ Dual-pane list selector used inside `MemberOfAddModal` for picking items to add.
 | `availableOptionsTitle?` | `string` | Left-pane heading |
 | `chosenOptionsTitle?` | `string` | Right-pane heading |
 | `ariaLabel?` | `string` | Accessibility label |
-| `isSearchable?` | `boolean` | Show search input in available pane |
-| `onSearchTextChange?` | `(searchText: string) => void` | Server-side search callback (submit-only) |
+| `searchProps?` | `{ onSearchTextChange: (searchText: string) => void }` | Enables search input; server-side callback on submit/clear |
 
 ---
 

--- a/doc/designs/components/02-lists.md
+++ b/doc/designs/components/02-lists.md
@@ -57,6 +57,37 @@ Certificate mapping data management.
 
 Kerberos principal alias management.
 
+### DualListSelectorGeneric
+
+Dual-pane list selector used inside `MemberOfAddModal` for picking items to add.
+
+**Search behaviour (`isSearchable` + `onSearchTextChange`):**
+
+| `onSearchTextChange` provided? | Filtering mode | `onChange` (keystroke) | `onSearch` (Enter / button) | `onClear` |
+|---|----|----|----|---|
+| **Yes** (server-side search) | Server handles filtering | Updates input text only | Calls `onSearchTextChange` → triggers RTK Query | Resets input + calls `onSearchTextChange("")` |
+| **No** (client-only) | Client-side `isVisible` | Filters local list per-keystroke | — | Resets local filter |
+
+> **Important:** When `onSearchTextChange` is connected to an RTK Query (via
+> `adderSearchValue`), `DualListSelectorGeneric` does **not** apply client-side
+> `isVisible` filtering — the server already returns filtered results. The search
+> input only fires the query on **submit** (Enter / search button), not on every
+> keystroke, matching the same pattern as `SearchInputLayout`.
+
+**Props:**
+| Prop | Type | Description |
+|------|------|-------------|
+| `id` | `string` | Component ID |
+| `availableOptions` | `DualListOption[]` | Left-pane options |
+| `setAvailableOptions` | `(options: DualListOption[]) => void` | Update available |
+| `chosenOptions` | `DualListOption[]` | Right-pane options |
+| `setChosenOptions` | `(options: DualListOption[]) => void` | Update chosen |
+| `availableOptionsTitle?` | `string` | Left-pane heading |
+| `chosenOptionsTitle?` | `string` | Right-pane heading |
+| `ariaLabel?` | `string` | Accessibility label |
+| `isSearchable?` | `boolean` | Show search input in available pane |
+| `onSearchTextChange?` | `(searchText: string) => void` | Server-side search callback (submit-only) |
+
 ---
 
 ## Specialized Components

--- a/doc/designs/sub-pages.md
+++ b/doc/designs/sub-pages.md
@@ -46,6 +46,25 @@ See [00-best-practices.md](sub-pages/00-best-practices.md) for the complete guid
 
 See [03-tabs-component.md](sub-pages/03-tabs-component.md) for Tabs details.
 
+## Bulk Selection (BulkSelectorPrep)
+
+Any sub-page that is **not** Settings, "Is a member of", Members, or ManagedBy
+must include a `BulkSelectorPrep` component in its toolbar to allow bulk
+operations (select page / select all / unselect) on the table.
+
+| Sub-Page Type | BulkSelectorPrep Required? |
+|---------------|---------------------------|
+| **Settings** | No |
+| **Members** | No |
+| **Is a member of** | No |
+| **ManagedBy** | No |
+| **Table tabs** (e.g., DNS Records) | **Yes** — see [05-table-tab.md](sub-pages/05-table-tab.md) |
+| **Independent** (e.g., Privileges) | **Yes** — see [17-independent-sub-pages.md](sub-pages/17-independent-sub-pages.md) |
+
+For independent sub-pages that use `MemberOfToolbar`, pass the `BulkSelectorPrep`
+via the `bulkSelector` prop. For table tabs that use `ToolbarLayout`, add it as
+the first toolbar item.
+
 ## Navigation Bar Highlighting
 
 **Every sub-page** must call `useUpdateRoute`:

--- a/doc/designs/sub-pages/08a-common-issues.md
+++ b/doc/designs/sub-pages/08a-common-issues.md
@@ -89,6 +89,28 @@ dispatch(addAlert({
 
 ## RTK Query Issues
 
+### Redundant `useEffect` + `refetch()` on Query Argument Changes
+
+RTK Query automatically re-fetches when its arguments change or when `skip`
+transitions from `true` to `false`. Do **not** wrap these triggers in a manual
+`useEffect` that calls `refetch()` — it duplicates work the hook already does.
+
+```tsx
+// ❌ Wrong: manual refetch is redundant
+const query = useGetPermissionsQuery(searchValue, { skip: !isOpen });
+
+React.useEffect(() => {
+  if (isOpen) {
+    query.refetch();
+  }
+}, [isOpen, searchValue]);
+
+// ✅ Correct: RTK Query handles both triggers automatically
+const query = useGetPermissionsQuery(searchValue, { skip: !isOpen });
+// No useEffect needed — the hook refetches when searchValue changes
+// or when skip goes from true → false.
+```
+
 ### Missing `skip` Option
 
 ```tsx

--- a/doc/designs/sub-pages/09-modals.md
+++ b/doc/designs/sub-pages/09-modals.md
@@ -85,6 +85,30 @@ const Add<ChildEntity>Modal = (props: Add<ChildEntity>ModalProps) => {
 export default Add<ChildEntity>Modal;
 ```
 
+### Searchable Add Modal (DualListSelector with server-side search)
+
+When the Add modal needs server-side search (e.g., searching hundreds of
+permissions), pass `isSearchable` and `onSearchTextChange` to `MemberOfAddModal`.
+The search fires on **submit** (Enter / search button), not per-keystroke.
+Do **not** add client-side filtering — the server returns already-filtered results.
+
+See [DualListSelectorGeneric](../components/02-lists.md#duallistselectorgeneric)
+for the full search behaviour table.
+
+```tsx
+<MemberOfAddModal
+  showModal={showAddModal}
+  onCloseModal={() => setShowAddModal(false)}
+  availableItems={availableItems}
+  onAdd={onAddItem}
+  onSearchTextChange={setAdderSearchValue}
+  title="Add items"
+  ariaLabel="Add items modal"
+  isSearchable
+  spinning={spinning}
+/>
+```
+
 ## Delete Modal
 
 ### Props Interface

--- a/doc/designs/sub-pages/09-modals.md
+++ b/doc/designs/sub-pages/09-modals.md
@@ -88,9 +88,9 @@ export default Add<ChildEntity>Modal;
 ### Searchable Add Modal (DualListSelector with server-side search)
 
 When the Add modal needs server-side search (e.g., searching hundreds of
-permissions), pass `isSearchable` and `onSearchTextChange` to `MemberOfAddModal`.
-The search fires on **submit** (Enter / search button), not per-keystroke.
-Do **not** add client-side filtering — the server returns already-filtered results.
+permissions), pass `searchProps` to `MemberOfAddModal`. The search input is
+shown automatically when `searchProps` is provided. The RTK Query fires on
+**submit** (Enter / search button), not per-keystroke.
 
 See [DualListSelectorGeneric](../components/02-lists.md#duallistselectorgeneric)
 for the full search behaviour table.
@@ -101,10 +101,9 @@ for the full search behaviour table.
   onCloseModal={() => setShowAddModal(false)}
   availableItems={availableItems}
   onAdd={onAddItem}
-  onSearchTextChange={setAdderSearchValue}
+  searchProps={{ onSearchTextChange: setAdderSearchValue }}
   title="Add items"
   ariaLabel="Add items modal"
-  isSearchable
   spinning={spinning}
 />
 ```

--- a/doc/designs/sub-pages/17-independent-sub-pages.md
+++ b/doc/designs/sub-pages/17-independent-sub-pages.md
@@ -74,6 +74,13 @@ Based on the sub-pages guide, generate a 'Privileges' independent page for 'Role
 
 **Parent entity query:** Must include `all: true` to return data fields.
 
+> **Important:** When passing a search value as the query argument and using
+> `skip` to gate fetching, do **not** add a `useEffect` that calls `refetch()`
+> on those same values. RTK Query automatically re-fetches when its arguments
+> change or when `skip` transitions from `true` to `false`. A manual `refetch()`
+> would duplicate those requests. See [08a-common-issues.md](08a-common-issues.md#redundant-useeffect--refetch-on-query-argument-changes)
+> for the full anti-pattern.
+
 ```typescript
 // Available items query
 getPrivileges: build.query<FindRPCResponse, string>({

--- a/doc/designs/sub-pages/17-independent-sub-pages.md
+++ b/doc/designs/sub-pages/17-independent-sub-pages.md
@@ -92,6 +92,60 @@ addPrivilegeToRole: build.mutation({
 }),
 ```
 
+## BulkSelectorPrep (Required)
+
+Independent sub-pages **must** include a `BulkSelectorPrep` component to allow
+bulk operations (select page / select all / unselect) on the table. Pass it to
+`MemberOfToolbar` via the `bulkSelector` prop.
+
+This requires tracking selected items as entity objects (not plain strings) so
+`BulkSelectorPrep` can manage them. Derive a `string[]` for `MemberTable`
+compatibility via `useMemo`.
+
+```tsx
+import BulkSelectorPrep from "src/components/BulkSelectorPrep";
+import { getSelectedPerPageData } from "src/utils/selectedPerPage";
+
+// Entity-based selection state
+const [selectedItems, setSelectedItems] = React.useState<ItemType[]>([]);
+
+// Derive string[] for MemberTable
+const selectedNames = useMemo(() => selectedItems.map((i) => i.cn), [selectedItems]);
+
+// Delete button disabled state (managed by BulkSelectorPrep and selection helpers)
+const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] = React.useState(true);
+
+// Update handler for BulkSelectorPrep
+const updateSelected = (items: ItemType[], isSelected: boolean) => {
+  let newSelected: ItemType[];
+  if (isSelected) {
+    const currentNames = new Set(selectedNames);
+    const toAdd = items.filter((item) => !currentNames.has(item.cn));
+    newSelected = [...selectedItems, ...toAdd];
+  } else {
+    const removeNames = new Set(items.map((item) => item.cn));
+    newSelected = selectedItems.filter((p) => !removeNames.has(p.cn));
+  }
+  setSelectedItems(newSelected);
+  setIsDeleteButtonDisabled(newSelected.length === 0);
+};
+
+// Adapter for MemberTable's string-based onCheckItemsChange
+const onCheckItemsChange = (checkedNames: string[]) => {
+  setSelectedItems(checkedNames.map((name) => ({ cn: name })));
+  setIsDeleteButtonDisabled(checkedNames.length === 0);
+};
+
+// BulkSelectorPrep data
+const selectedPerPageData = getSelectedPerPageData(items, selectedNames, (i) => i.cn);
+const bulkSelectorData = {
+  selected: selectedItems,
+  updateSelected,
+  selectableTable: items,
+  nameAttr: "cn",
+};
+```
+
 ## Component Structure
 
 ```tsx
@@ -100,8 +154,27 @@ const <Entity><SubPage> = (props) => {
   
   return (
     <TabLayout id="subpage">
-      <MemberOfToolbar ... />
-      <MemberTable entityList={data} idKey="cn" from="privileges" ... />
+      <MemberOfToolbar
+        bulkSelector={
+          <BulkSelectorPrep
+            list={data}
+            shownElementsList={data}
+            elementData={bulkSelectorData}
+            buttonsData={{ updateIsDeleteButtonDisabled: setIsDeleteButtonDisabled }}
+            selectedPerPageData={selectedPerPageData}
+          />
+        }
+        deleteButtonEnabled={!isDeleteButtonDisabled && isRefreshButtonEnabled}
+        ...
+      />
+      <MemberTable
+        entityList={data}
+        idKey="cn"
+        from="privileges"
+        checkedItems={selectedNames}
+        onCheckItemsChange={onCheckItemsChange}
+        ...
+      />
       <Pagination ... />
       {showAddModal && <MemberOfAddModal ... />}
       {showDeleteModal && <MemberOfDeleteModal ... />}
@@ -119,5 +192,6 @@ const <Entity><SubPage> = (props) => {
 
 ## Reference Implementations
 
+- `src/pages/Privileges/PrivilegesPermissions.tsx` — uses `MemberOfToolbar` with `bulkSelector` prop
 - `src/pages/Roles/RolesPrivileges.tsx`
-- `src/pages/DNSZones/DnsResourceRecords.tsx`
+- `src/pages/DNSZones/DnsResourceRecords.tsx` — uses `ToolbarLayout` with `BulkSelectorPrep` as first item

--- a/src/components/ManagedBy/ManagedByHosts.tsx
+++ b/src/components/ManagedBy/ManagedByHosts.tsx
@@ -334,7 +334,7 @@ const ManagedByHosts = (props: ManagedByHostsProps) => {
           onCloseModal={() => setShowAddModal(false)}
           availableItems={availableItems}
           onAdd={onAddHost}
-          onSearchTextChange={setAdderSearchValue}
+          searchProps={{ onSearchTextChange: setAdderSearchValue }}
           title={`Assign hosts to user ${props.id}`}
           ariaLabel="Add user of host modal"
           spinning={spinning}

--- a/src/components/ManagedBy/ManagedByUsers.tsx
+++ b/src/components/ManagedBy/ManagedByUsers.tsx
@@ -281,7 +281,7 @@ const ManagedByUsers = (props: ManagedByUsersProps) => {
           onCloseModal={() => setShowAddModal(false)}
           availableItems={availableItems}
           onAdd={onAddUser}
-          onSearchTextChange={setAdderSearchValue}
+          searchProps={{ onSearchTextChange: setAdderSearchValue }}
           title={`Assign users managing OTP token: ${props.id}`}
           ariaLabel="Add managed by user modal"
           spinning={spinning}

--- a/src/components/MemberManagers/ManagersUserGroups.tsx
+++ b/src/components/MemberManagers/ManagersUserGroups.tsx
@@ -317,7 +317,7 @@ const ManagersUserGroups = (props: PropsToManagersUsergroups) => {
           onCloseModal={() => setShowAddModal(false)}
           availableItems={availableItems}
           onAdd={onAddUserGroup}
-          onSearchTextChange={setAdderSearchValue}
+          searchProps={{ onSearchTextChange: setAdderSearchValue }}
           title={"Assign group member managers to: " + props.id}
           ariaLabel={"Add " + entityType + " to user group managers modal"}
           spinning={spinning}

--- a/src/components/MemberManagers/ManagersUsers.tsx
+++ b/src/components/MemberManagers/ManagersUsers.tsx
@@ -313,7 +313,7 @@ const ManagersUsers = (props: PropsToManagersUsers) => {
           onCloseModal={() => setShowAddModal(false)}
           availableItems={availableItems}
           onAdd={onAddUser}
-          onSearchTextChange={setAdderSearchValue}
+          searchProps={{ onSearchTextChange: setAdderSearchValue }}
           title={"Assign user member managers to: " + props.id}
           ariaLabel={"Add " + entityType + " to user managers modal"}
           spinning={spinning}

--- a/src/components/MemberOf/MemberOfAddModal.tsx
+++ b/src/components/MemberOf/MemberOfAddModal.tsx
@@ -20,16 +20,19 @@ export interface AvailableItems {
   title: string;
 }
 
+type SearchProps = {
+  onSearchTextChange: (searchText: string) => void;
+};
+
 interface PropsToAdd {
   showModal: boolean;
   onCloseModal: () => void;
   availableItems: AvailableItems[];
   onAdd: (items: AvailableItems[]) => void;
-  onSearchTextChange?: (searchText: string) => void;
   title: string;
   ariaLabel: string;
   spinning: boolean;
-  isSearchable?: boolean;
+  searchProps?: SearchProps;
 }
 
 const MemberOfAddModal = (props: PropsToAdd) => {
@@ -39,7 +42,7 @@ const MemberOfAddModal = (props: PropsToAdd) => {
   // States
   const [availableOptions, setAvailableOptions] = React.useState<
     DualListOption[]
-  >(optionsToDualListOptions(data));
+  >(() => optionsToDualListOptions(data));
   const [chosenOptions, setChosenOptions] = React.useState<DualListOption[]>(
     []
   );
@@ -70,8 +73,7 @@ const MemberOfAddModal = (props: PropsToAdd) => {
           setAvailableOptions={setAvailableOptions}
           chosenOptions={chosenOptions}
           setChosenOptions={setChosenOptions}
-          isSearchable={props.isSearchable}
-          onSearchTextChange={props.onSearchTextChange}
+          searchProps={props.searchProps}
         />
       ),
     },
@@ -84,14 +86,7 @@ const MemberOfAddModal = (props: PropsToAdd) => {
   };
 
   // Buttons are disabled until the user fills the required fields
-  const [buttonDisabled, setButtonDisabled] = React.useState(true);
-  React.useEffect(() => {
-    if (chosenOptions.length > 0) {
-      setButtonDisabled(false);
-    } else {
-      setButtonDisabled(true);
-    }
-  }, [chosenOptions]);
+  const buttonDisabled = chosenOptions.length === 0;
 
   // Add group option
   const onClickAddHandler = () => {

--- a/src/components/MemberOf/MemberOfAddModal.tsx
+++ b/src/components/MemberOf/MemberOfAddModal.tsx
@@ -25,10 +25,11 @@ interface PropsToAdd {
   onCloseModal: () => void;
   availableItems: AvailableItems[];
   onAdd: (items: AvailableItems[]) => void;
-  onSearchTextChange: (searchText: string) => void;
+  onSearchTextChange?: (searchText: string) => void;
   title: string;
   ariaLabel: string;
   spinning: boolean;
+  isSearchable?: boolean;
 }
 
 const MemberOfAddModal = (props: PropsToAdd) => {
@@ -69,6 +70,8 @@ const MemberOfAddModal = (props: PropsToAdd) => {
           setAvailableOptions={setAvailableOptions}
           chosenOptions={chosenOptions}
           setChosenOptions={setChosenOptions}
+          isSearchable={props.isSearchable}
+          onSearchTextChange={props.onSearchTextChange}
         />
       ),
     },

--- a/src/components/MemberOf/MemberOfHbacRules.tsx
+++ b/src/components/MemberOf/MemberOfHbacRules.tsx
@@ -354,7 +354,7 @@ const MemberOfHbacRules = (props: MemberOfHbacRulesProps) => {
         onCloseModal={() => setShowAddModal(false)}
         availableItems={availableItems}
         onAdd={onAddHbacRule}
-        onSearchTextChange={setAdderSearchValue}
+        searchProps={{ onSearchTextChange: setAdderSearchValue }}
         title={`Add '${props.id}' into HBAC rules`}
         ariaLabel={"Add HBAC rule modal"}
         spinning={spinning}

--- a/src/components/MemberOf/MemberOfHbacServiceGroups.tsx
+++ b/src/components/MemberOf/MemberOfHbacServiceGroups.tsx
@@ -293,7 +293,7 @@ const MemberOfHbacServices = (props: MemberOfHbacServicesProps) => {
         onCloseModal={() => setShowAddModal(false)}
         availableItems={availableItems}
         onAdd={onAddHbacService}
-        onSearchTextChange={setAdderSearchValue}
+        searchProps={{ onSearchTextChange: setAdderSearchValue }}
         title={`Add '${props.id}' to HBAC service groups`}
         ariaLabel={"Add HBAC service group member modal"}
         spinning={spinning}

--- a/src/components/MemberOf/MemberOfHostGroups.tsx
+++ b/src/components/MemberOf/MemberOfHostGroups.tsx
@@ -340,7 +340,7 @@ const MemberOfHostGroups = (props: MemberOfHostGroupsProps) => {
         onCloseModal={() => setShowAddModal(false)}
         availableItems={availableItems}
         onAdd={onAddHostGroup}
-        onSearchTextChange={setAdderSearchValue}
+        searchProps={{ onSearchTextChange: setAdderSearchValue }}
         title={`Add '${props.id}' into host groups`}
         ariaLabel="Add host of host group modal"
         spinning={spinning}

--- a/src/components/MemberOf/MemberOfNetgroups.tsx
+++ b/src/components/MemberOf/MemberOfNetgroups.tsx
@@ -376,7 +376,7 @@ const memberOfNetgroups = (props: MemberOfNetgroupsProps) => {
         onCloseModal={() => setShowAddModal(false)}
         availableItems={availableItems}
         onAdd={onAddNetgroup}
-        onSearchTextChange={setAdderSearchValue}
+        searchProps={{ onSearchTextChange: setAdderSearchValue }}
         title={`Add '${props.id}' into netgroups`}
         ariaLabel={"Add " + entityType + " of netgroup modal"}
         spinning={spinning}

--- a/src/components/MemberOf/MemberOfRoles.tsx
+++ b/src/components/MemberOf/MemberOfRoles.tsx
@@ -358,7 +358,7 @@ const MemberOfRoles = (props: MemberOfRolesProps) => {
         onCloseModal={() => setShowAddModal(false)}
         availableItems={availableItems}
         onAdd={onAddRole}
-        onSearchTextChange={setAdderSearchValue}
+        searchProps={{ onSearchTextChange: setAdderSearchValue }}
         title={`Add '${props.id}' into roles`}
         ariaLabel={"Add " + entityType + " of role modal"}
         spinning={spinning}

--- a/src/components/MemberOf/MemberOfSudoCmdGroups.tsx
+++ b/src/components/MemberOf/MemberOfSudoCmdGroups.tsx
@@ -289,7 +289,7 @@ const MemberOfSudoCmdGroups = (props: MemberOfSudoCmdGroupsProps) => {
         onCloseModal={() => setShowAddModal(false)}
         availableItems={availableItems}
         onAdd={onAddSudoCommand}
-        onSearchTextChange={setAdderSearchValue}
+        searchProps={{ onSearchTextChange: setAdderSearchValue }}
         title={`Add '${props.id}' to Sudo command groups`}
         ariaLabel={"Add Sudo cmd group member modal"}
         spinning={spinning}

--- a/src/components/MemberOf/MemberOfSudoRules.tsx
+++ b/src/components/MemberOf/MemberOfSudoRules.tsx
@@ -347,7 +347,7 @@ const MemberOfSudoRules = (props: MemberOfSudoRulesProps) => {
         onCloseModal={() => setShowAddModal(false)}
         availableItems={availableItems}
         onAdd={onAddSudoRule}
-        onSearchTextChange={setAdderSearchValue}
+        searchProps={{ onSearchTextChange: setAdderSearchValue }}
         title={`Add '${props.id}' into sudo rules`}
         ariaLabel={"Add " + entityType + " of Sudo rule modal"}
         spinning={spinning}

--- a/src/components/MemberOf/MemberOfToolbar.tsx
+++ b/src/components/MemberOf/MemberOfToolbar.tsx
@@ -19,6 +19,9 @@ import PaginationLayout from "../layouts/PaginationLayout";
 export type MembershipDirection = "direct" | "indirect";
 
 interface MemberOfToolbarProps {
+  // bulk selector (optional, rendered before search)
+  bulkSelector?: React.ReactNode;
+
   // search
   searchPlaceholder: string;
   searchAriaLabel: string;
@@ -56,6 +59,9 @@ const MemberOfToolbar = (props: MemberOfToolbarProps) => {
   return (
     <Toolbar>
       <ToolbarContent>
+        {props.bulkSelector && (
+          <ToolbarItem id="bulk-selector">{props.bulkSelector}</ToolbarItem>
+        )}
         <ToolbarItem id="search-input" gap={{ default: "gapMd" }}>
           <SearchInputLayout
             dataCy="search"

--- a/src/components/MemberOf/MemberOfUserGroups.tsx
+++ b/src/components/MemberOf/MemberOfUserGroups.tsx
@@ -333,7 +333,7 @@ const MemberOfUserGroups = (props: MemberOfUserGroupsProps) => {
         onCloseModal={() => setShowAddModal(false)}
         availableItems={availableItems}
         onAdd={onAddUserGroup}
-        onSearchTextChange={setAdderSearchValue}
+        searchProps={{ onSearchTextChange: setAdderSearchValue }}
         title={`Assign '${id}' to user groups`}
         ariaLabel="Add entry of user group modal"
         spinning={spinning}

--- a/src/components/Members/MembersHbacServices.tsx
+++ b/src/components/Members/MembersHbacServices.tsx
@@ -295,7 +295,7 @@ const MembersHBACServices = (props: PropsToMembersHBACServices) => {
         onCloseModal={() => setShowAddModal(false)}
         availableItems={availableItems}
         onAdd={onAddMember}
-        onSearchTextChange={setAdderSearchValue}
+        searchProps={{ onSearchTextChange: setAdderSearchValue }}
         title={"Assign HBAC service members to: " + props.id}
         ariaLabel={"Add mHBAC service members modal"}
         spinning={spinning}

--- a/src/components/Members/MembersHostGroups.tsx
+++ b/src/components/Members/MembersHostGroups.tsx
@@ -410,7 +410,7 @@ const MembersHostGroups = (props: PropsToMembersHostGroups) => {
           onCloseModal={() => setShowAddModal(false)}
           availableItems={availableItems}
           onAdd={onAddHostGroup}
-          onSearchTextChange={setAdderSearchValue}
+          searchProps={{ onSearchTextChange: setAdderSearchValue }}
           title={"Assign host groups to " + entityType + ": " + props.id}
           ariaLabel={"Add host groups modal"}
           spinning={spinning}

--- a/src/components/Members/MembersHosts.tsx
+++ b/src/components/Members/MembersHosts.tsx
@@ -396,7 +396,7 @@ const MembersHosts = (props: PropsToMembersHosts) => {
           onCloseModal={() => setShowAddModal(false)}
           availableItems={availableItems}
           onAdd={onAddHost}
-          onSearchTextChange={setAdderSearchValue}
+          searchProps={{ onSearchTextChange: setAdderSearchValue }}
           title={"Assign hosts to " + entityType + ": " + props.id}
           ariaLabel={"Add hosts  modal"}
           spinning={spinning}

--- a/src/components/Members/MembersNetgroups.tsx
+++ b/src/components/Members/MembersNetgroups.tsx
@@ -337,7 +337,7 @@ const MembersNetgroups = (props: PropsToMembersNetgroups) => {
         onCloseModal={() => setShowAddModal(false)}
         availableItems={availableItems}
         onAdd={onAddNetgroup}
-        onSearchTextChange={setAdderSearchValue}
+        searchProps={{ onSearchTextChange: setAdderSearchValue }}
         title={"Assign netgroups to netgroup: " + props.id}
         ariaLabel={"Add netgroups modal"}
         spinning={spinning}

--- a/src/components/Members/MembersServices.tsx
+++ b/src/components/Members/MembersServices.tsx
@@ -369,7 +369,7 @@ const MembersServices = (props: PropsToMembersServices) => {
           onCloseModal={() => setShowAddModal(false)}
           availableItems={availableItems}
           onAdd={onAddService}
-          onSearchTextChange={setAdderSearchValue}
+          searchProps={{ onSearchTextChange: setAdderSearchValue }}
           title={"Assign services to user group: " + props.id}
           ariaLabel={"Add services to user group"}
           spinning={spinning}

--- a/src/components/Members/MembersSudoCommands.tsx
+++ b/src/components/Members/MembersSudoCommands.tsx
@@ -273,7 +273,7 @@ const MembersSudoCommands = (props: PropsToMembersSudoGroups) => {
         onCloseModal={() => setShowAddModal(false)}
         availableItems={availableItems}
         onAdd={onAddMember}
-        onSearchTextChange={setAdderSearchValue}
+        searchProps={{ onSearchTextChange: setAdderSearchValue }}
         title={"Assign sudo command members to: " + props.id}
         ariaLabel={"Add sudo command members modal"}
         spinning={spinning}

--- a/src/components/Members/MembersSystemAccount.tsx
+++ b/src/components/Members/MembersSystemAccount.tsx
@@ -219,7 +219,7 @@ const MembersSystemAccount = (props: PropsToMembersSystemAccount) => {
           onCloseModal={() => setShowAddModal(false)}
           availableItems={availableItems}
           onAdd={onAddSystemAccount}
-          onSearchTextChange={setAdderSearchValue}
+          searchProps={{ onSearchTextChange: setAdderSearchValue }}
           title={"Assign system accounts to role: " + props.id}
           ariaLabel="Add system account to role modal"
           spinning={spinning}

--- a/src/components/Members/MembersUserGroups.tsx
+++ b/src/components/Members/MembersUserGroups.tsx
@@ -407,7 +407,7 @@ const MembersUserGroups = (props: PropsToMembersUsergroups) => {
           onCloseModal={() => setShowAddModal(false)}
           availableItems={availableItems}
           onAdd={onAddUserGroup}
-          onSearchTextChange={setAdderSearchValue}
+          searchProps={{ onSearchTextChange: setAdderSearchValue }}
           title={"Assign user groups to " + entityType + ": " + props.id}
           ariaLabel={"Add " + entityType + " to user groups modal"}
           spinning={spinning}

--- a/src/components/Members/MembersUserIdOverride.tsx
+++ b/src/components/Members/MembersUserIdOverride.tsx
@@ -230,7 +230,7 @@ const MembersUserIdOverride = (props: PropsToMembersUserIdOverride) => {
           onCloseModal={() => setShowAddModal(false)}
           availableItems={availableItems}
           onAdd={onAddIdOverrideUser}
-          onSearchTextChange={setAdderSearchValue}
+          searchProps={{ onSearchTextChange: setAdderSearchValue }}
           title={"Assign ID override users to role: " + props.id}
           ariaLabel="Add ID override user to role modal"
           spinning={spinning}

--- a/src/components/Members/MembersUsers.tsx
+++ b/src/components/Members/MembersUsers.tsx
@@ -400,7 +400,7 @@ const MembersUsers = (props: PropsToMembersUsers) => {
           onCloseModal={() => setShowAddModal(false)}
           availableItems={availableItems}
           onAdd={onAddUser}
-          onSearchTextChange={setAdderSearchValue}
+          searchProps={{ onSearchTextChange: setAdderSearchValue }}
           title={"Assign users to " + entityType + ": " + props.id}
           ariaLabel={"Add " + entityType + " of user modal"}
           spinning={spinning}

--- a/src/components/layouts/DualListSelectorGeneric.tsx
+++ b/src/components/layouts/DualListSelectorGeneric.tsx
@@ -66,9 +66,7 @@ const DualListSelectorGeneric = (props: DualListGenericProps) => {
   };
 
   const onSubmitSearch = (value: string) => {
-    if (props.searchProps) {
-      props.searchProps.onSearchTextChange(value);
-    }
+    props.searchProps?.onSearchTextChange(value);
   };
 
   // callback for moving selected options between lists

--- a/src/components/layouts/DualListSelectorGeneric.tsx
+++ b/src/components/layouts/DualListSelectorGeneric.tsx
@@ -6,6 +6,7 @@ import {
   DualListSelectorListItem,
   DualListSelectorControlsWrapper,
   DualListSelectorControl,
+  SearchInput,
 } from "@patternfly/react-core";
 import {
   AngleDoubleLeftIcon,
@@ -17,6 +18,7 @@ import {
 export interface DualListOption {
   text: string;
   selected: boolean;
+  isVisible: boolean;
   dataCy: string;
 }
 
@@ -29,6 +31,8 @@ interface DualListGenericProps {
   availableOptionsTitle?: string;
   chosenOptionsTitle?: string;
   ariaLabel?: string;
+  isSearchable?: boolean;
+  onSearchTextChange?: (searchText: string) => void;
 }
 
 // Helper function: Parse data to 'DualListOption'
@@ -38,6 +42,7 @@ export const optionsToDualListOptions = (
   return options.map((option) => ({
     text: option,
     selected: false,
+    isVisible: true,
     dataCy: `item-${option}`,
   }));
 };
@@ -51,6 +56,27 @@ const DualListSelectorGeneric = (props: DualListGenericProps) => {
     setChosenOptions,
   } = props;
 
+  const [availableFilter, setAvailableFilter] = React.useState("");
+
+  const onInputChange = (value: string) => {
+    setAvailableFilter(value);
+    if (!props.onSearchTextChange) {
+      const toFilter = [...availableOptions];
+      toFilter.forEach((option) => {
+        option.isVisible =
+          value === "" ||
+          option.text.toLowerCase().includes(value.toLowerCase());
+      });
+      setAvailableOptions(toFilter);
+    }
+  };
+
+  const onSubmitSearch = (value: string) => {
+    if (props.onSearchTextChange) {
+      props.onSearchTextChange(value);
+    }
+  };
+
   // callback for moving selected options between lists
   const moveSelected = (fromAvailable: boolean) => {
     const sourceOptions = fromAvailable
@@ -61,7 +87,7 @@ const DualListSelectorGeneric = (props: DualListGenericProps) => {
       : props.availableOptions;
     for (let i = 0; i < sourceOptions.length; i++) {
       const option = sourceOptions[i];
-      if (option.selected) {
+      if (option.selected && option.isVisible) {
         sourceOptions.splice(i, 1);
         destinationOptions.push(option);
         option.selected = false;
@@ -80,8 +106,13 @@ const DualListSelectorGeneric = (props: DualListGenericProps) => {
   // callback for moving all options between lists
   const moveAll = (fromAvailable: boolean) => {
     if (fromAvailable) {
-      setChosenOptions([...availableOptions, ...chosenOptions]);
-      setAvailableOptions([]);
+      setChosenOptions([
+        ...availableOptions.filter((option) => option.isVisible),
+        ...chosenOptions,
+      ]);
+      setAvailableOptions([
+        ...availableOptions.filter((option) => !option.isVisible),
+      ]);
     } else {
       setAvailableOptions([...chosenOptions, ...availableOptions]);
       setChosenOptions([]);
@@ -113,35 +144,58 @@ const DualListSelectorGeneric = (props: DualListGenericProps) => {
     >
       <DualListSelectorPane
         title={props.availableOptionsTitle || "Available options"}
-        status={`${availableOptions.filter((option) => option.selected).length} of ${
-          availableOptions.length
+        status={`${availableOptions.filter((option) => option.selected && option.isVisible).length} of ${
+          availableOptions.filter((option) => option.isVisible).length
         } options selected`}
+        searchInput={
+          props.isSearchable ? (
+            <SearchInput
+              value={availableFilter}
+              onChange={(_event, value) => onInputChange(value)}
+              onSearch={(_event, value) => onSubmitSearch(value)}
+              onClear={() => {
+                onInputChange("");
+                onSubmitSearch("");
+              }}
+              aria-label="Search available options"
+              data-cy="dual-list-available-search"
+            />
+          ) : undefined
+        }
         data-cy="dual-list-left"
       >
         <DualListSelectorList>
-          {availableOptions.map((option, index) => (
-            <DualListSelectorListItem
-              key={index}
-              isSelected={option.selected}
-              id={`basic-available-option-${index}`}
-              onOptionSelect={(e) => onOptionSelect(e, index, false)}
-              data-cy={option.dataCy}
-            >
-              {option.text}
-            </DualListSelectorListItem>
-          ))}
+          {availableOptions.map((option, index) =>
+            option.isVisible ? (
+              <DualListSelectorListItem
+                key={index}
+                isSelected={option.selected}
+                id={`basic-available-option-${index}`}
+                onOptionSelect={(e) => onOptionSelect(e, index, false)}
+                data-cy={option.dataCy}
+              >
+                {option.text}
+              </DualListSelectorListItem>
+            ) : null
+          )}
         </DualListSelectorList>
       </DualListSelectorPane>
       <DualListSelectorControlsWrapper>
         <DualListSelectorControl
-          isDisabled={!availableOptions.some((option) => option.selected)}
+          isDisabled={
+            !availableOptions.some(
+              (option) => option.selected && option.isVisible
+            )
+          }
           onClick={() => moveSelected(true)}
           aria-label="Add selected"
           data-cy="dual-list-add-selected"
           icon={<AngleRightIcon />}
         />
         <DualListSelectorControl
-          isDisabled={availableOptions.length === 0}
+          isDisabled={
+            availableOptions.filter((option) => option.isVisible).length === 0
+          }
           onClick={() => moveAll(true)}
           aria-label="Add all"
           data-cy="dual-list-add-all"

--- a/src/components/layouts/DualListSelectorGeneric.tsx
+++ b/src/components/layouts/DualListSelectorGeneric.tsx
@@ -18,9 +18,12 @@ import {
 export interface DualListOption {
   text: string;
   selected: boolean;
-  isVisible: boolean;
   dataCy: string;
 }
+
+type SearchProps = {
+  onSearchTextChange: (searchText: string) => void;
+};
 
 interface DualListGenericProps {
   id: string;
@@ -31,8 +34,7 @@ interface DualListGenericProps {
   availableOptionsTitle?: string;
   chosenOptionsTitle?: string;
   ariaLabel?: string;
-  isSearchable?: boolean;
-  onSearchTextChange?: (searchText: string) => void;
+  searchProps?: SearchProps;
 }
 
 // Helper function: Parse data to 'DualListOption'
@@ -42,7 +44,6 @@ export const optionsToDualListOptions = (
   return options.map((option) => ({
     text: option,
     selected: false,
-    isVisible: true,
     dataCy: `item-${option}`,
   }));
 };
@@ -56,38 +57,27 @@ const DualListSelectorGeneric = (props: DualListGenericProps) => {
     setChosenOptions,
   } = props;
 
+  const isSearchable = props.searchProps !== undefined;
+
   const [availableFilter, setAvailableFilter] = React.useState("");
 
   const onInputChange = (value: string) => {
     setAvailableFilter(value);
-    if (!props.onSearchTextChange) {
-      const toFilter = [...availableOptions];
-      toFilter.forEach((option) => {
-        option.isVisible =
-          value === "" ||
-          option.text.toLowerCase().includes(value.toLowerCase());
-      });
-      setAvailableOptions(toFilter);
-    }
   };
 
   const onSubmitSearch = (value: string) => {
-    if (props.onSearchTextChange) {
-      props.onSearchTextChange(value);
+    if (props.searchProps) {
+      props.searchProps.onSearchTextChange(value);
     }
   };
 
   // callback for moving selected options between lists
   const moveSelected = (fromAvailable: boolean) => {
-    const sourceOptions = fromAvailable
-      ? props.availableOptions
-      : chosenOptions;
-    const destinationOptions = fromAvailable
-      ? chosenOptions
-      : props.availableOptions;
+    const sourceOptions = fromAvailable ? availableOptions : chosenOptions;
+    const destinationOptions = fromAvailable ? chosenOptions : availableOptions;
     for (let i = 0; i < sourceOptions.length; i++) {
       const option = sourceOptions[i];
-      if (option.selected && option.isVisible) {
+      if (option.selected) {
         sourceOptions.splice(i, 1);
         destinationOptions.push(option);
         option.selected = false;
@@ -106,13 +96,8 @@ const DualListSelectorGeneric = (props: DualListGenericProps) => {
   // callback for moving all options between lists
   const moveAll = (fromAvailable: boolean) => {
     if (fromAvailable) {
-      setChosenOptions([
-        ...availableOptions.filter((option) => option.isVisible),
-        ...chosenOptions,
-      ]);
-      setAvailableOptions([
-        ...availableOptions.filter((option) => !option.isVisible),
-      ]);
+      setChosenOptions([...availableOptions, ...chosenOptions]);
+      setAvailableOptions([]);
     } else {
       setAvailableOptions([...chosenOptions, ...availableOptions]);
       setChosenOptions([]);
@@ -144,11 +129,11 @@ const DualListSelectorGeneric = (props: DualListGenericProps) => {
     >
       <DualListSelectorPane
         title={props.availableOptionsTitle || "Available options"}
-        status={`${availableOptions.filter((option) => option.selected && option.isVisible).length} of ${
-          availableOptions.filter((option) => option.isVisible).length
+        status={`${availableOptions.filter((option) => option.selected).length} of ${
+          availableOptions.length
         } options selected`}
         searchInput={
-          props.isSearchable ? (
+          isSearchable ? (
             <SearchInput
               value={availableFilter}
               onChange={(_event, value) => onInputChange(value)}
@@ -165,37 +150,29 @@ const DualListSelectorGeneric = (props: DualListGenericProps) => {
         data-cy="dual-list-left"
       >
         <DualListSelectorList>
-          {availableOptions.map((option, index) =>
-            option.isVisible ? (
-              <DualListSelectorListItem
-                key={index}
-                isSelected={option.selected}
-                id={`basic-available-option-${index}`}
-                onOptionSelect={(e) => onOptionSelect(e, index, false)}
-                data-cy={option.dataCy}
-              >
-                {option.text}
-              </DualListSelectorListItem>
-            ) : null
-          )}
+          {availableOptions.map((option, index) => (
+            <DualListSelectorListItem
+              key={index}
+              isSelected={option.selected}
+              id={`basic-available-option-${index}`}
+              onOptionSelect={(e) => onOptionSelect(e, index, false)}
+              data-cy={option.dataCy}
+            >
+              {option.text}
+            </DualListSelectorListItem>
+          ))}
         </DualListSelectorList>
       </DualListSelectorPane>
       <DualListSelectorControlsWrapper>
         <DualListSelectorControl
-          isDisabled={
-            !availableOptions.some(
-              (option) => option.selected && option.isVisible
-            )
-          }
+          isDisabled={!availableOptions.some((option) => option.selected)}
           onClick={() => moveSelected(true)}
           aria-label="Add selected"
           data-cy="dual-list-add-selected"
           icon={<AngleRightIcon />}
         />
         <DualListSelectorControl
-          isDisabled={
-            availableOptions.filter((option) => option.isVisible).length === 0
-          }
+          isDisabled={availableOptions.length === 0}
           onClick={() => moveAll(true)}
           aria-label="Add all"
           data-cy="dual-list-add-all"

--- a/src/components/tables/MembershipTable.tsx
+++ b/src/components/tables/MembershipTable.tsx
@@ -59,6 +59,7 @@ type FromTypes =
   | "host-groups"
   | "idoverrideuser"
   | "netgroups"
+  | "permissions"
   | "privileges"
   | "roles"
   | "services"
@@ -77,13 +78,14 @@ interface MemberTableProps {
   checkedItems?: string[];
   onCheckItemsChange?: (checkedItems: string[]) => void;
   showTableRows: boolean;
+  showLink?: boolean;
 }
 
 // Types that use string arrays instead of objects
 const STRING_ARRAY_TYPES = ["external", "sysaccount", "idoverrideuser"];
 
 // Track those types that don't have links
-const NO_LINK_TYPES: string[] = ["roles", "privileges"];
+const NO_LINK_TYPES: string[] = ["roles", "privileges", "permissions"];
 
 // Body
 const TableBody = (props: {
@@ -95,14 +97,19 @@ const TableBody = (props: {
   showCheckboxColumn: boolean;
   checkedItems: string[];
   onCheckboxChange: (checked: boolean, entityName: string) => void;
+  showLink?: boolean;
 }) => {
   const { list, idKey, propertiesToShow } = props;
 
   // Check if this is a string array type (external, sysaccount, idoverrideuser)
   const isStringArray = STRING_ARRAY_TYPES.includes(props.from);
 
-  const shouldRenderLink = (from: string, isStringArray: boolean) =>
-    !isStringArray && !NO_LINK_TYPES.includes(from);
+  const shouldRenderLink = (from: string, isStringArray: boolean) => {
+    if (props.showLink === false) return false;
+    if (isStringArray) return false;
+    if (props.showLink === true) return true;
+    return !NO_LINK_TYPES.includes(from);
+  };
 
   const getItemLink = (from: string, itemId: string) =>
     from === "services"
@@ -255,6 +262,7 @@ export default function MemberTable(props: MemberTableProps) {
             showCheckboxColumn={showCheckboxColumn}
             onCheckboxChange={onCheckboxChange}
             checkedItems={props.checkedItems || []}
+            showLink={props.showLink}
           />
         )}
       </Tbody>

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -613,6 +613,10 @@ export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
                     path=""
                     element={<PrivilegesTabs section="settings" />}
                   />
+                  <Route
+                    path="permissions"
+                    element={<PrivilegesTabs section="permissions" />}
+                  />
                 </Route>
               </Route>
               <Route path="configuration" element={<Configuration />} />

--- a/src/pages/Privileges/PrivilegesPermissions.tsx
+++ b/src/pages/Privileges/PrivilegesPermissions.tsx
@@ -125,10 +125,9 @@ const PermissionsAddModal = (props: PermissionsAddModalProps) => {
       onCloseModal={props.onClose}
       availableItems={availableItems}
       onAdd={onAddPermission}
-      onSearchTextChange={setAdderSearchValue}
       title={`Add permissions to privilege '${props.privilegeCn}'`}
       ariaLabel="Add permissions to privilege modal"
-      isSearchable
+      searchProps={{ onSearchTextChange: setAdderSearchValue }}
       spinning={spinning}
     />
   );

--- a/src/pages/Privileges/PrivilegesPermissions.tsx
+++ b/src/pages/Privileges/PrivilegesPermissions.tsx
@@ -63,12 +63,6 @@ const PermissionsAddModal = (props: PermissionsAddModalProps) => {
   });
 
   React.useEffect(() => {
-    if (props.showModal) {
-      permissionsQuery.refetch();
-    }
-  }, [props.showModal, adderSearchValue]);
-
-  React.useEffect(() => {
     if (permissionsQuery.data && !permissionsQuery.isFetching) {
       const results = (permissionsQuery.data.result?.result ||
         []) as unknown as Array<{ cn: string[] }>;

--- a/src/pages/Privileges/PrivilegesPermissions.tsx
+++ b/src/pages/Privileges/PrivilegesPermissions.tsx
@@ -1,0 +1,331 @@
+import React, { useMemo } from "react";
+// PatternFly
+import { PaginationVariant } from "@patternfly/react-core";
+// Data types
+import { Privilege } from "src/utils/datatypes/globalDataTypes";
+// Components
+import MemberOfToolbar from "src/components/MemberOf/MemberOfToolbar";
+import MemberTable from "src/components/tables/MembershipTable";
+import MemberOfAddModal, {
+  AvailableItems,
+} from "src/components/MemberOf/MemberOfAddModal";
+import MemberOfDeleteModal from "src/components/MemberOf/MemberOfDeleteModal";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
+// Layouts
+import TabLayout from "src/components/layouts/TabLayout";
+// Redux
+import { useAppDispatch } from "src/store/hooks";
+// Hooks
+import { addAlert } from "src/store/Global/alerts-slice";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
+import useUpdateRoute from "src/hooks/useUpdateRoute";
+// RPC
+import { ErrorResult } from "src/services/rpc";
+import {
+  useGetPrivilegeByIdQuery,
+  useGetPermissionsQuery,
+  useAddPermissionToPrivilegeMutation,
+  useRemovePermissionFromPrivilegeMutation,
+} from "src/services/rpcPrivileges";
+// Utils
+import { paginate } from "src/utils/utils";
+
+interface PropsToPrivilegesPermissions {
+  privilege: Privilege;
+  onOpenContextualPanel?: () => void;
+}
+
+interface PermissionItem {
+  cn: string;
+}
+
+interface PermissionsAddModalProps {
+  showModal: boolean;
+  onClose: () => void;
+  privilegeCn: string;
+  permissionNames: string[];
+  onSuccess: () => void;
+}
+
+const PermissionsAddModal = (props: PermissionsAddModalProps) => {
+  const dispatch = useAppDispatch();
+  const [spinning, setSpinning] = React.useState(false);
+  const [addPermissionToPrivilege] = useAddPermissionToPrivilegeMutation();
+  const [adderSearchValue, setAdderSearchValue] = React.useState("");
+  const [availableItems, setAvailableItems] = React.useState<AvailableItems[]>(
+    []
+  );
+
+  const permissionsQuery = useGetPermissionsQuery(adderSearchValue, {
+    skip: !props.showModal,
+  });
+
+  React.useEffect(() => {
+    if (props.showModal) {
+      permissionsQuery.refetch();
+    }
+  }, [props.showModal, adderSearchValue]);
+
+  React.useEffect(() => {
+    if (permissionsQuery.data && !permissionsQuery.isFetching) {
+      const results = (permissionsQuery.data.result?.result ||
+        []) as unknown as Array<{ cn: string[] }>;
+      let items: AvailableItems[] = results.map((perm) => ({
+        key: perm.cn[0],
+        title: perm.cn[0],
+      }));
+      items = items.filter((item) => !props.permissionNames.includes(item.key));
+      setAvailableItems(items);
+    }
+  }, [
+    permissionsQuery.data,
+    permissionsQuery.isFetching,
+    props.permissionNames,
+  ]);
+
+  const onAddPermission = (items: AvailableItems[]) => {
+    const newPermissionNames = items.map((item) => item.key);
+    if (!props.privilegeCn || newPermissionNames.length === 0) {
+      return;
+    }
+
+    setSpinning(true);
+    addPermissionToPrivilege({
+      privilegeCn: props.privilegeCn,
+      permissions: newPermissionNames,
+    })
+      .then((response) => {
+        if ("data" in response) {
+          if (response.data?.result) {
+            dispatch(
+              addAlert({
+                name: "add-permission-success",
+                title: `Added permissions to privilege '${props.privilegeCn}'`,
+                variant: "success",
+              })
+            );
+            props.onSuccess();
+            props.onClose();
+          } else if (response.data?.error) {
+            const errorMessage = response.data.error as unknown as ErrorResult;
+            dispatch(
+              addAlert({
+                name: "add-permission-error",
+                title: errorMessage.message,
+                variant: "danger",
+              })
+            );
+          }
+        }
+      })
+      .finally(() => {
+        setSpinning(false);
+      });
+  };
+
+  return (
+    <MemberOfAddModal
+      showModal={props.showModal}
+      onCloseModal={props.onClose}
+      availableItems={availableItems}
+      onAdd={onAddPermission}
+      onSearchTextChange={setAdderSearchValue}
+      title={`Add permissions to privilege '${props.privilegeCn}'`}
+      ariaLabel="Add permissions to privilege modal"
+      isSearchable
+      spinning={spinning}
+    />
+  );
+};
+
+const PrivilegesPermissions = (props: PropsToPrivilegesPermissions) => {
+  const dispatch = useAppDispatch();
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  useUpdateRoute({ pathname: "privileges", noBreadcrumb: true });
+
+  // Query used for refresh operations
+  const privilegeQuery = useGetPrivilegeByIdQuery(props.privilege.cn);
+
+  // Get parameters from URL
+  const { page, setPage, perPage, searchValue } = useListPageSearchParams();
+
+  // Other states
+  const [permissionsSelected, setPermissionsSelected] = React.useState<
+    string[]
+  >([]);
+
+  // Get permission names from privilege (prefer fresh query data, fallback to props)
+  const permissionNames = useMemo(
+    () =>
+      privilegeQuery.data?.memberof_permission ||
+      props.privilege.memberof_permission ||
+      [],
+    [
+      privilegeQuery.data?.memberof_permission,
+      props.privilege.memberof_permission,
+    ]
+  );
+
+  // Column configuration
+  const columnNames = ["Permission name"];
+  const properties: string[] = [];
+
+  const permissions = useMemo((): PermissionItem[] => {
+    let toLoad = [...permissionNames];
+    toLoad.sort();
+
+    // Filter by search
+    if (searchValue) {
+      toLoad = toLoad.filter((name) =>
+        name.toLowerCase().includes(searchValue.toLowerCase())
+      );
+    }
+
+    // Apply paging
+    toLoad = paginate(toLoad, page, perPage);
+
+    return toLoad.map((name) => ({ cn: name }));
+  }, [permissionNames, searchValue, page, perPage]);
+
+  // Show table rows when we have data (even during background refetches)
+  const showTableRows = !privilegeQuery.isFetching;
+
+  // Dialogs and actions
+  const [showAddModal, setShowAddModal] = React.useState(false);
+  const [showDeleteModal, setShowDeleteModal] = React.useState(false);
+  const [spinning, setSpinning] = React.useState(false);
+
+  // Buttons functionality
+  const isRefreshButtonEnabled = !privilegeQuery.isFetching;
+  const isDeleteButtonEnabled =
+    permissionsSelected.length > 0 && isRefreshButtonEnabled;
+  const isAddButtonEnabled = isRefreshButtonEnabled;
+
+  // API calls
+  const [removePermissionFromPrivilege] =
+    useRemovePermissionFromPrivilegeMutation();
+
+  // Refresh data
+  const onRefreshData = () => {
+    setPermissionsSelected([]);
+    privilegeQuery.refetch();
+  };
+
+  // Remove permissions from privilege
+  const onDeletePermission = () => {
+    if (props.privilege.cn === undefined || permissionsSelected.length === 0) {
+      return;
+    }
+
+    setSpinning(true);
+    removePermissionFromPrivilege({
+      privilegeCn: props.privilege.cn,
+      permissions: permissionsSelected,
+    })
+      .then((response) => {
+        if ("data" in response) {
+          if (response.data?.result) {
+            dispatch(
+              addAlert({
+                name: "remove-permission-success",
+                title: `Removed permissions from privilege '${props.privilege.cn}'`,
+                variant: "success",
+              })
+            );
+            onRefreshData();
+            setShowDeleteModal(false);
+            setPage(1);
+          } else if (response.data?.error) {
+            const errorMessage = response.data.error as unknown as ErrorResult;
+            dispatch(
+              addAlert({
+                name: "remove-permission-error",
+                title: errorMessage.message,
+                variant: "danger",
+              })
+            );
+          }
+        }
+      })
+      .finally(() => {
+        setSpinning(false);
+      });
+  };
+
+  // Get filtered permission names count for pagination
+  const getFilteredCount = (): number => {
+    if (!searchValue) {
+      return permissionNames.length;
+    }
+    return permissionNames.filter((name) =>
+      name.toLowerCase().includes(searchValue.toLowerCase())
+    ).length;
+  };
+
+  return (
+    <TabLayout id="permissions">
+      <MemberOfToolbar
+        searchPlaceholder="Search permissions"
+        searchAriaLabel="Search permissions"
+        refreshButtonEnabled={isRefreshButtonEnabled}
+        onRefreshButtonClick={onRefreshData}
+        deleteButtonEnabled={isDeleteButtonEnabled}
+        onDeleteButtonClick={() => setShowDeleteModal(true)}
+        addButtonEnabled={isAddButtonEnabled}
+        onAddButtonClick={() => setShowAddModal(true)}
+        helpIconEnabled
+        onHelpIconClick={props.onOpenContextualPanel}
+        totalItems={getFilteredCount()}
+      />
+      <MemberTable
+        entityList={permissions}
+        idKey="cn"
+        from="permissions"
+        columnNamesToShow={columnNames}
+        propertiesToShow={properties}
+        checkedItems={permissionsSelected}
+        onCheckItemsChange={setPermissionsSelected}
+        showTableRows={showTableRows}
+      />
+      {getFilteredCount() > 0 && (
+        <PaginationLayout
+          list={[]}
+          totalCount={getFilteredCount()}
+          variant={PaginationVariant.bottom}
+          widgetId="pagination-options-menu-bottom"
+          className="pf-v6-u-pb-0 pf-v6-u-pr-md"
+        />
+      )}
+      {showAddModal && (
+        <PermissionsAddModal
+          showModal={showAddModal}
+          onClose={() => setShowAddModal(false)}
+          privilegeCn={props.privilege.cn}
+          permissionNames={permissionNames}
+          onSuccess={onRefreshData}
+        />
+      )}
+      <MemberOfDeleteModal
+        showModal={showDeleteModal}
+        onCloseModal={() => setShowDeleteModal(false)}
+        title={`Remove permissions from privilege '${props.privilege.cn}'`}
+        onDelete={onDeletePermission}
+        spinning={spinning}
+      >
+        <MemberTable
+          entityList={permissions.filter((perm) =>
+            permissionsSelected.includes(perm.cn)
+          )}
+          from="permissions"
+          idKey="cn"
+          columnNamesToShow={columnNames}
+          propertiesToShow={properties}
+          showTableRows
+        />
+      </MemberOfDeleteModal>
+    </TabLayout>
+  );
+};
+
+export default PrivilegesPermissions;

--- a/src/pages/Privileges/PrivilegesPermissions.tsx
+++ b/src/pages/Privileges/PrivilegesPermissions.tsx
@@ -11,6 +11,7 @@ import MemberOfAddModal, {
 } from "src/components/MemberOf/MemberOfAddModal";
 import MemberOfDeleteModal from "src/components/MemberOf/MemberOfDeleteModal";
 import PaginationLayout from "src/components/layouts/PaginationLayout";
+import BulkSelectorPrep from "src/components/BulkSelectorPrep";
 // Layouts
 import TabLayout from "src/components/layouts/TabLayout";
 // Redux
@@ -29,6 +30,7 @@ import {
 } from "src/services/rpcPrivileges";
 // Utils
 import { paginate } from "src/utils/utils";
+import { getSelectedPerPageData } from "src/utils/selectedPerPage";
 
 interface PropsToPrivilegesPermissions {
   privilege: Privilege;
@@ -150,9 +152,9 @@ const PrivilegesPermissions = (props: PropsToPrivilegesPermissions) => {
   // Get parameters from URL
   const { page, setPage, perPage, searchValue } = useListPageSearchParams();
 
-  // Other states
-  const [permissionsSelected, setPermissionsSelected] = React.useState<
-    string[]
+  // Selection state (entity-based for BulkSelectorPrep compatibility)
+  const [selectedPermissions, setSelectedPermissions] = React.useState<
+    PermissionItem[]
   >([]);
 
   // Get permission names from privilege (prefer fresh query data, fallback to props)
@@ -188,6 +190,40 @@ const PrivilegesPermissions = (props: PropsToPrivilegesPermissions) => {
     return toLoad.map((name) => ({ cn: name }));
   }, [permissionNames, searchValue, page, perPage]);
 
+  // Derive string[] for MemberTable compatibility
+  const permissionsSelectedNames = useMemo(
+    () => selectedPermissions.map((p) => p.cn),
+    [selectedPermissions]
+  );
+
+  // Delete button disabled state (managed by BulkSelectorPrep and selection helpers)
+  const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
+    React.useState(true);
+
+  // Update selected permissions (used by BulkSelectorPrep and MemberTable)
+  const updateSelectedPermissions = (
+    items: PermissionItem[],
+    isSelected: boolean
+  ) => {
+    let newSelected: PermissionItem[];
+    if (isSelected) {
+      const currentNames = new Set(permissionsSelectedNames);
+      const toAdd = items.filter((item) => !currentNames.has(item.cn));
+      newSelected = [...selectedPermissions, ...toAdd];
+    } else {
+      const removeNames = new Set(items.map((item) => item.cn));
+      newSelected = selectedPermissions.filter((p) => !removeNames.has(p.cn));
+    }
+    setSelectedPermissions(newSelected);
+    setIsDeleteButtonDisabled(newSelected.length === 0);
+  };
+
+  // Adapter for MemberTable's string-based onCheckItemsChange
+  const onCheckItemsChange = (checkedNames: string[]) => {
+    setSelectedPermissions(checkedNames.map((name) => ({ cn: name })));
+    setIsDeleteButtonDisabled(checkedNames.length === 0);
+  };
+
   // Show table rows when we have data (even during background refetches)
   const showTableRows = !privilegeQuery.isFetching;
 
@@ -198,9 +234,23 @@ const PrivilegesPermissions = (props: PropsToPrivilegesPermissions) => {
 
   // Buttons functionality
   const isRefreshButtonEnabled = !privilegeQuery.isFetching;
-  const isDeleteButtonEnabled =
-    permissionsSelected.length > 0 && isRefreshButtonEnabled;
   const isAddButtonEnabled = isRefreshButtonEnabled;
+
+  // BulkSelectorPrep data
+  const selectablePermissionsTable = permissions;
+
+  const selectedPerPageData = getSelectedPerPageData(
+    permissions,
+    permissionsSelectedNames,
+    (perm) => perm.cn
+  );
+
+  const bulkSelectorData = {
+    selected: selectedPermissions,
+    updateSelected: updateSelectedPermissions,
+    selectableTable: selectablePermissionsTable,
+    nameAttr: "cn",
+  };
 
   // API calls
   const [removePermissionFromPrivilege] =
@@ -208,20 +258,24 @@ const PrivilegesPermissions = (props: PropsToPrivilegesPermissions) => {
 
   // Refresh data
   const onRefreshData = () => {
-    setPermissionsSelected([]);
+    setSelectedPermissions([]);
+    setIsDeleteButtonDisabled(true);
     privilegeQuery.refetch();
   };
 
   // Remove permissions from privilege
   const onDeletePermission = () => {
-    if (props.privilege.cn === undefined || permissionsSelected.length === 0) {
+    if (
+      props.privilege.cn === undefined ||
+      permissionsSelectedNames.length === 0
+    ) {
       return;
     }
 
     setSpinning(true);
     removePermissionFromPrivilege({
       privilegeCn: props.privilege.cn,
-      permissions: permissionsSelected,
+      permissions: permissionsSelectedNames,
     })
       .then((response) => {
         if ("data" in response) {
@@ -266,11 +320,22 @@ const PrivilegesPermissions = (props: PropsToPrivilegesPermissions) => {
   return (
     <TabLayout id="permissions">
       <MemberOfToolbar
+        bulkSelector={
+          <BulkSelectorPrep
+            list={permissions}
+            shownElementsList={permissions}
+            elementData={bulkSelectorData}
+            buttonsData={{
+              updateIsDeleteButtonDisabled: setIsDeleteButtonDisabled,
+            }}
+            selectedPerPageData={selectedPerPageData}
+          />
+        }
         searchPlaceholder="Search permissions"
         searchAriaLabel="Search permissions"
         refreshButtonEnabled={isRefreshButtonEnabled}
         onRefreshButtonClick={onRefreshData}
-        deleteButtonEnabled={isDeleteButtonEnabled}
+        deleteButtonEnabled={!isDeleteButtonDisabled && isRefreshButtonEnabled}
         onDeleteButtonClick={() => setShowDeleteModal(true)}
         addButtonEnabled={isAddButtonEnabled}
         onAddButtonClick={() => setShowAddModal(true)}
@@ -284,8 +349,8 @@ const PrivilegesPermissions = (props: PropsToPrivilegesPermissions) => {
         from="permissions"
         columnNamesToShow={columnNames}
         propertiesToShow={properties}
-        checkedItems={permissionsSelected}
-        onCheckItemsChange={setPermissionsSelected}
+        checkedItems={permissionsSelectedNames}
+        onCheckItemsChange={onCheckItemsChange}
         showTableRows={showTableRows}
       />
       {getFilteredCount() > 0 && (
@@ -315,7 +380,7 @@ const PrivilegesPermissions = (props: PropsToPrivilegesPermissions) => {
       >
         <MemberTable
           entityList={permissions.filter((perm) =>
-            permissionsSelected.includes(perm.cn)
+            permissionsSelectedNames.includes(perm.cn)
           )}
           from="permissions"
           idKey="cn"

--- a/src/pages/Privileges/PrivilegesTabs.tsx
+++ b/src/pages/Privileges/PrivilegesTabs.tsx
@@ -8,6 +8,9 @@ import PrivilegesSettings from "./PrivilegesSettings";
 import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
 import TitleLayout from "src/components/layouts/TitleLayout";
 import DataSpinner from "src/components/layouts/DataSpinner";
+import PrivilegesPermissions from "src/pages/Privileges/PrivilegesPermissions";
+// Utils
+import { partialPrivilegeToPrivilege } from "src/utils/privilegesUtils";
 // Hooks
 import { usePrivilegeSettings } from "src/hooks/usePrivilegeSettingsData";
 import useContextualHelpTopic from "src/hooks/useContextualHelpTopic";
@@ -25,6 +28,12 @@ import {
 interface PrivilegesTabsProps {
   section: string;
 }
+
+// Central mapping between tab keys and routes
+const TAB_ROUTES: Record<string, (cn: string) => string> = {
+  settings: (cn) => `/privileges/${cn}`,
+  permissions: (cn) => `/privileges/${cn}/permissions`,
+};
 
 const PrivilegesTabs = ({ section }: PrivilegesTabsProps) => {
   const { cn } = useSafeParams<CnParams>(["cn"]);
@@ -48,8 +57,10 @@ const PrivilegesTabs = ({ section }: PrivilegesTabsProps) => {
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
-    if (tabIndex === "settings") {
-      navigate("/privileges/" + cn);
+    const tabKey = String(tabIndex);
+    const toPath = TAB_ROUTES[tabKey];
+    if (toPath) {
+      navigate(toPath(cn));
     }
   };
 
@@ -124,6 +135,18 @@ const PrivilegesTabs = ({ section }: PrivilegesTabsProps) => {
               isModified={privilegeSettingsData.modified}
               onResetValues={privilegeSettingsData.resetValues}
               modifiedValues={privilegeSettingsData.modifiedValues}
+              onOpenContextualPanel={() => dispatch(toggleHelpPanel())}
+            />
+          </Tab>
+          <Tab
+            eventKey={"permissions"}
+            name="permissions-details"
+            title={<TabTitleText>Permissions</TabTitleText>}
+          >
+            <PrivilegesPermissions
+              privilege={partialPrivilegeToPrivilege(
+                privilegeSettingsData.privilege
+              )}
               onOpenContextualPanel={() => dispatch(toggleHelpPanel())}
             />
           </Tab>

--- a/src/pages/Roles/RolesPrivileges.tsx
+++ b/src/pages/Roles/RolesPrivileges.tsx
@@ -270,7 +270,7 @@ const RolesPrivileges = (props: PropsToRolesPrivileges) => {
         onCloseModal={() => setShowAddModal(false)}
         availableItems={availableItems}
         onAdd={onAddPrivilege}
-        onSearchTextChange={setAdderSearchValue}
+        searchProps={{ onSearchTextChange: setAdderSearchValue }}
         title={`Add privileges to role '${props.role.cn}'`}
         ariaLabel="Add privileges to role modal"
         spinning={spinning}

--- a/src/services/rpcPrivileges.ts
+++ b/src/services/rpcPrivileges.ts
@@ -6,9 +6,9 @@ import {
   BatchRPCResponse,
   FindRPCResponse,
 } from "./rpc";
+import { apiToPrivilege } from "src/utils/privilegesUtils";
 import { API_VERSION_BACKUP } from "../utils/utils";
 import { Privilege, cnType } from "../utils/datatypes/globalDataTypes";
-import { apiToPrivilege } from "../utils/privilegesUtils";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 
 /**
@@ -20,6 +20,9 @@ import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
  * - privilege_add: https://freeipa.readthedocs.io/en/latest/api/privilege_add.html
  * - privilege_del: https://freeipa.readthedocs.io/en/latest/api/privilege_del.html
  * - privilege_mod: https://freeipa.readthedocs.io/en/latest/api/privilege_mod.html
+ * - privilege_add_permission: https://freeipa.readthedocs.io/en/latest/api/privilege_add_permission.html
+ * - privilege_remove_permission: https://freeipa.readthedocs.io/en/latest/api/privilege_remove_permission.html
+ * - permission_find: https://freeipa.readthedocs.io/en/latest/api/permission_find.html
  */
 
 interface PrivilegeShowPayload {
@@ -39,6 +42,11 @@ interface PrivilegesFullDataPayload {
   apiVersion: string;
   startIdx: number;
   stopIdx: number;
+}
+
+interface PrivilegePermissionPayload {
+  privilegeCn: string;
+  permissions: string[];
 }
 
 const extendedApi = api.injectEndpoints({
@@ -180,6 +188,75 @@ const extendedApi = api.injectEndpoints({
         return getBatchCommand(commands, API_VERSION_BACKUP);
       },
     }),
+    /**
+     * Get a privilege by cn via `privilege_show`
+     * @param {string} cn - Privilege name
+     * @returns {Privilege} - Privilege data
+     */
+    getPrivilegeById: build.query<Privilege, string>({
+      query: (cn) =>
+        getCommand({
+          method: "privilege_show",
+          params: [[cn], { all: true, rights: true }],
+        }),
+      transformResponse: (response: FindRPCResponse): Privilege => {
+        return apiToPrivilege(response.result.result);
+      },
+    }),
+    /**
+     * Get available permissions via `permission_find`
+     * @param {string} searchValue - Search value for filtering permissions
+     * @returns {FindRPCResponse} - Response from API
+     */
+    getPermissions: build.query<FindRPCResponse, string>({
+      query: (searchValue) =>
+        getCommand({
+          method: "permission_find",
+          params: [
+            [searchValue],
+            {
+              no_members: true,
+              version: API_VERSION_BACKUP,
+            },
+          ],
+        }),
+    }),
+    /**
+     * Add permissions to a privilege via `privilege_add_permission`
+     * @param {PrivilegePermissionPayload} - Payload with privilege cn and permissions
+     * @returns {FindRPCResponse} - Response from API
+     */
+    addPermissionToPrivilege: build.mutation<
+      FindRPCResponse,
+      PrivilegePermissionPayload
+    >({
+      query: (payload) =>
+        getCommand({
+          method: "privilege_add_permission",
+          params: [
+            [payload.privilegeCn],
+            { permission: payload.permissions, version: API_VERSION_BACKUP },
+          ],
+        }),
+    }),
+    /**
+     * Remove permissions from a privilege via `privilege_remove_permission`
+     * @param {PrivilegePermissionPayload} - Payload with privilege cn and permissions
+     * @returns {FindRPCResponse} - Response from API
+     */
+    removePermissionFromPrivilege: build.mutation<
+      FindRPCResponse,
+      PrivilegePermissionPayload
+    >({
+      query: (payload) =>
+        getCommand({
+          method: "privilege_remove_permission",
+          params: [
+            [payload.privilegeCn],
+            { permission: payload.permissions, version: API_VERSION_BACKUP },
+          ],
+        }),
+    }),
   }),
   overrideExisting: false,
 });
@@ -201,4 +278,8 @@ export const {
   useAddPrivilegeMutation,
   useDeletePrivilegesMutation,
   useSavePrivilegeMutation,
+  useGetPrivilegeByIdQuery,
+  useGetPermissionsQuery,
+  useAddPermissionToPrivilegeMutation,
+  useRemovePermissionFromPrivilegeMutation,
 } = extendedApi;

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -223,6 +223,7 @@ export interface SysAccount {
 export interface Privilege {
   cn: string;
   description: string;
+  memberof_permission: string[];
 }
 
 export interface HBACRule {

--- a/src/utils/privilegesUtils.tsx
+++ b/src/utils/privilegesUtils.tsx
@@ -26,7 +26,12 @@ export function apiToPrivilege(apiRecord: Record<string, unknown>): Privilege {
     simpleValues,
     dateValues
   ) as Partial<Privilege>;
-  return partialPrivilegeToPrivilege(converted) as Privilege;
+
+  return {
+    ...createEmptyPrivilege(),
+    ...converted,
+    memberof_permission: (apiRecord.memberof_permission as string[]) || [],
+  };
 }
 
 export function partialPrivilegeToPrivilege(
@@ -42,6 +47,7 @@ export function createEmptyPrivilege(): Privilege {
   const privilege: Privilege = {
     cn: "",
     description: "",
+    memberof_permission: [],
   };
 
   return privilege;


### PR DESCRIPTION
The 'Permissions' subpage allows to
grant or revoke some permissions to
a given Privilege.

Assisted-by: Claude <noreply@anthropic.com>

## Summary by Sourcery

Add a new Privileges Permissions page and wire it into routing and RPC APIs to manage privilege-permission memberships.

New Features:
- Introduce a Privileges permissions tab page to view, search, paginate, and manage permissions assigned to a privilege.
- Add RPC endpoints for fetching a single privilege, listing permissions, and adding/removing permissions to/from a privilege.

Enhancements:
- Extend privilege data mapping and types to include member permissions and ensure empty defaults.
- Update privileges listing to support linking into a specific privilege and increase the fetch size limit.
- Teach the membership table to support a new permissions entity type without navigation links.