### PR TITLE
Add exception for React Router RSC vulnerability

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,4 +1,4 @@
 {
-  "allowlist": ["GHSA-73rr-hh4g-fpgx", "GHSA-g9mf-h72j-4rw9"],
+  "allowlist": ["GHSA-qwww-vcr4-c8h2"],
   "moderate": true
 }


### PR DESCRIPTION
The https://github.com/advisories/GHSA-qwww-vcr4-c8h2 vulnerability requires React Router 8+, we can't move to that version yet, as it requires node 22+, react19+, vite7+ with vite8 capabilities. The vulnerability does not apply to us, as we use do not use RSC.

## Summary by Sourcery

Build:
- Configure audit-ci to ignore the React Router RSC vulnerability advisory GHSA-qwww-vcr4-c8h2 due to incompatible version requirements and non-usage of RSC.