### PR TITLE
Update react-router to latest 7 version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-redux": "^9.2.0",
-        "react-router": "^7.14.2",
+        "react-router": "^7.18.1",
         "tiny-invariant": "^1.3.3"
       },
       "devDependencies": {
@@ -10769,9 +10769,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
-      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-redux": "^9.2.0",
-    "react-router": "^7.14.2",
+    "react-router": "^7.18.1",
     "tiny-invariant": "^1.3.3"
   },
   "scripts": {


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update react-router version in package.json and synchronize package-lock.json to match the new dependency version.