### PR TITLE
Add Cypress E2E tests for privilege Settings and Permissions subpages

### DIFF
--- a/cypress/e2e/common/members_table.ts
+++ b/cypress/e2e/common/members_table.ts
@@ -10,6 +10,12 @@ export const searchForMembersEntry = (name: string) => {
   cy.dataCy("search").find("button[type='submit']").click();
 };
 
+export const clearMembersTableSearch = () => {
+  cy.dataCy("search").find("input").clear();
+  cy.dataCy("search").find("input").should("have.value", "");
+  cy.dataCy("search").find("button[type='submit']").click();
+};
+
 export const selectMembersEntry = (name: string) => {
   searchForMembersEntry(name);
   checkEntry(name);
@@ -17,6 +23,10 @@ export const selectMembersEntry = (name: string) => {
 
 When("I search for {string} in the members table", (name: string) => {
   searchForMembersEntry(name);
+});
+
+When("I clear the search in the members table", () => {
+  clearMembersTableSearch();
 });
 
 When("I select entry {string} in the members table", (name: string) => {

--- a/cypress/e2e/common/ui/dual_list.ts
+++ b/cypress/e2e/common/ui/dual_list.ts
@@ -1,7 +1,15 @@
 import { Then, When } from "@badeball/cypress-cucumber-preprocessor";
+import { typeInTextbox } from "../ui/textbox";
 
 When("I click on search link in dual list", () => {
   cy.dataCy("dual-list-search-link").click();
+});
+
+When("I search for {string} in the dual list", (searchText: string) => {
+  cy.intercept("POST", "/ipa/session/json").as("dualListSearch");
+  typeInTextbox("dual-list-available-search", searchText);
+  cy.dataCy("dual-list-available-search").find("button[type='submit']").click();
+  cy.wait("@dualListSearch");
 });
 
 When("I click on {string} dual list item", (item: string) => {

--- a/cypress/e2e/common/ui/dual_list.ts
+++ b/cypress/e2e/common/ui/dual_list.ts
@@ -1,5 +1,4 @@
 import { Then, When } from "@badeball/cypress-cucumber-preprocessor";
-import { typeInTextbox } from "../ui/textbox";
 
 When("I click on search link in dual list", () => {
   cy.dataCy("dual-list-search-link").click();
@@ -7,7 +6,14 @@ When("I click on search link in dual list", () => {
 
 When("I search for {string} in the dual list", (searchText: string) => {
   cy.intercept("POST", "/ipa/session/json").as("dualListSearch");
-  typeInTextbox("dual-list-available-search", searchText);
+  cy.dataCy("dual-list-available-search").find("input").clear();
+  cy.dataCy("dual-list-available-search")
+    .find("input")
+    .should("have.value", "");
+  cy.dataCy("dual-list-available-search").find("input").type(searchText);
+  cy.dataCy("dual-list-available-search")
+    .find("input")
+    .should("have.value", searchText);
   cy.dataCy("dual-list-available-search").find("button[type='submit']").click();
   cy.wait("@dualListSearch");
 });

--- a/cypress/e2e/permissions/permissions.ts
+++ b/cypress/e2e/permissions/permissions.ts
@@ -1,0 +1,28 @@
+import { Given } from "@badeball/cypress-cucumber-preprocessor";
+
+Given("permission {string} exists", (permissionName: string) => {
+  cy.ipa({
+    command: "permission-add",
+    name: permissionName,
+    specificOptions:
+      "--bindtype=permission --right=read --type=user --attrs=uid",
+  });
+});
+
+Given(
+  "permission {string} is member of privilege {string}",
+  (permissionName: string, privilegeName: string) => {
+    cy.ipa({
+      command: "privilege-add-permission",
+      name: privilegeName,
+      specificOptions: `--permissions="${permissionName}"`,
+    });
+  }
+);
+
+Given("I delete permission {string}", (permissionName: string) => {
+  cy.ipa({
+    command: "permission-del",
+    name: permissionName,
+  });
+});

--- a/cypress/e2e/privileges/privileges.ts
+++ b/cypress/e2e/privileges/privileges.ts
@@ -7,6 +7,17 @@ Given("privilege {string} exists", (privilegeName: string) => {
   });
 });
 
+Given(
+  "privilege {string} exists with description {string}",
+  (privilegeName: string, description: string) => {
+    cy.ipa({
+      command: "privilege-add",
+      name: privilegeName,
+      specificOptions: `--desc="${description}"`,
+    });
+  }
+);
+
 Given("I delete privilege {string}", (privilegeName: string) => {
   cy.ipa({
     command: "privilege-del",

--- a/cypress/e2e/privileges/privileges_permissions.feature
+++ b/cypress/e2e/privileges/privileges_permissions.feature
@@ -1,0 +1,161 @@
+Feature: Privilege permissions manipulation
+  Manage permissions assigned to privileges
+
+  @seed
+  Scenario: Create seed data (privilege for add permission test)
+    Given privilege "add_perm_privilege" exists
+    And permission "a_permission_add" exists
+
+  @test
+  Scenario: Add a permission to the privilege
+    Given I am logged in as admin
+    And I am on "privileges/add_perm_privilege/permissions" page
+
+    When I click on the "member-of-button-add" button
+    Then I should see "member-of-add-modal" modal
+
+    When I search for "a_permission_add" in the dual list
+    Then I should see "item-a_permission_add" dual list item on the left
+
+    When I click on "item-a_permission_add" dual list item
+    Then I should see "item-a_permission_add" dual list item selected
+    When I click on the "dual-list-add-selected" button
+    Then I should see "item-a_permission_add" dual list item on the right
+
+    When I click on the "modal-button-add" button
+    Then I should not see "member-of-add-modal" modal
+    And I should see "add-permission-success" alert
+    And I should see "a_permission_add" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete privilege "add_perm_privilege"
+    And I delete permission "a_permission_add"
+
+  @seed
+  Scenario: Create seed data (privilege with permission for removal)
+    Given privilege "remove_perm_privilege" exists
+    And permission "a_permission_remove" exists
+    And permission "a_permission_remove" is member of privilege "remove_perm_privilege"
+
+  @test
+  Scenario: Remove a permission from the privilege
+    Given I am logged in as admin
+    And I am on "privileges/remove_perm_privilege/permissions" page
+
+    Then I should see "a_permission_remove" entry in the data table
+
+    When I check entry "a_permission_remove" in the data table
+    Then I should see "a_permission_remove" entry selected in the data table
+
+    When I click on the "member-of-button-delete" button
+    Then I should see "member-of-delete-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "member-of-delete-modal" modal
+    And I should see "remove-permission-success" alert
+    And I should not see "a_permission_remove" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete privilege "remove_perm_privilege"
+    And I delete permission "a_permission_remove"
+
+  @seed
+  Scenario: Create seed data for permissions search test
+    Given privilege "search_perm_privilege" exists
+    And permission "a_permission_alpha" exists
+    And permission "a_permission_beta" exists
+    And permission "a_permission_alpha" is member of privilege "search_perm_privilege"
+    And permission "a_permission_beta" is member of privilege "search_perm_privilege"
+
+  @test
+  Scenario: Search permissions
+    Given I am logged in as admin
+    And I am on "privileges/search_perm_privilege/permissions" page
+
+    Then I should see "a_permission_alpha" entry in the data table
+    And I should see "a_permission_beta" entry in the data table
+
+    When I search for "alpha" in the members table
+    Then I should see "a_permission_alpha" entry in the data table
+    And I should not see "a_permission_beta" entry in the data table
+
+    When I clear the search in the members table
+    Then I should see "a_permission_alpha" entry in the data table
+    And I should see "a_permission_beta" entry in the data table
+
+  @test
+  Scenario: Search permissions with no match
+    Given I am logged in as admin
+    And I am on "privileges/search_perm_privilege/permissions" page
+
+    When I search for "notthere" in the members table
+    Then I should not see "notthere" entry in the data table
+    And I should not see "a_permission_alpha" entry in the data table
+    And I should not see "a_permission_beta" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup permissions search test data
+    Given I delete privilege "search_perm_privilege"
+    And I delete permission "a_permission_alpha"
+    And I delete permission "a_permission_beta"
+
+  @seed
+  Scenario: Create seed data for cancel add test
+    Given privilege "cancel_add_privilege" exists
+    And permission "a_permission_cancel_add" exists
+
+  @test
+  Scenario: Cancel adding a permission
+    Given I am logged in as admin
+    And I am on "privileges/cancel_add_privilege/permissions" page
+
+    When I click on the "member-of-button-add" button
+    Then I should see "member-of-add-modal" modal
+
+    When I search for "a_permission_cancel_add" in the dual list
+    Then I should see "item-a_permission_cancel_add" dual list item on the left
+
+    When I click on "item-a_permission_cancel_add" dual list item
+    Then I should see "item-a_permission_cancel_add" dual list item selected
+    When I click on the "dual-list-add-selected" button
+    Then I should see "item-a_permission_cancel_add" dual list item on the right
+
+    When I click on the "modal-button-cancel" button
+    Then I should not see "member-of-add-modal" modal
+    And I should not see "a_permission_cancel_add" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup cancel add test data
+    Given I delete privilege "cancel_add_privilege"
+    And I delete permission "a_permission_cancel_add"
+
+  @seed
+  Scenario: Create seed data for cancel delete test
+    Given privilege "cancel_delete_privilege" exists
+    And permission "a_permission_cancel_delete" exists
+    And permission "a_permission_cancel_delete" is member of privilege "cancel_delete_privilege"
+
+  @test
+  Scenario: Cancel removing a permission
+    Given I am logged in as admin
+    And I am on "privileges/cancel_delete_privilege/permissions" page
+
+    Then I should see "a_permission_cancel_delete" entry in the data table
+
+    When I check entry "a_permission_cancel_delete" in the data table
+    Then I should see "a_permission_cancel_delete" entry selected in the data table
+
+    When I click on the "member-of-button-delete" button
+    Then I should see "member-of-delete-modal" modal
+    And I should see "a_permission_cancel_delete" entry in the data table
+
+    When I click on the "modal-button-cancel" button
+    Then I should not see "member-of-delete-modal" modal
+    And I should see "a_permission_cancel_delete" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup cancel delete test data
+    Given I delete privilege "cancel_delete_privilege"
+    And I delete permission "a_permission_cancel_delete"

--- a/cypress/e2e/privileges/privileges_permissions.ts
+++ b/cypress/e2e/privileges/privileges_permissions.ts
@@ -1,0 +1,1 @@
+import "../permissions/permissions";

--- a/cypress/e2e/privileges/privileges_roles.feature
+++ b/cypress/e2e/privileges/privileges_roles.feature
@@ -1,0 +1,155 @@
+Feature: Privilege roles manipulation
+  Manage roles assigned to privileges
+
+  @seed
+  Scenario: Create seed data (privilege for add role test)
+    Given privilege "add_role_privilege" exists
+    And role "add_role_test" exists
+
+  @test
+  Scenario: Add a role to the privilege
+    Given I am logged in as admin
+    And I am on "privileges/add_role_privilege/member_role" page
+
+    When I click on the "member-of-button-add" button
+    Then I should see "member-of-add-modal" modal
+
+    When I click on "item-add_role_test" dual list item
+    Then I should see "item-add_role_test" dual list item selected
+    When I click on the "dual-list-add-selected" button
+    Then I should see "item-add_role_test" dual list item on the right
+
+    When I click on the "modal-button-add" button
+    Then I should not see "member-of-add-modal" modal
+    And I should see "add-member-success" alert
+    And I should see "add_role_test" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete privilege "add_role_privilege"
+    And I delete role "add_role_test"
+
+  @seed
+  Scenario: Create seed data (privilege with role for removal)
+    Given privilege "remove_role_privilege" exists
+    And role "remove_role_test" exists
+    And privilege "remove_role_privilege" is member of role "remove_role_test"
+
+  @test
+  Scenario: Remove a role from the privilege
+    Given I am logged in as admin
+    And I am on "privileges/remove_role_privilege/member_role" page
+
+    Then I should see "remove_role_test" entry in the data table
+
+    When I check entry "remove_role_test" in the data table
+    Then I should see "remove_role_test" entry selected in the data table
+
+    When I click on the "member-of-button-delete" button
+    Then I should see "member-of-delete-modal" modal
+
+    When I click on the "modal-button-delete" button
+    Then I should not see "member-of-delete-modal" modal
+    And I should see "remove-members-success" alert
+    And I should not see "remove_role_test" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup seed data
+    Given I delete privilege "remove_role_privilege"
+    And I delete role "remove_role_test"
+
+  @seed
+  Scenario: Create seed data for roles search test
+    Given privilege "search_role_privilege" exists
+    And role "search_role_alpha" exists
+    And role "search_role_beta" exists
+    And privilege "search_role_privilege" is member of role "search_role_alpha"
+    And privilege "search_role_privilege" is member of role "search_role_beta"
+
+  @test
+  Scenario: Search roles
+    Given I am logged in as admin
+    And I am on "privileges/search_role_privilege/member_role" page
+
+    Then I should see "search_role_alpha" entry in the data table
+    And I should see "search_role_beta" entry in the data table
+
+    When I search for "alpha" in the members table
+    Then I should see "search_role_alpha" entry in the data table
+    And I should not see "search_role_beta" entry in the data table
+
+    When I clear the search in the members table
+    Then I should see "search_role_alpha" entry in the data table
+    And I should see "search_role_beta" entry in the data table
+
+  @test
+  Scenario: Search roles with no match
+    Given I am logged in as admin
+    And I am on "privileges/search_role_privilege/member_role" page
+
+    When I search for "notthere" in the members table
+    Then I should not see "notthere" entry in the data table
+    And I should not see "search_role_alpha" entry in the data table
+    And I should not see "search_role_beta" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup roles search test data
+    Given I delete privilege "search_role_privilege"
+    And I delete role "search_role_alpha"
+    And I delete role "search_role_beta"
+
+  @seed
+  Scenario: Create seed data for cancel add test
+    Given privilege "cancel_add_role_privilege" exists
+    And role "cancel_add_role_test" exists
+
+  @test
+  Scenario: Cancel adding a role
+    Given I am logged in as admin
+    And I am on "privileges/cancel_add_role_privilege/member_role" page
+
+    When I click on the "member-of-button-add" button
+    Then I should see "member-of-add-modal" modal
+
+    When I click on "item-cancel_add_role_test" dual list item
+    Then I should see "item-cancel_add_role_test" dual list item selected
+    When I click on the "dual-list-add-selected" button
+    Then I should see "item-cancel_add_role_test" dual list item on the right
+
+    When I click on the "modal-button-cancel" button
+    Then I should not see "member-of-add-modal" modal
+    And I should not see "cancel_add_role_test" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup cancel add test data
+    Given I delete privilege "cancel_add_role_privilege"
+    And I delete role "cancel_add_role_test"
+
+  @seed
+  Scenario: Create seed data for cancel delete test
+    Given privilege "cancel_delete_role_privilege" exists
+    And role "cancel_delete_role_test" exists
+    And privilege "cancel_delete_role_privilege" is member of role "cancel_delete_role_test"
+
+  @test
+  Scenario: Cancel removing a role
+    Given I am logged in as admin
+    And I am on "privileges/cancel_delete_role_privilege/member_role" page
+
+    Then I should see "cancel_delete_role_test" entry in the data table
+
+    When I check entry "cancel_delete_role_test" in the data table
+    Then I should see "cancel_delete_role_test" entry selected in the data table
+
+    When I click on the "member-of-button-delete" button
+    Then I should see "member-of-delete-modal" modal
+    And I should see "cancel_delete_role_test" entry in the data table
+
+    When I click on the "modal-button-cancel" button
+    Then I should not see "member-of-delete-modal" modal
+    And I should see "cancel_delete_role_test" entry in the data table
+
+  @cleanup
+  Scenario: Cleanup cancel delete test data
+    Given I delete privilege "cancel_delete_role_privilege"
+    And I delete role "cancel_delete_role_test"

--- a/cypress/e2e/privileges/privileges_roles.ts
+++ b/cypress/e2e/privileges/privileges_roles.ts
@@ -1,0 +1,2 @@
+import "./privileges";
+import "../roles/role_management";

--- a/cypress/e2e/privileges/privileges_settings.feature
+++ b/cypress/e2e/privileges/privileges_settings.feature
@@ -1,0 +1,47 @@
+Feature: Privilege settings manipulation
+  Modify privilege settings
+
+  @seed
+  Scenario: Create privilege for settings test
+    Given privilege "settings_privilege" exists
+
+  @test
+  Scenario: Set Description
+    Given I am logged in as admin
+    And I am on "privileges/settings_privilege" page
+
+    Then I should see "settings_privilege" in the "privileges-tab-settings-textinput-cn" textbox
+
+    When I type in the "privileges-tab-settings-textarea-description" textbox text "Test description"
+    Then I should see "Test description" in the "privileges-tab-settings-textarea-description" textbox
+    And I should see the "privileges-tab-settings-button-save" button is enabled
+
+    When I click on the "privileges-tab-settings-button-save" button
+    Then I should see "save-success" alert
+    And I should see "Test description" in the "privileges-tab-settings-textarea-description" textbox
+
+  @cleanup
+  Scenario: Delete settings_privilege
+    Given I delete privilege "settings_privilege"
+
+  @seed
+  Scenario: Create privilege for revert test
+    Given privilege "revert_privilege" exists with description "Original description"
+
+  @test
+  Scenario: Revert changes
+    Given I am logged in as admin
+    And I am on "privileges/revert_privilege" page
+
+    Then I should see "Original description" in the "privileges-tab-settings-textarea-description" textbox
+
+    When I type in the "privileges-tab-settings-textarea-description" textbox text "Modified description"
+    Then I should see "Modified description" in the "privileges-tab-settings-textarea-description" textbox
+
+    When I click on the "privileges-tab-settings-button-revert" button
+    Then I should see "revert-success" alert
+    And I should see "Original description" in the "privileges-tab-settings-textarea-description" textbox
+
+  @cleanup
+  Scenario: Delete revert_privilege
+    Given I delete privilege "revert_privilege"

--- a/cypress/e2e/privileges/privileges_settings.feature
+++ b/cypress/e2e/privileges/privileges_settings.feature
@@ -10,8 +10,6 @@ Feature: Privilege settings manipulation
     Given I am logged in as admin
     And I am on "privileges/settings_privilege" page
 
-    Then I should see "settings_privilege" in the "privileges-tab-settings-textinput-cn" textbox
-
     When I type in the "privileges-tab-settings-textarea-description" textbox text "Test description"
     Then I should see "Test description" in the "privileges-tab-settings-textarea-description" textbox
     And I should see the "privileges-tab-settings-button-save" button is enabled


### PR DESCRIPTION
EDIT: marking this as WIP as I will add the last Privilege test to be done.

Also added shared step definitions for IPA permission seeding, dual list search, and members table search clearing to support the new scenarios.

## Summary by Sourcery

Expand Cypress coverage for privilege settings and membership management workflows.

New Features:
- Add end-to-end coverage for managing privilege settings, assigned permissions, and assigned roles, including add, remove, search, and cancellation workflows.

Enhancements:
- Add reusable Cypress steps for creating privileges and permissions, searching dual lists, and clearing members-table searches.

Tests:
- Add seeded Cypress scenarios validating privilege settings updates and reverts, permission assignment flows, and role assignment flows.