### PR TITLE
Add 'Self service permissions' main page

### DIFF
--- a/doc/designs/main-pages/07-add-modal.md
+++ b/doc/designs/main-pages/07-add-modal.md
@@ -68,7 +68,7 @@ if (error) {
 }
 ```
 
-When an error occurs: dispatch a danger alert, reset the spinner, keep the modal open.
+When an error occurs: dispatch a danger alert and keep the modal open. The spinner reset (`setIsAddButtonSpinning(false)`) must always live in a `.finally()` block so it runs regardless of success, error, or rejection. See [Best Practices §6](../sub-pages/00-best-practices.md) for the full rule.
 
 ## Modal Action Buttons
 
@@ -143,11 +143,19 @@ const AddEntityModal = (props: PropsToAddModal) => {
 
   const onAdd = () => {
     setIsAddButtonSpinning(true);
-    addEntity({ cn: entityName, description: description || undefined }).then((response) => {
-      if ("data" in response) {
-        const error = response.data?.error as SerializedError;
-        if (error) {
-          dispatch(addAlert({ name: "add-entity-error", title: error.message, variant: "danger" }));
+    addEntity({ cn: entityName, description: description || undefined })
+      .then((response) => {
+        if ("data" in response) {
+          const error = response.data?.error as SerializedError;
+          if (error) {
+            dispatch(addAlert({ name: "add-entity-error", title: error.message, variant: "danger" }));
+          }
+          if (response.data?.result) {
+            dispatch(addAlert({ name: "add-entity-success", title: "New entity added", variant: "success" }));
+            clearFields();
+            props.onRefresh();
+            props.onClose();
+          }
         }
         if (response.data?.result) {
           dispatch(addAlert({ name: "add-entity-success", title: "New entity added", variant: "success" }));
@@ -155,6 +163,7 @@ const AddEntityModal = (props: PropsToAddModal) => {
           props.onRefresh();
         }
       }
+    }).finally(() => {
       setIsAddButtonSpinning(false);
     });
   };

--- a/doc/designs/sub-pages/00-best-practices.md
+++ b/doc/designs/sub-pages/00-best-practices.md
@@ -97,7 +97,38 @@ When creating membership tabs using `MembershipTable`:
 
 Failing to register types causes TypeScript errors that may surface later.
 
-### 6. Use Absolute Imports
+### 6. Reset UI Flags in `.finally()`, Not Inside `.then()`
+
+When an async command (add, delete, enable, disable, save, etc.) sets a UI flag like `setSpinning(true)` or `setBtnSpinning(true)` before the API call, the reset (`setSpinning(false)`) **must** go in a `.finally()` block — **not** at the end of `.then()`.
+
+This guarantees the flag is reset even when the promise rejects with a network error or an unhandled exception, preventing the UI from staying in a stuck/spinning state.
+
+```tsx
+// ✅ Correct — flag resets regardless of outcome:
+const onAdd = () => {
+  setSpinning(true);
+  addEntity(payload)
+    .then((response) => {
+      // handle success / error from response…
+    })
+    .finally(() => {
+      setSpinning(false);
+    });
+};
+
+// ❌ Wrong — if the promise rejects, setSpinning(false) never runs:
+const onAdd = () => {
+  setSpinning(true);
+  addEntity(payload).then((response) => {
+    // handle success / error…
+    setSpinning(false);
+  });
+};
+```
+
+This rule applies to **every** command operation: add modals, delete modals, enable/disable modals, save handlers, and any other async action that toggles a loading/spinner flag.
+
+### 7. Use Absolute Imports
 
 ```tsx
 // ✅ Correct:
@@ -137,6 +168,7 @@ Fix **all errors** before committing.
 | Missing `documentation-links.json` entry | Runtime crash |
 | Unregistered types in `MembershipTable` | TypeScript errors (may appear later) |
 | Disabled buttons without user approval | Incomplete, unusable component |
+| Spinner/flag reset inside `.then()` instead of `.finally()` | UI stuck in spinning state on network error or rejection |
 | Skipping validation commands | Build failures in CI |
 
 ---
@@ -150,6 +182,7 @@ Before committing any new sub-page:
 - [ ] **Set `showLink={true}`** in main page
 - [ ] **Added documentation-links.json entry** (even if empty array)
 - [ ] **Registered types** if using MembershipTable
+- [ ] **Reset UI flags in `.finally()`** (spinner, button state — never inside `.then()`)
 - [ ] **Used absolute imports** (starting with `src/`)
 - [ ] **Ran validation commands** and fixed all errors
 

--- a/doc/designs/sub-pages/09-modals.md
+++ b/doc/designs/sub-pages/09-modals.md
@@ -43,18 +43,21 @@ const Add<ChildEntity>Modal = (props: Add<ChildEntity>ModalProps) => {
 
   const onAdd = () => {
     setSpinning(true);
-    add<ChildEntity>({ <parentId>: props.<parentId>, field1 }).then((response) => {
-      if ("data" in response) {
-        if (response.data?.error) {
-          dispatch(addAlert({ name: "add-error", title: response.data.error.message, variant: "danger" }));
-        } else {
-          dispatch(addAlert({ name: "add-success", title: "<ChildEntity> added", variant: "success" }));
-          props.onRefresh();
-          onClose();
+    add<ChildEntity>({ <parentId>: props.<parentId>, field1 })
+      .then((response) => {
+        if ("data" in response) {
+          if (response.data?.error) {
+            dispatch(addAlert({ name: "add-error", title: response.data.error.message, variant: "danger" }));
+          } else {
+            dispatch(addAlert({ name: "add-success", title: "<ChildEntity> added", variant: "success" }));
+            props.onRefresh();
+            onClose();
+          }
         }
-      }
-      setSpinning(false);
-    });
+      })
+      .finally(() => {
+        setSpinning(false);
+      });
   };
 
   const onFormSubmit = (event: React.FormEvent) => {
@@ -149,21 +152,24 @@ const Delete<ChildEntity>Modal = (props: Delete<ChildEntity>ModalProps) => {
     setSpinning(true);
     const idsToDelete = props.elementsToDelete.map((el) => el.<pk>);
     
-    delete<ChildEntities>({ <parentId>: props.<parentId>, ids: idsToDelete }).then((response) => {
-      if ("data" in response) {
-        const data = response.data as BatchRPCResponse;
-        if (data.result) {
-          props.clearSelectedElements();
-          props.updateIsDeleteButtonDisabled(true);
-          dispatch(addAlert({ name: "delete-success", title: "Items deleted", variant: "success" }));
-          props.onRefresh();
-          props.onClose();
+    delete<ChildEntities>({ <parentId>: props.<parentId>, ids: idsToDelete })
+      .then((response) => {
+        if ("data" in response) {
+          const data = response.data as BatchRPCResponse;
+          if (data.result) {
+            props.clearSelectedElements();
+            props.updateIsDeleteButtonDisabled(true);
+            dispatch(addAlert({ name: "delete-success", title: "Items deleted", variant: "success" }));
+            props.onRefresh();
+            props.onClose();
+          }
+        } else if ("error" in response) {
+          dispatch(addAlert({ name: "delete-error", title: "Delete failed", variant: "danger" }));
         }
-      } else if ("error" in response) {
-        dispatch(addAlert({ name: "delete-error", title: "Delete failed", variant: "danger" }));
-      }
-      setSpinning(false);
-    });
+      })
+      .finally(() => {
+        setSpinning(false);
+      });
   };
 
   const modalActions = [

--- a/src/components/TypeAheadWithCheckbox.tsx
+++ b/src/components/TypeAheadWithCheckbox.tsx
@@ -318,6 +318,8 @@ export const TypeAheadWithCheckbox = <T,>({
       }}
       toggle={toggle}
       variant="typeahead"
+      isScrollable
+      maxMenuHeight="300px"
     >
       <SelectList
         isAriaMultiselectable

--- a/src/components/modals/SelfServicePermissionModals/AddSelfServicePermissionModal.tsx
+++ b/src/components/modals/SelfServicePermissionModals/AddSelfServicePermissionModal.tsx
@@ -1,0 +1,301 @@
+import React from "react";
+import { Button } from "@patternfly/react-core";
+import ModalWithFormLayout, {
+  Field,
+} from "src/components/layouts/ModalWithFormLayout";
+import InputWithValidation from "src/components/layouts/InputWithValidation";
+import type { RuleProps } from "src/components/layouts/InputWithValidation";
+import { TypeAheadWithCheckbox } from "src/components/TypeAheadWithCheckbox";
+import { useAddSelfServicePermissionMutation } from "src/services/rpcSelfServicePermissions";
+import { useAppDispatch } from "src/store/hooks";
+import { addAlert } from "src/store/Global/alerts-slice";
+import { SerializedError } from "@reduxjs/toolkit";
+
+const SELF_SERVICE_ATTRS = [
+  "audio",
+  "businesscategory",
+  "carlicense",
+  "cn",
+  "departmentnumber",
+  "description",
+  "destinationindicator",
+  "displayname",
+  "employeenumber",
+  "employeetype",
+  "facsimiletelephonenumber",
+  "gecos",
+  "gidnumber",
+  "givenname",
+  "homedirectory",
+  "homephone",
+  "homepostaladdress",
+  "inetuserhttpurl",
+  "inetuserstatus",
+  "initials",
+  "internationalisdnnumber",
+  "ipacertmapdata",
+  "ipaidpconfiglink",
+  "ipaidpsub",
+  "ipakrbauthzdata",
+  "ipanthash",
+  "ipanthomedirectory",
+  "ipanthomedirectorydrive",
+  "ipantlogonscript",
+  "ipantprofilepath",
+  "ipantsecurityidentifier",
+  "ipapasskey",
+  "ipasshpubkey",
+  "ipatokenradiusconfiglink",
+  "ipatokenradiususername",
+  "ipauniqueid",
+  "ipauserauthtype",
+  "jpegphoto",
+  "krballowedtodelegateto",
+  "krbauthindmaxrenewableage",
+  "krbauthindmaxticketlife",
+  "krbcanonicalname",
+  "krbextradata",
+  "krblastadminunlock",
+  "krblastfailedauth",
+  "krblastpwdchange",
+  "krblastsuccessfulauth",
+  "krbloginfailedcount",
+  "krbmaxrenewableage",
+  "krbmaxticketlife",
+  "krbpasswordexpiration",
+  "krbprincipalaliases",
+  "krbprincipalauthind",
+  "krbprincipalexpiration",
+  "krbprincipalkey",
+  "krbprincipalname",
+  "krbprincipaltype",
+  "krbpwdhistory",
+  "krbpwdpolicyreference",
+  "krbticketflags",
+  "krbticketpolicyreference",
+  "krbupenabled",
+  "l",
+  "labeleduri",
+  "loginshell",
+  "mail",
+  "manager",
+  "memberof",
+  "mepmanagedentry",
+  "mobile",
+  "o",
+  "objectclass",
+  "ou",
+  "pager",
+  "photo",
+  "physicaldeliveryofficename",
+  "postaladdress",
+  "postalcode",
+  "postofficebox",
+  "preferreddeliverymethod",
+  "preferredlanguage",
+  "registeredaddress",
+  "roomnumber",
+  "secretary",
+  "seealso",
+  "sn",
+  "st",
+  "street",
+  "telephonenumber",
+  "teletexterminalidentifier",
+  "telexnumber",
+  "title",
+  "uid",
+  "uidnumber",
+  "usercertificate",
+  "userclass",
+  "userpassword",
+  "userpkcs12",
+  "usersmimecertificate",
+  "x121address",
+  "x500uniqueidentifier",
+];
+
+const ATTR_OPTIONS = SELF_SERVICE_ATTRS.map((attr) => ({
+  value: attr,
+  children: attr,
+  "data-cy": `modal-select-attrs-${attr}`,
+}));
+
+interface PropsToAddModal {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  onRefresh: () => void;
+}
+
+const AddSelfServicePermissionModal = (props: PropsToAddModal) => {
+  const dispatch = useAppDispatch();
+  const [addSelfServicePermission] = useAddSelfServicePermissionMutation();
+
+  const [isAddButtonSpinning, setIsAddButtonSpinning] = React.useState(false);
+  const [selfServiceName, setSelfServiceName] = React.useState("");
+  const [selectedAttrs, setSelectedAttrs] = React.useState<string[]>([]);
+
+  const ACI_NAME_PATTERN = /^[-_ a-zA-Z0-9]+$/;
+
+  const aciNameRules: RuleProps[] = [
+    {
+      id: "no-leading-trailing-spaces",
+      message: "Must not have leading or trailing spaces",
+      validate: (value: string) => value === value.trim(),
+    },
+    {
+      id: "valid-characters",
+      message:
+        "Only letters, digits, hyphens, underscores, and spaces are allowed",
+      validate: (value: string) => ACI_NAME_PATTERN.test(value),
+    },
+  ];
+
+  const isAciNameValid = (name: string): boolean => {
+    if (name === "") return false;
+    return aciNameRules.every((rule) => rule.validate(name));
+  };
+
+  const clearFields = () => {
+    setSelfServiceName("");
+    setSelectedAttrs([]);
+  };
+
+  const onAdd = () => {
+    setIsAddButtonSpinning(true);
+
+    addSelfServicePermission({
+      aciname: selfServiceName,
+      attrs: selectedAttrs,
+    })
+      .then((response) => {
+        if ("error" in response && response.error) {
+          const error = response.error as SerializedError;
+
+          dispatch(
+            addAlert({
+              name: "add-self-service-permission-error",
+              title: error.message,
+              variant: "danger",
+            })
+          );
+
+          return;
+        }
+
+        if ("data" in response) {
+          const data = response.data?.result;
+          const error = response.data?.error as SerializedError;
+
+          if (error) {
+            dispatch(
+              addAlert({
+                name: "add-self-service-permission-error",
+                title: error.message,
+                variant: "danger",
+              })
+            );
+
+            return;
+          }
+
+          if (data) {
+            dispatch(
+              addAlert({
+                name: "add-self-service-permission-success",
+                title: "New self-service permission added",
+                variant: "success",
+              })
+            );
+            clearFields();
+            props.onRefresh();
+            props.onClose();
+          }
+        }
+      })
+      .finally(() => {
+        setIsAddButtonSpinning(false);
+      });
+  };
+
+  const cleanAndCloseModal = () => {
+    clearFields();
+    props.onClose();
+  };
+
+  const fields: Field[] = [
+    {
+      id: "modal-form-self-service-name",
+      name: "Self-service name",
+      pfComponent: (
+        <InputWithValidation
+          dataCy="modal-textbox-self-service-name"
+          id="modal-form-self-service-name"
+          name="aciname"
+          value={selfServiceName}
+          onChange={setSelfServiceName}
+          isRequired={true}
+          rules={aciNameRules}
+        />
+      ),
+      fieldRequired: true,
+    },
+    {
+      id: "modal-form-attrs",
+      name: "Attributes",
+      pfComponent: (
+        <TypeAheadWithCheckbox
+          id="modal-form-attrs"
+          dataCy="modal-select-attrs"
+          options={ATTR_OPTIONS}
+          selected={selectedAttrs}
+          setSelected={setSelectedAttrs}
+        />
+      ),
+      fieldRequired: true,
+    },
+  ];
+
+  const modalActions: JSX.Element[] = [
+    <Button
+      data-cy="modal-button-add"
+      key="add-new"
+      isDisabled={
+        isAddButtonSpinning ||
+        !isAciNameValid(selfServiceName) ||
+        selectedAttrs.length === 0
+      }
+      form="add-modal-form"
+      type="submit"
+    >
+      Add
+    </Button>,
+    <Button
+      data-cy="modal-button-cancel"
+      key="cancel-new"
+      variant="link"
+      onClick={cleanAndCloseModal}
+    >
+      Cancel
+    </Button>,
+  ];
+
+  return (
+    <ModalWithFormLayout
+      dataCy="add-self-service-permission-modal"
+      variantType="small"
+      modalPosition="top"
+      offPosition="76px"
+      title={props.title}
+      formId="add-modal-form"
+      fields={fields}
+      show={props.isOpen}
+      onSubmit={() => onAdd()}
+      onClose={cleanAndCloseModal}
+      actions={modalActions}
+    />
+  );
+};
+
+export default AddSelfServicePermissionModal;

--- a/src/components/modals/SelfServicePermissionModals/DeleteSelfServicePermissionsModal.tsx
+++ b/src/components/modals/SelfServicePermissionModals/DeleteSelfServicePermissionsModal.tsx
@@ -1,0 +1,204 @@
+import React from "react";
+import { Content, ContentVariants, Button } from "@patternfly/react-core";
+import ModalWithFormLayout from "src/components/layouts/ModalWithFormLayout";
+import DeletedElementsTable from "src/components/tables/DeletedElementsTable";
+import { addAlert } from "src/store/Global/alerts-slice";
+import { useAppDispatch } from "src/store/hooks";
+import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
+import { SerializedError } from "@reduxjs/toolkit";
+import {
+  ErrorData,
+  SelfServicePermission,
+} from "src/utils/datatypes/globalDataTypes";
+import ErrorModal from "src/components/modals/ErrorModal";
+import { BatchRPCResponse } from "src/services/rpc";
+import { useDeleteSelfServicePermissionsMutation } from "src/services/rpcSelfServicePermissions";
+
+interface DeleteSelfServicePermissionsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  elementsToDelete: SelfServicePermission[];
+  clearSelectedElements: () => void;
+  columnNames: string[];
+  keyNames: string[];
+  onRefresh: () => void;
+  updateIsDeleteButtonDisabled: (value: boolean) => void;
+  updateIsDeletion: (value: boolean) => void;
+}
+
+const DeleteSelfServicePermissionsModal = (
+  props: DeleteSelfServicePermissionsModalProps
+) => {
+  const dispatch = useAppDispatch();
+
+  const [executeDeleteCommand] = useDeleteSelfServicePermissionsMutation();
+
+  const [spinning, setBtnSpinning] = React.useState<boolean>(false);
+  const [isModalErrorOpen, setIsModalErrorOpen] = React.useState(false);
+  const [errorTitle, setErrorTitle] = React.useState("");
+  const [errorMessage, setErrorMessage] = React.useState("");
+
+  const fields = [
+    {
+      id: "question-text",
+      pfComponent: (
+        <Content component={ContentVariants.p}>
+          Are you sure you want to remove the selected self-service permissions?
+        </Content>
+      ),
+    },
+    {
+      id: "deleted-self-service-permissions-table",
+      pfComponent: (
+        <DeletedElementsTable
+          mode="passing_full_data"
+          elementsToDelete={props.elementsToDelete}
+          columnNames={props.columnNames}
+          columnIds={props.keyNames}
+          elementType="SelfServicePermission"
+          idAttr="aciname"
+        />
+      ),
+    },
+  ];
+
+  const handleAPIError = (error: FetchBaseQueryError | SerializedError) => {
+    if ("code" in error) {
+      setErrorTitle("IPA error " + error.code + ": " + error.name);
+      if (error.message !== undefined) {
+        setErrorMessage(error.message);
+      }
+    } else if ("data" in error) {
+      const errorData = error.data as ErrorData;
+      const errorCode = errorData.code as string;
+      const errorName = errorData.name as string;
+      const errorMsg = errorData.error as string;
+
+      setErrorTitle("IPA error " + errorCode + ": " + errorName);
+      setErrorMessage(errorMsg);
+    }
+    setIsModalErrorOpen(true);
+  };
+
+  const closeAndCleanErrorParameters = () => {
+    setIsModalErrorOpen(false);
+    setErrorTitle("");
+    setErrorMessage("");
+  };
+
+  const onDelete = () => {
+    setBtnSpinning(true);
+
+    executeDeleteCommand(props.elementsToDelete)
+      .then((response) => {
+        if ("data" in response) {
+          const data = response.data as BatchRPCResponse;
+          const result = data.result;
+
+          if (result) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const results = result.results as unknown as any[];
+            const errors = results.filter((r) => "error" in r && r.error);
+
+            if (errors.length > 0) {
+              const firstError = errors[0];
+              const errorData = {
+                code: firstError.error_code,
+                name: firstError.error_name,
+                error: firstError.error,
+              } as ErrorData;
+
+              const error = {
+                status: "CUSTOM_ERROR",
+                data: errorData,
+              } as FetchBaseQueryError;
+
+              handleAPIError(error);
+            } else {
+              props.clearSelectedElements();
+              props.updateIsDeleteButtonDisabled(true);
+              props.updateIsDeletion(true);
+
+              dispatch(
+                addAlert({
+                  name: "remove-self-service-permissions-success",
+                  title: "Self-service permissions removed",
+                  variant: "success",
+                })
+              );
+
+              props.onClose();
+              props.onRefresh();
+            }
+          }
+        }
+      })
+      .finally(() => {
+        setBtnSpinning(false);
+      });
+  };
+
+  const modalActions: JSX.Element[] = [
+    <Button
+      key="delete-self-service-permissions"
+      variant="danger"
+      onClick={onDelete}
+      form="delete-self-service-permissions-modal"
+      spinnerAriaValueText="Deleting"
+      spinnerAriaLabel="Deleting"
+      isLoading={spinning}
+      isDisabled={spinning}
+      data-cy="modal-button-delete"
+    >
+      {spinning ? "Deleting" : "Delete"}
+    </Button>,
+    <Button
+      key="cancel-delete-self-service-permissions"
+      variant="link"
+      onClick={props.onClose}
+      data-cy="modal-button-cancel"
+    >
+      Cancel
+    </Button>,
+  ];
+
+  const errorModalActions = [
+    <Button
+      key="cancel"
+      variant="link"
+      onClick={closeAndCleanErrorParameters}
+      data-cy="modal-button-ok"
+    >
+      OK
+    </Button>,
+  ];
+
+  return (
+    <>
+      <ModalWithFormLayout
+        dataCy="delete-self-service-permissions-modal"
+        variantType="medium"
+        modalPosition="top"
+        offPosition="76px"
+        title="Remove self-service permissions"
+        formId="delete-self-service-permissions-modal"
+        fields={fields}
+        show={props.isOpen}
+        onClose={props.onClose}
+        actions={modalActions}
+      />
+      {isModalErrorOpen && (
+        <ErrorModal
+          dataCy="delete-self-service-permissions-modal-error"
+          title={errorTitle}
+          isOpen={isModalErrorOpen}
+          onClose={closeAndCleanErrorParameters}
+          actions={errorModalActions}
+          errorMessage={errorMessage}
+        />
+      )}
+    </>
+  );
+};
+
+export default DeleteSelfServicePermissionsModal;

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -84,6 +84,7 @@ import RolesTabs from "src/pages/Roles/RolesTabs";
 import Privileges from "src/pages/Privileges/Privileges";
 import PrivilegesTabs from "src/pages/Privileges/PrivilegesTabs";
 import Permissions from "src/pages/Permissions/Permissions";
+import SelfServicePermissions from "src/pages/SelfServicePermissions/SelfServicePermissions";
 
 // Renders routes (React)
 export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
@@ -622,6 +623,9 @@ export const AppRoutes = ({ isInitialDataLoaded }): React.ReactElement => {
               </Route>
               <Route path="permissions">
                 <Route path="" element={<Permissions />} />
+              </Route>
+              <Route path="selfservice-permissions">
+                <Route path="" element={<SelfServicePermissions />} />
               </Route>
               <Route path="configuration" element={<Configuration />} />
               {/* Redirect to Active users page if user is logged in and navigates to the root page */}

--- a/src/navigation/NavRoutes.ts
+++ b/src/navigation/NavRoutes.ts
@@ -73,6 +73,7 @@ const TopologyGroupRef = "topology-graph";
 const RbacGroupRef = "rbac";
 const PrivilegesGroupRef = "privileges";
 const PermissionsGroupRef = "permissions";
+const SelfServicePermissionsGroupRef = "selfservice-permissions";
 // - Configuration
 const ConfigRef = "configuration";
 
@@ -451,6 +452,13 @@ export const getNavigationRoutes = (
               group: PermissionsGroupRef,
               title: `${BASE_TITLE} - Permissions`,
               path: "permissions",
+              items: [],
+            },
+            {
+              label: "Self service permissions",
+              group: SelfServicePermissionsGroupRef,
+              title: `${BASE_TITLE} - Self service permissions`,
+              path: "selfservice-permissions",
               items: [],
             },
           ],

--- a/src/pages/SelfServicePermissions/SelfServicePermissions.tsx
+++ b/src/pages/SelfServicePermissions/SelfServicePermissions.tsx
@@ -1,0 +1,399 @@
+import React, { useMemo, useState } from "react";
+import {
+  Flex,
+  FlexItem,
+  PageSection,
+  PaginationVariant,
+  ToolbarItemVariant,
+} from "@patternfly/react-core";
+import {
+  InnerScrollContainer,
+  OuterScrollContainer,
+} from "@patternfly/react-table";
+import { SelfServicePermission } from "src/utils/datatypes/globalDataTypes";
+import { ToolbarItem } from "src/components/layouts/ToolbarLayout";
+import { useAppDispatch, useAppSelector } from "src/store/hooks";
+import TitleLayout from "src/components/layouts/TitleLayout";
+import HelpTextWithIconLayout from "src/components/layouts/HelpTextWithIconLayout";
+import SecondaryButton from "src/components/layouts/SecondaryButton";
+import ToolbarLayout from "src/components/layouts/ToolbarLayout";
+import SearchInputLayout from "src/components/layouts/SearchInputLayout";
+import MainTable from "src/components/tables/MainTable";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
+import BulkSelectorPrep from "src/components/BulkSelectorPrep";
+import AddSelfServicePermissionModal from "src/components/modals/SelfServicePermissionModals/AddSelfServicePermissionModal";
+import DeleteSelfServicePermissionsModal from "src/components/modals/SelfServicePermissionModals/DeleteSelfServicePermissionsModal";
+import useUpdateRoute from "src/hooks/useUpdateRoute";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
+import useContextualHelpTopic from "src/hooks/useContextualHelpTopic";
+import { toggleHelpPanel } from "src/store/Global/contextual-help-slice";
+import {
+  API_VERSION_BACKUP,
+  isSelfServicePermissionSelectable,
+} from "src/utils/utils";
+import {
+  getSelectedPerPageData,
+  ipaPrimaryKey,
+} from "src/utils/selectedPerPage";
+import { useGetSelfServicePermissionsFullDataQuery } from "src/services/rpcSelfServicePermissions";
+import useApiError from "src/hooks/useApiError";
+import GlobalErrors from "src/components/errors/GlobalErrors";
+import ModalErrors from "src/components/errors/ModalErrors";
+
+const SelfServicePermissions = () => {
+  const dispatch = useAppDispatch();
+
+  useUpdateRoute({ pathname: "selfservice-permissions" });
+  useContextualHelpTopic("selfservice-permissions");
+
+  const apiVersion = useAppSelector(
+    (state) => state.global.environment.api_version
+  ) as string;
+
+  const { page, perPage, searchValue } = useListPageSearchParams();
+
+  const globalErrors = useApiError([]);
+  const modalErrors = useApiError([]);
+
+  const firstIdx = (page - 1) * perPage;
+  const lastIdx = page * perPage;
+
+  const dataResponse = useGetSelfServicePermissionsFullDataQuery({
+    searchValue: searchValue,
+    sizeLimit: 0,
+    apiVersion: apiVersion || API_VERSION_BACKUP,
+    startIdx: firstIdx,
+    stopIdx: lastIdx,
+  });
+
+  const {
+    data: batchResponse,
+    isLoading: isBatchLoading,
+    isFetching,
+    error: batchError,
+  } = dataResponse;
+
+  const { elementsList, totalCount } = useMemo(() => {
+    if (batchResponse?.result) {
+      const results = batchResponse.result.results;
+      const listSize = batchResponse.result.count;
+      const items: SelfServicePermission[] = [];
+
+      for (let i = 0; i < listSize; i++) {
+        if (results[i]?.result) {
+          items.push(results[i].result);
+        }
+      }
+
+      return {
+        elementsList: items,
+        totalCount: batchResponse.result.totalCount,
+      };
+    }
+
+    return { elementsList: [], totalCount: 0 };
+  }, [batchResponse]);
+
+  React.useEffect(() => {
+    if (isFetching) {
+      globalErrors.clear();
+    }
+  }, [isFetching]);
+
+  React.useEffect(() => {
+    if (
+      !isBatchLoading &&
+      !isFetching &&
+      dataResponse.isError &&
+      dataResponse.error !== undefined
+    ) {
+      const err = dataResponse.error;
+      let contextMsg = "Error loading self-service permissions";
+      if ("error" in err && typeof err.error === "string" && err.error) {
+        contextMsg += ": " + err.error;
+      }
+      globalErrors.addError(
+        err,
+        contextMsg,
+        "selfservice-permissions-fetch-error"
+      );
+    }
+  }, [
+    dataResponse.isError,
+    dataResponse.error,
+    isBatchLoading,
+    isFetching,
+    globalErrors,
+  ]);
+
+  const refreshData = () => {
+    clearSelectedPermissions();
+    dataResponse.refetch();
+  };
+
+  const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
+    useState<boolean>(true);
+
+  const [isDeletion, setIsDeletion] = useState(false);
+
+  const [selectedPermissions, setSelectedPermissions] = useState<
+    SelfServicePermission[]
+  >([]);
+
+  const clearSelectedPermissions = () => {
+    setSelectedPermissions([]);
+  };
+
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  const selectableTable = elementsList.filter(
+    isSelfServicePermissionSelectable
+  );
+
+  const updateSelectedPermissions = (
+    permissions: SelfServicePermission[],
+    isSelected: boolean
+  ) => {
+    let newSelected: SelfServicePermission[] = [];
+    if (isSelected) {
+      newSelected = JSON.parse(JSON.stringify(selectedPermissions));
+      for (let i = 0; i < permissions.length; i++) {
+        const alreadySelected = selectedPermissions.find(
+          (s) =>
+            ipaPrimaryKey(s.aciname) === ipaPrimaryKey(permissions[i].aciname)
+        );
+        if (alreadySelected) {
+          continue;
+        }
+        newSelected.push(permissions[i]);
+      }
+    } else {
+      for (let i = 0; i < selectedPermissions.length; i++) {
+        let found = false;
+        for (let ii = 0; ii < permissions.length; ii++) {
+          if (
+            ipaPrimaryKey(selectedPermissions[i].aciname) ===
+            ipaPrimaryKey(permissions[ii].aciname)
+          ) {
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          newSelected.push(selectedPermissions[i]);
+        }
+      }
+    }
+    setSelectedPermissions(newSelected);
+    setIsDeleteButtonDisabled(newSelected.length === 0);
+  };
+
+  const setPermissionSelected = (
+    permission: SelfServicePermission,
+    isSelecting = true
+  ) => {
+    if (isSelfServicePermissionSelectable(permission)) {
+      updateSelectedPermissions([permission], isSelecting);
+    }
+  };
+
+  const selectedPerPageData = getSelectedPerPageData(
+    elementsList,
+    selectedPermissions.map((item) => ipaPrimaryKey(item.aciname)),
+    (item) => ipaPrimaryKey(item.aciname)
+  );
+
+  const bulkSelectorData = {
+    selected: selectedPermissions,
+    updateSelected: updateSelectedPermissions,
+    selectableTable: selectableTable,
+    nameAttr: "aciname",
+  };
+
+  const buttonsData = {
+    updateIsDeleteButtonDisabled: setIsDeleteButtonDisabled,
+  };
+
+  const columnNames = ["Self-service name"];
+  const keyNames = ["aciname"];
+
+  const toolbarItems: ToolbarItem[] = [
+    {
+      key: 0,
+      element: (
+        <BulkSelectorPrep
+          list={elementsList}
+          shownElementsList={elementsList}
+          elementData={bulkSelectorData}
+          buttonsData={buttonsData}
+          selectedPerPageData={selectedPerPageData}
+        />
+      ),
+    },
+    {
+      key: 1,
+      element: (
+        <SearchInputLayout
+          dataCy="search"
+          name="search"
+          ariaLabel="Search self-service permissions"
+          placeholder="Search"
+        />
+      ),
+      toolbarItemVariant: ToolbarItemVariant.label,
+      toolbarItemGap: { default: "gapMd" },
+    },
+    {
+      key: 2,
+      toolbarItemVariant: ToolbarItemVariant.separator,
+    },
+    {
+      key: 3,
+      element: (
+        <SecondaryButton
+          onClickHandler={refreshData}
+          isDisabled={isFetching}
+          dataCy="selfservice-permissions-button-refresh"
+        >
+          Refresh
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 4,
+      element: (
+        <SecondaryButton
+          isDisabled={isDeleteButtonDisabled || isFetching}
+          onClickHandler={() => setShowDeleteModal(true)}
+          dataCy="selfservice-permissions-button-delete"
+        >
+          Delete
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 5,
+      element: (
+        <SecondaryButton
+          onClickHandler={() => setShowAddModal(true)}
+          isDisabled={isFetching}
+          dataCy="selfservice-permissions-button-add"
+        >
+          Add
+        </SecondaryButton>
+      ),
+    },
+    {
+      key: 6,
+      toolbarItemVariant: ToolbarItemVariant.separator,
+    },
+    {
+      key: 7,
+      element: (
+        <HelpTextWithIconLayout
+          textContent="Help"
+          onClick={() => dispatch(toggleHelpPanel())}
+        />
+      ),
+    },
+    {
+      key: 8,
+      element: (
+        <PaginationLayout
+          list={elementsList}
+          totalCount={totalCount}
+          widgetId="pagination-options-menu-top"
+          isCompact={true}
+        />
+      ),
+      toolbarItemAlignment: { default: "alignEnd" },
+    },
+  ];
+
+  return (
+    <div>
+      <PageSection hasBodyWrapper={false}>
+        <TitleLayout
+          id="selfservice-permissions-title"
+          headingLevel="h1"
+          text="Self service permissions"
+        />
+      </PageSection>
+      <PageSection hasBodyWrapper={false} isFilled={false}>
+        <Flex direction={{ default: "column" }}>
+          <FlexItem>
+            <ToolbarLayout toolbarItems={toolbarItems} />
+          </FlexItem>
+          <FlexItem style={{ flex: "0 0 auto" }}>
+            <OuterScrollContainer>
+              <InnerScrollContainer
+                style={{ height: "60vh", overflow: "auto" }}
+              >
+                {batchError !== undefined && batchError ? (
+                  <GlobalErrors errors={globalErrors.getAll()} />
+                ) : (
+                  <MainTable
+                    tableTitle="Self service permissions table"
+                    shownElementsList={elementsList}
+                    pk="aciname"
+                    keyNames={keyNames}
+                    columnNames={columnNames}
+                    hasCheckboxes={true}
+                    pathname="selfservice-permissions"
+                    showTableRows={!isFetching}
+                    showLink={false}
+                    elementsData={{
+                      isElementSelectable: isSelfServicePermissionSelectable,
+                      selectedElements: selectedPermissions,
+                      selectableElementsTable: selectableTable,
+                      setElementsSelected: setPermissionSelected,
+                      clearSelectedElements: clearSelectedPermissions,
+                    }}
+                    buttonsData={{
+                      updateIsDeleteButtonDisabled: setIsDeleteButtonDisabled,
+                      isDeletion,
+                      updateIsDeletion: setIsDeletion,
+                    }}
+                    paginationData={selectedPerPageData}
+                  />
+                )}
+              </InnerScrollContainer>
+            </OuterScrollContainer>
+          </FlexItem>
+          <FlexItem style={{ flex: "0 0 auto", position: "sticky", bottom: 0 }}>
+            <PaginationLayout
+              list={elementsList}
+              totalCount={totalCount}
+              variant={PaginationVariant.bottom}
+              widgetId="pagination-options-menu-bottom"
+            />
+          </FlexItem>
+        </Flex>
+      </PageSection>
+      <AddSelfServicePermissionModal
+        isOpen={showAddModal}
+        onClose={() => setShowAddModal(false)}
+        title="Add self-service permission"
+        onRefresh={refreshData}
+      />
+      <DeleteSelfServicePermissionsModal
+        isOpen={showDeleteModal}
+        onClose={() => setShowDeleteModal(false)}
+        elementsToDelete={selectedPermissions}
+        clearSelectedElements={clearSelectedPermissions}
+        columnNames={columnNames}
+        keyNames={keyNames}
+        onRefresh={refreshData}
+        updateIsDeleteButtonDisabled={setIsDeleteButtonDisabled}
+        updateIsDeletion={setIsDeletion}
+      />
+      <ModalErrors
+        errors={modalErrors.getAll()}
+        dataCy="selfservice-permissions-modal-error"
+      />
+    </div>
+  );
+};
+
+export default SelfServicePermissions;

--- a/src/services/rpcSelfServicePermissions.ts
+++ b/src/services/rpcSelfServicePermissions.ts
@@ -1,0 +1,154 @@
+import {
+  api,
+  Command,
+  ErrorResult,
+  getBatchCommand,
+  getCommand,
+  BatchRPCResponse,
+  FindRPCResponse,
+} from "./rpc";
+import { API_VERSION_BACKUP } from "../utils/utils";
+import { SelfServicePermission } from "../utils/datatypes/globalDataTypes";
+import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
+
+/**
+ * Self-service permission-related endpoints
+ *
+ * API commands:
+ * - selfservice_find: https://freeipa.readthedocs.io/en/latest/api/selfservice_find.html
+ * - selfservice_show: https://freeipa.readthedocs.io/en/latest/api/selfservice_show.html
+ * - selfservice_add:  https://freeipa.readthedocs.io/en/latest/api/selfservice_add.html
+ * - selfservice_del:  https://freeipa.readthedocs.io/en/latest/api/selfservice_del.html
+ */
+
+interface SelfServicePermissionsFullDataPayload {
+  searchValue: string;
+  sizeLimit?: number;
+  apiVersion: string;
+  startIdx: number;
+  stopIdx: number;
+}
+
+interface SelfServicePermissionAddPayload {
+  aciname: string;
+  attrs: string[];
+}
+
+const extendedApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    getSelfServicePermissionsFullData: build.query<
+      BatchRPCResponse,
+      SelfServicePermissionsFullDataPayload
+    >({
+      async queryFn(payloadData, _queryApi, _extraOptions, fetchWithBQ) {
+        const { searchValue, apiVersion, startIdx, stopIdx, sizeLimit } =
+          payloadData;
+
+        const effectiveStopIdx =
+          typeof sizeLimit === "number" && sizeLimit > 0
+            ? Math.min(stopIdx, startIdx + sizeLimit)
+            : stopIdx;
+
+        const params = {
+          pkey_only: true,
+          version: apiVersion,
+        };
+
+        const findCommand: Command = {
+          method: "selfservice_find",
+          params: [[searchValue], params],
+        };
+
+        const findResult = await fetchWithBQ(getCommand(findCommand));
+        if (findResult.error) {
+          return { error: findResult.error as FetchBaseQueryError };
+        }
+
+        const findResponse = findResult.data as FindRPCResponse;
+
+        if (!findResponse.result) {
+          const ipaError = findResponse.error as ErrorResult | string;
+          const errorMsg =
+            typeof ipaError === "object" && ipaError?.message
+              ? ipaError.message
+              : String(ipaError || "selfservice_find returned no result");
+
+          return {
+            error: {
+              status: "CUSTOM_ERROR",
+              data: errorMsg,
+              error: errorMsg,
+            } as FetchBaseQueryError,
+          };
+        }
+
+        const totalCount = findResponse.result.result.length as number;
+        const ids: string[] = [];
+
+        for (let i = startIdx; i < totalCount && i < effectiveStopIdx; i++) {
+          const item = findResponse.result.result[i] as Record<string, unknown>;
+          const aciname = item.aciname;
+          ids.push(
+            Array.isArray(aciname)
+              ? (aciname[0] as string)
+              : (aciname as string)
+          );
+        }
+
+        const showCommands: Command[] = ids.map((id) => ({
+          method: "selfservice_show",
+          params: [[id], {}],
+        }));
+
+        const showResult = await fetchWithBQ(
+          getBatchCommand(showCommands, apiVersion)
+        );
+
+        const response = showResult.data as BatchRPCResponse;
+        if (response) {
+          response.result.totalCount = totalCount;
+        }
+
+        return response
+          ? { data: response }
+          : { error: showResult.error as FetchBaseQueryError };
+      },
+    }),
+
+    addSelfServicePermission: build.mutation<
+      FindRPCResponse,
+      SelfServicePermissionAddPayload
+    >({
+      query: (payload) => {
+        const params: Record<string, unknown> = {
+          attrs: payload.attrs,
+          version: API_VERSION_BACKUP,
+        };
+        return getCommand({
+          method: "selfservice_add",
+          params: [[payload.aciname], params],
+        });
+      },
+    }),
+
+    deleteSelfServicePermissions: build.mutation<
+      BatchRPCResponse,
+      SelfServicePermission[]
+    >({
+      query: (permissions) => {
+        const commands: Command[] = permissions.map((perm) => ({
+          method: "selfservice_del",
+          params: [[perm.aciname], {}],
+        }));
+        return getBatchCommand(commands, API_VERSION_BACKUP);
+      },
+    }),
+  }),
+  overrideExisting: false,
+});
+
+export const {
+  useGetSelfServicePermissionsFullDataQuery,
+  useAddSelfServicePermissionMutation,
+  useDeleteSelfServicePermissionsMutation,
+} = extendedApi;

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -244,6 +244,13 @@ export interface Permission {
   type: string;
 }
 
+export interface SelfServicePermission {
+  aciname: string;
+  permissions: string[];
+  attrs: string[];
+  aci: string;
+}
+
 export interface HBACRule {
   hostcategory: string;
   servicecategory: string;

--- a/src/utils/selfServicePermissionsUtils.tsx
+++ b/src/utils/selfServicePermissionsUtils.tsx
@@ -1,0 +1,48 @@
+import { SelfServicePermission } from "src/utils/datatypes/globalDataTypes";
+import { convertApiObj } from "./ipaObjectUtils";
+
+export const asRecord = (
+  element: Partial<SelfServicePermission>,
+  onElementChange: (element: Partial<SelfServicePermission>) => void
+) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ipaObject = element as Record<string, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function recordOnChange(ipaObject: Record<string, any>) {
+    onElementChange(ipaObject as SelfServicePermission);
+  }
+
+  return { ipaObject, recordOnChange };
+};
+
+const simpleValues = new Set(["aciname", "aci"]);
+const dateValues = new Set([]);
+
+export function apiToSelfServicePermission(
+  apiRecord: Record<string, unknown>
+): SelfServicePermission {
+  const converted = convertApiObj(
+    apiRecord,
+    simpleValues,
+    dateValues
+  ) as Partial<SelfServicePermission>;
+  return partialToSelfServicePermission(converted);
+}
+
+export function partialToSelfServicePermission(
+  partial: Partial<SelfServicePermission>
+): SelfServicePermission {
+  return {
+    ...createEmptySelfServicePermission(),
+    ...partial,
+  };
+}
+
+export function createEmptySelfServicePermission(): SelfServicePermission {
+  return {
+    aciname: "",
+    permissions: [],
+    attrs: [],
+    aci: "",
+  };
+}

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -16,6 +16,7 @@ import {
   Permission,
   Privilege,
   Role,
+  SelfServicePermission,
   Service,
   SudoCmd,
   SudoCmdGroup,
@@ -252,6 +253,10 @@ export const isOtpTokenSelectable = (otpToken: OtpToken) =>
 
 export const isSelinuxUserMapSelectable = (map: SELinuxUserMap) =>
   map.cn !== "";
+
+export const isSelfServicePermissionSelectable = (
+  perm: SelfServicePermission
+) => perm.aciname !== "";
 
 /**
  * Write JSX error messages into 'apiErrorsJsx' array


### PR DESCRIPTION
The 'Self service permissions' page
must show a table with all the entries
from `selfservice_find` API command and
allow refresh, add, and delete operations.

Assisted-by: Claude <noreply@anthropic.com>

## Summary by Sourcery

Add a new Self service permissions management page wired into navigation and routing, backed by RPC endpoints for listing, creating, and deleting self-service permissions.

New Features:
- Introduce a Self service permissions list page with search, pagination, bulk selection, and contextual help.
- Add modals to create and delete self-service permissions, including selectable attribute configuration.
- Add a reusable typeahead-with-checkbox component supporting option creation and multi-select.

Enhancements:
- Extend global data types, selection utilities, and IPA object conversion helpers to support self-service permission entities.