### PR TITLE
Provide skill to locally deploy modern WebUI

### DIFF
--- a/.cursor/rules/deploy_webui.mdc
+++ b/.cursor/rules/deploy_webui.mdc
@@ -1,0 +1,13 @@
+# Project Automation Rules
+
+You have access to local automation scripts to manage the FreeIPA WebUI development environment.
+
+## Tool 1: WebUI Deployment
+- **When to use it:** Whenever the user asks to spin up, deploy, or install the FreeIPA WebUI environment.
+- **How to use it:** Execute `./deploy_webui.sh <scenario>` in the integrated terminal. (Default scenario: `single-server`).
+- **Important Note:** This script is interactive. If an environment already exists, it will pause and prompt the user with "Do you want to set a new environment?". **Do not try to answer this prompt automatically**; let the human user type 'y' or 'n' in the terminal.
+
+## Tool 2: WebUI Cleanup / Teardown
+- **When to use it:** Whenever the user asks to destroy, clean, or teardown the current FreeIPA WebUI containers.
+- **Normal Cleanup:** Execute `./clean_webui.sh` for standard container removal.
+- **Deep Cleanup:** Execute `./clean_webui.sh --deep` ONLY when the user explicitly asks for a full system reset, or if a standard clean didn't fix corrupted Podman images/storage.

--- a/skills/clean_webui.sh
+++ b/skills/clean_webui.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+DEEP_CLEAN=false
+
+# Check if the --deep flag was passed
+if [ "$1" == "--deep" ]; then
+    DEEP_CLEAN=true
+fi
+
+echo "=== Cleaning FreeIPA WebUI environment ==="
+
+if command -v podman &> /dev/null; then
+    echo "[INFO] Stopping Podman containers related to FreeIPA..."
+    podman stop webui freeipa-server 2>/dev/null || true
+    
+    echo "[INFO] Removing Podman containers related to FreeIPA..."
+    podman rm -f webui freeipa-server 2>/dev/null || true
+    
+    echo "[INFO] Pruning unused Podman networks..."
+    podman network prune -f 2>/dev/null || true
+
+    if [ "${DEEP_CLEAN}" = true ]; then
+        echo "[WARNING] Performing DEEP CLEAN: Purging all Podman cache and images..."
+        podman system prune --all --force
+        podman rmi --all --force
+    fi
+fi
+
+echo "=== Environment successfully cleaned ==="

--- a/skills/deploy_webui.sh
+++ b/skills/deploy_webui.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+set -e
+
+SCENARIO=${1:-single-server}
+FORCE_OVERWRITE=false
+
+# Check if the --force flag was passed as the second argument
+if [ "$2" == "--force" ]; then
+    FORCE_OVERWRITE=true
+fi
+
+# --- Safety Check ---
+if [ ! -f "./developer/dev-env.sh" ]; then
+    echo "[ERROR] This script must be run from the root of the freeipa-webui repository."
+    exit 1
+fi
+
+# --- Existing Environment Check ---
+if command -v podman &> /dev/null; then
+  container_list=$(podman ps -a --format "{{.Names}}" || true)
+  if echo "${container_list}" | grep -Eq "^webui$|^freeipa-"; then
+    echo "[INFO] An existing WebUI environment was detected."
+    
+    if [ "${FORCE_OVERWRITE}" = true ]; then
+        echo "[INFO] Force flag detected. Proceeding to clean the current environment automatically..."
+        ./skills/clean_webui.sh
+    else
+        # Check if running interactively (human in a terminal)
+        if [ -t 0 ]; then
+            read -rp "Do you want to set a new environment? (y/N): " choice
+            case "${choice}" in 
+              y|Y ) 
+                echo "[INFO] Proceeding to clean the current environment..."
+                ./skills/clean_webui.sh
+                ;;
+              * )
+                echo "[INFO] Deployment aborted by the user."
+                exit 0
+                ;;
+            esac
+        else
+            # Running non-interactively (e.g., via AI Agent like Lola or Cursor)
+            echo "[ERROR] Environment already exists and script is running in non-interactive mode."
+            echo "[HINT] Provide the '--force' flag to overwrite the environment automatically."
+            exit 1
+        fi
+    fi
+  fi
+fi
+# ------------------------------------------------
+
+echo "=== Starting FreeIPA WebUI deployment (Scenario: ${SCENARIO}) ==="
+
+# 1. Python Environment & Dependencies
+if [ ! -d "venv" ]; then
+    echo "[INFO] Creating Python virtual environment..."
+    python3 -m venv venv
+else
+    echo "[INFO] Python venv already exists."
+fi
+# shellcheck source=/dev/null
+source venv/bin/activate
+pip install --quiet -U pip podman ansible-core podman-compose
+
+# 2. Build and Setup the scenario
+echo "[INFO] Building scenario..."
+./developer/dev-env.sh -B "${SCENARIO}"
+echo "[INFO] Setting up scenario..."
+./developer/dev-env.sh -s "${SCENARIO}"
+
+# 3. Modify /etc/hosts using the scenario-specific hosts file
+HOSTS_FILE="./developer/scenarios/${SCENARIO}/hosts"
+WEBUI_HOSTNAME=$(awk '/^[^#]/ && /webui\./ { print $2; exit }' "${HOSTS_FILE}")
+WEBUI_HOSTNAME=${WEBUI_HOSTNAME:-webui.ipa.test}
+WEBUI_URL="https://${WEBUI_HOSTNAME}/ipa/modern-ui"
+
+if ! grep -qF "${WEBUI_HOSTNAME}" /etc/hosts; then
+    if sudo -n true 2>/dev/null; then
+            echo "[INFO] Adding ${SCENARIO} host entries to /etc/hosts..."
+            sudo tee -a /etc/hosts <<< "$(<"${HOSTS_FILE}")"
+    else
+        echo "[WARNING] Could not modify /etc/hosts. Sudo is required."
+        echo "Please add the following entries from ${HOSTS_FILE} manually:"
+        cat "${HOSTS_FILE}"
+    fi
+fi
+
+# 4. NPM Dependencies
+echo "[INFO] Installing NPM dependencies inside Podman..."
+podman exec webui npm install
+
+# 5. Build WebUI for production
+echo "[INFO] Building WebUI..."
+podman exec webui npm run build
+
+# 6. nss-tools and browser access
+if sudo -n true 2>/dev/null; then
+    sudo dnf install -y nss-tools
+else
+    echo "[WARNING] Could not install nss-tools automatically (requires sudo)."
+fi
+
+echo "=== Deployment completed ==="
+echo "The WebUI should be available shortly at: ${WEBUI_URL}"
+
+if [ -n "${DISPLAY}" ]; then
+    ./developer/open-browser.sh "${WEBUI_URL}" || true
+fi


### PR DESCRIPTION
The `deploy_webui.mdc` skill provides an easy way
to deploy the modern WebUI local environment
following the development environment steps[1].
It uses the following files to set the env:
- `deploy_webui.sh`: main steps to configure the local environment
- `clean_webui.sh`: performs a podman cleanup if there is already an environment set in local.
This ensures that the steps are executed from
a clean start point.

These steps can be executed via bash or any AI agent using a prompt like: `Please deploy the FreeIPA WebUI using the single-server scenario` (or any other scenario)

[1] - https://github.com/freeipa/freeipa-webui#development-environment
Assisted-by: Claude <noreply@anthropic.com>

## Summary by Sourcery

Provide automated scripts and agent guidance for deploying the modern WebUI development environment locally from a clean starting point.

New Features:
- Add a local deployment skill for setting up and launching the modern FreeIPA WebUI with selectable development scenarios.
- Add a cleanup utility for removing existing WebUI containers and optionally purging Podman resources.

## Summary by Sourcery

Provide scripts and agent guidance to deploy the modern FreeIPA WebUI locally from a clean environment.

New Features:
- Add a deployment skill for setting up the FreeIPA WebUI development environment with selectable scenarios and optional browser launch.
- Add a cleanup utility for removing existing WebUI containers and optionally performing a deep Podman cleanup.

Enhancements:
- Support safe replacement of existing environments through interactive confirmation or an explicit force option, including non-interactive use.