### PR TITLE
Hide main dropdown unused options

### DIFF
--- a/src/AppLayout.tsx
+++ b/src/AppLayout.tsx
@@ -23,10 +23,6 @@ import {
 } from "@patternfly/react-core";
 import React from "react";
 // Icons
-import { UserIcon } from "@patternfly/react-icons";
-import { KeyIcon } from "@patternfly/react-icons";
-import { CogIcon } from "@patternfly/react-icons";
-import { UnknownIcon } from "@patternfly/react-icons";
 import { ShareSquareIcon } from "@patternfly/react-icons";
 // Navigation
 import Navigation from "./navigation/Nav";
@@ -97,30 +93,6 @@ const AppLayout = (props: PropsToAppLayout) => {
   };
 
   const dropdownItems = [
-    <DropdownItem
-      key="profile"
-      component="button"
-      data-cy="toolbar-button-profile"
-    >
-      <UserIcon /> Profile
-    </DropdownItem>,
-    <DropdownItem
-      key="change-password"
-      component="button"
-      data-cy="toolbar-button-change-password"
-    >
-      <KeyIcon /> Change password
-    </DropdownItem>,
-    <DropdownItem
-      key="customization"
-      component="button"
-      data-cy="toolbar-button-customization"
-    >
-      <CogIcon /> Customization
-    </DropdownItem>,
-    <DropdownItem key="about" component="button" data-cy="toolbar-button-about">
-      <UnknownIcon /> About
-    </DropdownItem>,
     <DropdownItem
       key="logout"
       component="button"


### PR DESCRIPTION
Some main masthead options are not implemented,
so these must be be hidden until its functionality is provided.

Fixes: https://github.com/freeipa/freeipa-webui/issues/1152

## Summary by Sourcery

Hide unimplemented masthead dropdown options from the main layout.

Enhancements:
- Remove unused profile, change password, customization, and about entries from the masthead user dropdown.

Chores:
- Clean up unused icon imports associated with removed dropdown items.