### PR TITLE
Add Privileges settings sub-page

### DIFF
--- a/src/assets/documentation/documentation-links.json
+++ b/src/assets/documentation/documentation-links.json
@@ -209,5 +209,6 @@
       "url": "https://red.ht/manage-user-groups"
     }
   ],
-  "roles-settings": []
+  "roles-settings": [],
+  "privileges-settings": []
 }

--- a/src/hooks/usePrivilegeSettingsData.tsx
+++ b/src/hooks/usePrivilegeSettingsData.tsx
@@ -1,0 +1,116 @@
+import { useState, useEffect } from "react";
+
+// RPC
+import { useGetObjectMetadataQuery } from "src/services/rpc";
+import { usePrivilegeShowQuery } from "src/services/rpcPrivileges";
+// Data types
+import { Privilege, Metadata } from "src/utils/datatypes/globalDataTypes";
+
+type PrivilegeSettingsData = {
+  isLoading: boolean;
+  isFetching: boolean;
+  modified: boolean;
+  setModified: (value: boolean) => void;
+  resetValues: () => void;
+  metadata: Metadata;
+  originalPrivilege: Partial<Privilege>;
+  privilege: Partial<Privilege>;
+  setPrivilege: (privilege: Partial<Privilege>) => void;
+  refetch: () => void;
+  modifiedValues: () => Partial<Privilege>;
+};
+
+const usePrivilegeSettings = (privilegeId: string): PrivilegeSettingsData => {
+  const metadataQuery = useGetObjectMetadataQuery();
+  const metadata = metadataQuery.data || {};
+  const metadataLoading = metadataQuery.isLoading;
+
+  const privilegeQuery = usePrivilegeShowQuery(privilegeId);
+  const privilegeData = privilegeQuery.data;
+  const isPrivilegeLoading = privilegeQuery.isLoading;
+  const [modified, setModified] = useState(false);
+  const [initialized, setInitialized] = useState(false);
+  const [privilege, setPrivilege] = useState<Partial<Privilege>>({});
+  const [originalPrivilege, setOriginalPrivilege] = useState<
+    Partial<Privilege>
+  >({});
+
+  useEffect(() => {
+    setInitialized(false);
+    setPrivilege({});
+    setOriginalPrivilege({});
+  }, [privilegeId]);
+
+  useEffect(() => {
+    if (privilegeData !== undefined && !privilegeQuery.isFetching) {
+      if (privilegeData.length > 0) {
+        setPrivilege({ ...privilegeData[0] });
+        setOriginalPrivilege({ ...privilegeData[0] });
+      } else {
+        setPrivilege({});
+        setOriginalPrivilege({});
+      }
+      setInitialized(true);
+    }
+  }, [privilegeData, privilegeQuery.isFetching]);
+
+  const getModifiedValues = (): Partial<Privilege> => {
+    if (!originalPrivilege) {
+      return {};
+    }
+
+    const modifiedValues: Partial<Privilege> = {};
+    for (const [key, value] of Object.entries(privilege)) {
+      if (Array.isArray(value)) {
+        if (JSON.stringify(originalPrivilege[key]) !== JSON.stringify(value)) {
+          modifiedValues[key] = value;
+        }
+      } else if (originalPrivilege[key] !== value) {
+        modifiedValues[key] = value;
+      }
+    }
+    return modifiedValues;
+  };
+
+  useEffect(() => {
+    if (!originalPrivilege) {
+      return;
+    }
+    let isModified = false;
+    for (const [key, value] of Object.entries(privilege)) {
+      if (Array.isArray(value)) {
+        if (JSON.stringify(originalPrivilege[key]) !== JSON.stringify(value)) {
+          isModified = true;
+          break;
+        }
+      } else {
+        if (originalPrivilege[key] !== value) {
+          isModified = true;
+          break;
+        }
+      }
+    }
+    setModified(isModified);
+  }, [privilege, originalPrivilege]);
+
+  const onResetValues = () => {
+    setPrivilege({ ...originalPrivilege });
+    setModified(false);
+  };
+
+  return {
+    isLoading: metadataLoading || isPrivilegeLoading || !initialized,
+    isFetching: privilegeQuery.isFetching,
+    modified,
+    setModified,
+    metadata,
+    originalPrivilege,
+    privilege,
+    setPrivilege,
+    refetch: privilegeQuery.refetch,
+    modifiedValues: getModifiedValues,
+    resetValues: onResetValues,
+  };
+};
+
+export { usePrivilegeSettings };

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -82,6 +82,7 @@ import OtpTokensTabs from "src/pages/OtpTokens/OtpTokensTabs";
 import Roles from "src/pages/Roles/Roles";
 import RolesTabs from "src/pages/Roles/RolesTabs";
 import Privileges from "src/pages/Privileges/Privileges";
+import PrivilegesTabs from "src/pages/Privileges/PrivilegesTabs";
 
 // Renders routes (React)
 export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
@@ -607,6 +608,12 @@ export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
               </Route>
               <Route path="privileges">
                 <Route path="" element={<Privileges />} />
+                <Route path=":cn">
+                  <Route
+                    path=""
+                    element={<PrivilegesTabs section="settings" />}
+                  />
+                </Route>
               </Route>
               <Route path="configuration" element={<Configuration />} />
               {/* Redirect to Active users page if user is logged in and navigates to the root page */}

--- a/src/pages/Privileges/Privileges.tsx
+++ b/src/pages/Privileges/Privileges.tsx
@@ -442,7 +442,7 @@ const Privileges = () => {
                     hasCheckboxes={true}
                     pathname="privileges"
                     showTableRows={showTableRows}
-                    showLink={false}
+                    showLink={true}
                     elementsData={{
                       isElementSelectable: isPrivilegeSelectable,
                       selectedElements: selectedPrivileges,

--- a/src/pages/Privileges/PrivilegesSettings.tsx
+++ b/src/pages/Privileges/PrivilegesSettings.tsx
@@ -1,0 +1,203 @@
+import React, { useState } from "react";
+// PatternFly
+import {
+  Button,
+  Flex,
+  Form,
+  FormGroup,
+  Sidebar,
+  SidebarContent,
+  SidebarPanel,
+} from "@patternfly/react-core";
+// Forms
+import IpaTextInput from "src/components/Form/IpaTextInput";
+import IpaTextArea from "src/components/Form/IpaTextArea";
+// Layouts
+import TitleLayout from "src/components/layouts/TitleLayout";
+import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
+import TabLayout from "src/components/layouts/TabLayout";
+// Utils
+import { asRecord } from "src/utils/privilegesUtils";
+// Redux
+import { useAppDispatch } from "src/store/hooks";
+// Hooks
+import { addAlert } from "src/store/Global/alerts-slice";
+import useUpdateRoute from "src/hooks/useUpdateRoute";
+// Data types
+import { Privilege, Metadata } from "src/utils/datatypes/globalDataTypes";
+// RPC
+import { ErrorResult } from "src/services/rpc";
+import { useSavePrivilegeMutation } from "src/services/rpcPrivileges";
+
+interface PropsToSettings {
+  privilege: Partial<Privilege>;
+  originalPrivilege: Partial<Privilege>;
+  metadata: Metadata;
+  onPrivilegeChange: (privilege: Partial<Privilege>) => void;
+  onRefresh: () => void;
+  isModified: boolean;
+  isDataLoading?: boolean;
+  modifiedValues: () => Partial<Privilege>;
+  onResetValues: () => void;
+  onOpenContextualPanel?: () => void;
+}
+
+const PrivilegesSettings = (props: PropsToSettings) => {
+  const dispatch = useAppDispatch();
+
+  const [savePrivilege] = useSavePrivilegeMutation();
+
+  useUpdateRoute({ pathname: "privileges", noBreadcrumb: true });
+
+  const { ipaObject, recordOnChange } = asRecord(
+    props.privilege,
+    props.onPrivilegeChange
+  );
+
+  const [isSaving, setSaving] = useState(false);
+
+  const onSave = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const modifiedValues = props.modifiedValues();
+    modifiedValues.cn = props.privilege.cn;
+    setSaving(true);
+
+    savePrivilege(modifiedValues)
+      .then((response) => {
+        if ("data" in response) {
+          if (response.data?.result) {
+            dispatch(
+              addAlert({
+                name: "save-success",
+                title: "Privilege modified",
+                variant: "success",
+              })
+            );
+            props.onRefresh();
+          } else if (response.data?.error) {
+            const errorMessage = response.data.error as ErrorResult;
+            dispatch(
+              addAlert({
+                name: "save-error",
+                title: errorMessage.message,
+                variant: "danger",
+              })
+            );
+            props.onResetValues();
+          }
+        }
+      })
+      .finally(() => {
+        setSaving(false);
+      });
+  };
+
+  const onRevert = () => {
+    props.onPrivilegeChange(props.originalPrivilege);
+    dispatch(
+      addAlert({
+        name: "revert-success",
+        title: "Privilege data reverted",
+        variant: "success",
+      })
+    );
+  };
+
+  const toolbarFields = [
+    {
+      key: 0,
+      element: (
+        <Button
+          variant="secondary"
+          data-cy="privileges-tab-settings-button-refresh"
+          onClick={props.onRefresh}
+        >
+          Refresh
+        </Button>
+      ),
+    },
+    {
+      key: 1,
+      element: (
+        <Button
+          variant="secondary"
+          data-cy="privileges-tab-settings-button-revert"
+          isDisabled={!props.isModified}
+          onClick={onRevert}
+        >
+          Revert
+        </Button>
+      ),
+    },
+    {
+      key: 2,
+      element: (
+        <Button
+          variant="primary"
+          data-cy="privileges-tab-settings-button-save"
+          isDisabled={!props.isModified || isSaving}
+          type="submit"
+          form="privileges-settings-form"
+          isLoading={isSaving}
+          spinnerAriaValueText="Saving"
+          spinnerAriaLabel="Saving"
+        >
+          {isSaving ? "Saving" : "Save"}
+        </Button>
+      ),
+    },
+  ];
+
+  return (
+    <TabLayout id="settings-page" toolbarItems={toolbarFields}>
+      <Sidebar isPanelRight>
+        <SidebarPanel variant="sticky">
+          <HelpTextWithIconLayout
+            textContent="Help"
+            onClick={props.onOpenContextualPanel}
+          />
+        </SidebarPanel>
+        <SidebarContent className="pf-v6-u-mr-xl">
+          <Flex direction={{ default: "column" }} flex={{ default: "flex_1" }}>
+            <TitleLayout
+              key={0}
+              headingLevel="h1"
+              id="privilege-settings"
+              text="Privilege settings"
+            />
+            <Form
+              className="pf-v6-u-mt-sm pf-v6-u-mb-lg pf-v6-u-mr-md"
+              id="privileges-settings-form"
+              isHorizontal
+              onSubmit={onSave}
+            >
+              <FormGroup label="Privilege name" fieldId="cn">
+                <IpaTextInput
+                  dataCy="privileges-tab-settings-textinput-cn"
+                  name="cn"
+                  ariaLabel="Privilege name"
+                  ipaObject={ipaObject}
+                  onChange={recordOnChange}
+                  objectName="privilege"
+                  metadata={props.metadata}
+                />
+              </FormGroup>
+              <FormGroup label="Description" fieldId="description">
+                <IpaTextArea
+                  dataCy="privileges-tab-settings-textarea-description"
+                  name="description"
+                  ipaObject={ipaObject}
+                  onChange={recordOnChange}
+                  objectName="privilege"
+                  metadata={props.metadata}
+                />
+              </FormGroup>
+            </Form>
+          </Flex>
+        </SidebarContent>
+      </Sidebar>
+    </TabLayout>
+  );
+};
+
+export default PrivilegesSettings;

--- a/src/pages/Privileges/PrivilegesTabs.tsx
+++ b/src/pages/Privileges/PrivilegesTabs.tsx
@@ -1,0 +1,136 @@
+import React, { useState } from "react";
+// PatternFly
+import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
+// React Router DOM
+import { useNavigate } from "react-router";
+// Components
+import PrivilegesSettings from "./PrivilegesSettings";
+import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
+import TitleLayout from "src/components/layouts/TitleLayout";
+import DataSpinner from "src/components/layouts/DataSpinner";
+// Hooks
+import { usePrivilegeSettings } from "src/hooks/usePrivilegeSettingsData";
+import useContextualHelpTopic from "src/hooks/useContextualHelpTopic";
+// Navigation
+import { NotFound } from "src/components/errors/PageErrors";
+import { CnParams, useSafeParams } from "src/utils/paramsUtils";
+// Redux
+import { useAppDispatch } from "src/store/hooks";
+import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
+import {
+  closeHelpPanel,
+  toggleHelpPanel,
+} from "src/store/Global/contextual-help-slice";
+
+interface PrivilegesTabsProps {
+  section: string;
+}
+
+const PrivilegesTabs = ({ section }: PrivilegesTabsProps) => {
+  const { cn } = useSafeParams<CnParams>(["cn"]);
+  const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+  useContextualHelpTopic("privileges-settings");
+
+  const [breadcrumbItems, setBreadcrumbItems] = React.useState<
+    BreadCrumbItem[]
+  >([]);
+
+  React.useEffect(() => {
+    dispatch(closeHelpPanel());
+  }, [section, dispatch]);
+
+  const privilegeSettingsData = usePrivilegeSettings(cn);
+
+  const [activeTabKey, setActiveTabKey] = useState(section || "settings");
+
+  const handleTabClick = (
+    _event: React.MouseEvent<HTMLElement, MouseEvent>,
+    tabIndex: number | string
+  ) => {
+    if (tabIndex === "settings") {
+      navigate("/privileges/" + cn);
+    }
+  };
+
+  React.useEffect(() => {
+    const currentPath: BreadCrumbItem[] = [
+      {
+        name: "Privileges",
+        url: "/privileges",
+      },
+      {
+        name: cn,
+        url: "/privileges/" + cn,
+        isActive: true,
+      },
+    ];
+    setBreadcrumbItems(currentPath);
+    setActiveTabKey("settings");
+    dispatch(updateBreadCrumbPath(currentPath));
+  }, [cn, dispatch]);
+
+  React.useEffect(() => {
+    if (!section) {
+      navigate("/privileges/" + cn);
+    }
+    setActiveTabKey(section || "settings");
+  }, [section, cn, navigate]);
+
+  if (privilegeSettingsData.isLoading) {
+    return <DataSpinner />;
+  }
+
+  if (!privilegeSettingsData.privilege.cn) {
+    return <NotFound />;
+  }
+
+  return (
+    <>
+      <PageSection hasBodyWrapper={false}>
+        <BreadCrumb
+          className="pf-v6-u-mb-sm"
+          breadcrumbItems={breadcrumbItems}
+        />
+        <TitleLayout
+          id={privilegeSettingsData.privilege.cn}
+          preText="Privilege:"
+          text={privilegeSettingsData.privilege.cn}
+          headingLevel="h1"
+        />
+      </PageSection>
+      <PageSection hasBodyWrapper={false} type="tabs" isFilled>
+        <Tabs
+          activeKey={activeTabKey}
+          onSelect={handleTabClick}
+          variant="secondary"
+          isBox
+          className="pf-v6-u-ml-lg"
+          mountOnEnter
+          unmountOnExit
+        >
+          <Tab
+            eventKey={"settings"}
+            name="settings-details"
+            title={<TabTitleText>Settings</TabTitleText>}
+          >
+            <PrivilegesSettings
+              privilege={privilegeSettingsData.privilege}
+              originalPrivilege={privilegeSettingsData.originalPrivilege}
+              metadata={privilegeSettingsData.metadata}
+              onPrivilegeChange={privilegeSettingsData.setPrivilege}
+              isDataLoading={privilegeSettingsData.isFetching}
+              onRefresh={privilegeSettingsData.refetch}
+              isModified={privilegeSettingsData.modified}
+              onResetValues={privilegeSettingsData.resetValues}
+              modifiedValues={privilegeSettingsData.modifiedValues}
+              onOpenContextualPanel={() => dispatch(toggleHelpPanel())}
+            />
+          </Tab>
+        </Tabs>
+      </PageSection>
+    </>
+  );
+};
+
+export default PrivilegesTabs;

--- a/src/services/rpcPrivileges.ts
+++ b/src/services/rpcPrivileges.ts
@@ -8,6 +8,7 @@ import {
 } from "./rpc";
 import { API_VERSION_BACKUP } from "../utils/utils";
 import { Privilege, cnType } from "../utils/datatypes/globalDataTypes";
+import { apiToPrivilege } from "../utils/privilegesUtils";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 
 /**
@@ -18,7 +19,14 @@ import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
  * - privilege_show: https://freeipa.readthedocs.io/en/latest/api/privilege_show.html
  * - privilege_add: https://freeipa.readthedocs.io/en/latest/api/privilege_add.html
  * - privilege_del: https://freeipa.readthedocs.io/en/latest/api/privilege_del.html
+ * - privilege_mod: https://freeipa.readthedocs.io/en/latest/api/privilege_mod.html
  */
+
+interface PrivilegeShowPayload {
+  privilegeNamesList: string[];
+  no_members?: boolean;
+  version: string;
+}
 
 interface PrivilegeAddPayload {
   cn: string;
@@ -118,6 +126,51 @@ const extendedApi = api.injectEndpoints({
      * @param {Privilege[]} - Array of privileges to delete
      * @returns {BatchRPCResponse} - Batch response
      */
+    /**
+     * Given a list of privilege names, show the full data of those privileges
+     * @param {PrivilegeShowPayload} - Payload with privilege names and options
+     * @returns {BatchRPCResponse} - Batch response
+     */
+    getPrivilegesInfoByName: build.query<Privilege[], PrivilegeShowPayload>({
+      query: (payload) => {
+        const privilegeNames = payload.privilegeNamesList;
+        const noMembers = payload.no_members || false;
+        const apiVersion = payload.version || API_VERSION_BACKUP;
+        const showCommands: Command[] = privilegeNames.map((privilegeName) => ({
+          method: "privilege_show",
+          params: [[privilegeName], { no_members: noMembers }],
+        }));
+        return getBatchCommand(showCommands, apiVersion);
+      },
+      transformResponse: (response: BatchRPCResponse): Privilege[] => {
+        const privilegeList: Privilege[] = [];
+        const results = response.result.results;
+        const count = response.result.count;
+        for (let i = 0; i < count; i++) {
+          const privilegeData = apiToPrivilege(results[i].result);
+          privilegeList.push(privilegeData);
+        }
+        return privilegeList;
+      },
+    }),
+    /**
+     * Modify an existing privilege via `privilege_mod`
+     * @param {Partial<Privilege>} - Privilege data to modify (must include cn)
+     * @returns {FindRPCResponse} - Response from API
+     */
+    savePrivilege: build.mutation<FindRPCResponse, Partial<Privilege>>({
+      query: (privilege) => {
+        const params = {
+          version: API_VERSION_BACKUP,
+          ...privilege,
+        };
+        delete params.cn;
+        return getCommand({
+          method: "privilege_mod",
+          params: [[privilege.cn], params],
+        });
+      },
+    }),
     deletePrivileges: build.mutation<BatchRPCResponse, Privilege[]>({
       query: (privileges) => {
         const commands: Command[] = privileges.map((privilege) => ({
@@ -190,9 +243,22 @@ const extendedApi = api.injectEndpoints({
   overrideExisting: false,
 });
 
+export const usePrivilegeShowQuery = (privilegeId: string) => {
+  return useGetPrivilegesInfoByNameQuery(
+    {
+      privilegeNamesList: [privilegeId],
+      no_members: true,
+      version: API_VERSION_BACKUP,
+    },
+    { skip: !privilegeId }
+  );
+};
+
 export const {
   useGetPrivilegesFullDataQuery,
+  useGetPrivilegesInfoByNameQuery,
   useAddPrivilegeMutation,
   useDeletePrivilegesMutation,
   useSearchPrivilegesEntriesMutation,
+  useSavePrivilegeMutation,
 } = extendedApi;

--- a/src/utils/privilegesUtils.tsx
+++ b/src/utils/privilegesUtils.tsx
@@ -3,6 +3,20 @@ import { Privilege } from "src/utils/datatypes/globalDataTypes";
 // Utils
 import { convertApiObj } from "./ipaObjectUtils";
 
+export const asRecord = (
+  element: Partial<Privilege>,
+  onElementChange: (element: Partial<Privilege>) => void
+) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ipaObject = element as Record<string, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function recordOnChange(ipaObject: Record<string, any>) {
+    onElementChange(ipaObject as Privilege);
+  }
+
+  return { ipaObject, recordOnChange };
+};
+
 const simpleValues = new Set(["cn", "description"]);
 const dateValues = new Set([]);
 


### PR DESCRIPTION
Assisted-by: Cursor <cursoragent@cursor.com>

## Summary by Sourcery

Add a privilege details settings sub-page that allows viewing and editing individual privileges, wired into routing, data fetching, and saving.

New Features:
- Introduce a Privileges settings page with form inputs for name and description, accessible via a tabbed details view for a selected privilege.
- Add navigation and breadcrumb support for privilege detail routes with contextual help integration.

Enhancements:
- Extend the privileges RPC service with endpoints and hooks to fetch privilege details by name and to persist privilege modifications.
- Add a utility to expose privilege objects as mutable records for use in form components.
- Enable table rows in the Privileges list to link to the new privilege details settings view.