### PR TITLE
Add 'Permissions' main page

### DIFF
--- a/doc/designs/main-pages/07-add-modal.md
+++ b/doc/designs/main-pages/07-add-modal.md
@@ -151,9 +151,8 @@ const AddEntityModal = (props: PropsToAddModal) => {
         }
         if (response.data?.result) {
           dispatch(addAlert({ name: "add-entity-success", title: "New entity added", variant: "success" }));
-          clearFields();
+          cleanAndCloseModal();
           props.onRefresh();
-          props.onClose();
         }
       }
       setIsAddButtonSpinning(false);

--- a/src/components/TypeAheadSelect.tsx
+++ b/src/components/TypeAheadSelect.tsx
@@ -243,7 +243,7 @@ const TypeAheadSelect = (props: PropsToTypeAheadSelect) => {
           onClick={onInputClick}
           onChange={onTextInputChange}
           onKeyDown={onInputKeyDown}
-          id="typeahead-select-input"
+          id={`${props.id}-typeahead-select-input`}
           data-cy={"typeahead-select-input"}
           autoComplete="off"
           innerRef={textInputRef}

--- a/src/components/TypeAheadWithCheckbox.tsx
+++ b/src/components/TypeAheadWithCheckbox.tsx
@@ -1,0 +1,344 @@
+import React, { useEffect, useRef, useState } from "react";
+import {
+  Select,
+  SelectOption,
+  SelectList,
+  SelectOptionProps,
+  MenuToggle,
+  MenuToggleElement,
+  TextInputGroup,
+  TextInputGroupMain,
+  TextInputGroupUtilities,
+  Button,
+} from "@patternfly/react-core";
+import { CloseIcon } from "@patternfly/react-icons";
+
+type CreationProps<T> = {
+  // Whenever this property changes, the options will be reset
+  onChangeTarget: T;
+};
+
+type TypeAheadWithCheckboxProps<T> = {
+  id: string;
+  dataCy: string;
+  options: SelectOptionProps[];
+  selected: string[];
+  setSelected: (selected: string[]) => void;
+  creationProps?: CreationProps<T>;
+};
+
+const NO_RESULTS = "no results";
+const CREATE_NEW = "create";
+
+export const TypeAheadWithCheckbox = <T,>({
+  id,
+  dataCy,
+  options,
+  selected,
+  setSelected,
+  creationProps,
+}: TypeAheadWithCheckboxProps<T>) => {
+  // This is to allow mutations to options property
+  const [localOptions, setLocalOptions] =
+    useState<SelectOptionProps[]>(options);
+  // This one is actually shown, it can contain Create New options and no results
+  const [availableOptions, setAvailableOptions] =
+    useState<SelectOptionProps[]>(localOptions);
+  const [isOpen, setIsOpen] = useState(false);
+  const [inputValue, setInputValue] = useState<string>("");
+  const [focusedItemIndex, setFocusedItemIndex] = useState<number | null>(null);
+  const [activeItemId, setActiveItemId] = useState<string | null>(null);
+  const textInputRef = useRef<HTMLInputElement>(undefined);
+
+  const [previousTarget, setPreviousTarget] = useState<T | null>(null);
+  const allowCreation = creationProps !== undefined;
+
+  if (allowCreation && previousTarget !== creationProps?.onChangeTarget) {
+    setPreviousTarget(creationProps.onChangeTarget);
+    setLocalOptions(options);
+    setInputValue("");
+  }
+
+  useEffect(() => {
+    let newSelectOptions: SelectOptionProps[] = localOptions;
+
+    // Filter menu items based on the text input value when one exists
+    if (inputValue) {
+      newSelectOptions = localOptions.filter((menuItem) =>
+        String(menuItem.children)
+          .toLowerCase()
+          .includes(inputValue.toLowerCase())
+      );
+
+      // If no option matches the filter exactly, display creation option
+      if (allowCreation) {
+        if (!localOptions.some((option) => option.value === inputValue)) {
+          newSelectOptions = [
+            ...newSelectOptions,
+            {
+              children: `Create new option "${inputValue}"`,
+              value: CREATE_NEW,
+              "data-cy": `${dataCy}-create-new-option`,
+            },
+          ];
+        }
+      }
+
+      // When no options are found after filtering, display 'No results found'
+      if (newSelectOptions.length === 0) {
+        newSelectOptions = [
+          {
+            "data-cy": `${dataCy}-no-results`,
+            isAriaDisabled: true,
+            children: `No results found for "${inputValue}"`,
+            value: NO_RESULTS,
+            hasCheckbox: false,
+          },
+        ];
+      }
+    }
+
+    // This sucks, but we're forced to, due to how isOpenCallback
+    // works, with memo the we onOpenChange is fired
+    // eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
+    setAvailableOptions(newSelectOptions);
+    // We mutate options, if we don't, we end up with the same issue as above...
+  }, [inputValue, localOptions]);
+
+  const placeholder = `${selected.length} item${selected.length !== 1 ? "s" : ""} selected`;
+
+  const createItemId = (value: string) =>
+    `select-multi-typeahead-${value.replace(" ", "-")}`;
+
+  const setActiveAndFocusedItem = (itemIndex: number) => {
+    setFocusedItemIndex(itemIndex);
+    const focusedItem = availableOptions[itemIndex];
+    setActiveItemId(createItemId(focusedItem.value));
+  };
+
+  const resetActiveAndFocusedItem = () => {
+    setFocusedItemIndex(null);
+    setActiveItemId(null);
+  };
+
+  const closeMenu = () => {
+    setIsOpen(false);
+    resetActiveAndFocusedItem();
+  };
+
+  const onInputClick = () => {
+    if (!isOpen) {
+      setIsOpen(true);
+    } else if (!inputValue) {
+      closeMenu();
+    }
+  };
+
+  const handleMenuArrowKeys = (key: string) => {
+    let indexToFocus = 0;
+
+    if (!isOpen) {
+      setIsOpen(true);
+    }
+
+    if (availableOptions.every((option) => option.isDisabled)) {
+      return;
+    }
+
+    if (key === "ArrowUp") {
+      // When no index is set or at the first index, focus to the last, otherwise decrement focus index
+      if (focusedItemIndex === null || focusedItemIndex === 0) {
+        indexToFocus = availableOptions.length - 1;
+      } else {
+        indexToFocus = focusedItemIndex - 1;
+      }
+
+      // Skip disabled options
+      while (availableOptions[indexToFocus].isDisabled) {
+        indexToFocus--;
+        if (indexToFocus === -1) {
+          indexToFocus = availableOptions.length - 1;
+        }
+      }
+    }
+
+    if (key === "ArrowDown") {
+      // When no index is set or at the last index, focus to the first, otherwise increment focus index
+      if (
+        focusedItemIndex === null ||
+        focusedItemIndex === availableOptions.length - 1
+      ) {
+        indexToFocus = 0;
+      } else {
+        indexToFocus = focusedItemIndex + 1;
+      }
+
+      // Skip disabled options
+      while (availableOptions[indexToFocus].isDisabled) {
+        indexToFocus++;
+        if (indexToFocus === availableOptions.length) {
+          indexToFocus = 0;
+        }
+      }
+    }
+
+    setActiveAndFocusedItem(indexToFocus);
+  };
+
+  const onInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    const focusedItem =
+      focusedItemIndex !== null ? availableOptions[focusedItemIndex] : null;
+
+    switch (event.key) {
+      case "Enter":
+        if (
+          isOpen &&
+          focusedItem &&
+          focusedItem.value !== NO_RESULTS &&
+          !focusedItem.isAriaDisabled
+        ) {
+          onSelect(focusedItem.value);
+        }
+
+        if (!isOpen) {
+          setIsOpen(true);
+        }
+
+        break;
+      case "ArrowUp":
+      case "ArrowDown":
+        event.preventDefault();
+        handleMenuArrowKeys(event.key);
+        break;
+    }
+  };
+
+  const onToggleClick = () => {
+    setIsOpen(!isOpen);
+    textInputRef?.current?.focus();
+  };
+
+  const onTextInputChange = (
+    _event: React.FormEvent<HTMLInputElement>,
+    value: string
+  ) => {
+    setInputValue(value);
+    if (value !== "" && !isOpen) setIsOpen(true);
+    resetActiveAndFocusedItem();
+  };
+
+  const onSelect = (value: string) => {
+    if (value && value !== NO_RESULTS) {
+      if (value === CREATE_NEW) {
+        if (!availableOptions.some((item) => item.value === inputValue)) {
+          setLocalOptions([
+            ...localOptions,
+            {
+              value: inputValue,
+              children: inputValue,
+              "data-cy": `${dataCy}-${inputValue}-create-new-option`,
+            },
+          ]);
+        }
+        setSelected(
+          selected.includes(inputValue)
+            ? selected.filter((selection) => selection !== inputValue)
+            : [...selected, inputValue]
+        );
+        resetActiveAndFocusedItem();
+      } else {
+        setSelected(
+          selected.includes(value)
+            ? selected.filter((selection) => selection !== value)
+            : [...selected, value]
+        );
+      }
+    }
+
+    textInputRef.current?.focus();
+  };
+
+  const onClearButtonClick = () => {
+    setSelected([]);
+    setInputValue("");
+    resetActiveAndFocusedItem();
+    textInputRef?.current?.focus();
+  };
+
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      data-cy={`${dataCy}-multi-typeahead-checkbox-menu-toggle`}
+      variant="typeahead"
+      aria-label="Multi typeahead checkbox menu toggle"
+      onClick={onToggleClick}
+      innerRef={toggleRef}
+      isExpanded={isOpen}
+      isFullWidth
+    >
+      <TextInputGroup isPlain>
+        <TextInputGroupMain
+          value={inputValue}
+          onClick={onInputClick}
+          onChange={onTextInputChange}
+          onKeyDown={onInputKeyDown}
+          id={`${id}-multi-typeahead-select-checkbox-input`}
+          autoComplete="off"
+          innerRef={textInputRef}
+          placeholder={placeholder}
+          {...(activeItemId && { "aria-activedescendant": activeItemId })}
+          role="combobox"
+          isExpanded={isOpen}
+          aria-controls={`${id}-select-multi-typeahead-checkbox-listbox`}
+        />
+        <TextInputGroupUtilities
+          {...(selected.length === 0 ? { style: { display: "none" } } : {})}
+        >
+          <Button
+            data-cy={`${dataCy}-multi-typeahead-checkbox-clear-button`}
+            variant="plain"
+            onClick={onClearButtonClick}
+            aria-label="Clear input value"
+            icon={<CloseIcon />}
+          />
+        </TextInputGroupUtilities>
+      </TextInputGroup>
+    </MenuToggle>
+  );
+
+  return (
+    <Select
+      data-cy={`${dataCy}-multi-typeahead-checkbox-select`}
+      role="menu"
+      id={`${id}-multi-typeahead-checkbox-select`}
+      isOpen={isOpen}
+      selected={selected}
+      onSelect={(_event, selection) => onSelect(selection as string)}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) closeMenu();
+      }}
+      toggle={toggle}
+      variant="typeahead"
+    >
+      <SelectList
+        isAriaMultiselectable
+        id={`${id}-select-multi-typeahead-checkbox-listbox`}
+      >
+        {availableOptions.map((option, index) => (
+          <SelectOption
+            key={option.value || option.children}
+            {...(!option.isDisabled &&
+              !option.isAriaDisabled && { hasCheckbox: true })}
+            isSelected={selected.includes(option.value)}
+            isFocused={focusedItemIndex === index}
+            className={option.className}
+            id={`${id}-${createItemId(option.value)}`}
+            {...option}
+            ref={null}
+          >
+            {option.children}
+          </SelectOption>
+        ))}
+      </SelectList>
+    </Select>
+  );
+};

--- a/src/components/layouts/SimpleSelector.tsx
+++ b/src/components/layouts/SimpleSelector.tsx
@@ -17,6 +17,7 @@ interface PropsToSimpleSelector {
   dataCy: string;
   id: string;
   selected: string;
+  returnedProperty?: keyof SelectOptionProps;
   options: SelectOptionProps[];
   onSelectedChange: (selected: string) => void;
   ariaLabel?: string;
@@ -33,10 +34,10 @@ const SimpleSelector = (props: PropsToSimpleSelector) => {
 
   const onSelect = (
     _event: React.MouseEvent<Element, MouseEvent> | undefined,
-    value: string | number | undefined
+    value: SelectOptionProps
   ) => {
-    props.onSelectedChange(value as string);
-    setSelected(value as string);
+    props.onSelectedChange(value[props.returnedProperty ?? "value"]);
+    setSelected(value.value);
     setIsOpen(false);
   };
 
@@ -80,10 +81,10 @@ const SimpleSelector = (props: PropsToSimpleSelector) => {
           props.options.map((option, idx) => (
             <SelectOption
               data-cy={props.dataCy + "-select-" + option.key}
-              id={option.key + "-" + idx}
-              key={option.key + "-" + idx}
+              id={option.key}
+              key={option.key}
               tabIndex={idx}
-              value={option.value}
+              value={option}
             >
               {option.value}
             </SelectOption>

--- a/src/components/modals/PermissionModals/AddPermissionModal.tsx
+++ b/src/components/modals/PermissionModals/AddPermissionModal.tsx
@@ -1,0 +1,421 @@
+import React, { useMemo } from "react";
+// PatternFly
+import { Button, Checkbox, Grid, GridItem } from "@patternfly/react-core";
+// Components
+import ModalWithFormLayout, {
+  Field,
+} from "src/components/layouts/ModalWithFormLayout";
+import SimpleSelector, {
+  SelectOptionProps,
+} from "src/components/layouts/SimpleSelector";
+// RPC
+import { useAddPermissionMutation } from "src/services/rpcPermissions";
+// Redux
+import { useAppDispatch } from "src/store/hooks";
+// Hooks
+import { addAlert } from "src/store/Global/alerts-slice";
+// Errors
+import { SerializedError } from "@reduxjs/toolkit";
+import { useGetObjectMetadataQuery } from "src/services/rpc";
+import { Metadata } from "src/utils/datatypes/globalDataTypes";
+import TextInputList from "src/components/Form/TextInputList";
+import { TypeAheadWithCheckbox } from "src/components/TypeAheadWithCheckbox";
+import { useFindGroupsQuery } from "src/services/rpcUserGroups";
+import InputWithValidation from "src/components/layouts/InputWithValidation";
+import { isValidDn } from "src/utils/utils";
+
+interface PropsToAddModal {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  onRefresh: () => void;
+}
+
+const BIND_RULE_OPTIONS: SelectOptionProps[] = [
+  { key: "permission", value: "permission" },
+  { key: "all", value: "all" },
+  { key: "anonymous", value: "anonymous" },
+  { key: "self", value: "self" },
+];
+
+// There are records, that have the same name as others
+// but shouldn't really be used by the user, remove these.
+const FILTERED_OBJECTS: readonly string[] = ["automember_default_group"];
+
+const generateTypes = (metadata: Metadata | undefined) => {
+  if (!metadata) {
+    return [];
+  }
+
+  const objects: SelectOptionProps[] = [];
+
+  objects.push({ key: "", value: "Custom" });
+  for (const obj of Object.values(metadata.objects || {})) {
+    if (FILTERED_OBJECTS.includes(obj.name)) {
+      continue;
+    }
+
+    if (obj.can_have_permissions) {
+      objects.push({
+        key: obj.name,
+        value: (obj.label_singular === "Entry"
+          ? obj.label
+          : obj.label_singular) as string,
+      });
+    }
+  }
+
+  return objects;
+};
+
+const generateAttrs = (
+  metadata: Metadata | undefined,
+  currentObject: string
+) => {
+  if (!metadata) {
+    return [];
+  }
+
+  return (
+    metadata.objects?.[currentObject]?.aciattrs?.map((attr) => ({
+      children: attr,
+      value: attr,
+      "data-cy": `modal-select-attrs-${attr}`,
+    })) || []
+  );
+};
+
+const generateRights = (metadata: Metadata | undefined) => {
+  const rightParam = metadata?.objects?.permission?.takes_params?.find(
+    (param) => param.name === "ipapermright"
+  );
+
+  return rightParam?.values || [];
+};
+
+const AddPermissionModal = (props: PropsToAddModal) => {
+  const dispatch = useAppDispatch();
+
+  // API calls
+  const metadataQuery = useGetObjectMetadataQuery();
+  const groupsQuery = useFindGroupsQuery();
+  const [addPermission] = useAddPermissionMutation();
+
+  const types = useMemo(
+    () => generateTypes(metadataQuery.data),
+    [metadataQuery.data]
+  );
+
+  // States
+  const [isAddButtonSpinning, setIsAddButtonSpinning] = React.useState(false);
+  const [permissionName, setPermissionName] = React.useState("");
+  const [selectedRights, setSelectedRights] = React.useState<string[]>([]);
+  const [bindRuleType, setBindRuleType] = React.useState("permission");
+  const [type, setType] = React.useState("");
+  const [subtree, setSubtree] = React.useState("");
+  const [extraTargetFilter, setExtraTargetFilter] = React.useState<string[]>(
+    []
+  );
+  const [memberof, setMemberof] = React.useState<string[]>([]);
+  const [ipapermtarget, setIpapermtarget] = React.useState("");
+  const [attrs, setAttrs] = React.useState<string[]>([]);
+
+  const hasType = type.trim() !== "";
+  const hasTarget =
+    hasType ||
+    ipapermtarget.trim() !== "" ||
+    memberof.length > 0 ||
+    extraTargetFilter.length > 0 ||
+    attrs.length > 0;
+
+  // Clear fields
+  const clearFields = () => {
+    setPermissionName("");
+    setSelectedRights([]);
+    setBindRuleType("permission");
+    setType("");
+    setSubtree("");
+    setExtraTargetFilter([]);
+    setMemberof([]);
+    setIpapermtarget("");
+    setAttrs([]);
+  };
+
+  const toggleRight = (right: string, isChecked: boolean) => {
+    if (isChecked) {
+      setSelectedRights((prev) => [...prev, right]);
+    } else {
+      setSelectedRights((prev) => prev.filter((r) => r !== right));
+    }
+  };
+
+  // 'Add' button handler
+  const onAddPermission = () => {
+    setIsAddButtonSpinning(true);
+
+    addPermission({
+      cn: permissionName,
+      ipapermright: selectedRights,
+      ipapermbindruletype: bindRuleType,
+      type: type.trim() || undefined,
+      ipapermlocation: subtree.trim() || undefined,
+      extratargetfilter:
+        extraTargetFilter.length > 0 ? extraTargetFilter : undefined,
+      memberof: memberof.length > 0 ? memberof : undefined,
+      ipapermtarget: ipapermtarget.trim() || undefined,
+      attrs: attrs.length > 0 ? attrs : undefined,
+    }).then((response) => {
+      if ("data" in response) {
+        const data = response.data?.result;
+        const error = response.data?.error as SerializedError;
+
+        if (error) {
+          dispatch(
+            addAlert({
+              name: "add-permission-error",
+              title: error.message,
+              variant: "danger",
+            })
+          );
+        }
+
+        if (data) {
+          dispatch(
+            addAlert({
+              name: "add-permission-success",
+              title: "New permission added",
+              variant: "success",
+            })
+          );
+          cleanAndCloseModal();
+          props.onRefresh();
+        }
+      }
+      // Reset button spinner
+      setIsAddButtonSpinning(false);
+    });
+  };
+
+  // Clean and close modal
+  const cleanAndCloseModal = () => {
+    clearFields();
+    props.onClose();
+  };
+
+  const fields: Field[] = [
+    {
+      id: "modal-form-permission-name",
+      name: "Permission name",
+      pfComponent: (
+        <InputWithValidation
+          dataCy="modal-textbox-permission-name"
+          id="modal-form-permission-name"
+          name="modal-form-permission-name"
+          value={permissionName}
+          onChange={(value: string) => setPermissionName(value)}
+          isRequired
+          rules={[
+            {
+              id: "valid-chars",
+              message: "May only contain letters, numbers, -, _, ., and space",
+              validate: (value: string) => /^[-_ a-zA-Z0-9.]+$/.test(value),
+            },
+          ]}
+        />
+      ),
+      fieldRequired: true,
+    },
+    {
+      id: "modal-form-bind-rule-type",
+      name: "Bind rule type",
+      pfComponent: (
+        <SimpleSelector
+          dataCy="modal-select-bind-rule-type"
+          id="modal-form-bind-rule-type"
+          options={BIND_RULE_OPTIONS}
+          selected={bindRuleType}
+          onSelectedChange={setBindRuleType}
+          ariaLabel="Bind rule type"
+        />
+      ),
+      fieldRequired: true,
+    },
+    {
+      id: "modal-form-granted-rights",
+      name: "Granted rights",
+      pfComponent: (
+        <Grid sm={4}>
+          {generateRights(metadataQuery.data).map((right) => (
+            <GridItem key={right}>
+              <Checkbox
+                id={`modal-form-right-${right}`}
+                data-cy={`modal-checkbox-right-${right}`}
+                label={right}
+                name={right}
+                isChecked={selectedRights.includes(right)}
+                onChange={(_event, checked) => toggleRight(right, checked)}
+              />
+            </GridItem>
+          ))}
+        </Grid>
+      ),
+      fieldRequired: true,
+    },
+    {
+      id: "modal-form-type",
+      name: "Type",
+      pfComponent: (
+        <SimpleSelector
+          dataCy="modal-select-type"
+          id="modal-form-type"
+          options={types}
+          selected={type}
+          onSelectedChange={(newType) => {
+            setType(newType);
+            setSubtree("");
+            setAttrs([]);
+          }}
+          ariaLabel="Type"
+          returnedProperty="key"
+        />
+      ),
+    },
+    {
+      id: "modal-form-subtree",
+      name: "Subtree",
+      pfComponent: (
+        <InputWithValidation
+          dataCy="modal-textbox-subtree"
+          id="modal-form-subtree"
+          name="ipapermlocation"
+          value={subtree}
+          onChange={(value: string) => setSubtree(value)}
+          isDisabled={hasType}
+          rules={[
+            {
+              id: "valid-chars",
+              message: "Must be a valid DN, e.g. ou=users,dc=example,dc=com",
+              validate: (value: string) => isValidDn(value),
+            },
+          ]}
+        />
+      ),
+    },
+    {
+      id: "modal-form-filter",
+      name: "Extra target filter",
+      pfComponent: (
+        <TextInputList
+          dataCy="modal-textbox-filter"
+          name="extratargetfilter"
+          ariaLabel="Extra target filter"
+          list={extraTargetFilter}
+          setList={setExtraTargetFilter}
+        />
+      ),
+    },
+    {
+      id: "modal-form-ipapermtarget",
+      name: "Target DN",
+      pfComponent: (
+        <InputWithValidation
+          dataCy="modal-textbox-ipapermtarget"
+          id="modal-form-ipapermtarget"
+          name="ipapermtarget"
+          value={ipapermtarget}
+          onChange={(value: string) => setIpapermtarget(value)}
+          rules={[
+            {
+              id: "valid-chars",
+              message: "Must be a valid DN, e.g. ou=users,dc=example,dc=com",
+              validate: (value: string) => isValidDn(value),
+            },
+          ]}
+        />
+      ),
+    },
+    {
+      id: "modal-form-memberof",
+      name: "Member of group",
+      pfComponent: (
+        <TypeAheadWithCheckbox
+          id="modal-form-memberof"
+          dataCy="modal-select-memberof"
+          options={
+            (
+              groupsQuery.data?.result.result as unknown as Record<
+                string,
+                unknown[]
+              >[]
+            )?.map((group) => ({
+              children: group.cn[0] as string,
+              value: group.cn[0] as string,
+              "data-cy": `modal-select-attrs-${group.cn[0]}`,
+            })) || []
+          }
+          selected={memberof}
+          setSelected={setMemberof}
+        />
+      ),
+    },
+    {
+      id: "modal-form-attrs",
+      name: "Attributes",
+      pfComponent: (
+        <TypeAheadWithCheckbox
+          id="modal-form-attrs"
+          dataCy="modal-select-attrs"
+          options={generateAttrs(metadataQuery.data, type)}
+          selected={attrs}
+          setSelected={setAttrs}
+          creationProps={{ onChangeTarget: type }}
+        />
+      ),
+    },
+  ];
+
+  const isAddDisabled =
+    isAddButtonSpinning ||
+    permissionName === "" ||
+    selectedRights.length === 0 ||
+    !hasTarget;
+
+  // Actions
+  const modalActions: JSX.Element[] = [
+    <Button
+      data-cy="modal-button-add"
+      key="add-new"
+      isDisabled={isAddDisabled}
+      form="add-modal-form"
+      type="submit"
+    >
+      Add
+    </Button>,
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-new"
+      variant="link"
+      onClick={cleanAndCloseModal}
+    >
+      Cancel
+    </Button>,
+  ];
+
+  return (
+    <ModalWithFormLayout
+      dataCy="add-permission-modal"
+      variantType={"medium"}
+      modalPosition={"top"}
+      offPosition={"76px"}
+      title={props.title}
+      formId="add-modal-form"
+      fields={fields}
+      show={props.isOpen}
+      onSubmit={() => onAddPermission()}
+      onClose={cleanAndCloseModal}
+      actions={modalActions}
+    />
+  );
+};
+
+export default AddPermissionModal;

--- a/src/components/modals/PermissionModals/DeletePermissionsModal.tsx
+++ b/src/components/modals/PermissionModals/DeletePermissionsModal.tsx
@@ -1,0 +1,209 @@
+import React from "react";
+// PatternFly
+import { Content, ContentVariants, Button } from "@patternfly/react-core";
+// Layouts
+import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
+// Tables
+import DeletedElementsTable from "src/components/tables/DeletedElementsTable";
+// Hooks
+import { addAlert } from "src/store/Global/alerts-slice";
+// Redux
+import { useAppDispatch } from "src/store/hooks";
+import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
+import { SerializedError } from "@reduxjs/toolkit";
+// Data types
+import { ErrorData, Permission } from "src/utils/datatypes/globalDataTypes";
+// Modals
+import ErrorModal from "src/components/modals/ErrorModal";
+import { BatchRPCResponse, KwError } from "src/services/rpc";
+import { useDeletePermissionsMutation } from "src/services/rpcPermissions";
+
+interface DeletePermissionsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  elementsToDelete: Permission[];
+  clearSelectedElements: () => void;
+  columnNames: string[];
+  keyNames: string[];
+  onRefresh: () => void;
+  updateIsDeleteButtonDisabled: (value: boolean) => void;
+  updateIsDeletion: (value: boolean) => void;
+}
+
+const DeletePermissionsModal = (props: DeletePermissionsModalProps) => {
+  const dispatch = useAppDispatch();
+
+  // RPC calls
+  const [executePermissionsDelCommand] = useDeletePermissionsMutation();
+
+  // States
+  const [spinning, setBtnSpinning] = React.useState<boolean>(false);
+  const [isModalErrorOpen, setIsModalErrorOpen] = React.useState(false);
+  const [errorTitle, setErrorTitle] = React.useState("");
+  const [errorMessage, setErrorMessage] = React.useState("");
+
+  const fields = [
+    {
+      id: "question-text",
+      pfComponent: (
+        <Content component={ContentVariants.p}>
+          Are you sure you want to remove the selected permissions?
+        </Content>
+      ),
+    },
+    {
+      id: "deleted-permissions-table",
+      pfComponent: (
+        <DeletedElementsTable
+          mode="passing_full_data"
+          elementsToDelete={props.elementsToDelete}
+          columnNames={props.columnNames}
+          columnIds={props.keyNames}
+          elementType="Permission"
+          idAttr="cn"
+        />
+      ),
+    },
+  ];
+
+  // Handle API error data
+  const handleAPIError = (error: FetchBaseQueryError | SerializedError) => {
+    if ("code" in error) {
+      setErrorTitle("IPA error " + error.code + ": " + error.name);
+      if (error.message !== undefined) {
+        setErrorMessage(error.message);
+      }
+    } else if ("data" in error) {
+      const errorData = error.data as ErrorData;
+      const errorCode = errorData.code as string;
+      const errorName = errorData.name as string;
+      const errorMsg = errorData.error as string;
+
+      setErrorTitle("IPA error " + errorCode + ": " + errorName);
+      setErrorMessage(errorMsg);
+    }
+    setIsModalErrorOpen(true);
+  };
+
+  const closeAndCleanErrorParameters = () => {
+    setIsModalErrorOpen(false);
+    setErrorTitle("");
+    setErrorMessage("");
+  };
+
+  // Delete handler
+  const onDeletePermissions = () => {
+    setBtnSpinning(true);
+
+    executePermissionsDelCommand(props.elementsToDelete).then((response) => {
+      if ("data" in response) {
+        const data = response.data as BatchRPCResponse;
+        const result = data.result;
+
+        if (result) {
+          const results = result.results as unknown as KwError[];
+          if (results.some((r) => "error" in r && r.error)) {
+            for (const r of results) {
+              if ("error" in r && r.error) {
+                const errorData = {
+                  code: r.error_code,
+                  name: r.error_name,
+                  error: r.error,
+                };
+
+                const error = {
+                  status: "CUSTOM_ERROR",
+                  data: errorData,
+                } as FetchBaseQueryError;
+
+                handleAPIError(error);
+              }
+            }
+          } else {
+            props.clearSelectedElements();
+            props.updateIsDeleteButtonDisabled(true);
+            props.updateIsDeletion(true);
+
+            dispatch(
+              addAlert({
+                name: "remove-permissions-success",
+                title: "Permissions removed",
+                variant: "success",
+              })
+            );
+
+            props.onClose();
+            props.onRefresh();
+          }
+        }
+      }
+      setBtnSpinning(false);
+    });
+  };
+
+  // Modal actions
+  const modalActions: JSX.Element[] = [
+    <Button
+      key="delete-permissions"
+      variant="danger"
+      onClick={onDeletePermissions}
+      form="delete-permissions-modal"
+      spinnerAriaValueText="Deleting"
+      spinnerAriaLabel="Deleting"
+      isLoading={spinning}
+      isDisabled={spinning}
+      data-cy="modal-button-delete"
+    >
+      {spinning ? "Deleting" : "Delete"}
+    </Button>,
+    <Button
+      key="cancel-delete-permissions"
+      variant="link"
+      onClick={props.onClose}
+      data-cy="modal-button-cancel"
+    >
+      Cancel
+    </Button>,
+  ];
+
+  // Error modal actions
+  const errorModalActions = [
+    <Button
+      key="cancel"
+      variant="link"
+      onClick={closeAndCleanErrorParameters}
+      data-cy="modal-button-ok"
+    >
+      OK
+    </Button>,
+  ];
+
+  return (
+    <>
+      <ModalWithFormLayout
+        dataCy="delete-permissions-modal"
+        variantType="medium"
+        modalPosition="top"
+        offPosition="76px"
+        title="Remove permissions"
+        formId="delete-permissions-modal"
+        fields={fields}
+        show={props.isOpen}
+        onClose={props.onClose}
+        actions={modalActions}
+      />
+      {isModalErrorOpen && (
+        <ErrorModal
+          dataCy="delete-permissions-modal-error"
+          title={errorTitle}
+          isOpen={isModalErrorOpen}
+          onClose={closeAndCleanErrorParameters}
+          actions={errorModalActions}
+          errorMessage={errorMessage}
+        />
+      )}
+    </>
+  );
+};
+
+export default DeletePermissionsModal;

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -83,6 +83,7 @@ import Roles from "src/pages/Roles/Roles";
 import RolesTabs from "src/pages/Roles/RolesTabs";
 import Privileges from "src/pages/Privileges/Privileges";
 import PrivilegesTabs from "src/pages/Privileges/PrivilegesTabs";
+import Permissions from "src/pages/Permissions/Permissions";
 
 // Renders routes (React)
 export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
@@ -614,6 +615,9 @@ export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
                     element={<PrivilegesTabs section="settings" />}
                   />
                 </Route>
+              </Route>
+              <Route path="permissions">
+                <Route path="" element={<Permissions />} />
               </Route>
               <Route path="configuration" element={<Configuration />} />
               {/* Redirect to Active users page if user is logged in and navigates to the root page */}

--- a/src/navigation/NavRoutes.ts
+++ b/src/navigation/NavRoutes.ts
@@ -72,6 +72,7 @@ const TopologyGroupRef = "topology-graph";
 // - Role-based access control
 const RbacGroupRef = "rbac";
 const PrivilegesGroupRef = "privileges";
+const PermissionsGroupRef = "permissions";
 // - Configuration
 const ConfigRef = "configuration";
 
@@ -443,6 +444,13 @@ export const getNavigationRoutes = (
               group: PrivilegesGroupRef,
               title: `${BASE_TITLE} - Privileges`,
               path: "privileges",
+              items: [],
+            },
+            {
+              label: "Permissions",
+              group: PermissionsGroupRef,
+              title: `${BASE_TITLE} - Permissions`,
+              path: "permissions",
               items: [],
             },
           ],

--- a/src/pages/Permissions/Permissions.tsx
+++ b/src/pages/Permissions/Permissions.tsx
@@ -1,0 +1,394 @@
+import React, { useMemo, useState } from "react";
+// PatternFly
+import {
+  Flex,
+  FlexItem,
+  PageSection,
+  PaginationVariant,
+  ToolbarItemVariant,
+} from "@patternfly/react-core";
+// PatternFly table
+import {
+  InnerScrollContainer,
+  OuterScrollContainer,
+} from "@patternfly/react-table";
+// Data types
+import { Permission } from "src/utils/datatypes/globalDataTypes";
+import { ToolbarItem } from "src/components/layouts/ToolbarLayout";
+// Redux
+import { useAppDispatch, useAppSelector } from "src/store/hooks";
+// Layouts
+import TitleLayout from "src/components/layouts/TitleLayout";
+import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
+import SecondaryButton from "src/components/layouts/SecondaryButton";
+import ToolbarLayout from "src/components/layouts/ToolbarLayout";
+import SearchInputLayout from "src/components/layouts/SearchInputLayout";
+// Tables
+import MainTable from "src/components/tables/MainTable";
+// Components
+import PaginationLayout from "src/components/layouts/PaginationLayout";
+import BulkSelectorPrep from "src/components/BulkSelectorPrep";
+// Modals
+import AddPermissionModal from "src/components/modals/PermissionModals/AddPermissionModal";
+import DeletePermissionsModal from "src/components/modals/PermissionModals/DeletePermissionsModal";
+// Hooks
+import useUpdateRoute from "src/hooks/useUpdateRoute";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
+import useContextualHelpTopic from "src/hooks/useContextualHelpTopic";
+import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
+// Utils
+import { API_VERSION_BACKUP, isPermissionSelectable } from "src/utils/utils";
+// RPC client
+import { useGetPermissionsFullDataQuery } from "src/services/rpcPermissions";
+// Errors
+import useApiError from "src/hooks/useApiError";
+import GlobalErrors from "src/components/errors/GlobalErrors";
+import ModalErrors from "src/components/errors/ModalErrors";
+import { apiToPermission } from "src/utils/permissionsUtils";
+
+const Permissions = () => {
+  const dispatch = useAppDispatch();
+
+  useUpdateRoute({ pathname: "permissions" });
+  useContextualHelpTopic("permissions");
+
+  const apiVersion = useAppSelector(
+    (state) => state.global.environment.api_version
+  ) as string;
+
+  const { page, perPage, searchValue } = useListPageSearchParams();
+
+  const globalErrors = useApiError([]);
+  const modalErrors = useApiError([]);
+
+  const firstIdx = (page - 1) * perPage;
+  const lastIdx = page * perPage;
+
+  const permissionsDataResponse = useGetPermissionsFullDataQuery({
+    searchValue,
+    sizeLimit: 0,
+    apiVersion: apiVersion || API_VERSION_BACKUP,
+    startIdx: firstIdx,
+    stopIdx: lastIdx,
+  });
+
+  const {
+    data: batchResponse,
+    isLoading: isBatchLoading,
+    isFetching,
+    error: batchError,
+  } = permissionsDataResponse;
+
+  // Derive elementsList and totalCount from query response or search results
+  const { elementsList, totalCount } = useMemo(() => {
+    // Otherwise derive from query response
+    if (batchResponse?.result) {
+      const permissionsListResult = batchResponse.result.results;
+      const permissionsListSize = batchResponse.result.count;
+      const permissions: Permission[] = [];
+
+      for (let i = 0; i < permissionsListSize; i++) {
+        permissions.push(apiToPermission(permissionsListResult[i].result));
+      }
+
+      return {
+        elementsList: permissions,
+        totalCount: batchResponse.result.totalCount,
+      };
+    }
+
+    return { elementsList: [], totalCount: 0 };
+  }, [batchResponse]);
+
+  // Clear errors when fetching starts
+  React.useEffect(() => {
+    if (isFetching) {
+      globalErrors.clear();
+    }
+  }, [isFetching]);
+
+  // Handle query errors - add to global errors instead of reloading
+  React.useEffect(() => {
+    if (
+      !isBatchLoading &&
+      !isFetching &&
+      permissionsDataResponse.isError &&
+      permissionsDataResponse.error !== undefined
+    ) {
+      globalErrors.addError(
+        permissionsDataResponse.error,
+        "Error loading permissions",
+        "permissions-fetch-error"
+      );
+    }
+  }, [permissionsDataResponse.isError, isBatchLoading, isFetching]);
+
+  const refreshData = () => {
+    clearSelectedPermissions();
+    permissionsDataResponse.refetch();
+  };
+
+  const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
+    useState<boolean>(true);
+
+  const [isDeletion, setIsDeletion] = useState(false);
+
+  const [selectedPerPage, setSelectedPerPage] = useState<number>(0);
+
+  const [selectedPermissions, setSelectedPermissions] = useState<Permission[]>(
+    []
+  );
+
+  const clearSelectedPermissions = () => {
+    setSelectedPermissions([]);
+  };
+
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  const selectablePermissionsTable = elementsList.filter(
+    isPermissionSelectable
+  );
+
+  const updateSelectedPermissions = (
+    permissions: Permission[],
+    isSelected: boolean
+  ) => {
+    let newSelectedPermissions: Permission[] = [];
+    if (isSelected) {
+      newSelectedPermissions = JSON.parse(JSON.stringify(selectedPermissions));
+      for (let i = 0; i < permissions.length; i++) {
+        if (selectedPermissions.find((s) => s.cn === permissions[i].cn)) {
+          continue;
+        }
+        newSelectedPermissions.push(permissions[i]);
+      }
+    } else {
+      for (let i = 0; i < selectedPermissions.length; i++) {
+        let found = false;
+        for (let ii = 0; ii < permissions.length; ii++) {
+          if (selectedPermissions[i].cn === permissions[ii].cn) {
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          newSelectedPermissions.push(selectedPermissions[i]);
+        }
+      }
+    }
+    setSelectedPermissions(newSelectedPermissions);
+    setIsDeleteButtonDisabled(newSelectedPermissions.length === 0);
+  };
+
+  const setPermissionSelected = (
+    permission: Permission,
+    isSelecting = true
+  ) => {
+    if (isPermissionSelectable(permission)) {
+      updateSelectedPermissions([permission], isSelecting);
+    }
+  };
+
+  const bulkSelectorData = {
+    selected: selectedPermissions,
+    updateSelected: updateSelectedPermissions,
+    selectableTable: selectablePermissionsTable,
+    nameAttr: "cn",
+  };
+
+  const buttonsData = {
+    updateIsDeleteButtonDisabled: setIsDeleteButtonDisabled,
+  };
+
+  const selectedPerPageData = {
+    selectedPerPage,
+    updateSelectedPerPage: setSelectedPerPage,
+  };
+
+  const columnNames = ["Permission name", "Granted rights"];
+  const keyNames = ["cn", "ipapermright"];
+
+  const toolbarItems: ToolbarItem[] = [
+    {
+      key: 0,
+      element: (
+        <BulkSelectorPrep
+          list={elementsList}
+          shownElementsList={elementsList}
+          elementData={bulkSelectorData}
+          buttonsData={buttonsData}
+          selectedPerPageData={selectedPerPageData}
+        />
+      ),
+    },
+    {
+      key: 1,
+      element: (
+        <SearchInputLayout
+          dataCy="search"
+          name="search"
+          ariaLabel="Search permissions"
+          placeholder="Search"
+          isDisabled={isFetching}
+        />
+      ),
+      toolbarItemVariant: ToolbarItemVariant.label,
+      toolbarItemGap: { default: "gapMd" },
+    },
+    {
+      key: 2,
+      toolbarItemVariant: ToolbarItemVariant.separator,
+    },
+    {
+      key: 3,
+      element: (
+        <SecondaryButton
+          onClickHandler={refreshData}
+          isDisabled={isFetching}
+          dataCy="permissions-button-refresh"
+        >
+          Refresh
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 4,
+      element: (
+        <SecondaryButton
+          isDisabled={isDeleteButtonDisabled || isFetching}
+          onClickHandler={() => setShowDeleteModal(true)}
+          dataCy="permissions-button-delete"
+        >
+          Delete
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 5,
+      element: (
+        <SecondaryButton
+          onClickHandler={() => setShowAddModal(true)}
+          isDisabled={isFetching}
+          dataCy="permissions-button-add"
+        >
+          Add
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 6,
+      toolbarItemVariant: ToolbarItemVariant.separator,
+    },
+    {
+      key: 7,
+      element: (
+        <HelpTextWithIconLayout
+          textContent="Help"
+          onClick={() => dispatch(toggleHelpPanel())}
+        />
+      ),
+    },
+    {
+      key: 8,
+      element: (
+        <PaginationLayout
+          list={elementsList}
+          totalCount={totalCount}
+          widgetId="pagination-options-menu-top"
+          isCompact={true}
+        />
+      ),
+      toolbarItemAlignment: { default: "alignEnd" },
+    },
+  ];
+
+  return (
+    <div>
+      <PageSection hasBodyWrapper={false}>
+        <TitleLayout
+          id="permissions-title"
+          headingLevel="h1"
+          text="Permissions"
+        />
+      </PageSection>
+      <PageSection hasBodyWrapper={false} isFilled={false}>
+        <Flex direction={{ default: "column" }}>
+          <FlexItem>
+            <ToolbarLayout toolbarItems={toolbarItems} />
+          </FlexItem>
+          <FlexItem style={{ flex: "0 0 auto" }}>
+            <OuterScrollContainer>
+              <InnerScrollContainer
+                style={{ height: "60vh", overflow: "auto" }}
+              >
+                {batchError !== undefined && batchError ? (
+                  <GlobalErrors errors={globalErrors.getAll()} />
+                ) : (
+                  <MainTable
+                    tableTitle="Permissions table"
+                    shownElementsList={elementsList}
+                    pk="cn"
+                    keyNames={keyNames}
+                    columnNames={columnNames}
+                    hasCheckboxes={true}
+                    pathname="permissions"
+                    showTableRows={!isFetching}
+                    showLink={false}
+                    elementsData={{
+                      isElementSelectable: isPermissionSelectable,
+                      selectedElements: selectedPermissions,
+                      selectableElementsTable: selectablePermissionsTable,
+                      setElementsSelected: setPermissionSelected,
+                      clearSelectedElements: clearSelectedPermissions,
+                    }}
+                    buttonsData={{
+                      updateIsDeleteButtonDisabled: setIsDeleteButtonDisabled,
+                      isDeletion,
+                      updateIsDeletion: setIsDeletion,
+                    }}
+                    paginationData={{
+                      selectedPerPage,
+                      updateSelectedPerPage: setSelectedPerPage,
+                    }}
+                  />
+                )}
+              </InnerScrollContainer>
+            </OuterScrollContainer>
+          </FlexItem>
+          <FlexItem style={{ flex: "0 0 auto", position: "sticky", bottom: 0 }}>
+            <PaginationLayout
+              list={elementsList}
+              totalCount={totalCount}
+              variant={PaginationVariant.bottom}
+              widgetId="pagination-options-menu-bottom"
+            />
+          </FlexItem>
+        </Flex>
+      </PageSection>
+      <AddPermissionModal
+        isOpen={showAddModal}
+        onClose={() => setShowAddModal(false)}
+        title="Add permission"
+        onRefresh={refreshData}
+      />
+      <DeletePermissionsModal
+        isOpen={showDeleteModal}
+        onClose={() => setShowDeleteModal(false)}
+        elementsToDelete={selectedPermissions}
+        clearSelectedElements={clearSelectedPermissions}
+        columnNames={columnNames}
+        keyNames={keyNames}
+        onRefresh={refreshData}
+        updateIsDeleteButtonDisabled={setIsDeleteButtonDisabled}
+        updateIsDeletion={setIsDeletion}
+      />
+      <ModalErrors
+        errors={modalErrors.getAll()}
+        dataCy="permissions-modal-error"
+      />
+    </div>
+  );
+};
+
+export default Permissions;

--- a/src/services/rpcPermissions.ts
+++ b/src/services/rpcPermissions.ts
@@ -1,0 +1,162 @@
+import {
+  api,
+  Command,
+  getBatchCommand,
+  getCommand,
+  BatchRPCResponse,
+  FindRPCResponse,
+} from "./rpc";
+import { API_VERSION_BACKUP } from "../utils/utils";
+import { Permission, cnType } from "../utils/datatypes/globalDataTypes";
+import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
+
+/**
+ * Permissions-related endpoints
+ *
+ * API commands:
+ * - permission_find: https://freeipa.readthedocs.io/en/latest/api/permission_find.html
+ * - permission_show: https://freeipa.readthedocs.io/en/latest/api/permission_show.html
+ * - permission_add: https://freeipa.readthedocs.io/en/latest/api/permission_add.html
+ * - permission_del: https://freeipa.readthedocs.io/en/latest/api/permission_del.html
+ */
+
+interface PermissionAddPayload {
+  cn: string;
+  ipapermright: string[];
+  ipapermbindruletype: string;
+  type?: string;
+  ipapermlocation?: string;
+  extratargetfilter?: string[];
+  memberof?: string[];
+  ipapermtarget?: string;
+  attrs?: string[];
+}
+
+interface PermissionsFullDataPayload {
+  searchValue: string;
+  sizeLimit: number;
+  apiVersion: string;
+  startIdx: number;
+  stopIdx: number;
+}
+
+const extendedApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    /**
+     * Get permissions with full data via two-step permission_find + permission_show pattern
+     * @param {PermissionsFullDataPayload} - Payload with search parameters
+     * @returns {BatchRPCResponse} - Batch response with permission data
+     */
+    getPermissionsFullData: build.query<
+      BatchRPCResponse,
+      PermissionsFullDataPayload
+    >({
+      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
+        const { searchValue, sizeLimit, apiVersion, startIdx, stopIdx } =
+          payloadData;
+
+        const params = {
+          pkey_only: true,
+          sizelimit: sizeLimit,
+          version: apiVersion,
+        };
+
+        // Step 1: Find permission IDs
+        const findCommand: Command = {
+          method: "permission_find",
+          params: [[searchValue], params],
+        };
+
+        const findResult = await fetchWithBQ(getCommand(findCommand));
+        if (findResult.error) {
+          return { error: findResult.error as FetchBaseQueryError };
+        }
+
+        const findResponse = findResult.data as FindRPCResponse;
+        const totalCount = findResponse.result.result.length as number;
+        const ids: string[] = [];
+
+        for (let i = startIdx; i < totalCount && i < stopIdx; i++) {
+          const permissionId = findResponse.result.result[i] as cnType;
+          ids.push(permissionId.cn[0] as string);
+        }
+
+        // Step 2: Batch show for each permission
+        const showCommands: Command[] = ids.map((id) => ({
+          method: "permission_show",
+          params: [[id], { no_members: true }],
+        }));
+
+        const showResult = await fetchWithBQ(
+          getBatchCommand(showCommands, apiVersion)
+        );
+
+        const response = showResult.data as BatchRPCResponse;
+        if (response) {
+          response.result.totalCount = totalCount;
+        }
+
+        return response
+          ? { data: response }
+          : { error: showResult.error as FetchBaseQueryError };
+      },
+    }),
+    /**
+     * Add a new permission via `permission_add`
+     * @param {PermissionAddPayload} - Payload with permission fields
+     * @returns {FindRPCResponse} - Response from API
+     */
+    addPermission: build.mutation<FindRPCResponse, PermissionAddPayload>({
+      query: (payload) => {
+        const params: Record<string, unknown> = {
+          version: API_VERSION_BACKUP,
+          ipapermright: payload.ipapermright,
+          ipapermbindruletype: payload.ipapermbindruletype,
+        };
+        if (payload.type) {
+          params.type = payload.type;
+        }
+        if (payload.ipapermlocation) {
+          params.ipapermlocation = payload.ipapermlocation;
+        }
+        if (payload.extratargetfilter) {
+          params.extratargetfilter = payload.extratargetfilter;
+        }
+        if (payload.memberof) {
+          params.memberof = payload.memberof;
+        }
+        if (payload.ipapermtarget) {
+          params.ipapermtarget = payload.ipapermtarget;
+        }
+        if (payload.attrs && payload.attrs.length > 0) {
+          params.attrs = payload.attrs;
+        }
+        return getCommand({
+          method: "permission_add",
+          params: [[payload.cn], params],
+        });
+      },
+    }),
+    /**
+     * Delete permissions via batch `permission_del`
+     * @param {Permission[]} - Array of permissions to delete
+     * @returns {BatchRPCResponse} - Batch response
+     */
+    deletePermissions: build.mutation<BatchRPCResponse, Permission[]>({
+      query: (permissions) => {
+        const commands: Command[] = permissions.map((permission) => ({
+          method: "permission_del",
+          params: [[permission.cn], {}],
+        }));
+        return getBatchCommand(commands, API_VERSION_BACKUP);
+      },
+    }),
+  }),
+  overrideExisting: false,
+});
+
+export const {
+  useGetPermissionsFullDataQuery,
+  useAddPermissionMutation,
+  useDeletePermissionsMutation,
+} = extendedApi;

--- a/src/services/rpcUserGroups.ts
+++ b/src/services/rpcUserGroups.ts
@@ -144,6 +144,14 @@ const extendedApi = api.injectEndpoints({
         });
       },
     }),
+    findGroups: build.query<FindRPCResponse, void>({
+      query: () => {
+        return getCommand({
+          method: "group_find",
+          params: [[], { version: API_VERSION_BACKUP }],
+        });
+      },
+    }),
     /**
      * Remove groups
      * @param {UserGroup[]} listOfGroups - List of groups to remove
@@ -437,6 +445,7 @@ export const useGettingGroupsQuery = (payloadData) => {
 
 export const {
   useAddGroupMutation,
+  useFindGroupsQuery,
   useRemoveGroupsMutation,
   useRemoveGroupMutation,
   useAddToGroupsMutation,

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -225,6 +225,24 @@ export interface Privilege {
   description: string;
 }
 
+export interface Permission {
+  cn: string;
+  ipapermright: string[];
+  attrs: string[];
+  ipapermincludedattrmultivalued: string[]; // mod only
+  ipapermexcludedattrmultivalued: string[]; // mod only
+  ipapermbindruletype: string;
+  ipapermlocation: string;
+  extratargetfilter: string[];
+  ipapermtargetfilter: string[];
+  ipapermtarget: string;
+  ipapermtargetto: string;
+  ipapermtargetfrom: string;
+  memberof: string[];
+  targetgroup: string;
+  type: string;
+}
+
 export interface HBACRule {
   hostcategory: string;
   servicecategory: string;
@@ -538,6 +556,7 @@ export interface ParamMetadata {
   required: boolean;
   sortorder: number;
   type: string;
+  values?: string[];
 }
 
 export interface RadiusServer {

--- a/src/utils/permissionsUtils.tsx
+++ b/src/utils/permissionsUtils.tsx
@@ -1,0 +1,83 @@
+// Data types
+import { Permission } from "src/utils/datatypes/globalDataTypes";
+// Utils
+import { convertApiObj } from "./ipaObjectUtils";
+
+export const asRecord = (
+  element: Partial<Permission>,
+  onElementChange: (element: Partial<Permission>) => void
+) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ipaObject = element as Record<string, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function recordOnChange(ipaObject: Record<string, any>) {
+    onElementChange(ipaObject as Permission);
+  }
+
+  return { ipaObject, recordOnChange };
+};
+
+const simpleValues = new Set([
+  "cn",
+  "ipapermbindruletype",
+  "ipapermlocation",
+  "ipapermtarget",
+  "ipapermtargetto",
+  "ipapermtargetfrom",
+  "targetgroup",
+  "type",
+]);
+const dateValues = new Set([]);
+
+export function apiToPermission(
+  apiRecord: Record<string, unknown>
+): Permission {
+  const converted = convertApiObj(
+    apiRecord,
+    simpleValues,
+    dateValues
+  ) as Partial<Permission>;
+
+  return {
+    ...createEmptyPermission(),
+    ...converted,
+    ipapermright: (apiRecord.ipapermright as string[]) || [],
+    attrs: (apiRecord.attrs as string[]) || [],
+    ipapermincludedattrmultivalued:
+      (apiRecord.ipapermincludedattrmultivalued as string[]) || [],
+    ipapermexcludedattrmultivalued:
+      (apiRecord.ipapermexcludedattrmultivalued as string[]) || [],
+    extratargetfilter: (apiRecord.extratargetfilter as string[]) || [],
+    ipapermtargetfilter: (apiRecord.ipapermtargetfilter as string[]) || [],
+    memberof: (apiRecord.memberof as string[]) || [],
+  };
+}
+
+export function partialPermissionToPermission(
+  partialPermission: Partial<Permission>
+): Permission {
+  return {
+    ...createEmptyPermission(),
+    ...partialPermission,
+  };
+}
+
+export function createEmptyPermission(): Permission {
+  return {
+    cn: "",
+    ipapermright: [],
+    attrs: [],
+    ipapermincludedattrmultivalued: [],
+    ipapermexcludedattrmultivalued: [],
+    ipapermbindruletype: "",
+    ipapermlocation: "",
+    extratargetfilter: [],
+    ipapermtargetfilter: [],
+    ipapermtarget: "",
+    ipapermtargetto: "",
+    ipapermtargetfrom: "",
+    memberof: [],
+    targetgroup: "",
+    type: "",
+  };
+}

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -13,6 +13,7 @@ import {
   IdRange,
   Metadata,
   Netgroup,
+  Permission,
   Privilege,
   Role,
   Service,
@@ -214,6 +215,9 @@ export const isRoleSelectable = (role: Role) => role.cn !== "";
 
 export const isPrivilegeSelectable = (privilege: Privilege) =>
   privilege.cn !== "";
+
+export const isPermissionSelectable = (permission: Permission) =>
+  permission.cn !== "";
 
 export const isIdpServerSelectable = (idpServer: IDPServer) =>
   idpServer.cn !== "";
@@ -502,6 +506,17 @@ export const parseDn = (dn: string) => {
 
   return result as DN;
 };
+
+/**
+ * Validate a DN, very simple validation, as there are too many cases to handle
+ * @param dn - The DN to validate
+ * @returns {boolean} - True if the DN is valid, false otherwise
+ */
+export const isValidDn = (dn: string) =>
+  dn.split(",").every((rdn) => {
+    const splitted = rdn.split("=");
+    return splitted.length === 2 && splitted[0] !== "" && splitted[1] !== "";
+  });
 
 /**
  * Given a (potential) __datetime__ object, parse it into a Date object or null (if empty)


### PR DESCRIPTION
Add the 'Permissions' page under the 'Role-based access control' section, allowing users to list, search, add, and delete permissions.

Changes:
- Create `Permissions` main page with table, search, and pagination
- Add `AddPermissionModal` and `DeletePermissionsModal` components
- Add permissions navigation route and menu item
- Add `rpcPermissions` service with find/show/add/delete/search endpoints
- Add `Permission` data type and related utilities
- Add reusable `SelectMultiTypeaheadCheckbox` form component
- Extend `SimpleSelector` to support returning a custom property
- Add `findGroups` query to `rpcUserGroups` service

Assisted-by: Cursor <cursoragent@cursor.com>

## Summary by Sourcery

Introduce a new Permissions management page under role-based access control, backed by RPC services and utilities for listing, searching, adding, and deleting permissions.

New Features:
- Add a Permissions main page with table view, bulk selection, search, and pagination controls.
- Add modals for creating permissions and confirming bulk deletion of selected permissions.
- Add a reusable SelectMultiTypeaheadCheckbox form control for multi-select, typeahead, and optional option creation.

Enhancements:
- Extend SimpleSelector to support returning a custom property from selected options.
- Add Permission data type definitions and conversion utilities for handling API objects.
- Add a findGroups query to the user groups RPC service for populating group selections in the permissions UI.