### PR TITLE
Allow spaces in user names and auto-generate login

### DIFF
--- a/src/components/modals/UserModals/AddUser.tsx
+++ b/src/components/modals/UserModals/AddUser.tsx
@@ -17,6 +17,7 @@ import { useAppDispatch, useAppSelector } from "src/store/hooks";
 // RPC
 import {
   useSimpleMutCommandMutation,
+  useGetObjectMetadataQuery,
   Command,
   FindRPCResponse,
 } from "src/services/rpc";
@@ -28,6 +29,7 @@ import ErrorModal from "src/components/modals/ErrorModal";
 import { addAlert } from "src/store/Global/alerts-slice";
 // Utils
 import { NO_SELECTION_OPTION } from "src/utils/constUtils";
+import { generateLogin } from "src/utils/loginUtils";
 // Components
 import TypeAheadSelectWithCreate from "src/components/TypeAheadSelectWithCreate";
 import InputWithValidation from "src/components/layouts/InputWithValidation";
@@ -58,13 +60,17 @@ const AddUser = (props: PropsToAddUser) => {
     (state) => state.global.environment.api_version
   ) as string;
 
+  // [API call] Metadata
+  const metadataQuery = useGetObjectMetadataQuery();
+  const metadata = metadataQuery.data || {};
+
   // Define 'executeCommand' to add user data to IPA server
   const [addUser] = useAddUserMutation();
   // Define handler to execute when getting gids
   const [retrieveGIDs] = useSimpleMutCommandMutation();
 
   // useStates for TextInputs
-  const [userLogin, setUserLogin] = React.useState("");
+  const [customLogin, setCustomLogin] = React.useState("");
   const [firstName, setFirstName] = React.useState("");
   const [lastName, setLastName] = React.useState("");
   const [userClass, setUserClass] = React.useState("");
@@ -74,6 +80,13 @@ const AddUser = (props: PropsToAddUser) => {
   const [verifyNewPassword, setVerifyNewPassword] = React.useState("");
   const [addSpinning, setAddBtnSpinning] = React.useState<boolean>(false);
 
+  // Generated login shown as placeholder; used as fallback on submit
+  const generatedLogin = generateLogin(firstName, lastName);
+
+  const handleLoginChange = (value: string) => {
+    setCustomLogin(value);
+  };
+
   const newPasswordValueHandler = (value: string) => {
     setNewPassword(value);
   };
@@ -82,12 +95,16 @@ const AddUser = (props: PropsToAddUser) => {
     setVerifyNewPassword(value);
   };
 
-  // User login: Valid characters in first char: ., _
-  const userLoginFormatFirst = /^([A-Za-z._]).*$/;
-  // User login: Valid characters in body (every char must be in set): letters, digits, '_', '-', '.', '$'
-  const userLoginFormatBody = /^[A-Za-z0-9._\-$]*$/;
-  // Valid characters: '-' symbols only
-  const formatWithoutSpaces = /[`!@#$%^&*()_+=[\]{};':"\\|,.<>/?~\s]/;
+  // User login pattern from server metadata (falls back to hardcoded default)
+  const uidParam = metadata.objects?.user?.takes_params?.find(
+    (param) => param.name === "uid"
+  );
+  const userLoginPattern = uidParam?.pattern
+    ? new RegExp(uidParam.pattern)
+    : /(?!^[0-9]+$)^[a-zA-Z0-9_.][a-zA-Z0-9_.-]*[a-zA-Z0-9_.$-]?$/;
+  const userLoginPatternErrMsg =
+    uidParam?.pattern_errmsg ||
+    "may only include letters, numbers, _, -, . and $";
 
   // [API call] Get GIDs
   const getGIDs = () => {
@@ -154,9 +171,8 @@ const AddUser = (props: PropsToAddUser) => {
   // Buttons are disabled until the user fills the required fields
   const buttonDisabled = !(
     firstName.length > 0 &&
-    !formatWithoutSpaces.test(firstName) &&
     lastName.length > 0 &&
-    !formatWithoutSpaces.test(lastName) &&
+    (customLogin === "" || userLoginPattern.test(customLogin)) &&
     verifiedPasswords &&
     (isNoPrivateGroupChecked === true ? gidSelected !== "" : true)
   );
@@ -183,16 +199,14 @@ const AddUser = (props: PropsToAddUser) => {
           dataCy="modal-textbox-login"
           id="modal-form-user-login"
           name="modal-form-user-login"
-          isRequired
-          value={userLogin}
-          onChange={setUserLogin}
+          value={customLogin}
+          placeholder={generatedLogin}
+          onChange={handleLoginChange}
           rules={[
             {
               id: "ruleCharacters",
-              message: "Only alphanumeric and special characters _-.$",
-              validate: (v: string) =>
-                userLoginFormatFirst.test(v.charAt(0)) &&
-                userLoginFormatBody.test(v.substring(1)),
+              message: userLoginPatternErrMsg,
+              validate: (v: string) => userLoginPattern.test(v),
             },
           ]}
         />
@@ -202,21 +216,13 @@ const AddUser = (props: PropsToAddUser) => {
       id: "modal-form-first-name",
       name: "First name",
       pfComponent: (
-        <InputWithValidation
-          dataCy="modal-textbox-first-name"
+        <TextInput
+          data-cy="modal-textbox-first-name"
           id="modal-form-first-name"
           name="modal-form-first-name"
           value={firstName}
-          onChange={setFirstName}
+          onChange={(_event, value: string) => setFirstName(value)}
           isRequired
-          rules={[
-            {
-              id: "ruleCharacters",
-              message:
-                "First name should not contain special characters or spaces",
-              validate: (v: string) => !formatWithoutSpaces.test(v),
-            },
-          ]}
         />
       ),
       fieldRequired: true,
@@ -225,21 +231,13 @@ const AddUser = (props: PropsToAddUser) => {
       id: "modal-form-last-name",
       name: "Last name",
       pfComponent: (
-        <InputWithValidation
-          dataCy="modal-textbox-last-name"
+        <TextInput
+          data-cy="modal-textbox-last-name"
           id="modal-form-last-name"
           name="modal-form-last-name"
           value={lastName}
-          onChange={setLastName}
+          onChange={(_event, value: string) => setLastName(value)}
           isRequired
-          rules={[
-            {
-              id: "ruleCharacters",
-              message:
-                "Last name should not contain special characters or spaces",
-              validate: (v: string) => !formatWithoutSpaces.test(v),
-            },
-          ]}
         />
       ),
       fieldRequired: true,
@@ -362,8 +360,9 @@ const AddUser = (props: PropsToAddUser) => {
       sn: lastName,
     };
 
-    if (userLogin !== "") {
-      newUserPayload.uid = userLogin;
+    const effectiveLogin = customLogin || generatedLogin;
+    if (effectiveLogin !== "") {
+      newUserPayload.uid = effectiveLogin;
     }
 
     if (userClass !== "") {
@@ -421,7 +420,7 @@ const AddUser = (props: PropsToAddUser) => {
 
   // Helper method to clean the fields
   const cleanAllFields = () => {
-    setUserLogin("");
+    setCustomLogin("");
     setFirstName("");
     setLastName("");
     setUserClass("");

--- a/src/utils/loginUtils.ts
+++ b/src/utils/loginUtils.ts
@@ -1,0 +1,21 @@
+/**
+ * Strips diacritics and removes characters not valid in a FreeIPA login.
+ */
+export const sanitizeLoginPart = (s: string): string =>
+  s
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^A-Za-z0-9._\-$]/g, "")
+    .toLowerCase();
+
+/**
+ * Generates a sanitized login from first + last name,
+ * matching FreeIPA's default: givenname[0] + sn (lowercased).
+ */
+export const generateLogin = (first: string, last: string): string => {
+  const sanitizedFirst = sanitizeLoginPart(first);
+  const sanitizedLast = sanitizeLoginPart(last);
+
+  if (!sanitizedFirst || !sanitizedLast) return "";
+  return sanitizedFirst.charAt(0) + sanitizedLast;
+};


### PR DESCRIPTION
The Add User modal previously rejected first/last names containing spaces (e.g., "Maria José", "Van den Berg"), which are valid values for the givenname/sn LDAP attributes in FreeIPA.

This change:
- Removes the whitespace restriction from name field validation, allowing composed names and multi-word surnames.
- Auto-generates a sanitized user login (uid) from the first and last name as the user types, stripping diacritics, spaces, and other characters invalid for a login. This prevents the server-side ValidationError that occurred when no uid was provided and the auto-generated default contained spaces.
- Allows the user to override the suggested login; clearing it re-triggers auto-generation from the current name values.

Assisted-by: Claude <noreply@anthropic.com>
Fixes: https://github.com/freeipa/freeipa-webui/issues/1151

## Summary by Sourcery

Allow spaces in user first and last names in the Add User modal and auto-generate a sanitized login from those names, while still permitting manual override.

New Features:
- Automatically derive a suggested user login from the entered first and last names, sanitizing it to match FreeIPA uid constraints and updating as the user types.

Enhancements:
- Relax first and last name validation to accept spaces while still blocking special characters.
- Track whether the login field has been manually edited to stop auto-generation and resume it if the field is cleared.
- Reset the login touch state when clearing the Add User form to restore default auto-generation behavior.