### PR TITLE
Permissions > 'Privileges' page

### DIFF
--- a/doc/designs/sub-pages/06a-membership-custom.md
+++ b/doc/designs/sub-pages/06a-membership-custom.md
@@ -97,6 +97,10 @@ const [namesToLoad, setNamesToLoad] = React.useState<string[]>(getMembersToLoad(
   </MemberOfDeleteModal>
 )}
 
+> If the displayed table list is a **paginated slice**, pass the selection
+> state (`selectedItems` / `selectedPrivileges`) instead of filtering that
+> slice. See [08a-common-issues.md](08a-common-issues.md#delete-modal-lists-only-the-current-page).
+
 // ❌ Wrong: No children - modal shows empty list
 <MemberOfDeleteModal ... />
 ```

--- a/doc/designs/sub-pages/08-checklist.md
+++ b/doc/designs/sub-pages/08-checklist.md
@@ -139,7 +139,8 @@ import OtpTokensManagedBy from "./OtpTokensManagedBy";
 - [ ] Pagination and search work
 - [ ] Add modal fetches available items from correct API
 - [ ] Add operation uses correct entity-specific API (not generic `_add_member`)
-- [ ] Delete modal shows selected items
+- [ ] Delete modal shows **all** selected items (the selection state, not a filter of the current page)
+- [ ] Table visibility uses `showTableRows={!query.isFetching}` (not `isLoading`)
 - [ ] Delete operation uses correct entity-specific API (not generic `_remove_member`)
 - [ ] Success/error alerts display correctly
 - [ ] Page wrapped in `PageSection` for proper alignment
@@ -223,4 +224,6 @@ See [08a-common-issues.md](08a-common-issues.md) for detailed solutions to:
 - API array response handling
 - RTK Query skip option
 - Modal integration issues
+- Delete modal listing only the current page
+- Table rows driven by `isLoading` instead of `isFetching`
 - Boolean status comparison failures

--- a/doc/designs/sub-pages/08a-common-issues.md
+++ b/doc/designs/sub-pages/08a-common-issues.md
@@ -162,9 +162,45 @@ const isDisabled = props.entity.statusField === true || String(props.entity.stat
 
 ```tsx
 <MemberOfDeleteModal showModal={showDeleteModal} ...>
-  <MemberTable entityList={members.filter((m) => selectedItems.includes(m.uid))} ... />
+  <MemberTable entityList={selectedItems} ... />
 </MemberOfDeleteModal>
 ```
+
+### Delete Modal Lists Only the Current Page
+
+The on-screen table list is often **already paginated**. Selection is kept as a
+separate array and can include rows from other pages. Filtering the paginated
+list for the delete modal hides those rows even though the delete API still
+removes them.
+
+```tsx
+// ❌ Wrong: `items` is the current page only
+<MemberTable
+  entityList={items.filter((item) => selectedNames.includes(item.cn))}
+  ...
+/>
+
+// ✅ Correct: the full selection state
+<MemberTable entityList={selectedItems} ... />
+```
+
+See [17-independent-sub-pages.md](17-independent-sub-pages.md#delete-modal-full-selection-not-the-current-page).
+
+### Table Rows Driven by `isLoading` Instead of `isFetching`
+
+Use RTK Query `isFetching` to hide table rows and disable Refresh/Add while a
+request is in flight. `isLoading` is only `true` on the first request (no cached
+data), so Refresh would leave stale rows visible.
+
+```tsx
+// ✅ Correct
+<MemberTable showTableRows={!entityQuery.isFetching} ... />
+
+// ❌ Wrong
+<MemberTable showTableRows={!entityQuery.isLoading} ... />
+```
+
+See [17-independent-sub-pages.md](17-independent-sub-pages.md#table-visibility-isfetching).
 
 ### Modals Must Be Outside TabLayout
 

--- a/doc/designs/sub-pages/09-modals.md
+++ b/doc/designs/sub-pages/09-modals.md
@@ -113,6 +113,13 @@ for the full search behaviour table.
 
 ## Delete Modal
 
+Independent and membership tabs that use `MemberOfDeleteModal` must pass a
+table of the **full selection state** as children. Do not filter the paginated
+on-screen list: selected rows on other pages would disappear from the
+confirmation while still being deleted. See
+[Independent sub-pages](17-independent-sub-pages.md#delete-modal-full-selection-not-the-current-page)
+and [Common issues](08a-common-issues.md#delete-modal-lists-only-the-current-page).
+
 ### Props Interface
 
 The Delete modal also receives the parent entity ID:

--- a/doc/designs/sub-pages/17-independent-sub-pages.md
+++ b/doc/designs/sub-pages/17-independent-sub-pages.md
@@ -180,14 +180,58 @@ const <Entity><SubPage> = (props) => {
         from="privileges"
         checkedItems={selectedNames}
         onCheckItemsChange={onCheckItemsChange}
+        showTableRows={!entityQuery.isFetching}
         ...
       />
       <Pagination ... />
       {showAddModal && <MemberOfAddModal ... />}
-      {showDeleteModal && <MemberOfDeleteModal ... />}
+      {showDeleteModal && (
+        <MemberOfDeleteModal ...>
+          {/* Full selection — not the paginated `data` list */}
+          <MemberTable entityList={selectedItems} ... showTableRows />
+        </MemberOfDeleteModal>
+      )}
     </TabLayout>
   );
 };
+```
+
+## Table visibility (`isFetching`)
+
+Drive table rows and refresh/add enablement from RTK Query **`isFetching`**, not
+`isLoading`. `isFetching` is `true` on the initial request **and** on Refresh /
+refetch, so the table shows its skeleton and toolbar actions disable while data
+reloads.
+
+```tsx
+// ✅ Correct
+<MemberTable showTableRows={!entityQuery.isFetching} ... />
+const isRefreshButtonEnabled = !entityQuery.isFetching;
+
+// ❌ Wrong: `isLoading` is only true on the first request (no cached data).
+// Refresh would leave the old rows visible and keep buttons enabled.
+<MemberTable showTableRows={!entityQuery.isLoading} ... />
+```
+
+Do not introduce a `showTableRows` state variable synced with `useEffect`. Pass
+`!query.isFetching` directly (same rule as [main pages](../main-pages/03-walkthrough-init-fetch.md#table-visibility)).
+
+## Delete modal: full selection, not the current page
+
+The table list (`data` / `privileges`) is **already paginated**. Selection state
+(`selectedItems`) can include rows from other pages. The delete confirmation
+table must use that full selection. Filtering the paginated list hides selected
+rows that are not on the current page, while the delete API still removes them.
+
+```tsx
+// ✅ Correct — every selected item, including other pages
+<MemberTable entityList={selectedItems} ... />
+
+// ❌ Wrong — only selected rows that happen to be on the current page
+<MemberTable
+  entityList={data.filter((item) => selectedNames.includes(item.cn))}
+  ...
+/>
 ```
 
 ## Differences from Membership Tabs
@@ -201,4 +245,5 @@ const <Entity><SubPage> = (props) => {
 
 - `src/pages/Privileges/PrivilegesPermissions.tsx` — uses `MemberOfToolbar` with `bulkSelector` prop
 - `src/pages/Roles/RolesPrivileges.tsx`
+- `src/pages/Permissions/PermissionsPrivileges.tsx` — delete modal uses full `selectedItems`; table uses `!query.isFetching`
 - `src/pages/DNSZones/DnsResourceRecords.tsx` — uses `ToolbarLayout` with `BulkSelectorPrep` as first item

--- a/src/assets/documentation/documentation-links.json
+++ b/src/assets/documentation/documentation-links.json
@@ -212,5 +212,6 @@
   "roles-settings": [],
   "privileges-settings": [],
   "selfservice-permissions-settings": [],
-  "delegations-settings": []
+  "delegations-settings": [],
+  "permissions-settings": []
 }

--- a/src/components/Form/IpaCheckboxes/IpaCheckboxes.test.tsx
+++ b/src/components/Form/IpaCheckboxes/IpaCheckboxes.test.tsx
@@ -173,4 +173,16 @@ describe("IpaCheckboxes Component", () => {
       "ipauserauthtype2"
     );
   });
+
+  it("renders checkboxes in a grid when withGrid is true", () => {
+    const { container } = render(<IpaCheckboxes {...defaultProps} withGrid />);
+
+    expect(container.querySelector(".pf-v6-l-grid")).toBeInTheDocument();
+    expect(container.querySelectorAll(".pf-v6-l-grid__item")).toHaveLength(
+      defaultProps.options.length
+    );
+    expect(screen.getAllByLabelText("ipauserauthtype2")).toHaveLength(
+      defaultProps.options.length
+    );
+  });
 });

--- a/src/components/Form/IpaCheckboxes/IpaCheckboxes.tsx
+++ b/src/components/Form/IpaCheckboxes/IpaCheckboxes.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 // PatternFly
-import { Checkbox } from "@patternfly/react-core";
+import { Checkbox, Grid, GridItem } from "@patternfly/react-core";
 // Utils
 import {
   IPAParamDefinition,
@@ -17,6 +17,7 @@ interface CheckboxOption {
 export interface IPAParamDefinitionCheckboxes extends IPAParamDefinition {
   dataCy: string;
   options: CheckboxOption[];
+  withGrid?: boolean;
 }
 
 const IpaCheckboxes = (props: IPAParamDefinitionCheckboxes) => {
@@ -42,32 +43,40 @@ const IpaCheckboxes = (props: IPAParamDefinitionCheckboxes) => {
     }
   };
 
-  return (
-    <>
-      {props.options.map((option, idx) => (
-        <Checkbox
-          data-cy={props.dataCy + "-" + option.value}
-          key={props.name + "-" + option.value}
-          id={props.name + "-" + option.value} // Mandatory
-          name={props.name}
-          label={option.text}
-          onChange={(_event, checked) => updateList(checked, option.value)}
-          isRequired={required}
-          readOnly={readOnly}
-          isChecked={
-            valueAsArray.find((val) => val === option.value) !== undefined
-          }
-          aria-label={props.name}
-          className={
-            idx !== props.options.length - 1
-              ? "pf-v6-u-mt-xs pf-v6-u-mb-sm"
-              : ""
-          }
-          isDisabled={readOnly}
-        />
-      ))}
-    </>
+  const renderCheckbox = (option: CheckboxOption, idx: number) => (
+    <Checkbox
+      data-cy={props.dataCy + "-" + option.value}
+      key={props.name + "-" + option.value}
+      id={props.name + "-" + option.value} // Mandatory
+      name={props.name}
+      label={option.text}
+      onChange={(_event, checked) => updateList(checked, option.value)}
+      isRequired={required}
+      readOnly={readOnly}
+      isChecked={valueAsArray.find((val) => val === option.value) !== undefined}
+      aria-label={props.name}
+      className={
+        !props.withGrid && idx !== props.options.length - 1
+          ? "pf-v6-u-mt-xs pf-v6-u-mb-sm"
+          : ""
+      }
+      isDisabled={readOnly}
+    />
   );
+
+  if (props.withGrid) {
+    return (
+      <Grid sm={4}>
+        {props.options.map((option, idx) => (
+          <GridItem key={props.name + "-" + option.value}>
+            {renderCheckbox(option, idx)}
+          </GridItem>
+        ))}
+      </Grid>
+    );
+  }
+
+  return <>{props.options.map((option, idx) => renderCheckbox(option, idx))}</>;
 };
 
 export default IpaCheckboxes;

--- a/src/components/Form/IpaSimpleSelector/IpaSimpleSelector.test.tsx
+++ b/src/components/Form/IpaSimpleSelector/IpaSimpleSelector.test.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import { vi, describe, afterEach, it, expect } from "vitest";
+import IpaSimpleSelector, {
+  IPAParamDefinitionSimpleSelector,
+} from "./IpaSimpleSelector";
+
+describe("IpaSimpleSelector Component", () => {
+  const mockOnChange = vi.fn();
+
+  const mockMetadata = {
+    objects: {
+      permission: {
+        name: "permission",
+        takes_params: [
+          {
+            alwaysask: false,
+            attribute: true,
+            autofill: false,
+            class: "StrEnum",
+            cli_metavar: "['permission', 'all', 'anonymous', 'self']",
+            cli_name: "bindtype",
+            confirm: false,
+            deprecated_cli_aliases: [],
+            deprecated: false,
+            doc: "Bind rule type",
+            flags: [],
+            label: "Bind rule type",
+            maxlength: 255,
+            multivalue: false,
+            name: "ipapermbindruletype",
+            no_convert: false,
+            noextrawhitespace: true,
+            pattern_errmsg: "",
+            pattern: "",
+            primary_key: false,
+            query: false,
+            required: false,
+            sortorder: 1,
+            type: "str",
+            values: ["permission", "all", "anonymous", "self"],
+            writable: true,
+          },
+        ],
+      },
+    },
+  };
+
+  const defaultProps: IPAParamDefinitionSimpleSelector = {
+    dataCy: "ipa-simple-selector",
+    name: "ipapermbindruletype",
+    ariaLabel: "ipapermbindruletype",
+    ipaObject: { ipapermbindruletype: "permission" },
+    objectName: "permission",
+    onChange: mockOnChange,
+    required: true,
+    readOnly: false,
+    metadata: mockMetadata,
+    options: [
+      { key: "permission", value: "permission" },
+      { key: "all", value: "all" },
+      { key: "anonymous", value: "anonymous" },
+      { key: "self", value: "self" },
+    ],
+  };
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    cleanup();
+  });
+
+  it("renders a select option for each provided option", async () => {
+    render(<IpaSimpleSelector {...defaultProps} />);
+
+    const selectToggle = screen.getByRole("button");
+    expect(selectToggle).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(selectToggle);
+    });
+
+    const selectOptions = screen.getAllByRole("option");
+    expect(selectOptions).toHaveLength(defaultProps.options.length);
+
+    defaultProps.options.forEach((option, idx) => {
+      expect(selectOptions[idx]).toHaveTextContent(option.value);
+      expect(selectOptions[idx]).toHaveAttribute("id", option.key);
+    });
+  });
+
+  it("shows the current value on the toggle", () => {
+    render(<IpaSimpleSelector {...defaultProps} />);
+
+    const selectToggle = screen.getByRole("button", {
+      name: "ipapermbindruletype",
+    });
+    expect(selectToggle).toBeInTheDocument();
+    expect(selectToggle).toHaveTextContent("permission");
+  });
+
+  it("calls onChange with the selected option", async () => {
+    render(<IpaSimpleSelector {...defaultProps} />);
+
+    const selectToggle = screen.getByRole("button", {
+      name: "ipapermbindruletype",
+    });
+
+    await act(async () => {
+      fireEvent.click(selectToggle);
+    });
+
+    const options = screen.getAllByRole("option");
+    await act(async () => {
+      fireEvent.click(options[1]);
+    });
+
+    expect(mockOnChange).toHaveBeenCalledWith({
+      ipapermbindruletype: "all",
+    });
+    expect(selectToggle).toHaveTextContent("all");
+  });
+
+  it("disables the select when readOnly is true", () => {
+    render(<IpaSimpleSelector {...defaultProps} readOnly={true} />);
+
+    const selectToggle = screen.getByRole("button");
+    expect(selectToggle).toBeDisabled();
+  });
+});

--- a/src/components/Form/IpaSimpleSelector/IpaSimpleSelector.tsx
+++ b/src/components/Form/IpaSimpleSelector/IpaSimpleSelector.tsx
@@ -1,0 +1,124 @@
+import React from "react";
+// PatternFly
+import {
+  MenuToggle,
+  MenuToggleElement,
+  Select,
+  SelectList,
+  SelectOption,
+} from "@patternfly/react-core";
+// Utils
+import {
+  convertToString,
+  getParamProperties,
+  IPAParamDefinition,
+} from "src/utils/ipaObjectUtils";
+import { SelectOptionProps } from "src/components/layouts/SimpleSelector";
+
+export interface IPAParamDefinitionSimpleSelector extends IPAParamDefinition {
+  dataCy: string;
+  id?: string;
+  options: SelectOptionProps[];
+  returnedProperty?: keyof SelectOptionProps;
+  noOptionsMessage?: string;
+}
+
+const IpaSimpleSelector = (props: IPAParamDefinitionSimpleSelector) => {
+  const { readOnly, value, onChange } = getParamProperties(props);
+  const id = props.id || props.name;
+  const returnedProperty = props.returnedProperty ?? "value";
+  const currentValue = convertToString(value);
+
+  const getDisplayValue = (raw: string) => {
+    const match = props.options.find(
+      (option) => option[returnedProperty] === raw || option.value === raw
+    );
+    return match?.value ?? raw;
+  };
+
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [selected, setSelected] = React.useState<string>(
+    getDisplayValue(currentValue)
+  );
+
+  React.useEffect(() => {
+    const match = props.options.find(
+      (option) =>
+        option[returnedProperty] === currentValue ||
+        option.value === currentValue
+    );
+    setSelected(match?.value ?? currentValue);
+  }, [currentValue, props.options, returnedProperty]);
+
+  const onToggleClick = () => {
+    if (readOnly) {
+      return;
+    }
+    setIsOpen(!isOpen);
+  };
+
+  const onSelect = (
+    _event: React.MouseEvent<Element, MouseEvent> | undefined,
+    option: SelectOptionProps
+  ) => {
+    onChange(option[returnedProperty]);
+    setSelected(option.value);
+    setIsOpen(false);
+  };
+
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      data-cy={props.dataCy + "-select-toggle"}
+      id={id}
+      ref={toggleRef}
+      aria-label={
+        props.ariaLabel ? props.ariaLabel : "Basic selector menu toggle"
+      }
+      onClick={onToggleClick}
+      isExpanded={isOpen}
+      isDisabled={readOnly}
+      isFullWidth
+    >
+      {selected}
+    </MenuToggle>
+  );
+
+  return (
+    <Select
+      data-cy={props.dataCy + "-select"}
+      id={id + "-select"}
+      isOpen={isOpen}
+      selected={selected}
+      onSelect={onSelect}
+      onOpenChange={(isOpen) => setIsOpen(isOpen)}
+      toggle={toggle}
+      isScrollable
+    >
+      <SelectList id={id + "-selector-list"}>
+        {props.options.length === 0 ? (
+          <SelectOption
+            data-cy={props.dataCy + "-select-no-options"}
+            isDisabled
+            value="no-options"
+          >
+            {props.noOptionsMessage || "No options available"}
+          </SelectOption>
+        ) : (
+          props.options.map((option, idx) => (
+            <SelectOption
+              data-cy={props.dataCy + "-select-" + option.key}
+              id={option.key}
+              key={option.key}
+              tabIndex={idx}
+              value={option}
+            >
+              {option.value}
+            </SelectOption>
+          ))
+        )}
+      </SelectList>
+    </Select>
+  );
+};
+
+export default IpaSimpleSelector;

--- a/src/components/Form/IpaSimpleSelector/index.ts
+++ b/src/components/Form/IpaSimpleSelector/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./IpaSimpleSelector";
+export * from "./IpaSimpleSelector";

--- a/src/hooks/usePermissionSettingsData.tsx
+++ b/src/hooks/usePermissionSettingsData.tsx
@@ -1,0 +1,122 @@
+import { useState, useEffect } from "react";
+import { useGetObjectMetadataQuery } from "src/services/rpc";
+import { useGetPermissionByIdQuery } from "src/services/rpcPermissions";
+import { Permission, Metadata } from "src/utils/datatypes/globalDataTypes";
+
+type PermissionSettingsData = {
+  isLoading: boolean;
+  isFetching: boolean;
+  modified: boolean;
+  setModified: (value: boolean) => void;
+  resetValues: () => void;
+  metadata: Metadata;
+  originalPermission: Partial<Permission>;
+  permission: Partial<Permission>;
+  setPermission: (permission: Partial<Permission>) => void;
+  refetch: () => void;
+  modifiedValues: () => Partial<Permission>;
+};
+
+const usePermissionSettings = (cn: string): PermissionSettingsData => {
+  const metadataQuery = useGetObjectMetadataQuery();
+  const metadata = metadataQuery.data || {};
+  const metadataLoading = metadataQuery.isLoading;
+
+  const permissionQuery = useGetPermissionByIdQuery(cn, {
+    skip: !cn,
+  });
+  const permissionData = permissionQuery.data;
+  const isPermissionLoading = permissionQuery.isLoading;
+
+  const [modified, setModified] = useState(false);
+  const [initialized, setInitialized] = useState(false);
+  const [permission, setPermission] = useState<Partial<Permission>>({});
+  const [originalPermission, setOriginalPermission] = useState<
+    Partial<Permission>
+  >({});
+
+  useEffect(() => {
+    setInitialized(false);
+    setPermission({});
+    setOriginalPermission({});
+  }, [cn]);
+
+  useEffect(() => {
+    if (permissionQuery.isError) {
+      setPermission({});
+      setOriginalPermission({});
+      setInitialized(true);
+      return;
+    }
+    if (permissionData !== undefined && !permissionQuery.isFetching) {
+      if (permissionData.length > 0) {
+        setPermission({ ...permissionData[0] });
+        setOriginalPermission({ ...permissionData[0] });
+      } else {
+        setPermission({});
+        setOriginalPermission({});
+      }
+      setInitialized(true);
+    }
+  }, [permissionData, permissionQuery.isFetching, permissionQuery.isError]);
+
+  const getModifiedValues = (): Partial<Permission> => {
+    if (!originalPermission) {
+      return {};
+    }
+
+    const modifiedValues: Partial<Permission> = {};
+    for (const [key, value] of Object.entries(permission)) {
+      if (Array.isArray(value)) {
+        if (JSON.stringify(originalPermission[key]) !== JSON.stringify(value)) {
+          modifiedValues[key] = value;
+        }
+      } else if (originalPermission[key] !== value) {
+        modifiedValues[key] = value;
+      }
+    }
+    return modifiedValues;
+  };
+
+  useEffect(() => {
+    if (!originalPermission) {
+      return;
+    }
+    let isModified = false;
+    for (const [key, value] of Object.entries(permission)) {
+      if (Array.isArray(value)) {
+        if (JSON.stringify(originalPermission[key]) !== JSON.stringify(value)) {
+          isModified = true;
+          break;
+        }
+      } else {
+        if (originalPermission[key] !== value) {
+          isModified = true;
+          break;
+        }
+      }
+    }
+    setModified(isModified);
+  }, [permission, originalPermission]);
+
+  const onResetValues = () => {
+    setPermission({ ...originalPermission });
+    setModified(false);
+  };
+
+  return {
+    isLoading: metadataLoading || isPermissionLoading || !initialized,
+    isFetching: permissionQuery.isFetching,
+    modified,
+    setModified,
+    metadata,
+    originalPermission,
+    permission,
+    setPermission,
+    refetch: permissionQuery.refetch,
+    modifiedValues: getModifiedValues,
+    resetValues: onResetValues,
+  };
+};
+
+export { usePermissionSettings };

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -81,6 +81,7 @@ import RolesTabs from "src/pages/Roles/RolesTabs";
 import Privileges from "src/pages/Privileges/Privileges";
 import PrivilegesTabs from "src/pages/Privileges/PrivilegesTabs";
 import Permissions from "src/pages/Permissions/Permissions";
+import PermissionsTabs from "src/pages/Permissions/PermissionsTabs";
 import SelfServicePermissions from "src/pages/SelfServicePermissions/SelfServicePermissions";
 import SelfServicePermissionsTabs from "src/pages/SelfServicePermissions/SelfServicePermissionsTabs";
 import { AppLayout } from "src/AppLayout";
@@ -605,6 +606,12 @@ export const AppRoutes = (): React.ReactElement => {
             </Route>
             <Route path="permissions">
               <Route path="" element={<Permissions />} />
+              <Route path=":cn">
+                <Route
+                  path=""
+                  element={<PermissionsTabs section="settings" />}
+                />
+              </Route>
             </Route>
             <Route path="selfservice-permissions">
               <Route path="" element={<SelfServicePermissions />} />

--- a/src/navigation/AppRoutes.tsx
+++ b/src/navigation/AppRoutes.tsx
@@ -611,6 +611,10 @@ export const AppRoutes = (): React.ReactElement => {
                   path=""
                   element={<PermissionsTabs section="settings" />}
                 />
+                <Route
+                  path="privileges"
+                  element={<PermissionsTabs section="privileges" />}
+                />
               </Route>
             </Route>
             <Route path="selfservice-permissions">

--- a/src/pages/Permissions/Permissions.tsx
+++ b/src/pages/Permissions/Permissions.tsx
@@ -334,7 +334,7 @@ const Permissions = () => {
                     hasCheckboxes={true}
                     pathname="permissions"
                     showTableRows={!isFetching}
-                    showLink={false}
+                    showLink={true}
                     elementsData={{
                       isElementSelectable: isPermissionSelectable,
                       selectedElements: selectedPermissions,

--- a/src/pages/Permissions/PermissionsPrivileges.tsx
+++ b/src/pages/Permissions/PermissionsPrivileges.tsx
@@ -1,0 +1,377 @@
+import React, { useMemo } from "react";
+// PatternFly
+import { PaginationVariant } from "@patternfly/react-core";
+// Data types
+import { Permission } from "src/utils/datatypes/globalDataTypes";
+// Components
+import MemberOfToolbar from "src/components/MemberOf/MemberOfToolbar";
+import MemberTable from "src/components/tables/MembershipTable";
+import MemberOfAddModal, {
+  AvailableItems,
+} from "src/components/MemberOf/MemberOfAddModal";
+import MemberOfDeleteModal from "src/components/MemberOf/MemberOfDeleteModal";
+import PaginationLayout from "src/components/layouts/PaginationLayout";
+import BulkSelectorPrep from "src/components/BulkSelectorPrep";
+// Layouts
+import TabLayout from "src/components/layouts/TabLayout";
+// Redux
+import { useAppDispatch } from "src/store/hooks";
+// Hooks
+import { addAlert } from "src/store/Global/alerts-slice";
+import useListPageSearchParams from "src/hooks/useListPageSearchParams";
+import useUpdateRoute from "src/hooks/useUpdateRoute";
+// RPC
+import { ErrorResult } from "src/services/rpc";
+import {
+  useGetPermissionByIdQuery,
+  useAddPrivilegeToPermissionMutation,
+  useRemovePrivilegeFromPermissionMutation,
+} from "src/services/rpcPermissions";
+import { useGetAvailablePrivilegesQuery } from "src/services/rpcPrivileges";
+// Utils
+import { paginate } from "src/utils/utils";
+import { getSelectedPerPageData } from "src/utils/selectedPerPage";
+
+interface PropsToPermissionsPrivileges {
+  permission: Permission;
+  onOpenContextualPanel?: () => void;
+}
+
+interface PrivilegeItem {
+  cn: string;
+}
+
+interface PrivilegesAddModalProps {
+  showModal: boolean;
+  onClose: () => void;
+  permissionCn: string;
+  privilegeNames: string[];
+  onSuccess: () => void;
+}
+
+const PrivilegesAddModal = (props: PrivilegesAddModalProps) => {
+  const dispatch = useAppDispatch();
+  const [spinning, setSpinning] = React.useState(false);
+  const [addPrivilegeToPermission] = useAddPrivilegeToPermissionMutation();
+  const [adderSearchValue, setAdderSearchValue] = React.useState("");
+  const [availableItems, setAvailableItems] = React.useState<AvailableItems[]>(
+    []
+  );
+
+  const privilegesQuery = useGetAvailablePrivilegesQuery(adderSearchValue, {
+    skip: !props.showModal,
+  });
+
+  React.useEffect(() => {
+    if (privilegesQuery.data && !privilegesQuery.isFetching) {
+      const results = (privilegesQuery.data.result?.result ||
+        []) as unknown as Array<{ cn: string[] | string }>;
+      let items: AvailableItems[] = results.map((priv) => ({
+        key: Array.isArray(priv.cn) ? priv.cn[0] : priv.cn,
+        title: Array.isArray(priv.cn) ? priv.cn[0] : priv.cn,
+      }));
+      items = items.filter((item) => !props.privilegeNames.includes(item.key));
+      setAvailableItems(items);
+    }
+  }, [privilegesQuery.data, privilegesQuery.isFetching, props.privilegeNames]);
+
+  const onAddPrivilege = (items: AvailableItems[]) => {
+    const newPrivilegeNames = items.map((item) => item.key);
+    if (!props.permissionCn || newPrivilegeNames.length === 0) {
+      return;
+    }
+
+    setSpinning(true);
+    addPrivilegeToPermission({
+      permissionCn: props.permissionCn,
+      privileges: newPrivilegeNames,
+    })
+      .then((response) => {
+        if ("data" in response) {
+          if (response.data?.result) {
+            dispatch(
+              addAlert({
+                name: "add-privilege-success",
+                title: `Added privileges to permission '${props.permissionCn}'`,
+                variant: "success",
+              })
+            );
+            props.onSuccess();
+            props.onClose();
+          } else if (response.data?.error) {
+            const errorMessage = response.data.error as unknown as ErrorResult;
+            dispatch(
+              addAlert({
+                name: "add-privilege-error",
+                title: errorMessage.message,
+                variant: "danger",
+              })
+            );
+          }
+        }
+      })
+      .finally(() => {
+        setSpinning(false);
+      });
+  };
+
+  return (
+    <MemberOfAddModal
+      showModal={props.showModal}
+      onCloseModal={props.onClose}
+      availableItems={availableItems}
+      onAdd={onAddPrivilege}
+      title={`Add privileges to permission '${props.permissionCn}'`}
+      ariaLabel="Add privileges to permission modal"
+      searchProps={{ onSearchTextChange: setAdderSearchValue }}
+      spinning={spinning}
+    />
+  );
+};
+
+const PermissionsPrivileges = (props: PropsToPermissionsPrivileges) => {
+  const dispatch = useAppDispatch();
+
+  // Update current route data to Redux and highlight the current page in the Nav bar
+  useUpdateRoute({ pathname: "permissions", noBreadcrumb: true });
+
+  // Query used for refresh operations
+  const permissionQuery = useGetPermissionByIdQuery(props.permission.cn);
+
+  // Get parameters from URL
+  const { page, setPage, perPage, searchValue } = useListPageSearchParams();
+
+  // Selection state (entity-based for BulkSelectorPrep compatibility)
+  const [selectedPrivileges, setSelectedPrivileges] = React.useState<
+    PrivilegeItem[]
+  >([]);
+
+  // Get privilege names from permission (prefer fresh query data, fallback to props)
+  const privilegeNames = useMemo(
+    () =>
+      permissionQuery.data?.[0]?.member_privilege ||
+      props.permission.member_privilege ||
+      [],
+    [
+      permissionQuery.data?.[0]?.member_privilege,
+      props.permission.member_privilege,
+    ]
+  );
+
+  // Column configuration
+  const columnNames = ["Privilege name"];
+  const properties: string[] = [];
+
+  const privileges = useMemo((): PrivilegeItem[] => {
+    let toLoad = [...privilegeNames];
+    toLoad.sort();
+
+    // Filter by search
+    if (searchValue) {
+      toLoad = toLoad.filter((name) =>
+        name.toLowerCase().includes(searchValue.toLowerCase())
+      );
+    }
+
+    // Apply paging
+    toLoad = paginate(toLoad, page, perPage);
+
+    return toLoad.map((name) => ({ cn: name }));
+  }, [privilegeNames, searchValue, page, perPage]);
+
+  // Derive string[] for MemberTable compatibility
+  const privilegesSelectedNames = useMemo(
+    () => selectedPrivileges.map((p) => p.cn),
+    [selectedPrivileges]
+  );
+
+  // Delete button disabled state (managed by BulkSelectorPrep and selection helpers)
+  const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] =
+    React.useState(true);
+
+  // Update selected privileges (used by BulkSelectorPrep and MemberTable)
+  const updateSelectedPrivileges = (
+    items: PrivilegeItem[],
+    isSelected: boolean
+  ) => {
+    let newSelected: PrivilegeItem[];
+    if (isSelected) {
+      const currentNames = new Set(privilegesSelectedNames);
+      const toAdd = items.filter((item) => !currentNames.has(item.cn));
+      newSelected = [...selectedPrivileges, ...toAdd];
+    } else {
+      const removeNames = new Set(items.map((item) => item.cn));
+      newSelected = selectedPrivileges.filter((p) => !removeNames.has(p.cn));
+    }
+    setSelectedPrivileges(newSelected);
+    setIsDeleteButtonDisabled(newSelected.length === 0);
+  };
+
+  // Adapter for MemberTable's string-based onCheckItemsChange
+  const onCheckItemsChange = (checkedNames: string[]) => {
+    setSelectedPrivileges(checkedNames.map((name) => ({ cn: name })));
+    setIsDeleteButtonDisabled(checkedNames.length === 0);
+  };
+
+  // Dialogs and actions
+  const [showAddModal, setShowAddModal] = React.useState(false);
+  const [showDeleteModal, setShowDeleteModal] = React.useState(false);
+  const [spinning, setSpinning] = React.useState(false);
+
+  // Buttons functionality
+  const isRefreshButtonEnabled = !permissionQuery.isFetching;
+
+  const selectedPerPageData = getSelectedPerPageData(
+    privileges,
+    privilegesSelectedNames,
+    (priv) => priv.cn
+  );
+
+  const bulkSelectorData = {
+    selected: selectedPrivileges,
+    updateSelected: updateSelectedPrivileges,
+    selectableTable: privileges,
+    nameAttr: "cn",
+  };
+
+  // API calls
+  const [removePrivilegeFromPermission] =
+    useRemovePrivilegeFromPermissionMutation();
+
+  // Refresh data
+  const onRefreshData = () => {
+    setSelectedPrivileges([]);
+    setIsDeleteButtonDisabled(true);
+    permissionQuery.refetch();
+  };
+
+  // Remove privileges from permission
+  const onDeletePrivilege = () => {
+    if (
+      props.permission.cn === undefined ||
+      privilegesSelectedNames.length === 0
+    ) {
+      return;
+    }
+
+    setSpinning(true);
+    removePrivilegeFromPermission({
+      permissionCn: props.permission.cn,
+      privileges: privilegesSelectedNames,
+    })
+      .then((response) => {
+        if ("data" in response) {
+          if (response.data?.result) {
+            dispatch(
+              addAlert({
+                name: "remove-privilege-success",
+                title: `Removed privileges from permission '${props.permission.cn}'`,
+                variant: "success",
+              })
+            );
+            onRefreshData();
+            setShowDeleteModal(false);
+            setPage(1);
+          } else if (response.data?.error) {
+            const errorMessage = response.data.error as unknown as ErrorResult;
+            dispatch(
+              addAlert({
+                name: "remove-privilege-error",
+                title: errorMessage.message,
+                variant: "danger",
+              })
+            );
+          }
+        }
+      })
+      .finally(() => {
+        setSpinning(false);
+      });
+  };
+
+  // Get filtered privilege names count for pagination
+  const getFilteredCount = (): number => {
+    if (!searchValue) {
+      return privilegeNames.length;
+    }
+    return privilegeNames.filter((name) =>
+      name.toLowerCase().includes(searchValue.toLowerCase())
+    ).length;
+  };
+
+  return (
+    <TabLayout id="privileges">
+      <MemberOfToolbar
+        bulkSelector={
+          <BulkSelectorPrep
+            list={privileges}
+            shownElementsList={privileges}
+            elementData={bulkSelectorData}
+            buttonsData={{
+              updateIsDeleteButtonDisabled: setIsDeleteButtonDisabled,
+            }}
+            selectedPerPageData={selectedPerPageData}
+          />
+        }
+        searchPlaceholder="Search privileges"
+        searchAriaLabel="Search privileges"
+        refreshButtonEnabled={isRefreshButtonEnabled}
+        onRefreshButtonClick={onRefreshData}
+        deleteButtonEnabled={!isDeleteButtonDisabled && isRefreshButtonEnabled}
+        onDeleteButtonClick={() => setShowDeleteModal(true)}
+        addButtonEnabled={isRefreshButtonEnabled}
+        onAddButtonClick={() => setShowAddModal(true)}
+        helpIconEnabled
+        onHelpIconClick={props.onOpenContextualPanel}
+        totalItems={getFilteredCount()}
+      />
+      <MemberTable
+        entityList={privileges}
+        idKey="cn"
+        from="privileges"
+        columnNamesToShow={columnNames}
+        propertiesToShow={properties}
+        checkedItems={privilegesSelectedNames}
+        onCheckItemsChange={onCheckItemsChange}
+        showTableRows={!permissionQuery.isFetching}
+        showLink
+      />
+      {getFilteredCount() > 0 && (
+        <PaginationLayout
+          list={[]}
+          totalCount={getFilteredCount()}
+          variant={PaginationVariant.bottom}
+          widgetId="pagination-options-menu-bottom"
+          className="pf-v6-u-pb-0 pf-v6-u-pr-md"
+        />
+      )}
+      {showAddModal && (
+        <PrivilegesAddModal
+          showModal={showAddModal}
+          onClose={() => setShowAddModal(false)}
+          permissionCn={props.permission.cn}
+          privilegeNames={privilegeNames}
+          onSuccess={onRefreshData}
+        />
+      )}
+      <MemberOfDeleteModal
+        showModal={showDeleteModal}
+        onCloseModal={() => setShowDeleteModal(false)}
+        title={`Remove privileges from permission '${props.permission.cn}'`}
+        onDelete={onDeletePrivilege}
+        spinning={spinning}
+      >
+        <MemberTable
+          entityList={selectedPrivileges}
+          from="privileges"
+          idKey="cn"
+          columnNamesToShow={columnNames}
+          propertiesToShow={properties}
+          showTableRows
+        />
+      </MemberOfDeleteModal>
+    </TabLayout>
+  );
+};
+
+export default PermissionsPrivileges;

--- a/src/pages/Permissions/PermissionsSettings.tsx
+++ b/src/pages/Permissions/PermissionsSettings.tsx
@@ -1,0 +1,286 @@
+import React, { useState } from "react";
+import { Button, Flex, Form, FormGroup } from "@patternfly/react-core";
+import IpaTextInput from "src/components/Form/IpaTextInput";
+import IpaCheckboxes from "src/components/Form/IpaCheckboxes";
+import IpaSimpleSelector from "src/components/Form/IpaSimpleSelector";
+import TitleLayout from "src/components/layouts/TitleLayout";
+import TabLayout from "src/components/layouts/TabLayout";
+import SidebarLayout from "src/components/layouts/SidebarLayout";
+import { asRecord } from "src/utils/permissionsUtils";
+import { useAppDispatch } from "src/store/hooks";
+import { addAlert } from "src/store/Global/alerts-slice";
+import useUpdateRoute from "src/hooks/useUpdateRoute";
+import { Permission, Metadata } from "src/utils/datatypes/globalDataTypes";
+import { ErrorResult } from "src/services/rpc";
+import { useSavePermissionMutation } from "src/services/rpcPermissions";
+
+const BIND_RULE_OPTIONS = [
+  { key: "permission", value: "permission" },
+  { key: "all", value: "all" },
+  { key: "anonymous", value: "anonymous" },
+  { key: "self", value: "self" },
+];
+
+const GRANTED_RIGHTS_OPTIONS = [
+  { value: "read", text: "read" },
+  { value: "search", text: "search" },
+  { value: "compare", text: "compare" },
+  { value: "write", text: "write" },
+  { value: "add", text: "add" },
+  { value: "delete", text: "delete" },
+  { value: "all", text: "all" },
+];
+
+interface PropsToSettings {
+  permission: Partial<Permission>;
+  originalPermission: Partial<Permission>;
+  metadata: Metadata;
+  onPermissionChange: (permission: Partial<Permission>) => void;
+  onRefresh: () => void;
+  isModified: boolean;
+  isDataLoading?: boolean;
+  modifiedValues: () => Partial<Permission>;
+  onResetValues: () => void;
+  onOpenContextualPanel?: () => void;
+}
+
+const PermissionsSettings = (props: PropsToSettings) => {
+  const dispatch = useAppDispatch();
+
+  const [savePermission] = useSavePermissionMutation();
+
+  useUpdateRoute({ pathname: "permissions", noBreadcrumb: true });
+
+  const { ipaObject, recordOnChange } = asRecord(
+    props.permission,
+    props.onPermissionChange
+  );
+
+  const [isSaving, setSaving] = useState(false);
+
+  const onSave = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const modifiedValues = props.modifiedValues();
+    modifiedValues.cn = props.permission.cn;
+    setSaving(true);
+
+    savePermission(modifiedValues)
+      .then((response) => {
+        if ("data" in response) {
+          if (response.data?.result) {
+            dispatch(
+              addAlert({
+                name: "save-success",
+                title: "Permission modified",
+                variant: "success",
+              })
+            );
+            props.onRefresh();
+          } else if (response.data?.error) {
+            const errorMessage = response.data.error as ErrorResult;
+            dispatch(
+              addAlert({
+                name: "save-error",
+                title: errorMessage.message,
+                variant: "danger",
+              })
+            );
+            props.onResetValues();
+          }
+        }
+      })
+      .finally(() => {
+        setSaving(false);
+      });
+  };
+
+  const onRevert = () => {
+    props.onPermissionChange(props.originalPermission);
+    dispatch(
+      addAlert({
+        name: "revert-success",
+        title: "Permission data reverted",
+        variant: "success",
+      })
+    );
+  };
+
+  const toolbarFields = [
+    {
+      key: 0,
+      element: (
+        <Button
+          variant="secondary"
+          data-cy="permissions-tab-settings-button-refresh"
+          onClick={props.onRefresh}
+        >
+          Refresh
+        </Button>
+      ),
+    },
+    {
+      key: 1,
+      element: (
+        <Button
+          variant="secondary"
+          data-cy="permissions-tab-settings-button-revert"
+          isDisabled={!props.isModified || isSaving || props.isDataLoading}
+          onClick={onRevert}
+        >
+          Revert
+        </Button>
+      ),
+    },
+    {
+      key: 2,
+      element: (
+        <Button
+          variant="primary"
+          data-cy="permissions-tab-settings-button-save"
+          isDisabled={!props.isModified || isSaving || props.isDataLoading}
+          type="submit"
+          form="permissions-settings-form"
+          isLoading={isSaving}
+          spinnerAriaValueText="Saving"
+          spinnerAriaLabel="Saving"
+        >
+          {isSaving ? "Saving" : "Save"}
+        </Button>
+      ),
+    },
+  ];
+
+  return (
+    <TabLayout id="settings-page" toolbarItems={toolbarFields}>
+      <SidebarLayout
+        itemNames={["Permission settings", "Target"]}
+        onHelpClick={props.onOpenContextualPanel}
+      >
+        <Form
+          className="pf-v6-u-mt-sm pf-v6-u-mb-lg pf-v6-u-mr-md"
+          id="permissions-settings-form"
+          isHorizontal
+          onSubmit={onSave}
+        >
+          <Flex direction={{ default: "column" }} flex={{ default: "flex_1" }}>
+            <TitleLayout
+              headingLevel="h2"
+              id="permission-settings"
+              text="Permission settings"
+            />
+            <FormGroup label="Permission name" fieldId="cn">
+              <IpaTextInput
+                dataCy="permissions-tab-settings-textbox-cn"
+                name="cn"
+                ariaLabel="Permission name"
+                ipaObject={ipaObject}
+                onChange={recordOnChange}
+                objectName="permission"
+                metadata={props.metadata}
+              />
+            </FormGroup>
+            <FormGroup label="Bind rule type" fieldId="ipapermbindruletype">
+              <IpaSimpleSelector
+                dataCy="permissions-tab-settings-select-ipapermbindruletype"
+                name="ipapermbindruletype"
+                ariaLabel="Bind rule type"
+                ipaObject={ipaObject}
+                onChange={recordOnChange}
+                objectName="permission"
+                metadata={props.metadata}
+                options={BIND_RULE_OPTIONS}
+              />
+            </FormGroup>
+            <FormGroup label="Granted rights" fieldId="ipapermright">
+              <IpaCheckboxes
+                dataCy="permissions-tab-settings-checkbox-ipapermright"
+                name="ipapermright"
+                ipaObject={ipaObject}
+                onChange={recordOnChange}
+                objectName="permission"
+                metadata={props.metadata}
+                withGrid
+                options={GRANTED_RIGHTS_OPTIONS}
+              />
+            </FormGroup>
+          </Flex>
+          <Flex
+            direction={{ default: "column" }}
+            flex={{ default: "flex_1" }}
+            className="pf-v6-u-mt-xl"
+          >
+            <TitleLayout headingLevel="h2" id="target" text="Target" />
+            <FormGroup label="Type" fieldId="type">
+              <IpaTextInput
+                dataCy="permissions-tab-settings-textbox-type"
+                name="type"
+                ariaLabel="Type"
+                ipaObject={ipaObject}
+                onChange={recordOnChange}
+                objectName="permission"
+                metadata={props.metadata}
+              />
+            </FormGroup>
+            <FormGroup label="Subtree" fieldId="ipapermlocation">
+              <IpaTextInput
+                dataCy="permissions-tab-settings-textbox-ipapermlocation"
+                name="ipapermlocation"
+                ariaLabel="Subtree"
+                ipaObject={ipaObject}
+                onChange={recordOnChange}
+                objectName="permission"
+                metadata={props.metadata}
+              />
+            </FormGroup>
+            <FormGroup label="Extra target filter" fieldId="extratargetfilter">
+              <IpaTextInput
+                dataCy="permissions-tab-settings-textbox-extratargetfilter"
+                name="extratargetfilter"
+                ariaLabel="Extra target filter"
+                ipaObject={ipaObject}
+                onChange={recordOnChange}
+                objectName="permission"
+                metadata={props.metadata}
+              />
+            </FormGroup>
+            <FormGroup label="Target DN" fieldId="ipapermtarget">
+              <IpaTextInput
+                dataCy="permissions-tab-settings-textbox-ipapermtarget"
+                name="ipapermtarget"
+                ariaLabel="Target DN"
+                ipaObject={ipaObject}
+                onChange={recordOnChange}
+                objectName="permission"
+                metadata={props.metadata}
+              />
+            </FormGroup>
+            <FormGroup label="Member of group" fieldId="memberof">
+              <IpaTextInput
+                dataCy="permissions-tab-settings-textbox-memberof"
+                name="memberof"
+                ariaLabel="Member of group"
+                ipaObject={ipaObject}
+                onChange={recordOnChange}
+                objectName="permission"
+                metadata={props.metadata}
+              />
+            </FormGroup>
+            <FormGroup label="Effective attributes" fieldId="attrs">
+              <IpaTextInput
+                dataCy="permissions-tab-settings-textbox-attrs"
+                name="attrs"
+                ariaLabel="Effective attributes"
+                ipaObject={ipaObject}
+                onChange={recordOnChange}
+                objectName="permission"
+                metadata={props.metadata}
+              />
+            </FormGroup>
+          </Flex>
+        </Form>
+      </SidebarLayout>
+    </TabLayout>
+  );
+};
+
+export default PermissionsSettings;

--- a/src/pages/Permissions/PermissionsTabs.tsx
+++ b/src/pages/Permissions/PermissionsTabs.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
 import { useNavigate } from "react-router";
 import PermissionsSettings from "src/pages/Permissions/PermissionsSettings";
+import PermissionsPrivileges from "src/pages/Permissions/PermissionsPrivileges";
 import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
 import TitleLayout from "src/components/layouts/TitleLayout";
 import DataSpinner from "src/components/layouts/DataSpinner";
@@ -9,6 +10,7 @@ import { usePermissionSettings } from "src/hooks/usePermissionSettingsData";
 import useContextualHelpTopic from "src/hooks/useContextualHelpTopic";
 import { NotFound } from "src/components/errors/PageErrors";
 import { CnParams, useSafeParams } from "src/utils/paramsUtils";
+import { partialPermissionToPermission } from "src/utils/permissionsUtils";
 import { useAppDispatch } from "src/store/hooks";
 import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
 import {
@@ -19,6 +21,11 @@ import {
 interface PermissionsTabsProps {
   section: string;
 }
+
+const TAB_ROUTES: Record<string, (cn: string) => string> = {
+  settings: (cn) => `/permissions/${cn}`,
+  privileges: (cn) => `/permissions/${cn}/privileges`,
+};
 
 const PermissionsTabs = ({ section }: PermissionsTabsProps) => {
   const { cn } = useSafeParams<CnParams>(["cn"]);
@@ -42,8 +49,10 @@ const PermissionsTabs = ({ section }: PermissionsTabsProps) => {
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
-    if (tabIndex === "settings") {
-      navigate("/permissions/" + cn);
+    const tabKey = String(tabIndex);
+    const toPath = TAB_ROUTES[tabKey];
+    if (toPath) {
+      navigate(toPath(cn));
     }
   };
 
@@ -66,7 +75,7 @@ const PermissionsTabs = ({ section }: PermissionsTabsProps) => {
 
   React.useEffect(() => {
     if (!section) {
-      navigate("/permissions/" + cn);
+      navigate(TAB_ROUTES.settings(cn));
     }
     setActiveTabKey(section || "settings");
   }, [section, cn, navigate]);
@@ -118,6 +127,18 @@ const PermissionsTabs = ({ section }: PermissionsTabsProps) => {
               isModified={permissionSettingsData.modified}
               onResetValues={permissionSettingsData.resetValues}
               modifiedValues={permissionSettingsData.modifiedValues}
+              onOpenContextualPanel={() => dispatch(toggleHelpPanel())}
+            />
+          </Tab>
+          <Tab
+            eventKey={"privileges"}
+            name="privileges-details"
+            title={<TabTitleText>Privileges</TabTitleText>}
+          >
+            <PermissionsPrivileges
+              permission={partialPermissionToPermission(
+                permissionSettingsData.permission
+              )}
               onOpenContextualPanel={() => dispatch(toggleHelpPanel())}
             />
           </Tab>

--- a/src/pages/Permissions/PermissionsTabs.tsx
+++ b/src/pages/Permissions/PermissionsTabs.tsx
@@ -1,0 +1,130 @@
+import React, { useState } from "react";
+import { PageSection, Tabs, Tab, TabTitleText } from "@patternfly/react-core";
+import { useNavigate } from "react-router";
+import PermissionsSettings from "src/pages/Permissions/PermissionsSettings";
+import BreadCrumb, { BreadCrumbItem } from "src/components/layouts/BreadCrumb";
+import TitleLayout from "src/components/layouts/TitleLayout";
+import DataSpinner from "src/components/layouts/DataSpinner";
+import { usePermissionSettings } from "src/hooks/usePermissionSettingsData";
+import useContextualHelpTopic from "src/hooks/useContextualHelpTopic";
+import { NotFound } from "src/components/errors/PageErrors";
+import { CnParams, useSafeParams } from "src/utils/paramsUtils";
+import { useAppDispatch } from "src/store/hooks";
+import { updateBreadCrumbPath } from "src/store/Global/routes-slice";
+import {
+  closeHelpPanel,
+  toggleHelpPanel,
+} from "src/store/Global/contextual-help-slice";
+
+interface PermissionsTabsProps {
+  section: string;
+}
+
+const PermissionsTabs = ({ section }: PermissionsTabsProps) => {
+  const { cn } = useSafeParams<CnParams>(["cn"]);
+  const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+  useContextualHelpTopic("permissions-settings");
+
+  const [breadcrumbItems, setBreadcrumbItems] = React.useState<
+    BreadCrumbItem[]
+  >([]);
+
+  React.useEffect(() => {
+    dispatch(closeHelpPanel());
+  }, [section, dispatch]);
+
+  const permissionSettingsData = usePermissionSettings(cn);
+
+  const [activeTabKey, setActiveTabKey] = useState(section || "settings");
+
+  const handleTabClick = (
+    _event: React.MouseEvent<HTMLElement, MouseEvent>,
+    tabIndex: number | string
+  ) => {
+    if (tabIndex === "settings") {
+      navigate("/permissions/" + cn);
+    }
+  };
+
+  React.useEffect(() => {
+    const currentPath: BreadCrumbItem[] = [
+      {
+        name: "Permissions",
+        url: "/permissions",
+      },
+      {
+        name: cn,
+        url: "/permissions/" + cn,
+        isActive: true,
+      },
+    ];
+    setBreadcrumbItems(currentPath);
+    setActiveTabKey("settings");
+    dispatch(updateBreadCrumbPath(currentPath));
+  }, [cn, dispatch]);
+
+  React.useEffect(() => {
+    if (!section) {
+      navigate("/permissions/" + cn);
+    }
+    setActiveTabKey(section || "settings");
+  }, [section, cn, navigate]);
+
+  if (permissionSettingsData.isLoading) {
+    return <DataSpinner />;
+  }
+
+  if (!permissionSettingsData.permission.cn) {
+    return <NotFound />;
+  }
+
+  return (
+    <>
+      <PageSection hasBodyWrapper={false}>
+        <BreadCrumb
+          className="pf-v6-u-mb-sm"
+          breadcrumbItems={breadcrumbItems}
+        />
+        <TitleLayout
+          id={permissionSettingsData.permission.cn}
+          preText="Permission:"
+          text={permissionSettingsData.permission.cn}
+          headingLevel="h1"
+        />
+      </PageSection>
+      <PageSection hasBodyWrapper={false} type="tabs" isFilled>
+        <Tabs
+          activeKey={activeTabKey}
+          onSelect={handleTabClick}
+          variant="secondary"
+          isBox
+          className="pf-v6-u-ml-lg"
+          mountOnEnter
+          unmountOnExit
+        >
+          <Tab
+            eventKey={"settings"}
+            name="settings-details"
+            title={<TabTitleText>Settings</TabTitleText>}
+          >
+            <PermissionsSettings
+              permission={permissionSettingsData.permission}
+              originalPermission={permissionSettingsData.originalPermission}
+              metadata={permissionSettingsData.metadata}
+              onPermissionChange={permissionSettingsData.setPermission}
+              isDataLoading={permissionSettingsData.isFetching}
+              onRefresh={permissionSettingsData.refetch}
+              isModified={permissionSettingsData.modified}
+              onResetValues={permissionSettingsData.resetValues}
+              modifiedValues={permissionSettingsData.modifiedValues}
+              onOpenContextualPanel={() => dispatch(toggleHelpPanel())}
+            />
+          </Tab>
+        </Tabs>
+      </PageSection>
+    </>
+  );
+};
+
+export default PermissionsTabs;

--- a/src/services/rpcPermissions.ts
+++ b/src/services/rpcPermissions.ts
@@ -8,6 +8,7 @@ import {
 } from "./rpc";
 import { API_VERSION_BACKUP } from "../utils/utils";
 import { Permission, cnType } from "../utils/datatypes/globalDataTypes";
+import { apiToPermission } from "../utils/permissionsUtils";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 
 /**
@@ -18,7 +19,40 @@ import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
  * - permission_show: https://freeipa.readthedocs.io/en/latest/api/permission_show.html
  * - permission_add: https://freeipa.readthedocs.io/en/latest/api/permission_add.html
  * - permission_del: https://freeipa.readthedocs.io/en/latest/api/permission_del.html
+ * - permission_mod: https://freeipa.readthedocs.io/en/latest/api/permission_mod.html
  */
+
+const PERMISSION_MOD_KEYS = [
+  "ipapermright",
+  "attrs",
+  "ipapermbindruletype",
+  "ipapermlocation",
+  "extratargetfilter",
+  "ipapermtarget",
+  "memberof",
+  "type",
+  "targetgroup",
+] as const;
+
+const ARRAY_MOD_KEYS = new Set([
+  "ipapermright",
+  "attrs",
+  "extratargetfilter",
+  "memberof",
+]);
+
+const toModValue = (key: string, value: unknown): unknown => {
+  if (!ARRAY_MOD_KEYS.has(key)) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    return value.trim() === "" ? [] : [value];
+  }
+  return value;
+};
 
 interface PermissionAddPayload {
   cn: string;
@@ -151,6 +185,51 @@ const extendedApi = api.injectEndpoints({
         return getBatchCommand(commands, API_VERSION_BACKUP);
       },
     }),
+    /**
+     * Get a single permission by cn via `permission_show`
+     * @param {string} cn - Permission name
+     * @returns {Permission[]} - Permission data
+     */
+    getPermissionById: build.query<Permission[], string>({
+      query: (cn) => {
+        return getCommand({
+          method: "permission_show",
+          params: [[cn], { all: true, rights: true }],
+        });
+      },
+      transformResponse: (response: FindRPCResponse): Permission[] => {
+        if (response.result?.result) {
+          return [
+            apiToPermission(
+              response.result.result as unknown as Record<string, unknown>
+            ),
+          ];
+        }
+        return [];
+      },
+    }),
+    /**
+     * Modify an existing permission via `permission_mod`
+     * @param {Partial<Permission>} - Permission data to modify (must include cn)
+     * @returns {FindRPCResponse} - Response from API
+     */
+    savePermission: build.mutation<FindRPCResponse, Partial<Permission>>({
+      query: (permission) => {
+        const params: Record<string, unknown> = {
+          version: API_VERSION_BACKUP,
+        };
+        for (const key of PERMISSION_MOD_KEYS) {
+          const value = permission[key];
+          if (value !== undefined) {
+            params[key] = toModValue(key, value);
+          }
+        }
+        return getCommand({
+          method: "permission_mod",
+          params: [[permission.cn], params],
+        });
+      },
+    }),
   }),
   overrideExisting: false,
 });
@@ -159,4 +238,6 @@ export const {
   useGetPermissionsFullDataQuery,
   useAddPermissionMutation,
   useDeletePermissionsMutation,
+  useGetPermissionByIdQuery,
+  useSavePermissionMutation,
 } = extendedApi;

--- a/src/services/rpcPermissions.ts
+++ b/src/services/rpcPermissions.ts
@@ -20,6 +20,8 @@ import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
  * - permission_add: https://freeipa.readthedocs.io/en/latest/api/permission_add.html
  * - permission_del: https://freeipa.readthedocs.io/en/latest/api/permission_del.html
  * - permission_mod: https://freeipa.readthedocs.io/en/latest/api/permission_mod.html
+ * - permission_add_member: https://freeipa.readthedocs.io/en/latest/api/permission_add_member.html
+ * - permission_remove_member: https://freeipa.readthedocs.io/en/latest/api/permission_remove_member.html
  */
 
 const PERMISSION_MOD_KEYS = [
@@ -72,6 +74,11 @@ interface PermissionsFullDataPayload {
   apiVersion: string;
   startIdx: number;
   stopIdx: number;
+}
+
+interface PermissionPrivilegePayload {
+  permissionCn: string;
+  privileges: string[];
 }
 
 const extendedApi = api.injectEndpoints({
@@ -230,6 +237,42 @@ const extendedApi = api.injectEndpoints({
         });
       },
     }),
+    /**
+     * Add privileges to a permission via `permission_add_member`
+     * @param {PermissionPrivilegePayload} - Payload with permission cn and privileges
+     * @returns {FindRPCResponse} - Response from API
+     */
+    addPrivilegeToPermission: build.mutation<
+      FindRPCResponse,
+      PermissionPrivilegePayload
+    >({
+      query: (payload) =>
+        getCommand({
+          method: "permission_add_member",
+          params: [
+            [payload.permissionCn],
+            { privilege: payload.privileges, version: API_VERSION_BACKUP },
+          ],
+        }),
+    }),
+    /**
+     * Remove privileges from a permission via `permission_remove_member`
+     * @param {PermissionPrivilegePayload} - Payload with permission cn and privileges
+     * @returns {FindRPCResponse} - Response from API
+     */
+    removePrivilegeFromPermission: build.mutation<
+      FindRPCResponse,
+      PermissionPrivilegePayload
+    >({
+      query: (payload) =>
+        getCommand({
+          method: "permission_remove_member",
+          params: [
+            [payload.permissionCn],
+            { privilege: payload.privileges, version: API_VERSION_BACKUP },
+          ],
+        }),
+    }),
   }),
   overrideExisting: false,
 });
@@ -240,4 +283,6 @@ export const {
   useDeletePermissionsMutation,
   useGetPermissionByIdQuery,
   useSavePermissionMutation,
+  useAddPrivilegeToPermissionMutation,
+  useRemovePrivilegeFromPermissionMutation,
 } = extendedApi;

--- a/src/services/rpcPrivileges.ts
+++ b/src/services/rpcPrivileges.ts
@@ -215,6 +215,21 @@ const extendedApi = api.injectEndpoints({
       },
     }),
     /**
+     * Get available privileges via `privilege_find`
+     * @param {string} searchValue - Search value for filtering privileges
+     * @returns {FindRPCResponse} - Response from API
+     */
+    getAvailablePrivileges: build.query<FindRPCResponse, string>({
+      query: (searchValue) =>
+        getCommand({
+          method: "privilege_find",
+          params: [
+            [searchValue],
+            { no_members: true, version: API_VERSION_BACKUP },
+          ],
+        }),
+    }),
+    /**
      * Get available permissions via `permission_find`
      * @param {string} searchValue - Search value for filtering permissions
      * @returns {FindRPCResponse} - Response from API
@@ -330,6 +345,7 @@ export const {
   useDeletePrivilegesMutation,
   useSavePrivilegeMutation,
   useGetPrivilegeByIdQuery,
+  useGetAvailablePrivilegesQuery,
   useGetPermissionsQuery,
   useAddPermissionToPrivilegeMutation,
   useRemovePermissionFromPrivilegeMutation,

--- a/src/utils/datatypes/globalDataTypes.ts
+++ b/src/utils/datatypes/globalDataTypes.ts
@@ -241,6 +241,7 @@ export interface Permission {
   ipapermtargetto: string;
   ipapermtargetfrom: string;
   memberof: string[];
+  member_privilege: string[];
   targetgroup: string;
   type: string;
 }

--- a/src/utils/permissionsUtils.tsx
+++ b/src/utils/permissionsUtils.tsx
@@ -50,6 +50,7 @@ export function apiToPermission(
     extratargetfilter: (apiRecord.extratargetfilter as string[]) || [],
     ipapermtargetfilter: (apiRecord.ipapermtargetfilter as string[]) || [],
     memberof: (apiRecord.memberof as string[]) || [],
+    member_privilege: (apiRecord.member_privilege as string[]) || [],
   };
 }
 
@@ -77,6 +78,7 @@ export function createEmptyPermission(): Permission {
     ipapermtargetto: "",
     ipapermtargetfrom: "",
     memberof: [],
+    member_privilege: [],
     targetgroup: "",
     type: "",
   };


### PR DESCRIPTION
This PR depends on this one to be merged: https://github.com/freeipa/freeipa-webui/pull/1171

## Summary by Sourcery

Add routed permission detail pages with editable settings and privilege management.

New Features:
- Add Settings and Privileges sub-pages for individual permissions, with routed navigation and contextual help support.
- Enable editing and saving permission settings, including bind rule type, granted rights, and target fields.
- Enable adding, selecting, and removing privileges associated with a permission.
- Add reusable simple-selector and grid-layout checkbox form controls.

Enhancements:
- Add permission-specific data handling, change tracking, reset behavior, and API integrations for permission management.
- Expose permission links from the permissions listing and support paginated privilege selection across pages.
- Use request-fetching state to control table visibility and toolbar actions during refreshes.

Documentation:
- Document full-selection handling for delete modals and request-fetching-based table visibility in sub-page design guidance and checklists.

Tests:
- Add coverage for grid-rendered checkbox groups and simple selector behavior.

Chores:
- Extend permission and privilege data models and API utilities for member privileges and permission updates.