### PR TITLE
Make all modals to be submittable by pressing Enter

### DIFF
--- a/doc/designs/sub-pages/09-modals.md
+++ b/doc/designs/sub-pages/09-modals.md
@@ -57,11 +57,16 @@ const Add<ChildEntity>Modal = (props: Add<ChildEntity>ModalProps) => {
     });
   };
 
+  const onFormSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    onAdd();
+  };
+
   return (
     <Modal isOpen={props.isOpen} onClose={onClose} variant="small">
       <ModalHeader title="Add <child entity>" />
       <ModalBody>
-        <Form id="add-<child-entity>-form">
+        <Form id="add-<child-entity>-form" onSubmit={onFormSubmit}>
           <FormGroup label="Field 1" fieldId="field1" isRequired>
             <TextInput id="field1" value={field1} onChange={(_e, val) => setField1(val)} />
           </FormGroup>
@@ -69,7 +74,7 @@ const Add<ChildEntity>Modal = (props: Add<ChildEntity>ModalProps) => {
       </ModalBody>
       <ModalFooter>
         <Button variant="secondary" onClick={onClose}>Cancel</Button>
-        <Button variant="primary" onClick={onAdd} isDisabled={!field1 || spinning}>
+        <Button variant="primary" type="submit" form="add-<child-entity>-form" isDisabled={!field1 || spinning}>
           {spinning ? <Spinner size="sm" /> : "Add"}
         </Button>
       </ModalFooter>
@@ -140,7 +145,7 @@ const Delete<ChildEntity>Modal = (props: Delete<ChildEntity>ModalProps) => {
 
   const modalActions = [
     <Button key="cancel" variant="link" onClick={props.onClose}>Cancel</Button>,
-    <Button key="delete" variant="danger" onClick={onDelete} isDisabled={spinning}>
+    <Button key="delete" variant="danger" type="submit" form="delete-<child-entity>-form" isDisabled={spinning}>
       {spinning ? <Spinner size="sm" /> : "Delete"}
     </Button>,
   ];
@@ -158,6 +163,7 @@ const Delete<ChildEntity>Modal = (props: Delete<ChildEntity>ModalProps) => {
       actions={modalActions}
       isOpen={props.isOpen}
       onClose={props.onClose}
+      onSubmit={onDelete}
     />
   );
 };

--- a/src/components/Form/IpaCertificateMappingData/IpaCertificateMappingData.tsx
+++ b/src/components/Form/IpaCertificateMappingData/IpaCertificateMappingData.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   Flex,
   FlexItem,
+  Form,
   Modal,
   ModalBody,
   ModalFooter,
@@ -115,7 +116,8 @@ const IpaCertificateMappingData = (props: PropsToIpaCertificateMappingData) => {
       data-cy="modal-button-delete"
       key="del-certificate-mapping-data"
       variant="danger"
-      onClick={() => onRemoveCertificateMappingData(idxToDelete)}
+      type="submit"
+      form="remove-certificate-mapping-data-form"
       isDisabled={modalSpinning}
       isLoading={modalSpinning}
       spinnerAriaValueText="Deleting"
@@ -293,11 +295,17 @@ const IpaCertificateMappingData = (props: PropsToIpaCertificateMappingData) => {
     });
   };
 
+  const onAddFormSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    onAddCertificateMappingData();
+  };
+
   const actions = [
     <SecondaryButton
       dataCy="modal-button-add"
       key="add"
-      onClickHandler={onAddCertificateMappingData}
+      type="submit"
+      form="add-certificate-mapping-data-form"
       isDisabled={isAddButtonDisabled}
       isLoading={modalSpinning}
       spinnerAriaValueText="Adding"
@@ -366,25 +374,30 @@ const IpaCertificateMappingData = (props: PropsToIpaCertificateMappingData) => {
           labelId="add-certificate-mapping-data-modal"
         />
         <ModalBody id="add-certificate-mapping-data-modal-body">
-          <CertificateMappingDataOption
-            dataCy="modal-cert-map-data"
-            isCertMappingDataChecked={isCertMappingDataChecked}
-            onChangeCertMappingDataCheck={onChangeCertMappingDataCheck}
-            setIsAddButtonDisabled={setIsAddButtonDisabled}
-            certificatesList={certificatesList}
-            setCertificateList={setCertificatesList}
-            certificateMappingDataList={certificateMappingDataList}
-            setCertificateMappingDataList={setCertificateMappingDataList}
-          />
-          <IssuerAndSubjectOption
-            isIssuerAndSubjectChecked={isIssuerAndSubjectChecked}
-            onChangeIssuerAndSubjectCheck={onChangeIssuerAndSubjectCheck}
-            setIsAddButtonDisabled={setIsAddButtonDisabled}
-            issuerValue={issuer}
-            setIssuerValue={setIssuer}
-            subjectValue={subject}
-            setSubjectValue={setSubject}
-          />
+          <Form
+            id="add-certificate-mapping-data-form"
+            onSubmit={onAddFormSubmit}
+          >
+            <CertificateMappingDataOption
+              dataCy="modal-cert-map-data"
+              isCertMappingDataChecked={isCertMappingDataChecked}
+              onChangeCertMappingDataCheck={onChangeCertMappingDataCheck}
+              setIsAddButtonDisabled={setIsAddButtonDisabled}
+              certificatesList={certificatesList}
+              setCertificateList={setCertificatesList}
+              certificateMappingDataList={certificateMappingDataList}
+              setCertificateMappingDataList={setCertificateMappingDataList}
+            />
+            <IssuerAndSubjectOption
+              isIssuerAndSubjectChecked={isIssuerAndSubjectChecked}
+              onChangeIssuerAndSubjectCheck={onChangeIssuerAndSubjectCheck}
+              setIsAddButtonDisabled={setIsAddButtonDisabled}
+              issuerValue={issuer}
+              setIssuerValue={setIssuer}
+              subjectValue={subject}
+              setSubjectValue={setSubject}
+            />
+          </Form>
         </ModalBody>
         <ModalFooter>{actions}</ModalFooter>
       </Modal>
@@ -396,6 +409,8 @@ const IpaCertificateMappingData = (props: PropsToIpaCertificateMappingData) => {
         actions={deletionModalActions}
         messageText={deletionMessage}
         messageObj={deletionMessageObj}
+        formId="remove-certificate-mapping-data-form"
+        onSubmit={() => onRemoveCertificateMappingData(idxToDelete)}
       />
     </>
   );

--- a/src/components/Form/IpaCertificates/IpaCertificates.tsx
+++ b/src/components/Form/IpaCertificates/IpaCertificates.tsx
@@ -456,7 +456,8 @@ const IpaCertificates = (props: PropsToIpaCertificates) => {
       data-cy="modal-button-delete"
       key="del-certificate-conf"
       variant="danger"
-      onClick={() => onDeleteCertificate(idxToDelete)}
+      type="submit"
+      form="remove-certificate-form"
       isDisabled={modalSpinning}
       isLoading={modalSpinning}
       spinnerAriaValueText="Deleting"
@@ -614,13 +615,18 @@ const IpaCertificates = (props: PropsToIpaCertificates) => {
         onChange={onChangeTextAreaValue}
         isOpen={isModalOpen}
         onClose={onClickCancel}
+        formId={
+          textareaModalOption === "add" ? "add-certificate-form" : undefined
+        }
+        onSubmit={textareaModalOption === "add" ? onAddCertificate : undefined}
         actions={
           textareaModalOption === "add"
             ? [
                 <SecondaryButton
                   dataCy="modal-button-add"
                   key="add-certificate"
-                  onClickHandler={onAddCertificate}
+                  type="submit"
+                  form="add-certificate-form"
                   isDisabled={modalSpinning}
                   isLoading={modalSpinning}
                   spinnerAriaValueText="Adding"
@@ -681,6 +687,8 @@ const IpaCertificates = (props: PropsToIpaCertificates) => {
         actions={deletionConfModalActions}
         messageText={messageDeletionConf}
         messageObj={messageDeletionObj}
+        formId="remove-certificate-form"
+        onSubmit={() => onDeleteCertificate(idxToDelete)}
       />
       {certificatesList[idxSelected] !== undefined && (
         <>

--- a/src/components/Form/IpaSshPublicKeys/IpaSshPublicKeys.tsx
+++ b/src/components/Form/IpaSshPublicKeys/IpaSshPublicKeys.tsx
@@ -88,7 +88,8 @@ const IpaSshPublicKeys = (props: PropsToSshPublicKeysModal) => {
       data-cy="modal-button-delete"
       key="del-ssh-key"
       variant="danger"
-      onClick={() => onRemoveSSHKey(idxToDelete)}
+      type="submit"
+      form="remove-ssh-public-key-form"
       isDisabled={modalSpinning}
       isLoading={modalSpinning}
       spinnerAriaValueText="Deleting"
@@ -281,11 +282,17 @@ const IpaSshPublicKeys = (props: PropsToSshPublicKeysModal) => {
     setIsTextAreaSshPublicKeysOpen(true);
   };
 
+  const onSshKeyFormSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    onClickSetTextAreaSshPublicKeys();
+  };
+
   const modal_actions = [
     <SecondaryButton
       dataCy="modal-button-set"
       key="set"
-      onClickHandler={onClickSetTextAreaSshPublicKeys}
+      type="submit"
+      form="set-ssh-public-key-form"
       isDisabled={isSetButtonDisabled || modalSpinning}
       isLoading={modalSpinning}
       spinnerAriaValueText="Setting"
@@ -365,7 +372,7 @@ const IpaSshPublicKeys = (props: PropsToSshPublicKeysModal) => {
           labelId="ssh-public-key-title"
         />
         <ModalBody id="modal-box-body-basic">
-          <Form>
+          <Form id="set-ssh-public-key-form" onSubmit={onSshKeyFormSubmit}>
             <FormGroup
               label="SSH public key:"
               type="string"
@@ -406,6 +413,8 @@ const IpaSshPublicKeys = (props: PropsToSshPublicKeysModal) => {
         actions={deletionModalActions}
         messageText={deletionMessage}
         messageObj={deletionMessageObj}
+        formId="remove-ssh-public-key-form"
+        onSubmit={() => onRemoveSSHKey(idxToDelete)}
       />
     </>
   );

--- a/src/components/Form/PrincipalAliasMultiTextBox/PrincipalAliasMultiTextBox.tsx
+++ b/src/components/Form/PrincipalAliasMultiTextBox/PrincipalAliasMultiTextBox.tsx
@@ -150,7 +150,8 @@ const PrincipalAliasMultiTextBox = (props: PrincipalAliasMultiTextBoxProps) => {
       data-cy="modal-button-delete"
       key="del-principal-alias"
       variant="danger"
-      onClick={() => onRemovePrincipalAlias(aliasIdxToDelete)}
+      type="submit"
+      form="remove-kerberos-alias-form"
       isDisabled={modalSpinning}
       isLoading={modalSpinning}
       spinnerAriaValueText="Deleting"
@@ -308,6 +309,8 @@ const PrincipalAliasMultiTextBox = (props: PrincipalAliasMultiTextBoxProps) => {
         actions={deletionConfModalActions}
         messageText={messageDeletionConf}
         messageObj={messageDeletionObj}
+        formId="remove-kerberos-alias-form"
+        onSubmit={() => onRemovePrincipalAlias(aliasIdxToDelete)}
       />
     </>
   );

--- a/src/components/MemberOf/MemberOfAddModal.tsx
+++ b/src/components/MemberOf/MemberOfAddModal.tsx
@@ -103,6 +103,11 @@ const MemberOfAddModal = (props: PropsToAdd) => {
     setChosenOptions([]);
   };
 
+  const onFormSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    onClickAddHandler();
+  };
+
   // Buttons that will be shown at the end of the form
   const modalActions = [
     <Button
@@ -110,8 +115,8 @@ const MemberOfAddModal = (props: PropsToAdd) => {
       key="add-new-user"
       variant="secondary"
       isDisabled={buttonDisabled || props.spinning}
-      form="modal-form"
-      onClick={onClickAddHandler}
+      type="submit"
+      form="is-member-of-add-modal"
       spinnerAriaValueText="Adding"
       spinnerAriaLabel="Adding"
       isLoading={props.spinning}
@@ -140,7 +145,7 @@ const MemberOfAddModal = (props: PropsToAdd) => {
     >
       <ModalHeader title={props.title} labelId="member-of-add-modal-title" />
       <ModalBody id="member-of-add-modal-body">
-        <Form id={"is-member-of-add-modal"}>
+        <Form id={"is-member-of-add-modal"} onSubmit={onFormSubmit}>
           {fields.map((field) => (
             <FormGroup key={field.id} fieldId={field.id}>
               {field.pfComponent}

--- a/src/components/MemberOf/MemberOfDeleteModal.tsx
+++ b/src/components/MemberOf/MemberOfDeleteModal.tsx
@@ -25,13 +25,18 @@ const MemberOfDeleteModal = (props: React.PropsWithChildren<PropsToDelete>) => {
     props.onDelete();
   };
 
+  const onFormSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    onDelete();
+  };
+
   const modalActionsDelete: JSX.Element[] = [
     <Button
       data-cy="modal-button-delete"
       key="delete-groups"
       variant="danger"
-      onClick={onDelete}
-      form="active-users-remove-groups-modal"
+      type="submit"
+      form="is-member-of-delete-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
       isLoading={props.spinning}
@@ -61,7 +66,7 @@ const MemberOfDeleteModal = (props: React.PropsWithChildren<PropsToDelete>) => {
     >
       <ModalHeader title={props.title} labelId="member-of-delete-modal-title" />
       <ModalBody id="member-of-delete-modal-body">
-        <Form id={"is-member-of-delete-modal"}>
+        <Form id={"is-member-of-delete-modal"} onSubmit={onFormSubmit}>
           <FormGroup key={"question-text"} fieldId={"question-text"}>
             <Content component={ContentVariants.p}>
               Are you sure you want to remove the following entries?

--- a/src/components/UsersSections/UsersAccountSettings.tsx
+++ b/src/components/UsersSections/UsersAccountSettings.tsx
@@ -87,7 +87,8 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
     <SecondaryButton
       dataCy="modal-button-add"
       key="add"
-      onClickHandler={onClickAddTextAreaCertificates}
+      type="submit"
+      form="add-user-certificate-form"
     >
       Add
     </SecondaryButton>,
@@ -418,6 +419,8 @@ const UsersAccountSettings = (props: PropsToUsersAccountSettings) => {
         objectName="user"
         ipaObject={ipaObject}
         metadata={props.metadata}
+        formId="add-user-certificate-form"
+        onSubmit={onClickAddTextAreaCertificates}
       />
     </>
   );

--- a/src/components/layouts/DualListLayout/DualListLayout.tsx
+++ b/src/components/layouts/DualListLayout/DualListLayout.tsx
@@ -232,8 +232,8 @@ const DualListTableLayoutInner = (props: DualListProps) => {
       dataCy="modal-button-add"
       key={"dual-list-" + props.target}
       isDisabled={chosenOptions.length === 0 || props.spinning}
-      form="modal-form"
-      onClickHandler={onButtonClick}
+      type="submit"
+      form={"dual-list-" + props.target + "-modal"}
       spinnerAriaValueText={props.addSpinningBtnName}
       spinnerAriaLabel={props.addSpinningBtnName}
       isLoading={props.spinning}
@@ -470,6 +470,7 @@ const DualListTableLayoutInner = (props: DualListProps) => {
       fields={fields}
       show={props.showModal}
       onClose={props.onCloseModal}
+      onSubmit={onButtonClick}
       actions={modalActions}
     />
   );

--- a/src/components/layouts/ModalWithTextAreaLayout.tsx
+++ b/src/components/layouts/ModalWithTextAreaLayout.tsx
@@ -32,9 +32,16 @@ interface PropsToPKModal {
   metadata: Metadata;
   variant?: "default" | "small" | "medium" | "large";
   isTextareaDisabled?: boolean;
+  formId?: string;
+  onSubmit?: (event: React.FormEvent) => void;
 }
 
 const ModalWithTextAreaLayout = (props: PropsToPKModal) => {
+  const onSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    props.onSubmit?.(event);
+  };
+
   return (
     <Modal
       data-cy={props.dataCy + "-modal"}
@@ -44,7 +51,7 @@ const ModalWithTextAreaLayout = (props: PropsToPKModal) => {
     >
       <ModalHeader title={props.title} labelId={props.dataCy} />
       <ModalBody id={props.dataCy + "-modal-body"}>
-        <Form>
+        <Form onSubmit={onSubmit} id={props.formId}>
           <FormGroup
             label={props.subtitle}
             type="string"

--- a/src/components/layouts/SecondaryButton.tsx
+++ b/src/components/layouts/SecondaryButton.tsx
@@ -23,6 +23,7 @@ interface PropsToSecondaryButton {
   spinnerAriaValueText?: string;
   spinnerAriaLabelledBy?: string;
   spinnerAriaLabel?: string;
+  type?: "button" | "submit" | "reset";
 }
 
 const SecondaryButton = (props: PropsToSecondaryButton) => {
@@ -41,6 +42,7 @@ const SecondaryButton = (props: PropsToSecondaryButton) => {
       ouiaId={props.ouijaId}
       ouiaSafe={props.ouijaSafe}
       onClick={props.onClickHandler}
+      type={props.type}
       innerRef={props.innerRef}
       form={props.form}
       isLoading={props.isLoading}

--- a/src/components/modals/AddService.tsx
+++ b/src/components/modals/AddService.tsx
@@ -496,8 +496,8 @@ const AddService = (props: PropsToAddService) => {
       key="add-new-service"
       name="add"
       isDisabled={buttonDisabled || addSpinning}
-      onClick={() => addServiceHandler()}
-      form="modal-form"
+      type="submit"
+      form="add-service-modal"
       spinnerAriaValueText="Adding"
       spinnerAriaLabel="Adding"
       isLoading={addSpinning}
@@ -524,6 +524,7 @@ const AddService = (props: PropsToAddService) => {
         offPosition="76px"
         title="Add service"
         formId="add-service-modal"
+        onSubmit={addServiceHandler}
         fields={fields}
         show={props.show}
         onClose={cleanAndCloseModal}

--- a/src/components/modals/AddTextInputFromListModal.tsx
+++ b/src/components/modals/AddTextInputFromListModal.tsx
@@ -19,6 +19,7 @@ interface PropsToAddModal {
   title: string;
   isOpen: boolean;
   onClose: () => void;
+  onSubmit?: () => void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   actions: any[];
   textInputTitle: string;
@@ -43,7 +44,13 @@ const AddTextInputFromListModal = (props: PropsToAddModal) => {
     >
       <ModalHeader title={props.title} labelId={props.title} />
       <ModalBody id="modal-box-body-basic">
-        <Form>
+        <Form
+          id={props.id + "-form"}
+          onSubmit={(e) => {
+            e.preventDefault();
+            props.onSubmit?.();
+          }}
+        >
           <FormGroup
             label={props.textInputTitle}
             type="string"

--- a/src/components/modals/Automember/AddRule.tsx
+++ b/src/components/modals/Automember/AddRule.tsx
@@ -193,7 +193,8 @@ const AddRule = (props: PropsToAddRule) => {
     <Button
       data-cy={"modal-button-add"}
       key="add"
-      onClick={() => onAdd()}
+      type="submit"
+      form="add-rule-modal"
       isLoading={addSpinning}
       spinnerAriaValueText="Adding"
       spinnerAriaLabel="Adding"
@@ -221,6 +222,7 @@ const AddRule = (props: PropsToAddRule) => {
         offPosition="76px"
         title="Add rule"
         formId="add-rule-modal"
+        onSubmit={() => onAdd()}
         fields={fields}
         show={props.show}
         onClose={cleanAndCloseModal}

--- a/src/components/modals/Automember/DeleteRule.tsx
+++ b/src/components/modals/Automember/DeleteRule.tsx
@@ -135,8 +135,8 @@ const DeleteRule = (props: PropsToDeleteRule) => {
       data-cy="modal-button-delete"
       key="delete-rules"
       variant="danger"
-      onClick={onDelete}
-      form="delete-rules-modal"
+      type="submit"
+      form="remove-rules-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
       isLoading={spinning}
@@ -163,6 +163,7 @@ const DeleteRule = (props: PropsToDeleteRule) => {
         offPosition="76px"
         title="Remove auto membership rules"
         formId="remove-rules-modal"
+        onSubmit={onDelete}
         fields={fields}
         show={props.show}
         onClose={closeModal}

--- a/src/components/modals/CertificateMapping/AddRuleModal.tsx
+++ b/src/components/modals/CertificateMapping/AddRuleModal.tsx
@@ -237,7 +237,6 @@ const AddRuleModal = (props: PropsToAddRuleModal) => {
     <Button
       data-cy="modal-button-add"
       key="add-new"
-      variant="secondary"
       isDisabled={isAddButtonSpinning || ruleName === ""}
       form="add-modal-form"
       type="submit"

--- a/src/components/modals/CertificateMapping/DeleteMultipleRulesModal.tsx
+++ b/src/components/modals/CertificateMapping/DeleteMultipleRulesModal.tsx
@@ -162,8 +162,8 @@ const DeleteMultipleRulesModal = (props: DeleteMultipleRulesModalProps) => {
       data-cy="modal-button-delete"
       key="delete-certmaprules"
       variant="danger"
-      onClick={onDelete}
-      form="delete-certmaprules-modal"
+      type="submit"
+      form="remove-certmaprule-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
       isLoading={spinning}
@@ -191,6 +191,7 @@ const DeleteMultipleRulesModal = (props: DeleteMultipleRulesModalProps) => {
         offPosition="76px"
         title="Remove certificate identity mapping rules"
         formId="remove-certmaprule-modal"
+        onSubmit={onDelete}
         fields={fields}
         show={props.isOpen}
         onClose={props.onClose}

--- a/src/components/modals/CertificateMapping/DeleteRuleModal.tsx
+++ b/src/components/modals/CertificateMapping/DeleteRuleModal.tsx
@@ -68,14 +68,15 @@ const DeleteRuleModal = (props: DeleteRuleModalProps) => {
       data-cy="modal-button-ok"
       variant="danger"
       key={"delete-" + props.ruleId}
-      onClick={onDelete}
+      type="submit"
+      form="delete-certrule-modal"
     >
       Delete
     </Button>,
     <Button
       data-cy="modal-button-cancel"
       key={"cancel-delete-" + props.ruleId}
-      variant="secondary"
+      variant="link"
       onClick={onClose}
     >
       Cancel
@@ -88,6 +89,8 @@ const DeleteRuleModal = (props: DeleteRuleModalProps) => {
       <ConfirmationModal
         dataCy="delete-rule-modal"
         title={"Confirmation"}
+        formId="delete-certrule-modal"
+        onSubmit={onDelete}
         isOpen={props.isOpen}
         onClose={onClose}
         actions={modalActions}

--- a/src/components/modals/CertificateMapping/EnableDisableMultipleRules.tsx
+++ b/src/components/modals/CertificateMapping/EnableDisableMultipleRules.tsx
@@ -74,14 +74,15 @@ const EnableDisableMultipleRulesModal = (
       data-cy="modal-button-ok"
       key={props.operation + "-certmaprules"}
       variant="primary"
-      onClick={onEnableDisable}
+      type="submit"
+      form={props.operation + "-certmaprules-modal"}
     >
       OK
     </Button>,
     <Button
       data-cy="modal-button-cancel"
       key={"cancel-" + props.operation + "-certmaprules"}
-      variant="secondary"
+      variant="link"
       onClick={onCloseWithoutClearingElements}
     >
       Cancel
@@ -94,6 +95,8 @@ const EnableDisableMultipleRulesModal = (
       <ConfirmationModal
         dataCy="enable-disable-multiple-rules-modal"
         title={capitalizeFirstLetter(props.operation) + " confirmation"}
+        formId={props.operation + "-certmaprules-modal"}
+        onSubmit={onEnableDisable}
         isOpen={props.isOpen}
         onClose={onClose}
         actions={modalActions}

--- a/src/components/modals/CertificateMapping/EnableDisableRuleModal.tsx
+++ b/src/components/modals/CertificateMapping/EnableDisableRuleModal.tsx
@@ -70,14 +70,15 @@ const EnableDisableRuleModal = (props: EnableDisableRuleModalProps) => {
       data-cy="modal-button-ok"
       key={props.operation + "-" + props.ruleId}
       variant="primary"
-      onClick={onEnableDisable}
+      type="submit"
+      form={props.operation + "-certrule-modal"}
     >
       OK
     </Button>,
     <Button
       data-cy="modal-button-cancel"
       key={"cancel-" + props.operation + "-" + props.ruleId}
-      variant="secondary"
+      variant="link"
       onClick={onClose}
     >
       Cancel
@@ -90,6 +91,8 @@ const EnableDisableRuleModal = (props: EnableDisableRuleModalProps) => {
       <ConfirmationModal
         dataCy="enable-disable-rule-modal"
         title={"Confirmation"}
+        formId={props.operation + "-certrule-modal"}
+        onSubmit={onEnableDisable}
         isOpen={props.isOpen}
         onClose={onClose}
         actions={modalActions}

--- a/src/components/modals/CertificateModals/RevokeCertificate.tsx
+++ b/src/components/modals/CertificateModals/RevokeCertificate.tsx
@@ -190,7 +190,8 @@ const RevokeCertificate = (props: PropsToRevokeCertificate) => {
     <SecondaryButton
       dataCy="modal-button-revoke"
       key="revoke"
-      onClickHandler={onRevokeCert}
+      type="submit"
+      form="revoke-certificate"
     >
       Revoke
     </SecondaryButton>,
@@ -271,6 +272,7 @@ const RevokeCertificate = (props: PropsToRevokeCertificate) => {
         modalPosition="top"
         title={"Certificate for " + certName}
         formId={"revoke-certificate"}
+        onSubmit={onRevokeCert}
         fields={fields}
         show={props.isOpen}
         onClose={props.onClose}

--- a/src/components/modals/ConfirmationModal.tsx
+++ b/src/components/modals/ConfirmationModal.tsx
@@ -19,9 +19,16 @@ interface PropsToConfModal {
   actions: JSX.Element[];
   messageText: string;
   messageObj: string;
+  formId?: string;
+  onSubmit?: (event: React.FormEvent) => void;
 }
 
 const ConfirmationModal = (props: PropsToConfModal) => {
+  const onSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    props.onSubmit?.(event);
+  };
+
   return (
     <Modal
       data-cy={props.dataCy}
@@ -31,10 +38,12 @@ const ConfirmationModal = (props: PropsToConfModal) => {
     >
       <ModalHeader title={props.title} labelId="confirmation-modal-title" />
       <ModalBody id="confirmation-modal-body">
-        <Content component="p">{props.messageText}</Content>
-        <Card className="pf-v6-u-mt-md" isCompact>
-          <CardTitle>{props.messageObj}</CardTitle>
-        </Card>
+        <form onSubmit={onSubmit} id={props.formId}>
+          <Content component="p">{props.messageText}</Content>
+          <Card className="pf-v6-u-mt-md" isCompact>
+            <CardTitle>{props.messageObj}</CardTitle>
+          </Card>
+        </form>
       </ModalBody>
       <ModalFooter>{props.actions}</ModalFooter>
     </Modal>

--- a/src/components/modals/DeleteHostGroups.tsx
+++ b/src/components/modals/DeleteHostGroups.tsx
@@ -179,8 +179,8 @@ const DeleteHostGroups = (props: PropsToDeleteGroups) => {
       data-cy="modal-button-delete"
       key="delete-hostgroups"
       variant="danger"
-      onClick={deleteGroups}
-      form="delete-hostgroups-modal"
+      type="submit"
+      form="remove-hostgroups-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
       isLoading={spinning}
@@ -207,6 +207,7 @@ const DeleteHostGroups = (props: PropsToDeleteGroups) => {
         offPosition="76px"
         title="Remove host groups"
         formId="remove-hostgroups-modal"
+        onSubmit={deleteGroups}
         fields={fields}
         show={props.show}
         onClose={closeModal}

--- a/src/components/modals/DeleteIDViews.tsx
+++ b/src/components/modals/DeleteIDViews.tsx
@@ -179,8 +179,8 @@ const DeleteIDViewsModal = (props: PropsToDeleteViews) => {
       data-cy="modal-button-delete"
       key="delete-id-views"
       variant="danger"
-      onClick={deleteViews}
-      form="delete-id-views-modal"
+      type="submit"
+      form="remove-id-views-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
       isLoading={spinning}
@@ -207,6 +207,7 @@ const DeleteIDViewsModal = (props: PropsToDeleteViews) => {
         offPosition="76px"
         title="Remove ID views"
         formId="remove-id-views-modal"
+        onSubmit={deleteViews}
         fields={fields}
         show={props.show}
         onClose={closeModal}

--- a/src/components/modals/DeleteNetgroups.tsx
+++ b/src/components/modals/DeleteNetgroups.tsx
@@ -179,8 +179,8 @@ const DeleteNetgroups = (props: PropsToDeleteGroups) => {
       data-cy="modal-button-delete"
       key="delete-netgroups"
       variant="danger"
-      onClick={deleteGroups}
-      form="delete-netgroups-modal"
+      type="submit"
+      form="remove-netgroups-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
       isLoading={spinning}
@@ -207,6 +207,7 @@ const DeleteNetgroups = (props: PropsToDeleteGroups) => {
         offPosition="76px"
         title="Remove netgroups"
         formId="remove-netgroups-modal"
+        onSubmit={deleteGroups}
         fields={fields}
         show={props.show}
         onClose={closeModal}

--- a/src/components/modals/DeleteServices.tsx
+++ b/src/components/modals/DeleteServices.tsx
@@ -179,8 +179,8 @@ const DeleteServices = (props: PropsToDeleteServices) => {
       data-cy="modal-button-delete"
       key="delete-services"
       variant="danger"
-      onClick={deleteServices}
-      form="delete-services-modal"
+      type="submit"
+      form="remove-services-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
       isLoading={spinning}
@@ -207,6 +207,7 @@ const DeleteServices = (props: PropsToDeleteServices) => {
         offPosition="76px"
         title="Remove services"
         formId="remove-services-modal"
+        onSubmit={deleteServices}
         fields={fields}
         show={props.show}
         onClose={closeModal}

--- a/src/components/modals/DeleteUserGroups.tsx
+++ b/src/components/modals/DeleteUserGroups.tsx
@@ -179,8 +179,8 @@ const DeleteUserGroups = (props: PropsToDeleteGroups) => {
       data-cy="modal-button-delete"
       key="delete-usergroups"
       variant="danger"
-      onClick={deleteGroups}
-      form="delete-user-groups-modal"
+      type="submit"
+      form="remove-user-groups-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
       isLoading={spinning}
@@ -207,6 +207,7 @@ const DeleteUserGroups = (props: PropsToDeleteGroups) => {
         offPosition="76px"
         title="Remove user groups"
         formId="remove-user-groups-modal"
+        onSubmit={deleteGroups}
         fields={fields}
         show={props.show}
         onClose={closeModal}

--- a/src/components/modals/DnsZones/AddDnsForwardZoneModal.tsx
+++ b/src/components/modals/DnsZones/AddDnsForwardZoneModal.tsx
@@ -113,9 +113,15 @@ const AddDnsForwardZoneModalInner = (props: PropsToAddModal) => {
       });
   };
 
+  const onFormSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    setIsAddButtonSpinning(true);
+    onAddDnsForwardZone();
+  };
+
   // Form fields
   const formFields = (
-    <Form id="add-dns-forward-zone-modal-form">
+    <Form onSubmit={onFormSubmit} id="add-dns-forward-zone-modal-form">
       <Flex
         direction={{ default: "column" }}
         className="pf-v6-u-ml-lg pf-v6-u-mb-md"
@@ -262,11 +268,6 @@ const AddDnsForwardZoneModalInner = (props: PropsToAddModal) => {
         (isReverseZoneIpRadioChecked && reverseZoneIP === "")
       }
       form="add-dns-forward-zone-modal-form"
-      onClick={(e) => {
-        e.preventDefault();
-        setIsAddButtonSpinning(true);
-        onAddDnsForwardZone();
-      }}
     >
       {isAddButtonSpinning ? (
         <>

--- a/src/components/modals/DnsZones/AddDnsRecordsModal.tsx
+++ b/src/components/modals/DnsZones/AddDnsRecordsModal.tsx
@@ -411,9 +411,14 @@ const AddDnsRecordsModal = (props: PropsToAddModal) => {
     ));
   };
 
+  const onFormSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    onAddOperation();
+  };
+
   // Form fields
   const formFields = (
-    <Form>
+    <Form onSubmit={onFormSubmit} id="add-dns-records-modal-form">
       <FormGroup label="Record name" isRequired>
         <TextInput
           value={basicFormValues.recordName}
@@ -487,9 +492,9 @@ const AddDnsRecordsModal = (props: PropsToAddModal) => {
     <Button
       key="add-new"
       variant="secondary"
+      type="submit"
       isDisabled={isAddButtonSpinning || !areMandatoryFieldsFilled}
-      form="add-modal-form"
-      onClick={() => onAddOperation()}
+      form="add-dns-records-modal-form"
       data-cy={"add-dns-records-modal-add-button"}
     >
       {isAddButtonSpinning ? (

--- a/src/components/modals/DnsZones/AddDnsZoneModal.tsx
+++ b/src/components/modals/DnsZones/AddDnsZoneModal.tsx
@@ -122,9 +122,14 @@ const AddDnsZoneModal = (props: PropsToAddModal) => {
   const zoneNameLabel = <b>Zone name</b>;
   const reverseZoneLabel = <b>Reverse zone</b>;
 
+  const onFormSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    onAddDnsZone();
+  };
+
   // Form fields
   const formFields = (
-    <Form id="add-modal-form-zone-name">
+    <Form onSubmit={onFormSubmit} id="add-modal-form-zone-name">
       <Flex
         direction={{ default: "column" }}
         className="pf-v6-u-ml-lg pf-v6-u-mb-md"
@@ -221,15 +226,13 @@ const AddDnsZoneModal = (props: PropsToAddModal) => {
     <Button
       data-cy="modal-button-add"
       key="add-new"
+      type="submit"
       isDisabled={
         isAddButtonSpinning ||
         (isZoneNameRadioChecked && dnsZoneName === "") ||
         (isReverseZoneIpRadioChecked && reverseZoneIp === "")
       }
-      form="add-modal-form"
-      onClick={() => {
-        onAddDnsZone();
-      }}
+      form="add-modal-form-zone-name"
     >
       {isAddButtonSpinning ? (
         <>

--- a/src/components/modals/DnsZones/AddRemovePermission.tsx
+++ b/src/components/modals/DnsZones/AddRemovePermission.tsx
@@ -72,7 +72,8 @@ const AddRemovePermission = (props: AddRemovePermissionProps) => {
       data-cy="modal-button-ok"
       key={"delete-" + props.dnsZoneId}
       variant="primary"
-      onClick={onAddRemovePermission}
+      type="submit"
+      form="add-remove-permission-modal"
     >
       OK
     </Button>,
@@ -95,6 +96,8 @@ const AddRemovePermission = (props: AddRemovePermissionProps) => {
         isOpen={props.isOpen}
         onClose={props.onClose}
         actions={modalActions}
+        formId="add-remove-permission-modal"
+        onSubmit={onAddRemovePermission}
         messageText={
           "Are you sure you want to " +
           props.operation +

--- a/src/components/modals/DnsZones/DeleteDnsForwardZonesModal.tsx
+++ b/src/components/modals/DnsZones/DeleteDnsForwardZonesModal.tsx
@@ -178,11 +178,8 @@ const DeleteDnsForwardZonesModal = (props: DeleteDnsForwardZonesModalProps) => {
       data-cy="modal-button-delete"
       key="delete-dnsforwardzones"
       variant="danger"
-      onClick={(e) => {
-        e.preventDefault();
-        onDelete();
-      }}
-      form="delete-dnsforwardzones-modal"
+      type="submit"
+      form="remove-dnsforwardzones-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
       isLoading={spinning}
@@ -220,6 +217,7 @@ const DeleteDnsForwardZonesModal = (props: DeleteDnsForwardZonesModalProps) => {
         fields={fields}
         show={props.isOpen}
         onClose={props.onClose}
+        onSubmit={onDelete}
         actions={modalActions}
       />
       {isModalErrorOpen && (

--- a/src/components/modals/DnsZones/DeleteDnsRecords.tsx
+++ b/src/components/modals/DnsZones/DeleteDnsRecords.tsx
@@ -244,7 +244,8 @@ const DeleteDnsRecordsModal = (props: DeleteDnsRecordsModalProps) => {
     <Button
       key="delete"
       variant="danger"
-      onClick={onDelete}
+      type="submit"
+      form="remove-dnsrecords-modal"
       isDisabled={spinning}
       data-cy="modal-button-delete"
     >
@@ -271,6 +272,7 @@ const DeleteDnsRecordsModal = (props: DeleteDnsRecordsModalProps) => {
         fields={fields}
         show={props.isOpen}
         onClose={props.onClose}
+        onSubmit={onDelete}
         actions={modalActions}
         dataCy="modal-delete-dns-records"
       />

--- a/src/components/modals/DnsZones/DeleteDnsZonesModal.tsx
+++ b/src/components/modals/DnsZones/DeleteDnsZonesModal.tsx
@@ -175,8 +175,8 @@ const DeleteDnsZonesModal = (props: DeleteDnsZonesModalProps) => {
       data-cy="modal-button-ok"
       key="delete-dnszones"
       variant="danger"
-      onClick={onDelete}
-      form="delete-dnszones-modal"
+      type="submit"
+      form="remove-dnszones-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
       isLoading={spinning}
@@ -214,6 +214,7 @@ const DeleteDnsZonesModal = (props: DeleteDnsZonesModalProps) => {
         fields={fields}
         show={props.isOpen}
         onClose={props.onClose}
+        onSubmit={onDelete}
         actions={modalActions}
       />
       {isModalErrorOpen && (

--- a/src/components/modals/DnsZones/EditDnsRecordModal.tsx
+++ b/src/components/modals/DnsZones/EditDnsRecordModal.tsx
@@ -306,9 +306,14 @@ const EditDnsRecordModal = (props: EditDnsRecordModalProps) => {
       ));
   };
 
+  const onFormSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    onSave();
+  };
+
   // Form fields
   const formFields = (
-    <Form>
+    <Form onSubmit={onFormSubmit} id="edit-dns-record-modal-form">
       <FormGroup label="Record name" isRequired>
         <TextInput
           value={props.recordName}
@@ -338,8 +343,9 @@ const EditDnsRecordModal = (props: EditDnsRecordModalProps) => {
     <Button
       key="save"
       variant="primary"
+      type="submit"
       isDisabled={isSaveButtonSpinning || !areMandatoryFieldsFilled}
-      onClick={onSave}
+      form="edit-dns-record-modal-form"
       data-cy="edit-dns-record-modal-save-button"
     >
       {isSaveButtonSpinning ? (

--- a/src/components/modals/DnsZones/EnableDisableDnsForwardZonesModal.tsx
+++ b/src/components/modals/DnsZones/EnableDisableDnsForwardZonesModal.tsx
@@ -77,10 +77,8 @@ const EnableDisableDnsForwardZonesModal = (
       data-cy={"modal-button-" + props.operation}
       key={props.operation + "-dnsforwardzones"}
       variant="primary"
-      onClick={(e) => {
-        e.preventDefault();
-        onEnableDisable();
-      }}
+      type="submit"
+      form="enable-disable-dns-forward-zones-modal"
     >
       OK
     </Button>,
@@ -102,6 +100,8 @@ const EnableDisableDnsForwardZonesModal = (
       isOpen={props.isOpen}
       onClose={onClose}
       actions={modalActions}
+      formId="enable-disable-dns-forward-zones-modal"
+      onSubmit={onEnableDisable}
       messageText={
         "Are you sure you want to " +
         props.operation +

--- a/src/components/modals/DnsZones/EnableDisableDnsZonesModal.tsx
+++ b/src/components/modals/DnsZones/EnableDisableDnsZonesModal.tsx
@@ -77,7 +77,8 @@ const EnableDisableDnsZonesModal = (props: EnableDisableDnsZonesModalProps) => {
       data-cy="modal-button-ok"
       key={props.operation + "-dnszones"}
       variant="primary"
-      onClick={onEnableDisable}
+      type="submit"
+      form="enable-disable-dns-zones-modal"
     >
       OK
     </Button>,
@@ -100,6 +101,8 @@ const EnableDisableDnsZonesModal = (props: EnableDisableDnsZonesModalProps) => {
         isOpen={props.isOpen}
         onClose={onClose}
         actions={modalActions}
+        formId="enable-disable-dns-zones-modal"
+        onSubmit={onEnableDisable}
         messageText={
           "Are you sure you want to " +
           props.operation +

--- a/src/components/modals/HbacModals/DeleteHBACRule.tsx
+++ b/src/components/modals/HbacModals/DeleteHBACRule.tsx
@@ -178,8 +178,8 @@ const DeleteHBACRule = (props: PropsToDeleteRules) => {
     <Button
       key="delete-hbacrules"
       variant="danger"
-      onClick={deleteRules}
-      form="delete-hbacrules-modal"
+      type="submit"
+      form="remove-hbacrules-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
       isLoading={spinning}
@@ -210,6 +210,7 @@ const DeleteHBACRule = (props: PropsToDeleteRules) => {
         fields={fields}
         show={props.show}
         onClose={closeModal}
+        onSubmit={deleteRules}
         actions={modalActionsDelete}
       />
       {isModalErrorOpen && (

--- a/src/components/modals/HbacModals/DeleteHBACService.tsx
+++ b/src/components/modals/HbacModals/DeleteHBACService.tsx
@@ -178,8 +178,8 @@ const DeleteHBACService = (props: PropsToDeleteServices) => {
     <Button
       key="delete-hbacservices"
       variant="danger"
-      onClick={deleteServices}
-      form="delete-hbacservices-modal"
+      type="submit"
+      form="remove-hbacservices-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
       isLoading={spinning}
@@ -210,6 +210,7 @@ const DeleteHBACService = (props: PropsToDeleteServices) => {
         fields={fields}
         show={props.show}
         onClose={closeModal}
+        onSubmit={deleteServices}
         actions={modalActionsDelete}
       />
       {isModalErrorOpen && (

--- a/src/components/modals/HbacModals/DeleteHBACServiceGroup.tsx
+++ b/src/components/modals/HbacModals/DeleteHBACServiceGroup.tsx
@@ -181,8 +181,8 @@ const DeleteHBACServiceGroup = (props: PropsToDeleteServices) => {
     <Button
       key="delete-hbacservicegroups"
       variant="danger"
-      onClick={deleteServices}
-      form="delete-hbacservicegroups-modal"
+      type="submit"
+      form="remove-hbacservicesgroup-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
       isLoading={spinning}
@@ -213,6 +213,7 @@ const DeleteHBACServiceGroup = (props: PropsToDeleteServices) => {
         fields={fields}
         show={props.show}
         onClose={closeModal}
+        onSubmit={deleteServices}
         actions={modalActionsDelete}
       />
       {isModalErrorOpen && (

--- a/src/components/modals/HbacModals/DisableEnableHBACRules.tsx
+++ b/src/components/modals/HbacModals/DisableEnableHBACRules.tsx
@@ -270,12 +270,7 @@ const DisableEnableHBACRules = (props: PropsToDisableEnableHBACRules) => {
     <Button
       key="disable-hbacrules"
       variant="primary"
-      onClick={() =>
-        modifyStatus(
-          props.optionSelected,
-          props.selectedRulesData.selectedRules
-        )
-      }
+      type="submit"
       form="hbacrules-enable-disable-hbacrules-modal"
       data-cy="modal-button-disable"
     >
@@ -302,6 +297,12 @@ const DisableEnableHBACRules = (props: PropsToDisableEnableHBACRules) => {
       fields={fields}
       show={props.show}
       onClose={closeModal}
+      onSubmit={() =>
+        modifyStatus(
+          props.optionSelected,
+          props.selectedRulesData.selectedRules
+        )
+      }
       actions={modalActionsDisable}
     />
   );
@@ -311,12 +312,7 @@ const DisableEnableHBACRules = (props: PropsToDisableEnableHBACRules) => {
     <Button
       key="enable-hbacrules"
       variant="primary"
-      onClick={() =>
-        modifyStatus(
-          props.optionSelected,
-          props.selectedRulesData.selectedRules
-        )
-      }
+      type="submit"
       form="hbacrules-enable-disable-hbacrules-modal"
       data-cy="modal-button-enable"
     >
@@ -343,6 +339,12 @@ const DisableEnableHBACRules = (props: PropsToDisableEnableHBACRules) => {
       fields={fields}
       show={props.show}
       onClose={closeModal}
+      onSubmit={() =>
+        modifyStatus(
+          props.optionSelected,
+          props.selectedRulesData.selectedRules
+        )
+      }
       actions={modalActionsEnable}
     />
   );

--- a/src/components/modals/HostModals/DeleteHosts.tsx
+++ b/src/components/modals/HostModals/DeleteHosts.tsx
@@ -196,8 +196,8 @@ const DeleteHosts = (props: PropsToDeleteHosts) => {
       data-cy="modal-button-delete"
       key="delete-hosts"
       variant="danger"
-      onClick={deleteHosts}
-      form="delete-hosts-modal"
+      type="submit"
+      form="remove-hosts-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
       isLoading={spinning}
@@ -227,6 +227,7 @@ const DeleteHosts = (props: PropsToDeleteHosts) => {
         fields={fields}
         show={props.show}
         onClose={closeModal}
+        onSubmit={deleteHosts}
         actions={modalActionsDelete}
       />
       {isModalErrorOpen && (

--- a/src/components/modals/IdOverrideModals/DeleteIdOverrideGroups.tsx
+++ b/src/components/modals/IdOverrideModals/DeleteIdOverrideGroups.tsx
@@ -174,8 +174,8 @@ const DeleteIdOverrideGroupsModal = (props: PropsToDelete) => {
       data-cy="modal-button-delete"
       key="delete-id-override"
       variant="danger"
-      onClick={deleteViews}
-      form="delete-id-voverride-modal"
+      type="submit"
+      form="remove-id-override-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
       isLoading={spinning}
@@ -205,6 +205,7 @@ const DeleteIdOverrideGroupsModal = (props: PropsToDelete) => {
         fields={fields}
         show={props.show}
         onClose={closeModal}
+        onSubmit={deleteViews}
         actions={modalActionsDelete}
       />
       {isModalErrorOpen && (

--- a/src/components/modals/IdOverrideModals/DeleteIdOverrideUsers.tsx
+++ b/src/components/modals/IdOverrideModals/DeleteIdOverrideUsers.tsx
@@ -174,8 +174,8 @@ const DeleteIdOverrideUsersModal = (props: PropsToDelete) => {
       data-cy="modal-button-delete"
       key="delete-id-override"
       variant="danger"
-      onClick={deleteViews}
-      form="delete-id-voverride-modal"
+      type="submit"
+      form="remove-id-override-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
       isLoading={spinning}
@@ -205,6 +205,7 @@ const DeleteIdOverrideUsersModal = (props: PropsToDelete) => {
         fields={fields}
         show={props.show}
         onClose={closeModal}
+        onSubmit={deleteViews}
         actions={modalActionsDelete}
       />
       {isModalErrorOpen && (

--- a/src/components/modals/IdRanges/AddIdRangeModal.tsx
+++ b/src/components/modals/IdRanges/AddIdRangeModal.tsx
@@ -365,7 +365,7 @@ const AddIdRangeModal = (props: PropsToAddModal) => {
       key="add-new"
       name="add"
       isDisabled={disabledAdd || isAddButtonSpinning}
-      onClick={() => onAdd()}
+      type="submit"
       form="add-id-range-modal"
       spinnerAriaValueText="Adding"
       spinnerAriaLabel="Adding"
@@ -394,6 +394,7 @@ const AddIdRangeModal = (props: PropsToAddModal) => {
       fields={fields}
       show={props.isOpen}
       onClose={cleanAndClose}
+      onSubmit={() => onAdd()}
       actions={modalActions}
     />
   );

--- a/src/components/modals/IdRanges/DeleteModal.tsx
+++ b/src/components/modals/IdRanges/DeleteModal.tsx
@@ -171,8 +171,8 @@ const DeleteModal = (props: PropsToDelete) => {
       data-cy="modal-button-delete"
       key="delete-idranges"
       variant="danger"
-      onClick={deleteRanges}
-      form="delete-idranges-modal"
+      type="submit"
+      form="remove-idranges-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
       isLoading={spinning}
@@ -202,6 +202,7 @@ const DeleteModal = (props: PropsToDelete) => {
         fields={fields}
         show={props.show}
         onClose={props.onClose}
+        onSubmit={deleteRanges}
         actions={modalActionsDelete}
       />
       {isModalErrorOpen && (

--- a/src/components/modals/IdpReferences/DeleteModal.tsx
+++ b/src/components/modals/IdpReferences/DeleteModal.tsx
@@ -173,8 +173,8 @@ const DeleteModal = (props: PropsToDelete) => {
       data-cy="modal-button-delete"
       key="delete-idpreferences"
       variant="danger"
-      onClick={deleteIdpReferences}
-      form="delete-idpreferences-modal"
+      type="submit"
+      form="remove-idpreferences-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
       isLoading={spinning}
@@ -204,6 +204,7 @@ const DeleteModal = (props: PropsToDelete) => {
         fields={fields}
         show={props.show}
         onClose={props.onClose}
+        onSubmit={deleteIdpReferences}
         actions={modalActionsDelete}
       />
       {isModalErrorOpen && (

--- a/src/components/modals/KeytabElementsDeleteModal.tsx
+++ b/src/components/modals/KeytabElementsDeleteModal.tsx
@@ -81,8 +81,10 @@ const KeytabElementsDeleteModal = (props: PropsToDelete) => {
       data-cy="modal-button-delete"
       variant="danger"
       key={"delete-" + props.elementType}
-      form="modal-form"
-      onClick={removeElementFromList}
+      type="submit"
+      form={
+        props.operationType + "-keytab-" + props.elementType + "s-delete-modal"
+      }
     >
       Delete
     </Button>,
@@ -113,6 +115,7 @@ const KeytabElementsDeleteModal = (props: PropsToDelete) => {
       formId={
         props.operationType + "-keytab-" + props.elementType + "s-delete-modal"
       }
+      onSubmit={removeElementFromList}
       fields={fields}
       show={props.showModal}
       onClose={closeModal}

--- a/src/components/modals/PrivilegeModals/DeletePrivilegesModal.tsx
+++ b/src/components/modals/PrivilegeModals/DeletePrivilegesModal.tsx
@@ -141,7 +141,7 @@ const DeletePrivilegesModal = (props: DeletePrivilegesModalProps) => {
     <Button
       key="delete-privileges"
       variant="danger"
-      onClick={onDeletePrivileges}
+      type="submit"
       form="delete-privileges-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
@@ -185,6 +185,7 @@ const DeletePrivilegesModal = (props: DeletePrivilegesModalProps) => {
         fields={fields}
         show={props.isOpen}
         onClose={props.onClose}
+        onSubmit={onDeletePrivileges}
         actions={modalActions}
       />
       {isModalErrorOpen && (

--- a/src/components/modals/PwPoliciesModals/DeleteModal.tsx
+++ b/src/components/modals/PwPoliciesModals/DeleteModal.tsx
@@ -172,8 +172,8 @@ const DeleteModal = (props: PropsToDelete) => {
       data-cy="modal-button-delete"
       key="delete-pwpolicies"
       variant="danger"
-      onClick={deletePasswordPolicies}
-      form="delete-pwpolicies-modal"
+      type="submit"
+      form="remove-pwpolicies-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
       isLoading={spinning}
@@ -203,6 +203,7 @@ const DeleteModal = (props: PropsToDelete) => {
         fields={fields}
         show={props.show}
         onClose={props.onClose}
+        onSubmit={deletePasswordPolicies}
         actions={modalActionsDelete}
       />
       {isModalErrorOpen && (

--- a/src/components/modals/RebuildAutoMembership.tsx
+++ b/src/components/modals/RebuildAutoMembership.tsx
@@ -78,7 +78,7 @@ const RebuildAutoMembership = (props: PropsToRebuildAutoMembership) => {
       data-cy="modal-button-ok"
       key="rebuild-auto-membership"
       variant="primary"
-      onClick={onRebuildAutoMembership}
+      type="submit"
       form="rebuild-auto-membership-modal"
     >
       OK
@@ -119,6 +119,7 @@ const RebuildAutoMembership = (props: PropsToRebuildAutoMembership) => {
         offPosition="76px"
         title="Confirmation"
         formId="rebuild-auto-membership-modal"
+        onSubmit={onRebuildAutoMembership}
         fields={confirmationQuestion}
         show={props.isOpen}
         onClose={props.onClose}

--- a/src/components/modals/RemoveNetgroupMembers.tsx
+++ b/src/components/modals/RemoveNetgroupMembers.tsx
@@ -49,8 +49,8 @@ const RemoveNetgroupMembersModal = (props: PropsToDelete) => {
       variant="danger"
       data-cy="modal-button-delete"
       key={"delete-" + props.elementType}
-      form="modal-form"
-      onClick={() => props.removeMembers(props.elementsToDelete)}
+      type="submit"
+      form={props.elementType + "-delete-modal"}
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
       isLoading={props.spinning}
@@ -76,6 +76,7 @@ const RemoveNetgroupMembersModal = (props: PropsToDelete) => {
       modalPosition="top"
       title={"Remove " + label.toLowerCase() + "s from Netgroup"}
       formId={props.elementType + "-delete-modal"}
+      onSubmit={() => props.removeMembers(props.elementsToDelete)}
       fields={fields}
       show={props.showModal}
       onClose={props.closeModal}

--- a/src/components/modals/RoleModals/DeleteRolesModal.tsx
+++ b/src/components/modals/RoleModals/DeleteRolesModal.tsx
@@ -141,7 +141,7 @@ const DeleteRolesModal = (props: DeleteRolesModalProps) => {
     <Button
       key="delete-roles"
       variant="danger"
-      onClick={onDeleteRoles}
+      type="submit"
       form="delete-roles-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
@@ -185,6 +185,7 @@ const DeleteRolesModal = (props: DeleteRolesModalProps) => {
         fields={fields}
         show={props.isOpen}
         onClose={props.onClose}
+        onSubmit={onDeleteRoles}
         actions={modalActions}
       />
       {isModalErrorOpen && (

--- a/src/components/modals/SelinuxUserMapModals/AddSelinuxUserMapModal.tsx
+++ b/src/components/modals/SelinuxUserMapModals/AddSelinuxUserMapModal.tsx
@@ -147,7 +147,8 @@ const AddSelinuxUserMapModal = (props: PropsToAddSelinuxUserMapModal) => {
       key="add-new-selinux-user-map"
       isDisabled={buttonDisabled || isAddButtonSpinning}
       isLoading={isAddButtonSpinning}
-      onClick={onAdd}
+      type="submit"
+      form="add-selinux-user-map-modal"
     >
       Add
     </Button>,

--- a/src/components/modals/SelinuxUserMapModals/DeleteSelinuxUserMapsModal.tsx
+++ b/src/components/modals/SelinuxUserMapModals/DeleteSelinuxUserMapsModal.tsx
@@ -124,8 +124,8 @@ const DeleteSelinuxUserMapsModal = (props: DeleteSelinuxUserMapsModalProps) => {
       data-cy="modal-button-ok"
       key="delete-selinux-user-maps"
       variant="danger"
-      onClick={onDelete}
-      form="delete-selinux-user-maps-modal"
+      type="submit"
+      form="remove-selinux-user-maps-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
       isLoading={spinning}
@@ -162,6 +162,7 @@ const DeleteSelinuxUserMapsModal = (props: DeleteSelinuxUserMapsModalProps) => {
         fields={fields}
         show={props.isOpen}
         onClose={props.onClose}
+        onSubmit={onDelete}
         actions={modalActionsDelete}
       />
       {ErrorModalComponent}

--- a/src/components/modals/SelinuxUserMapModals/EnableDisableSelinuxUserMapsModal.tsx
+++ b/src/components/modals/SelinuxUserMapModals/EnableDisableSelinuxUserMapsModal.tsx
@@ -75,7 +75,8 @@ const EnableDisableSelinuxUserMapsModal = (
       data-cy="modal-button-ok"
       key={props.operation + "-selinux-user-maps"}
       variant="primary"
-      onClick={onEnableDisable}
+      type="submit"
+      form="selinux-user-maps-enable-disable-modal"
     >
       OK
     </Button>,
@@ -95,6 +96,8 @@ const EnableDisableSelinuxUserMapsModal = (
       title={capitalizeFirstLetter(props.operation) + " confirmation"}
       isOpen={props.isOpen}
       onClose={onClose}
+      formId="selinux-user-maps-enable-disable-modal"
+      onSubmit={onEnableDisable}
       actions={modalActions}
       messageText={
         "Are you sure you want to " +

--- a/src/components/modals/SubIdsModals/AddModal.tsx
+++ b/src/components/modals/SubIdsModals/AddModal.tsx
@@ -189,10 +189,8 @@ const AddModal = (props: PropsToAddModal) => {
       data-cy="modal-button-add"
       key="add-new"
       isDisabled={isAddButtonSpinning || selectedItem === ""}
+      type="submit"
       form="add-modal-form"
-      onClick={() => {
-        onAdd();
-      }}
     >
       Add
     </Button>,
@@ -219,6 +217,7 @@ const AddModal = (props: PropsToAddModal) => {
         fields={fields}
         show={props.isOpen}
         onClose={cleanAndCloseModal}
+        onSubmit={() => onAdd()}
         actions={modalActions}
       />
     </>

--- a/src/components/modals/SudoModals/DeleteSudoCmd.tsx
+++ b/src/components/modals/SudoModals/DeleteSudoCmd.tsx
@@ -178,8 +178,8 @@ const DeleteSudoCmd = (props: PropsToDeleteRules) => {
     <Button
       key="delete-sudo-commands"
       variant="danger"
-      onClick={deleteRules}
-      form="delete-sudo-commands-modal"
+      type="submit"
+      form="remove-sudo-commands-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
       isLoading={spinning}
@@ -210,6 +210,7 @@ const DeleteSudoCmd = (props: PropsToDeleteRules) => {
         fields={fields}
         show={props.show}
         onClose={closeModal}
+        onSubmit={deleteRules}
         actions={modalActionsDelete}
       />
       {isModalErrorOpen && (

--- a/src/components/modals/SudoModals/DeleteSudoCmdGroups.tsx
+++ b/src/components/modals/SudoModals/DeleteSudoCmdGroups.tsx
@@ -179,8 +179,8 @@ const DeleteSudoCmdGroups = (props: PropsToDeleteRules) => {
       data-cy="modal-button-delete"
       key="delete-sudo-command-groups"
       variant="danger"
-      onClick={deleteRules}
-      form="delete-sudo-command-groups-modal"
+      type="submit"
+      form="remove-sudo-command-groups-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
       isLoading={spinning}
@@ -210,6 +210,7 @@ const DeleteSudoCmdGroups = (props: PropsToDeleteRules) => {
         fields={fields}
         show={props.show}
         onClose={closeModal}
+        onSubmit={deleteRules}
         actions={modalActionsDelete}
       />
       {isModalErrorOpen && (

--- a/src/components/modals/SudoModals/DeleteSudoRule.tsx
+++ b/src/components/modals/SudoModals/DeleteSudoRule.tsx
@@ -186,8 +186,8 @@ const DeleteSudoRule = (props: PropsToDeleteRules) => {
       data-cy="modal-button-delete"
       key="delete-sudorules"
       variant="danger"
-      onClick={deleteRules}
-      form="delete-sudorules-modal"
+      type="submit"
+      form="remove-sudorules-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
       isLoading={spinning}
@@ -217,6 +217,7 @@ const DeleteSudoRule = (props: PropsToDeleteRules) => {
         fields={fields}
         show={props.show}
         onClose={closeModal}
+        onSubmit={deleteRules}
         actions={modalActionsDelete}
       />
       {isModalErrorOpen && (

--- a/src/components/modals/SudoModals/DisableEnableSudoRules.tsx
+++ b/src/components/modals/SudoModals/DisableEnableSudoRules.tsx
@@ -273,12 +273,7 @@ const DisableEnableSudoRules = (props: PropsToDisableEnableRules) => {
       data-cy="modal-button-disable"
       key="disable-sudorules"
       variant="primary"
-      onClick={() =>
-        modifyStatus(
-          props.optionSelected,
-          props.selectedRulesData.selectedRules
-        )
-      }
+      type="submit"
       form="sudorules-enable-disable-modal"
     >
       Disable
@@ -304,6 +299,12 @@ const DisableEnableSudoRules = (props: PropsToDisableEnableRules) => {
       fields={fields}
       show={props.show}
       onClose={closeModal}
+      onSubmit={() =>
+        modifyStatus(
+          props.optionSelected,
+          props.selectedRulesData.selectedRules
+        )
+      }
       actions={modalActionsDisable}
     />
   );
@@ -314,12 +315,7 @@ const DisableEnableSudoRules = (props: PropsToDisableEnableRules) => {
       data-cy="modal-button-enable"
       key="enable-sudorules"
       variant="primary"
-      onClick={() =>
-        modifyStatus(
-          props.optionSelected,
-          props.selectedRulesData.selectedRules
-        )
-      }
+      type="submit"
       form="sudorules-enable-disable-modal"
     >
       Enable
@@ -345,6 +341,12 @@ const DisableEnableSudoRules = (props: PropsToDisableEnableRules) => {
       fields={fields}
       show={props.show}
       onClose={closeModal}
+      onSubmit={() =>
+        modifyStatus(
+          props.optionSelected,
+          props.selectedRulesData.selectedRules
+        )
+      }
       actions={modalActionsEnable}
     />
   );

--- a/src/components/modals/UserModals/ActivateStageUsers.tsx
+++ b/src/components/modals/UserModals/ActivateStageUsers.tsx
@@ -112,8 +112,8 @@ const ActivateStageUsers = (props: PropsToActivateUsers) => {
     <Button
       key="stage-users"
       variant="primary"
-      onClick={activateUsers}
-      form="stage-users-modal"
+      type="submit"
+      form="stage-user-activate-modal"
       data-cy="modal-button-activate"
     >
       Activate
@@ -141,6 +141,7 @@ const ActivateStageUsers = (props: PropsToActivateUsers) => {
         fields={fields}
         show={props.show}
         onClose={closeModal}
+        onSubmit={activateUsers}
         actions={modalStageActions}
       />
     </>

--- a/src/components/modals/UserModals/DeleteUsers.tsx
+++ b/src/components/modals/UserModals/DeleteUsers.tsx
@@ -284,9 +284,7 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
       data-cy="modal-button-delete"
       key="delete-users"
       variant="danger"
-      onClick={() => {
-        deleteUsers(props.selectedUsersData.selectedUsers);
-      }}
+      type="submit"
       form="remove-users-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
@@ -327,6 +325,7 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
       fields={fields}
       show={props.show}
       onClose={closeModal}
+      onSubmit={() => deleteUsers(props.selectedUsersData.selectedUsers)}
       actions={modalActionsDelete}
     />
   );
@@ -337,9 +336,7 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
       data-cy="modal-button-preserve"
       key="preserve-users"
       variant="primary"
-      onClick={() => {
-        deleteUsers(props.selectedUsersData.selectedUsers);
-      }}
+      type="submit"
       form="remove-users-modal"
       spinnerAriaValueText="Preserving"
       spinnerAriaLabel="Preserving"
@@ -369,6 +366,7 @@ const DeleteUsers = (props: PropsToDeleteUsers) => {
       fields={fields}
       show={props.show}
       onClose={closeModal}
+      onSubmit={() => deleteUsers(props.selectedUsersData.selectedUsers)}
       actions={modalActionsPreserve}
     />
   );

--- a/src/components/modals/UserModals/DisableEnableUsers.tsx
+++ b/src/components/modals/UserModals/DisableEnableUsers.tsx
@@ -277,12 +277,7 @@ const DisableEnableUsers = (props: PropsToDisableEnableUsers) => {
     <Button
       key="disable-users"
       variant="primary"
-      onClick={() =>
-        modifyStatus(
-          props.optionSelected,
-          props.selectedUsersData.selectedUsers
-        )
-      }
+      type="submit"
       form="users-enable-disable-users-modal"
       data-cy="modal-button-disable"
     >
@@ -309,6 +304,12 @@ const DisableEnableUsers = (props: PropsToDisableEnableUsers) => {
       fields={fields}
       show={props.show}
       onClose={closeModal}
+      onSubmit={() =>
+        modifyStatus(
+          props.optionSelected,
+          props.selectedUsersData.selectedUsers
+        )
+      }
       actions={modalActionsDisable}
     />
   );
@@ -318,13 +319,8 @@ const DisableEnableUsers = (props: PropsToDisableEnableUsers) => {
     <Button
       key="enable-users"
       variant="primary"
-      onClick={() =>
-        modifyStatus(
-          props.optionSelected,
-          props.selectedUsersData.selectedUsers
-        )
-      }
-      form="active-users-enable-disable-users-modal"
+      type="submit"
+      form="users-enable-disable-users-modal"
       data-cy="modal-button-enable"
     >
       Enable
@@ -350,6 +346,12 @@ const DisableEnableUsers = (props: PropsToDisableEnableUsers) => {
       fields={fields}
       show={props.show}
       onClose={closeModal}
+      onSubmit={() =>
+        modifyStatus(
+          props.optionSelected,
+          props.selectedUsersData.selectedUsers
+        )
+      }
       actions={modalActionsEnable}
     />
   );

--- a/src/components/modals/UserModals/RestorePreservedUsers.tsx
+++ b/src/components/modals/UserModals/RestorePreservedUsers.tsx
@@ -110,8 +110,8 @@ const RestorePreservedUsers = (props: PropsToPreservedUsers) => {
     <Button
       key="restore-users"
       variant="primary"
-      onClick={restoreUsers}
-      form="restore-users-modal"
+      type="submit"
+      form="restore-users-stage-modal"
       spinnerAriaValueText="Restoring"
       spinnerAriaLabel="Restoring"
       isLoading={spinning}
@@ -142,6 +142,7 @@ const RestorePreservedUsers = (props: PropsToPreservedUsers) => {
         fields={fields}
         show={props.show}
         onClose={closeModal}
+        onSubmit={restoreUsers}
         actions={modalRestoreActions}
       />
     </>

--- a/src/components/modals/UserModals/StagePreservedUsers.tsx
+++ b/src/components/modals/UserModals/StagePreservedUsers.tsx
@@ -175,8 +175,8 @@ const StagePreservedUsers = (props: PropsToStagePreservedUsers) => {
     <Button
       key="stage-users"
       variant="primary"
-      onClick={stageUsers}
-      form="stage-users-modal"
+      type="submit"
+      form="preserved-users-stage-modal"
       spinnerAriaValueText="Staging"
       spinnerAriaLabel="Staging"
       isLoading={spinning}
@@ -206,6 +206,7 @@ const StagePreservedUsers = (props: PropsToStagePreservedUsers) => {
       fields={fields}
       show={props.show}
       onClose={closeModal}
+      onSubmit={stageUsers}
       actions={modalStageActions}
     />
   );

--- a/src/components/modals/UserModals/UnlockUser.tsx
+++ b/src/components/modals/UserModals/UnlockUser.tsx
@@ -85,8 +85,8 @@ const UnlockUser = (props: propsToUnlockUser) => {
     <Button
       key="unlock-user"
       variant="primary"
-      onClick={onUnlockUser}
-      form="unlock-user-modal"
+      type="submit"
+      form="unlock-user-form"
       data-cy="modal-button-ok"
     >
       Ok
@@ -112,6 +112,7 @@ const UnlockUser = (props: propsToUnlockUser) => {
         fields={fields}
         show={props.isOpen}
         onClose={props.onClose}
+        onSubmit={onUnlockUser}
         actions={actions}
       />
     </>

--- a/src/pages/ActiveUsers/ActiveUsers.tsx
+++ b/src/pages/ActiveUsers/ActiveUsers.tsx
@@ -267,7 +267,7 @@ const ActiveUsers = () => {
       data-cy="modal-button-ok"
       key="rebuild-auto-membership"
       variant="primary"
-      onClick={onRebuildAutoMembership}
+      type="submit"
       form="rebuild-auto-membership-modal"
     >
       OK
@@ -697,6 +697,7 @@ const ActiveUsers = () => {
           fields={confirmationQuestion}
           show={isMembershipModalOpen}
           onClose={() => setIsMembershipModalOpen(!isMembershipModalOpen)}
+          onSubmit={onRebuildAutoMembership}
           actions={membershipModalActions}
         />
       )}

--- a/src/pages/AutoMemHostRules/AutoMemHostRules.tsx
+++ b/src/pages/AutoMemHostRules/AutoMemHostRules.tsx
@@ -562,14 +562,15 @@ const AutoMemHostRules = () => {
         title="Default hostgroup"
         isOpen={showChangeConfirmationModal}
         onClose={onCloseConfirmationModal}
+        formId="auto-member-default-host-rules-form"
+        onSubmit={() => onSelectDefaultGroup(defaultGroup)}
         actions={[
           <Button
             data-cy="modal-button-ok"
             variant="primary"
             key="change-default"
-            onClick={() => {
-              onSelectDefaultGroup(defaultGroup);
-            }}
+            type="submit"
+            form="auto-member-default-host-rules-form"
           >
             OK
           </Button>,

--- a/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
+++ b/src/pages/AutoMemUserRules/AutoMemUserRules.tsx
@@ -569,9 +569,8 @@ const AutoMemUserRules = () => {
             data-cy="modal-button-ok"
             variant="primary"
             key="change-default"
-            onClick={() => {
-              onSelectDefaultGroup(defaultGroup);
-            }}
+            type="submit"
+            form="auto-member-default-user-rules-form"
           >
             OK
           </Button>,
@@ -585,6 +584,10 @@ const AutoMemUserRules = () => {
         ]}
         messageText="Are you sure you want to change default group?"
         messageObj={defaultGroup}
+        formId="auto-member-default-user-rules-form"
+        onSubmit={() => {
+          onSelectDefaultGroup(defaultGroup);
+        }}
       />
     </div>
   );

--- a/src/pages/AutomountLocations/DeleteAutomountLocationsModal.tsx
+++ b/src/pages/AutomountLocations/DeleteAutomountLocationsModal.tsx
@@ -130,7 +130,7 @@ const DeleteAutomountLocationsModal = (
       data-cy="modal-button-delete"
       key="delete-automount-locations"
       variant="danger"
-      onClick={onDelete}
+      type="submit"
       form="delete-automount-locations-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
@@ -168,6 +168,7 @@ const DeleteAutomountLocationsModal = (
         fields={fields}
         show={props.isOpen}
         onClose={props.onClose}
+        onSubmit={onDelete}
         actions={modalActionsDelete}
       />
       {ErrorModalComponent}

--- a/src/pages/Configuration/ConfigObjectclassTable.tsx
+++ b/src/pages/Configuration/ConfigObjectclassTable.tsx
@@ -92,7 +92,13 @@ const ConfigObjectclassTable = (props: PropsToTable) => {
       >
         <ModalHeader title={"Add objectclass"} labelId="add-oc-modal-title" />
         <ModalBody id="add-oc-modal-body">
-          <Form id={"add-oc-modal"}>
+          <Form
+            id={"add-oc-modal"}
+            onSubmit={(event) => {
+              event.preventDefault();
+              addOC();
+            }}
+          >
             <FormGroup
               key={"oc"}
               label={"New objectclass"}
@@ -125,7 +131,8 @@ const ConfigObjectclassTable = (props: PropsToTable) => {
             isDisabled={
               newOC === "" || values.indexOf(newOC.toLowerCase()) !== -1
             }
-            onClick={addOC}
+            type="submit"
+            form="add-oc-modal"
           >
             Add
           </Button>

--- a/src/pages/Hosts/HostsSettings.tsx
+++ b/src/pages/Hosts/HostsSettings.tsx
@@ -109,7 +109,8 @@ const HostsSettings = (props: PropsToHostsSettings) => {
       data-cy="modal-button-unprovision"
       key="unprov-host"
       variant="danger"
-      onClick={() => onUnprovisionHost(props.host.fqdn ? props.host.fqdn : "")}
+      type="submit"
+      form="unprovision-host-form"
       isDisabled={modalSpinning}
       isLoading={modalSpinning}
       spinnerAriaValueText="Unprovisioning"
@@ -229,7 +230,7 @@ const HostsSettings = (props: PropsToHostsSettings) => {
       data-cy="modal-button-ok"
       key="rebuild-auto-membership"
       variant="primary"
-      onClick={onRebuildAutoMembership}
+      type="submit"
       form="rebuild-auto-membership-modal"
     >
       OK
@@ -514,6 +515,7 @@ const HostsSettings = (props: PropsToHostsSettings) => {
           fields={confirmationQuestion}
           show={isMembershipModalOpen}
           onClose={() => setIsMembershipModalOpen(!isMembershipModalOpen)}
+          onSubmit={onRebuildAutoMembership}
           actions={membershipModalActions}
         />
       )}
@@ -541,6 +543,10 @@ const HostsSettings = (props: PropsToHostsSettings) => {
         actions={unprovisionHostModalActions}
         messageText={"Unprovision/disable this host?"}
         messageObj={props.host.fqdn ? props.host.fqdn : ""}
+        formId="unprovision-host-form"
+        onSubmit={() =>
+          onUnprovisionHost(props.host.fqdn ? props.host.fqdn : "")
+        }
       />
     </TabLayout>
   );

--- a/src/pages/Netgroups/NetgroupsMemberTable.tsx
+++ b/src/pages/Netgroups/NetgroupsMemberTable.tsx
@@ -499,7 +499,13 @@ const NetgroupsMemberTable = (props: PropsToTable) => {
           labelId="add-external-host-modal-title"
         />
         <ModalBody id="add-external-host-modal-body">
-          <Form id={"external-modal"}>
+          <Form
+            id={"external-modal"}
+            onSubmit={(event) => {
+              event.preventDefault();
+              addMembers([externalHostName]);
+            }}
+          >
             <FormGroup
               key={"externalHostName"}
               label={"External hostname"}
@@ -533,7 +539,8 @@ const NetgroupsMemberTable = (props: PropsToTable) => {
               !externalHostName.includes(".") ||
               addSpinning
             }
-            onClick={() => addMembers([externalHostName])}
+            type="submit"
+            form="external-modal"
             spinnerAriaValueText="Adding"
             spinnerAriaLabel="Adding"
             isLoading={addSpinning}

--- a/src/pages/OtpTokens/DeleteOtpTokensModal.tsx
+++ b/src/pages/OtpTokens/DeleteOtpTokensModal.tsx
@@ -172,7 +172,7 @@ const DeleteOtpTokensModal = (props: DeleteOtpTokensModalProps) => {
       data-cy="modal-button-ok"
       key="delete-otp-tokens"
       variant="danger"
-      onClick={onDelete}
+      type="submit"
       form="delete-otp-tokens-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
@@ -210,6 +210,7 @@ const DeleteOtpTokensModal = (props: DeleteOtpTokensModalProps) => {
         fields={fields}
         show={props.isOpen}
         onClose={props.onClose}
+        onSubmit={onDelete}
         actions={modalActionsDelete}
       />
       {isModalErrorOpen && (

--- a/src/pages/OtpTokens/EnableDisableOtpTokensModal.tsx
+++ b/src/pages/OtpTokens/EnableDisableOtpTokensModal.tsx
@@ -82,7 +82,8 @@ const EnableDisableOtpTokensModal = (
       data-cy="modal-button-ok"
       key={props.operation + "-otp-tokens"}
       variant="primary"
-      onClick={onEnableDisable}
+      type="submit"
+      form="enable-disable-otp-tokens-form"
     >
       OK
     </Button>,
@@ -105,6 +106,8 @@ const EnableDisableOtpTokensModal = (
       actions={modalActions}
       messageText={`Are you sure you want to ${props.operation} the following OTP tokens?`}
       messageObj={props.elementsList.join(", ")}
+      formId="enable-disable-otp-tokens-form"
+      onSubmit={onEnableDisable}
     />
   );
 };

--- a/src/pages/Services/ServicesSettings.tsx
+++ b/src/pages/Services/ServicesSettings.tsx
@@ -102,7 +102,8 @@ const ServicesSettings = (props: PropsToServicesSettings) => {
       data-cy="modal-button-unprovision"
       key="unprov-host"
       variant="danger"
-      onClick={() => onUnprovision()}
+      type="submit"
+      form="services-unprovision-form"
       isDisabled={modalSpinning}
       isLoading={modalSpinning}
       spinnerAriaValueText="Unprovisioning"
@@ -412,6 +413,8 @@ const ServicesSettings = (props: PropsToServicesSettings) => {
         messageObj={
           props.service.krbcanonicalname ? props.service.krbcanonicalname : ""
         }
+        formId="services-unprovision-form"
+        onSubmit={() => onUnprovision()}
       />
       <IssueNewCertificate
         isOpen={isCertModalOpen}

--- a/src/pages/Trusts/AddTrustModal.tsx
+++ b/src/pages/Trusts/AddTrustModal.tsx
@@ -472,7 +472,7 @@ const AddTrustModal = (props: PropsToAddTrustModal) => {
       isDisabled={isButtonDisabled}
       isLoading={isAddButtonSpinning}
       type="submit"
-      onClick={onAddTrust}
+      form="add-trust-modal"
     >
       Add
     </Button>,

--- a/src/pages/Trusts/DeleteTrustModal.tsx
+++ b/src/pages/Trusts/DeleteTrustModal.tsx
@@ -132,8 +132,8 @@ const DeleteTrustModal = (props: DeleteTrustModalProps) => {
       data-cy="modal-button-ok"
       key="delete-trusts"
       variant="danger"
-      onClick={onDelete}
-      form="delete-trusts-modal"
+      type="submit"
+      form="remove-trusts-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
       isLoading={spinning}
@@ -170,6 +170,7 @@ const DeleteTrustModal = (props: DeleteTrustModalProps) => {
         fields={fields}
         show={props.isOpen}
         onClose={props.onClose}
+        onSubmit={onDelete}
         actions={modalActionsDelete}
       />
       {ErrorModalComponent}

--- a/src/pages/Trusts/DeleteTrustedDomainsModal.tsx
+++ b/src/pages/Trusts/DeleteTrustedDomainsModal.tsx
@@ -141,7 +141,7 @@ const DeleteTrustedDomainsModal = (props: DeleteTrustedDomainsModalProps) => {
       data-cy="modal-button-delete"
       key="delete-trusted-domains"
       variant="danger"
-      onClick={onDelete}
+      type="submit"
       form="delete-trusted-domains-modal"
       spinnerAriaValueText="Deleting"
       spinnerAriaLabel="Deleting"
@@ -172,6 +172,7 @@ const DeleteTrustedDomainsModal = (props: DeleteTrustedDomainsModalProps) => {
         fields={fields}
         show={props.isOpen}
         onClose={props.onClose}
+        onSubmit={onDelete}
         actions={modalActions}
       />
       {isModalErrorOpen && (

--- a/src/pages/Trusts/EnableDisableTrustedDomainsModal.tsx
+++ b/src/pages/Trusts/EnableDisableTrustedDomainsModal.tsx
@@ -86,7 +86,8 @@ const EnableDisableTrustedDomainsModal = (
       data-cy="modal-button-ok"
       key={props.operation + "-certmaprules"}
       variant="primary"
-      onClick={onEnableDisable}
+      type="submit"
+      form="enable-disable-trusted-domains-form"
     >
       OK
     </Button>,
@@ -109,6 +110,8 @@ const EnableDisableTrustedDomainsModal = (
       actions={modalActions}
       messageText={`Are you sure you want to ${props.operation} the following domains?`}
       messageObj={props.domainNames.join(", ")}
+      formId="enable-disable-trusted-domains-form"
+      onSubmit={onEnableDisable}
     />
   );
 };


### PR DESCRIPTION
Add `type="submit"` and form attribute to primary
action buttons, wire `onSubmit` handlers to layout components, and extend `ConfirmationModal` and
`ModalWithTextAreaLayout` to support form-based
submission. Update doc templates accordingly.

Related: https://github.com/freeipa/freeipa-webui/issues/760
Assisted-by: Claude <noreply@anthropic.com>

## Summary by Sourcery

Allow modal primary actions across the app to be triggered via form submission (e.g. pressing Enter) by wiring modals and layouts to underlying forms and submit handlers.

Bug Fixes:
- Enable keyboard-based submission (Enter key) for modal add/edit/delete/confirm actions that previously required clicking buttons.

Enhancements:
- Standardize modal primary buttons as submit actions associated with explicit form IDs across user, DNS, certificate, sudo, automember, trust, OTP, and other entity modals.
- Extend shared ConfirmationModal, ModalWithTextAreaLayout, and SecondaryButton components to support form-based submission via optional formId/onSubmit/type props for consistent behavior.
- Refine various modal form wiring to prevent default browser submission and delegate to existing handler logic while preserving loading and disabled states.

Documentation:
- Update modal design documentation to recommend form-bound submit buttons and onSubmit handlers in examples to reflect the new interaction pattern.