### PR TITLE
Add Cypress integration tests for Host groups pages

### DIFF
--- a/cypress/e2e/common/alert.ts
+++ b/cypress/e2e/common/alert.ts
@@ -1,5 +1,13 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { Then, When } from "@badeball/cypress-cucumber-preprocessor";
 
 Then("I should see {string} alert", (name: string) => {
   cy.dataCy(name).should("be.visible");
+});
+
+When("I close the {string} alert", (name: string) => {
+  cy.dataCy(name)
+    .should("be.visible")
+    .find("[data-cy='alert-button-close']")
+    .click();
+  cy.dataCy(name).should("not.exist");
 });

--- a/cypress/e2e/common/members_table.ts
+++ b/cypress/e2e/common/members_table.ts
@@ -1,13 +1,26 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { When, Then } from "@badeball/cypress-cucumber-preprocessor";
 import { checkEntry } from "./data_tables";
 
-export const searchForMembersEntry = (name: string) => {
+export const typeInMembersTableSearch = (name: string) => {
   cy.dataCy("search").find("input").clear();
   cy.dataCy("search").find("input").should("have.value", "");
   cy.dataCy("search").find("input").type(name);
   cy.dataCy("search").find("input").should("have.value", name);
+};
 
+export const submitMembersTableSearch = () => {
   cy.dataCy("search").find("button[type='submit']").click();
+};
+
+export const clearMembersTableSearch = () => {
+  cy.dataCy("search").find("input").clear();
+  cy.dataCy("search").find("input").should("have.value", "");
+  submitMembersTableSearch();
+};
+
+export const searchForMembersEntry = (name: string) => {
+  typeInMembersTableSearch(name);
+  submitMembersTableSearch();
 };
 
 export const selectMembersEntry = (name: string) => {
@@ -17,6 +30,25 @@ export const selectMembersEntry = (name: string) => {
 
 When("I search for {string} in the members table", (name: string) => {
   searchForMembersEntry(name);
+});
+
+When("I type {string} in the members table search field", (name: string) => {
+  typeInMembersTableSearch(name);
+});
+
+Then(
+  "I should see {string} in the members table search field",
+  (name: string) => {
+    cy.dataCy("search").find("input").should("have.value", name);
+  }
+);
+
+When("I submit the members table search", () => {
+  submitMembersTableSearch();
+});
+
+When("I clear the members table search field", () => {
+  clearMembersTableSearch();
 });
 
 When("I select entry {string} in the members table", (name: string) => {

--- a/cypress/e2e/common/modal.ts
+++ b/cypress/e2e/common/modal.ts
@@ -7,3 +7,26 @@ Then("I should see {string} modal", (modalName: string) => {
 Then("I should not see {string} modal", (modalName: string) => {
   cy.get(`[data-cy='${modalName}']`, { timeout: 30000 }).should("not.exist");
 });
+
+const MODAL_TITLE_IDS: Record<string, string> = {
+  "member-of-add-modal": "member-of-add-modal-title",
+  "member-of-delete-modal": "member-of-delete-modal-title",
+};
+
+Then(
+  "I should see {string} modal with title {string}",
+  (modalName: string, title: string) => {
+    const titleId = MODAL_TITLE_IDS[modalName];
+    if (!titleId) {
+      throw new Error(`Unknown modal "${modalName}" for title assertion`);
+    }
+    cy.get(`#${titleId}`).should("be.visible").and("contain.text", title);
+  }
+);
+
+Then(
+  "I should see {string} entry in the {string} modal",
+  (entry: string, modalName: string) => {
+    cy.dataCy(modalName).contains("td", entry).should("exist");
+  }
+);

--- a/cypress/e2e/hostgroups/hostgroup.feature
+++ b/cypress/e2e/hostgroups/hostgroup.feature
@@ -1,25 +1,105 @@
 Feature: Hostgroup management
+  Create, and delete host groups
 
-    @test
-    Scenario: Create new host group
-        Given I am logged in as admin
-        And I am on "host-groups" page
+  @test
+  Scenario: Add a new host group
+    Given I am logged in as admin
+    And I am on "host-groups" page
 
-        When I create hostgroup "my_automember_hostgroup" with description "test"
-        Then I should see hostgroup "my_automember_hostgroup" in the data table
+    When I click on the "host-groups-button-add" button
+    Then I should see "add-hostgroup-modal" modal
 
-    @cleanup
-    Scenario: Delete host group
-        Given I delete hostgroup "my_automember_hostgroup"
+    When I type in the "modal-textbox-hostgroup-name" textbox text "a-hostgroup"
+    Then I should see "a-hostgroup" in the "modal-textbox-hostgroup-name" textbox
 
-    @seed
-    Scenario: Create new host group
-        Given hostgroup "my_automember_hostgroup" with description "test" exists
+    When I type in the "modal-textbox-hostgroup-description" textbox text "test"
+    Then I should see "test" in the "modal-textbox-hostgroup-description" textbox
 
-    @test
-    Scenario: Delete host group
-        Given I am logged in as admin
-        And I am on "host-groups" page
+    When I click on the "modal-button-add" button
+    Then I should not see "add-hostgroup-modal" modal
+    And I should see "add-hostgroup-success" alert
 
-        When I try to delete hostgroup "my_automember_hostgroup"
-        Then I should not see hostgroup "my_automember_hostgroup" in the data table
+    When I search for "a-hostgroup" in the data table
+    Then I should see "a-hostgroup" entry in the data table
+
+  @cleanup
+  Scenario: Delete a host group
+    Given I delete hostgroup "a-hostgroup"
+
+  @seed
+  Scenario: Create a host group
+    Given hostgroup "a-hostgroup" exists
+
+  @test
+  Scenario: Delete a host group
+    Given I am logged in as admin
+    And I am on "host-groups" page
+
+    When I search for "a-hostgroup" in the data table
+    Then I should see "a-hostgroup" entry in the data table
+
+    When I select entry "a-hostgroup" in the data table
+    Then I should see "a-hostgroup" entry selected in the data table
+
+    When I click on the "host-groups-button-delete" button
+    Then I should see "delete-hostgroups-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "delete-hostgroups-modal" modal
+    And I should see "remove-hostgroups-success" alert
+
+    When I search for "a-hostgroup" in the data table
+    Then I should not see "a-hostgroup" entry in the data table
+
+  @seed
+  Scenario: Create host groups
+    Given hostgroup "hostgroup1" exists
+    And hostgroup "hostgroup2" exists
+
+  @test
+  Scenario: Delete many host groups
+    Given I am logged in as admin
+    And I am on "host-groups" page
+
+    When I search for "hostgroup1" in the data table
+    Then I should see "hostgroup1" entry in the data table
+    When I select entry "hostgroup1" in the data table
+    Then I should see "hostgroup1" entry selected in the data table
+
+    When I search for "hostgroup2" in the data table
+    Then I should see "hostgroup2" entry in the data table
+    When I select entry "hostgroup2" in the data table
+    Then I should see "hostgroup2" entry selected in the data table
+
+    When I click on the "host-groups-button-delete" button
+    Then I should see "delete-hostgroups-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "delete-hostgroups-modal" modal
+    And I should see "remove-hostgroups-success" alert
+
+    When I search for "hostgroup1" in the data table
+    Then I should not see "hostgroup1" entry in the data table
+
+    When I search for "hostgroup2" in the data table
+    Then I should not see "hostgroup2" entry in the data table
+
+  @test
+  Scenario: Cancel creation of a host group
+    Given I am logged in as admin
+    And I am on "host-groups" page
+
+    When I search for "cancelhostgroup" in the data table
+    Then I should not see "cancelhostgroup" entry in the data table
+
+    When I click on the "host-groups-button-add" button
+    Then I should see "add-hostgroup-modal" modal
+
+    When I type in the "modal-textbox-hostgroup-name" textbox text "cancelhostgroup"
+    Then I should see "cancelhostgroup" in the "modal-textbox-hostgroup-name" textbox
+
+    When I click on the "modal-button-cancel" button
+    Then I should not see "add-hostgroup-modal" modal
+
+    When I search for "cancelhostgroup" in the data table
+    Then I should not see "cancelhostgroup" entry in the data table

--- a/cypress/e2e/hostgroups/hostgroup.ts
+++ b/cypress/e2e/hostgroups/hostgroup.ts
@@ -7,6 +7,64 @@ import {
 } from "../common/data_tables";
 import { navigateTo } from "../common/navigation";
 
+type MemberType = "member_host" | "member_hostgroup";
+
+type MemberOfType =
+  | "memberof_netgroup"
+  | "memberof_hbacrule"
+  | "memberof_sudorule";
+
+const MEMBERS_TAB_COUNT_MAP = {
+  host: "host-groups-tab-member-host-count",
+  hostgroup: "host-groups-tab-member-hostgroup-count",
+} as const;
+
+type MembersTabName = keyof typeof MEMBERS_TAB_COUNT_MAP;
+
+const addMember = (
+  type: MemberType | MemberOfType,
+  member: string,
+  hostgroup: string
+) => {
+  switch (type) {
+    case "member_host":
+      cy.ipa({
+        command: "hostgroup-add-member",
+        name: hostgroup,
+        specificOptions: `--hosts=${member}`,
+      });
+      break;
+    case "member_hostgroup":
+      cy.ipa({
+        command: "hostgroup-add-member",
+        name: hostgroup,
+        specificOptions: `--hostgroups=${member}`,
+      });
+      break;
+    case "memberof_netgroup":
+      cy.ipa({
+        command: "netgroup-add-member",
+        name: member,
+        specificOptions: `--hostgroups=${hostgroup}`,
+      });
+      break;
+    case "memberof_hbacrule":
+      cy.ipa({
+        command: "hbacrule-add-host",
+        name: member,
+        specificOptions: `--hostgroups=${hostgroup}`,
+      });
+      break;
+    case "memberof_sudorule":
+      cy.ipa({
+        command: "sudorule-add-host",
+        name: member,
+        specificOptions: `--hostgroups=${hostgroup}`,
+      });
+      break;
+  }
+};
+
 const fillHostgroup = (hostgroupName: string, hostgroupDescription: string) => {
   cy.dataCy("modal-textbox-hostgroup-name").type(hostgroupName);
   cy.dataCy("modal-textbox-hostgroup-name").should("have.value", hostgroupName);
@@ -71,6 +129,13 @@ Then(
   }
 );
 
+Given("hostgroup {string} exists", (hostgroupName: string) => {
+  cy.ipa({
+    command: "hostgroup-add",
+    name: hostgroupName,
+  });
+});
+
 Given(
   "hostgroup {string} with description {string} exists",
   (hostgroupName: string, hostgroupDescription: string) => {
@@ -95,6 +160,58 @@ When("I try to delete hostgroup {string}", (hostgroupName: string) => {
   searchForEntry(hostgroupName);
   entryDoesNotExist(hostgroupName);
 });
+
+Given(
+  "host {string} is member of hostgroup {string}",
+  (host: string, hostgroup: string) => {
+    addMember("member_host", host, hostgroup);
+  }
+);
+
+Given(
+  "hostgroup {string} is member of hostgroup {string}",
+  (memberHostgroup: string, hostgroup: string) => {
+    addMember("member_hostgroup", memberHostgroup, hostgroup);
+  }
+);
+
+Given(
+  "hostgroup {string} is member of netgroup {string}",
+  (hostgroup: string, netgroup: string) => {
+    addMember("memberof_netgroup", netgroup, hostgroup);
+  }
+);
+
+Given(
+  "hostgroup {string} is member of hbac rule {string}",
+  (hostgroup: string, hbacRule: string) => {
+    addMember("memberof_hbacrule", hbacRule, hostgroup);
+  }
+);
+
+Given(
+  "hostgroup {string} is member of sudo rule {string}",
+  (hostgroup: string, sudoRule: string) => {
+    addMember("memberof_sudorule", sudoRule, hostgroup);
+  }
+);
+
+Then(
+  "I should see the host groups members tab {string} count is {string}",
+  (tab: string, count: string) => {
+    const dataCy = MEMBERS_TAB_COUNT_MAP[tab as MembersTabName];
+    if (!dataCy) {
+      throw new Error(
+        `Unknown host groups members tab "${tab}". Expected one of: ${Object.keys(MEMBERS_TAB_COUNT_MAP).join(", ")}`
+      );
+    }
+
+    cy.dataCy("member-of-button-add", { timeout: 30000 }).should("be.visible");
+    cy.dataCy(dataCy, { timeout: 20000 })
+      .should("be.visible")
+      .and("contain.text", count);
+  }
+);
 
 Given(
   "user {string} is manager of hostgroup {string}",

--- a/cypress/e2e/hostgroups/hostgroup_memberof.feature
+++ b/cypress/e2e/hostgroups/hostgroup_memberof.feature
@@ -1,0 +1,238 @@
+Feature: Hostgroup is a member of
+  Work with hostgroup Is a member of section and its operations in all the available tabs
+
+  @seed
+  Scenario: Create seed data
+    Given hostgroup "a-hostgroup" exists
+
+  @test
+  Scenario: Add a Host groups membership to the host group
+    Given I am logged in as admin
+    And I am on "host-groups/a-hostgroup/memberof_hostgroup" page
+
+    When I click on the "member-of-button-add" button
+    Then I should see "member-of-add-modal" modal
+    And I should see "item-ipaservers" dual list item on the left
+
+    When I click on "item-ipaservers" dual list item
+    Then I should see "item-ipaservers" dual list item selected
+    When I click on the "dual-list-add-selected" button
+    Then I should see "item-ipaservers" dual list item on the right
+
+    When I click on the "modal-button-add" button
+    Then I should not see "member-of-add-modal" modal
+    And I should see "add-member-success" alert
+
+    When I search for "ipaservers" in the members table
+    Then I should see "ipaservers" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete hostgroup "a-hostgroup"
+
+  @seed
+  Scenario: Create seed data
+    Given hostgroup "a-hostgroup" exists
+    And hostgroup "a-hostgroup" is member of hostgroup "ipaservers"
+
+  @test
+  Scenario: Delete a Host groups membership from the host group
+    Given I am logged in as admin
+    And I am on "host-groups/a-hostgroup/memberof_hostgroup" page
+
+    When I select entry "ipaservers" in the members table
+    Then I should see "ipaservers" entry selected in the data table
+
+    When I click on the "member-of-button-delete" button
+    Then I should see "member-of-delete-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "member-of-delete-modal" modal
+    And I should see "remove-host-groups-success" alert
+
+    When I search for "ipaservers" in the members table
+    Then I should not see "ipaservers" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete hostgroup "a-hostgroup"
+
+  @seed
+  Scenario: Create seed data
+    Given hostgroup "a-hostgroup" exists
+    And netgroup "test" exists
+
+  @test
+  Scenario: Add a netgroup membership to the host group
+    Given I am logged in as admin
+    And I am on "host-groups/a-hostgroup/memberof_netgroup" page
+
+    When I click on the "member-of-button-add" button
+    Then I should see "member-of-add-modal" modal
+    And I should see "item-test" dual list item on the left
+
+    When I click on "item-test" dual list item
+    Then I should see "item-test" dual list item selected
+    When I click on the "dual-list-add-selected" button
+    Then I should see "item-test" dual list item on the right
+
+    When I click on the "modal-button-add" button
+    Then I should not see "member-of-add-modal" modal
+    And I should see "add-member-success" alert
+
+    When I search for "test" in the members table
+    Then I should see "test" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete hostgroup "a-hostgroup"
+    And I delete netgroup "test"
+
+  @seed
+  Scenario: Create seed data
+    Given hostgroup "a-hostgroup" exists
+    And netgroup "test" exists
+    And hostgroup "a-hostgroup" is member of netgroup "test"
+
+  @test
+  Scenario: Delete a netgroup membership from the host group
+    Given I am logged in as admin
+    And I am on "host-groups/a-hostgroup/memberof_netgroup" page
+
+    When I select entry "test" in the members table
+    Then I should see "test" entry selected in the data table
+
+    When I click on the "member-of-button-delete" button
+    Then I should see "member-of-delete-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "member-of-delete-modal" modal
+    And I should see "remove-netgroups-success" alert
+
+    When I search for "test" in the members table
+    Then I should not see "test" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete hostgroup "a-hostgroup"
+    And I delete netgroup "test"
+
+  @seed
+  Scenario: Create seed data
+    Given hostgroup "a-hostgroup" exists
+    And hbac rule "test" exists
+
+  @test
+  Scenario: Add a hbac rule membership to the host group
+    Given I am logged in as admin
+    And I am on "host-groups/a-hostgroup/memberof_hbacrule" page
+
+    When I click on the "member-of-button-add" button
+    Then I should see "member-of-add-modal" modal
+    And I should see "item-test" dual list item on the left
+
+    When I click on "item-test" dual list item
+    Then I should see "item-test" dual list item selected
+    When I click on the "dual-list-add-selected" button
+    Then I should see "item-test" dual list item on the right
+
+    When I click on the "modal-button-add" button
+    Then I should not see "member-of-add-modal" modal
+    And I should see "add-member-success" alert
+
+    When I search for "test" in the members table
+    Then I should see "test" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete hostgroup "a-hostgroup"
+    And I delete hbac rule "test"
+
+  @seed
+  Scenario: Create seed data
+    Given hostgroup "a-hostgroup" exists
+    And hbac rule "test" exists
+    And hostgroup "a-hostgroup" is member of hbac rule "test"
+
+  @test
+  Scenario: Delete a hbac rule membership from the host group
+    Given I am logged in as admin
+    And I am on "host-groups/a-hostgroup/memberof_hbacrule" page
+
+    When I select entry "test" in the members table
+    Then I should see "test" entry selected in the data table
+
+    When I click on the "member-of-button-delete" button
+    Then I should see "member-of-delete-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "member-of-delete-modal" modal
+    And I should see "remove-hbac-rules-success" alert
+
+    When I search for "test" in the members table
+    Then I should not see "test" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete hostgroup "a-hostgroup"
+    And I delete hbac rule "test"
+
+  @seed
+  Scenario: Create seed data
+    Given hostgroup "a-hostgroup" exists
+    And sudo rule "test" exists
+
+  @test
+  Scenario: Add a sudo rule membership to the host group
+    Given I am logged in as admin
+    And I am on "host-groups/a-hostgroup/memberof_sudorule" page
+
+    When I click on the "member-of-button-add" button
+    Then I should see "member-of-add-modal" modal
+    And I should see "item-test" dual list item on the left
+
+    When I click on "item-test" dual list item
+    Then I should see "item-test" dual list item selected
+    When I click on the "dual-list-add-selected" button
+    Then I should see "item-test" dual list item on the right
+
+    When I click on the "modal-button-add" button
+    Then I should not see "member-of-add-modal" modal
+    And I should see "add-member-success" alert
+
+    When I search for "test" in the members table
+    Then I should see "test" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete hostgroup "a-hostgroup"
+    And I delete sudo rule "test"
+
+  @seed
+  Scenario: Create seed data
+    Given hostgroup "a-hostgroup" exists
+    And sudo rule "test" exists
+    And hostgroup "a-hostgroup" is member of sudo rule "test"
+
+  @test
+  Scenario: Delete a sudo rule membership from the host group
+    Given I am logged in as admin
+    And I am on "host-groups/a-hostgroup/memberof_sudorule" page
+
+    When I select entry "test" in the members table
+    Then I should see "test" entry selected in the data table
+
+    When I click on the "member-of-button-delete" button
+    Then I should see "member-of-delete-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "member-of-delete-modal" modal
+    And I should see "remove-sudo-rules-success" alert
+
+    When I search for "test" in the members table
+    Then I should not see "test" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete hostgroup "a-hostgroup"
+    And I delete sudo rule "test"

--- a/cypress/e2e/hostgroups/hostgroup_members.feature
+++ b/cypress/e2e/hostgroups/hostgroup_members.feature
@@ -1,0 +1,238 @@
+Feature: Hostgroup members
+  Manage host group members across Hosts and Host groups tabs
+
+  @seed
+  Scenario: Create seed data
+    Given hostgroup "a-hostgroup" exists
+
+  @test
+  Scenario: Add a Host member into the host group
+    Given I am logged in as admin
+    And I am on "host-groups/a-hostgroup/member_host" page
+
+    Then I should see the host groups members tab "host" count is "0"
+
+    When I click on the "member-of-button-add" button
+    Then I should see "member-of-add-modal" modal
+    And I should see "member-of-add-modal" modal with title "Assign hosts to host group: a-hostgroup"
+    And I should see "item-webui.ipa.test" dual list item on the left
+
+    When I click on "item-webui.ipa.test" dual list item
+    Then I should see "item-webui.ipa.test" dual list item selected
+    When I click on the "dual-list-add-selected" button
+    Then I should see "item-webui.ipa.test" dual list item on the right
+
+    When I click on the "modal-button-add" button
+    Then I should not see "member-of-add-modal" modal
+    And I should see "add-member-success" alert
+
+    When I search for "webui.ipa.test" in the members table
+    Then I should see "webui.ipa.test" entry in the data table
+    And I should see the host groups members tab "host" count is "1"
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete hostgroup "a-hostgroup"
+
+  @seed
+  Scenario: Create seed data
+    Given hostgroup "a-hostgroup" exists
+    And host "webui.ipa.test" is member of hostgroup "a-hostgroup"
+
+  @test
+  Scenario: Search for a host
+    Given I am logged in as admin
+    And I am on "host-groups/a-hostgroup/member_host" page
+
+    When I type "webui" in the members table search field
+    Then I should see "webui" in the members table search field
+    When I submit the members table search
+    Then I should see "webui.ipa.test" entry in the data table
+    And I should not see "ipaservers" entry in the data table
+
+    When I clear the members table search field
+    When I type "notthere" in the members table search field
+    Then I should see "notthere" in the members table search field
+    When I submit the members table search
+    Then I should not see "webui.ipa.test" entry in the data table
+    And I should not see "ipaservers" entry in the data table
+
+    When I clear the members table search field
+    When I submit the members table search
+    Then I should see "webui.ipa.test" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete hostgroup "a-hostgroup"
+
+  @seed
+  Scenario: Create seed data
+    Given hostgroup "a-hostgroup" exists
+
+  @test
+  Scenario: Switch between direct and indirect memberships (Hosts)
+    Given I am logged in as admin
+    And I am on "host-groups/a-hostgroup/member_host" page
+
+    When I click on the "member-of-toggle-group-item-indirect" button
+    Then I should see the "member-of-toggle-group-item-indirect" toggle button is pressed
+    And I should see the "member-of-button-add" button is disabled
+    And I should see the host groups members tab "host" count is "0"
+
+    When I click on the "member-of-toggle-group-item-direct" button
+    Then I should see the "member-of-toggle-group-item-indirect" toggle button is not pressed
+    And I should see the "member-of-toggle-group-item-direct" toggle button is pressed
+    And I should see the "member-of-button-add" button is enabled
+    And I should see the host groups members tab "host" count is "0"
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete hostgroup "a-hostgroup"
+
+  @seed
+  Scenario: Create seed data
+    Given hostgroup "a-hostgroup" exists
+    And host "webui.ipa.test" is member of hostgroup "a-hostgroup"
+
+  @test
+  Scenario: Remove Host from the host group
+    Given I am logged in as admin
+    And I am on "host-groups/a-hostgroup/member_host" page
+
+    When I select entry "webui.ipa.test" in the members table
+    Then I should see "webui.ipa.test" entry selected in the data table
+
+    When I click on the "member-of-button-delete" button
+    Then I should see "member-of-delete-modal" modal
+    And I should see "member-of-delete-modal" modal with title "Delete hosts from host group: a-hostgroup"
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "member-of-delete-modal" modal
+    And I should see "remove-host-success" alert
+
+    When I search for "webui.ipa.test" in the members table
+    Then I should not see "webui.ipa.test" entry in the data table
+    And I should see the host groups members tab "host" count is "0"
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete hostgroup "a-hostgroup"
+
+  @seed
+  Scenario: Create seed data
+    Given hostgroup "a-hostgroup" exists
+
+  @test
+  Scenario: Add a Host group member into the host group
+    Given I am logged in as admin
+    And I am on "host-groups/a-hostgroup/member_hostgroup" page
+
+    Then I should see the host groups members tab "hostgroup" count is "0"
+
+    When I click on the "member-of-button-add" button
+    Then I should see "member-of-add-modal" modal
+    And I should see "member-of-add-modal" modal with title "Assign host groups to host group: a-hostgroup"
+    And I should see "item-ipaservers" dual list item on the left
+
+    When I click on "item-ipaservers" dual list item
+    Then I should see "item-ipaservers" dual list item selected
+    When I click on the "dual-list-add-selected" button
+    Then I should see "item-ipaservers" dual list item on the right
+
+    When I click on the "modal-button-add" button
+    Then I should not see "member-of-add-modal" modal
+    And I should see "add-member-success" alert
+
+    When I search for "ipaservers" in the members table
+    Then I should see "ipaservers" entry in the data table
+    And I should see the host groups members tab "hostgroup" count is "1"
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete hostgroup "a-hostgroup"
+
+  @seed
+  Scenario: Create seed data
+    Given hostgroup "a-hostgroup" exists
+    And hostgroup "nested-hostgroup" exists
+    And hostgroup "nested-hostgroup" is member of hostgroup "a-hostgroup"
+
+  @test
+  Scenario: Search for a host group
+    Given I am logged in as admin
+    And I am on "host-groups/a-hostgroup/member_hostgroup" page
+
+    When I type "nested-hostgroup" in the members table search field
+    Then I should see "nested-hostgroup" in the members table search field
+    When I submit the members table search
+    Then I should see "nested-hostgroup" entry in the data table
+    And I should not see "ipaservers" entry in the data table
+
+    When I clear the members table search field
+    When I type "notthere" in the members table search field
+    Then I should see "notthere" in the members table search field
+    When I submit the members table search
+    Then I should not see "nested-hostgroup" entry in the data table
+    And I should not see "ipaservers" entry in the data table
+
+    When I clear the members table search field
+    When I submit the members table search
+    Then I should see "nested-hostgroup" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete hostgroup "a-hostgroup"
+    And I delete hostgroup "nested-hostgroup"
+
+  @seed
+  Scenario: Create seed data
+    Given hostgroup "a-hostgroup" exists
+
+  @test
+  Scenario: Switch between direct and indirect memberships (Host groups)
+    Given I am logged in as admin
+    And I am on "host-groups/a-hostgroup/member_hostgroup" page
+
+    When I click on the "member-of-toggle-group-item-indirect" button
+    Then I should see the "member-of-toggle-group-item-indirect" toggle button is pressed
+    And I should see the "member-of-button-add" button is disabled
+    And I should see the host groups members tab "hostgroup" count is "0"
+
+    When I click on the "member-of-toggle-group-item-direct" button
+    Then I should see the "member-of-toggle-group-item-indirect" toggle button is not pressed
+    And I should see the "member-of-toggle-group-item-direct" toggle button is pressed
+    And I should see the "member-of-button-add" button is enabled
+    And I should see the host groups members tab "hostgroup" count is "0"
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete hostgroup "a-hostgroup"
+
+  @seed
+  Scenario: Create seed data
+    Given hostgroup "a-hostgroup" exists
+    And hostgroup "ipaservers" is member of hostgroup "a-hostgroup"
+
+  @test
+  Scenario: Remove Host group from the host group
+    Given I am logged in as admin
+    And I am on "host-groups/a-hostgroup/member_hostgroup" page
+
+    When I select entry "ipaservers" in the members table
+    Then I should see "ipaservers" entry selected in the data table
+
+    When I click on the "member-of-button-delete" button
+    Then I should see "member-of-delete-modal" modal
+    And I should see "member-of-delete-modal" modal with title "Delete host groups from host group: a-hostgroup"
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "member-of-delete-modal" modal
+    And I should see "remove-hostgroups-success" alert
+
+    When I search for "ipaservers" in the members table
+    Then I should not see "ipaservers" entry in the data table
+    And I should see the host groups members tab "hostgroup" count is "0"
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete hostgroup "a-hostgroup"

--- a/cypress/e2e/hostgroups/hostgroup_settings.feature
+++ b/cypress/e2e/hostgroups/hostgroup_settings.feature
@@ -1,0 +1,44 @@
+Feature: Host group settings manipulation
+  Modify host group settings
+
+  @seed
+  Scenario: Create hostgroup
+    Given hostgroup "a-hostgroup" exists
+
+  @test
+  Scenario: Set Description
+    Given I am logged in as admin
+    And I am on "host-groups/a-hostgroup" page
+
+    When I type in the "host-groups-tab-settings-textbox-description" textbox text "test"
+    Then I should see "test" in the "host-groups-tab-settings-textbox-description" textbox
+    And I should see the "host-groups-tab-settings-button-save" button is enabled
+
+    When I click on the "host-groups-tab-settings-button-save" button
+    Then I should see "save-success" alert
+
+  @cleanup
+  Scenario: Delete hostgroup
+    Given I delete hostgroup "a-hostgroup"
+
+  @seed
+  Scenario: Create hostgroup
+    Given hostgroup "a-hostgroup" with description "original" exists
+
+  @test
+  Scenario: Revert Description
+    Given I am logged in as admin
+    And I am on "host-groups/a-hostgroup" page
+
+    When I type in the "host-groups-tab-settings-textbox-description" textbox text "temporary"
+    Then I should see "temporary" in the "host-groups-tab-settings-textbox-description" textbox
+    And I should see the "host-groups-tab-settings-button-revert" button is enabled
+
+    When I click on the "host-groups-tab-settings-button-revert" button
+    Then I should see "revert-success" alert
+    And I should see "original" in the "host-groups-tab-settings-textbox-description" textbox
+    And I should see the "host-groups-tab-settings-button-save" button is disabled
+
+  @cleanup
+  Scenario: Delete hostgroup
+    Given I delete hostgroup "a-hostgroup"

--- a/src/components/Members/MembersHosts.tsx
+++ b/src/components/Members/MembersHosts.tsx
@@ -132,7 +132,7 @@ const MembersHosts = (props: PropsToMembersHosts) => {
 
   // Get type of the entity to show as text
   const getEntityType = () => {
-    if (props.from === "hostgroups") {
+    if (props.from === "host-groups") {
       return "host group";
     } else if (props.from === "netgroup") {
       return "netgroup";

--- a/src/pages/HostGroups/HostGroupsMembers.tsx
+++ b/src/pages/HostGroups/HostGroupsMembers.tsx
@@ -134,7 +134,12 @@ const HostGroupsMembers = (props: PropsToHostGroupsMembers) => {
             title={
               <TabTitleText>
                 Hosts{" "}
-                <Badge key={0} id="host_count" isRead>
+                <Badge
+                  key={0}
+                  id="host_count"
+                  data-cy="host-groups-tab-member-host-count"
+                  isRead
+                >
                   {hostCount}
                 </Badge>
               </TabTitleText>
@@ -158,7 +163,12 @@ const HostGroupsMembers = (props: PropsToHostGroupsMembers) => {
             title={
               <TabTitleText>
                 Host groups{" "}
-                <Badge key={1} id="hostgroup_count" isRead>
+                <Badge
+                  key={1}
+                  id="hostgroup_count"
+                  data-cy="host-groups-tab-member-hostgroup-count"
+                  isRead
+                >
                   {groupCount}
                 </Badge>
               </TabTitleText>


### PR DESCRIPTION
Introduce feature files for host group settings, members, and member-of tabs, and expand the main host groups list tests to use the current Cypress step conventions. Add shared steps for members-table search, modal titles, modal table entries, and closing alerts, plus host group seed/cleanup helpers. Expose member tab badge counts via data-cy on HostGroupsMembers for test assertions.

Addresses IDM-2438

## Summary by Sourcery

Expand host group end-to-end coverage and testability across list, settings, members, and member-of pages.

New Features:
- Add Cypress coverage for host group creation, deletion, settings, member management, and member-of workflows across supported entity types.

Bug Fixes:
- Correct host group source identification in member display logic.

Enhancements:
- Add reusable Cypress steps for member-table search, modal assertions, alert dismissal, and host group membership setup and cleanup.
- Expose host and host group membership counts through test selectors.

Tests:
- Expand host group end-to-end scenarios to cover search, cancellation, direct and indirect membership views, and add/remove operations.